### PR TITLE
feat(cosmos): add TLS trust documentation and clarify sidecar port binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,14 +637,18 @@ services:
     ports:
       - "4577:4577"
       - "4578:4578"
-      - "27017:27017"   # MongoDB (Cosmos MongoDB API)
-      - "5432:5432"     # PostgreSQL (Cosmos PostgreSQL API)
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       FLOCI_AZ_SERVICES_COSMOS_ENGINES_MONGODB_ENABLED: "true"
       FLOCI_AZ_SERVICES_COSMOS_ENGINES_POSTGRESQL_ENABLED: "true"
 ```
+
+> **Note:** Do **not** publish the engine ports (`27017`, `5432`, etc.) on the `floci-az` service.
+> Engines are launched as **sibling containers** by the host Docker daemon (via the mounted socket), so
+> they bind their ports directly on the host — `localhost:27017`, `localhost:5432`, etc. are already
+> accessible without extra mappings. Adding those ports to the `floci-az` service would cause a
+> conflict when the engine container tries to bind the same port.
 
 **How it works (Docker-backed):** when you first send a request to `/{account}-cosmos-mongo/`, floci-az pulls `mongo:7` and starts the container. Subsequent requests go directly to the container's native port (`localhost:27017`). The `/connect` endpoint returns the connection string:
 

--- a/docs/configuration/docker-compose.md
+++ b/docs/configuration/docker-compose.md
@@ -102,6 +102,32 @@ services:
       FLOCI_AZ_STORAGE_SERVICES_BLOB_MODE: wal
 ```
 
+### With Docker-backed engines (Cosmos MongoDB, Event Hubs…)
+
+Docker-backed engines (Cosmos MongoDB/PostgreSQL/Cassandra/Gremlin) and Event Hubs sidecars
+(Artemis, Redpanda) are launched as **sibling containers** by floci-az via the Docker socket.
+They bind their ports directly on the host — **do not** publish those ports on the `floci-az` service:
+
+```yaml
+services:
+  floci-az:
+    image: floci/floci-az:latest
+    ports:
+      - "4577:4577"
+      - "4578:4578"   # Cosmos DB — Java SDK (HTTPS)
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      # Cosmos engines
+      FLOCI_AZ_SERVICES_COSMOS_ENGINES_MONGODB_ENABLED: "true"
+      FLOCI_AZ_SERVICES_COSMOS_ENGINES_POSTGRESQL_ENABLED: "true"
+      # Event Hubs
+      FLOCI_AZ_SERVICES_EVENT_HUB_ENABLED: "true"
+```
+
+Once the sidecars start, their ports are available on the host: `localhost:27017` (MongoDB),
+`localhost:5432` (PostgreSQL), `localhost:5672` (AMQP / Artemis).
+
 ### Multi-container (your app + floci-az)
 
 When your application also runs in Docker, use the service name as the hostname:
@@ -180,6 +206,9 @@ All variables are optional; the default applies when unset.
 | `FLOCI_AZ_SERVICES_TABLE_ENABLED` | `true` | Enable or disable Table Storage |
 | `FLOCI_AZ_SERVICES_FUNCTIONS_ENABLED` | `true` | Enable or disable Azure Functions |
 | `FLOCI_AZ_SERVICES_APP_CONFIG_ENABLED` | `true` | Enable or disable App Configuration |
+| `FLOCI_AZ_SERVICES_COSMOS_ENABLED` | `true` | Enable or disable Cosmos DB (NoSQL always-on endpoint) |
+| `FLOCI_AZ_SERVICES_KEY_VAULT_ENABLED` | `true` | Enable or disable Key Vault |
+| `FLOCI_AZ_SERVICES_EVENT_HUB_ENABLED` | `true` | Enable or disable Event Hubs |
 
 ### Azure Functions
 

--- a/docs/configuration/ports.md
+++ b/docs/configuration/ports.md
@@ -1,12 +1,21 @@
 # Ports Reference
 
-Floci-AZ uses a **single port** for all services — no per-service port mapping needed.
+Floci-AZ uses a **single HTTP port** for all management APIs, plus one HTTPS port for the Cosmos Java SDK.
+Sidecar services (Event Hubs, Cosmos engines) bind their own ports directly on the host — they are not
+proxied through floci-az.
 
-| Port | Protocol | Services |
+## floci-az ports
+
+| Port | Protocol | Purpose |
 |---|---|---|
-| `4577` | HTTP | Blob, Queue, Table, Functions, App Configuration |
+| `4577` | HTTP | All REST services (Blob, Queue, Table, Functions, App Config, Cosmos, Key Vault) |
+| `4578` | HTTPS | Cosmos DB — Java SDK only (enforces TLS in gateway mode) |
 
-Services are distinguished by URL path prefix:
+Both ports are exposed by floci-az itself. Only publish these two in your `docker-compose.yml`.
+
+## Path-based routing (port 4577)
+
+All services share port 4577 and are routed by URL path prefix:
 
 | Service | Path prefix |
 |---|---|
@@ -15,18 +24,36 @@ Services are distinguished by URL path prefix:
 | Table Storage | `/{account}-table/` |
 | Azure Functions | `/{account}-functions/` |
 | App Configuration | `/{account}-appconfig/` |
+| Cosmos DB (NoSQL — always-on) | `/{account}-cosmos/` |
+| Cosmos DB engines (opt-in) | `/{account}-cosmos-{api}/` |
+| Key Vault | `/{account}-keyvault/` |
+| Event Hubs management | `/{account}-eventhub/` |
 
-Change the port with `FLOCI_AZ_PORT`:
+## Sidecar ports (bound directly on the host)
+
+When Docker-backed engines or Event Hubs sidecars are enabled, floci-az launches them as sibling
+containers via the mounted Docker socket. These containers bind their own ports **directly on the host**
+— they are not forwarded through the floci-az container.
+
+| Sidecar | Default port | Controlled by |
+|---|---|---|
+| Event Hubs AMQP (Artemis) | `5672` | `FLOCI_AZ_SERVICES_EVENT_HUB_AMQP_PORT` |
+| Event Hubs Kafka (Redpanda) | `9093` | `FLOCI_AZ_SERVICES_EVENT_HUB_KAFKA_PORT` |
+| Cosmos MongoDB engine | `27017` | `FLOCI_AZ_SERVICES_COSMOS_ENGINES_MONGODB_PORT` |
+| Cosmos PostgreSQL engine | `5432` | `FLOCI_AZ_SERVICES_COSMOS_ENGINES_POSTGRESQL_PORT` |
+| Cosmos Cassandra engine | `9042` | `FLOCI_AZ_SERVICES_COSMOS_ENGINES_CASSANDRA_PORT` |
+| Cosmos Gremlin engine | `8182` | `FLOCI_AZ_SERVICES_COSMOS_ENGINES_GREMLIN_PORT` |
+
+> **Do not** publish sidecar ports on the `floci-az` service in `docker-compose.yml`.
+> Doing so creates a port conflict when the sidecar container tries to bind the same port.
+
+## Changing the default port
 
 ```yaml
 environment:
-  FLOCI_AZ_PORT: "4578"
+  FLOCI_AZ_PORT: "4580"
+  FLOCI_AZ_BASE_URL: "http://localhost:4580"
 ```
 
-When changing the port, also update `FLOCI_AZ_BASE_URL` so URLs embedded in API responses (SAS tokens, operation locations) are correct:
-
-```yaml
-environment:
-  FLOCI_AZ_PORT: "4578"
-  FLOCI_AZ_BASE_URL: "http://localhost:4578"
-```
+Always update `FLOCI_AZ_BASE_URL` together with `FLOCI_AZ_PORT` so URLs embedded in API responses
+(SAS tokens, operation locations) point to the right address.

--- a/docs/services/cosmos.md
+++ b/docs/services/cosmos.md
@@ -36,12 +36,27 @@ Default endpoint: `http://localhost:4577/devstoreaccount1-cosmos`
     import com.azure.cosmos.CosmosClientBuilder;
 
     CosmosClient client = new CosmosClientBuilder()
-            .endpoint("https://localhost:4578/devstoreaccount1-cosmos")
+            .endpoint("https://localhost:4578")
             .key("C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==")
             .gatewayMode()
             .endpointDiscoveryEnabled(false)
             .buildClient();
     ```
+
+    > **TLS trust:** The Java SDK enforces TLS in gateway mode. floci-az ships a self-signed certificate
+    > on port 4578. To trust it, pass the bundled cert as a JVM truststore at startup:
+    >
+    > ```bash
+    > java -Djavax.net.ssl.trustStore=/path/to/floci-az.p12 \
+    >      -Djavax.net.ssl.trustStorePassword=floci-az \
+    >      -Djavax.net.ssl.trustStoreType=PKCS12 \
+    >      -Dio.netty.handler.ssl.noOpenSsl=true \
+    >      -jar your-app.jar
+    > ```
+    >
+    > The `.p12` file is available at `src/main/resources/certs/floci-az.p12` in the floci-az repo,
+    > or you can download it from the running emulator at
+    > `http://localhost:4577/devstoreaccount1-cosmos/cert`.
 
 === "Python"
 
@@ -71,7 +86,7 @@ Default endpoint: `http://localhost:4577/devstoreaccount1-cosmos`
 
 > [!NOTE]
 > **Port difference by SDK:** The **Java SDK** enforces TLS in gateway mode and cannot use plain HTTP, so it connects
-> to `https://localhost:4578` (HTTPS, bundled self-signed cert — no import required). **Python and Node.js SDKs** accept
+> to `https://localhost:4578` (HTTPS — see the TLS trust note above). **Python and Node.js SDKs** accept
 > plain HTTP and connect to `http://localhost:4577/...`.
 
 ## API Reference

--- a/docs/services/event-hub.md
+++ b/docs/services/event-hub.md
@@ -80,8 +80,6 @@ services:
     image: floci/floci-az:latest
     ports:
       - "4577:4577"   # floci-az HTTP
-      - "5672:5672"   # Event Hubs AMQP (Artemis)
-      - "9093:9093"   # Event Hubs Kafka (Redpanda, optional)
     environment:
       FLOCI_AZ_SERVICES_EVENT_HUB_ENABLED: "true"
       FLOCI_AZ_SERVICES_EVENT_HUB_DEFAULT_NAMESPACE: "emulatorNs1"
@@ -90,6 +88,12 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
 ```
+
+> **Note:** Do **not** publish the AMQP (`5672`) or Kafka (`9093`) ports on the `floci-az` service.
+> Artemis and Redpanda are launched as **sibling containers** by the host Docker daemon (via the
+> mounted socket). They bind their ports directly on the host, so `localhost:5672` and
+> `localhost:9093` are accessible without any extra mappings. Adding those ports to the `floci-az`
+> service would conflict when the sidecar container tries to bind the same port.
 
 ### Environment variables
 

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -9,9 +9,10 @@ Floci-AZ provides emulation for several core Azure services.
 | **Table Storage** | `/{account}-table/` | ✅ Full CRUD |
 | **Azure Functions** | `/{account}-functions/` | ✅ HTTP Triggers, Docker runtimes |
 | **App Configuration** | `/{account}-appconfig/` | ✅ Key-values, labels, feature flags, snapshots, revisions, locks |
-| **Cosmos DB (SQL API)** | `/{account}-cosmos/` | ✅ Databases, containers, documents CRUD, SQL queries, partition keys |
+| **Cosmos DB (NoSQL — always-on)** | `/{account}-cosmos/` | ✅ Databases, containers, documents CRUD, full SQL dialect, PATCH, transactional batch |
+| **Cosmos DB engines (opt-in)** | `/{account}-cosmos-{api}/` | ✅ MongoDB · PostgreSQL · Cassandra · Gremlin (Docker-backed) · Table · NoSQL (embedded) |
 | **Key Vault** | `/{account}-keyvault/` | ✅ Secrets CRUD, versioning, soft-delete, properties update |
-| **Event Hubs** | AMQP `:5672` / Kafka `:9093` | ✅ AMQP 1.0 (Artemis), Kafka-compatible (Redpanda, opt-in) |
+| **Event Hubs** | AMQP `:5672` / Kafka `:9093` | ✅ AMQP 1.0 (Artemis sidecar), Kafka-compatible (Redpanda, opt-in) |
 
 ## Unified Endpoint
 


### PR DESCRIPTION
Add Java SDK TLS certificate trust instructions for Cosmos DB HTTPS endpoint. Document that Docker-backed engines and Event Hubs sidecars bind ports directly on the host, clarifying users should not publish sidecar ports on the floci-az service to avoid conflicts.

## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [X] Docs / chore

## Azure Compatibility

<!-- For new actions: which SDK version and Azure CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [X] `./mvnw test` passes locally
- [X] New or updated integration test added
- [X] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
