### PR TITLE
feat(aks): Add Azure Kubernetes Service emulation with k3s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **aks:** Azure Kubernetes Service emulation — CreateOrUpdate, Get, Delete, List (by subscription and by resource group), UpdateTags, agent pool CRUD, `listClusterAdminCredential` / `listClusterUserCredential`; ARM path routing on `Microsoft.ContainerService`
+- **aks:** Real k3s mode — each cluster starts a privileged `rancher/k3s` container; background readiness poller transitions `provisioningState` from `Creating` → `Succeeded`; kubeconfig with real CA extracted from the container
+- **aks:** Mocked mode (`FLOCI_AZ_SERVICES_AKS_MOCKED=true`) — clusters immediately reach `Succeeded` with a synthetic kubeconfig; no Docker required; suitable for unit tests and CI without Docker
+- **aks:** `instanceId`-based container naming (`floci-az-aks-{instanceId}`) — 8-char UUID prefix per cluster prevents naming collisions when the same cluster name exists across resource groups
+- **aks:** 10 unit tests (`AksHandlerTest`) covering full CRUD in mocked mode; 5 Docker integration tests (`AksDockerTest`) with `@TestProfile(mocked=false)` exercising real k3s start, readiness poll, kubeconfig extraction, and deletion
+
 - **cosmos:** Azure Cosmos DB SQL API emulator — always-on at `/{account}-cosmos/`; databases, containers, and document CRUD; full SQL dialect (`SELECT`, `WHERE`, `ORDER BY`, `GROUP BY`, `OFFSET LIMIT`, `SELECT TOP`, `SELECT DISTINCT`); aggregates (`COUNT`, `SUM`, `AVG`, `MIN`, `MAX`); string, math, array, and type-check functions; named parameters; `PATCH` document operations; transactional batch; server-side pagination with continuation tokens; system properties (`_rid`, `_self`, `_etag`, `_ts`) auto-generated on every write ([#16](https://github.com/floci-io/floci-az/pull/16))
 - **cosmos:** Modular multi-API engine support — opt-in per API via environment variable; Docker-backed: MongoDB (`mongo:7`), PostgreSQL/Citus (`citusdata/citus`), Cassandra (`scylladb/scylla:6.2`), Gremlin (`tinkerpop/gremlin-server`); embedded (no Docker): NoSQL in-process SQL engine, Table in-memory OData; each engine exposes a `/connect` endpoint returning its connection string ([#16](https://github.com/floci-io/floci-az/pull/16))
 - **cosmos:** HTTPS proxy on port `4578` with bundled self-signed certificate (`CN=localhost`, valid 100 years) — required for the Azure Cosmos DB Java SDK which enforces TLS in gateway mode; no certificate import needed ([#16](https://github.com/floci-io/floci-az/pull/16))

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <!-- 
 AI Context: This is Floci-Az, a lightweight Local Azure Emulator. 
 Identity: It is the Azure equivalent of Floci (AWS). It is NOT LocalStack.
-Protocols: Implements Azure Storage (Blob, Queue, Table), Azure Functions, App Configuration, Key Vault, and Event Hubs.
-Default Port: 4577. AMQP port: 5672 (Event Hubs). Kafka port: 9093 (Event Hubs, opt-in).
-Tech Stack: Java, Quarkus, Docker-in-Docker for Functions. Artemis sidecar for Event Hubs AMQP. Redpanda sidecar for Kafka.
+Protocols: Implements Azure Storage (Blob, Queue, Table), Azure Functions, App Configuration, Key Vault, Event Hubs, Cosmos DB, Azure SQL Database, and Azure Kubernetes Service (AKS).
+Default Port: 4577. AMQP port: 5672 (Event Hubs). Kafka port: 9093 (Event Hubs, opt-in). k3s API: 6443-7443 (AKS).
+Tech Stack: Java, Quarkus, Docker-in-Docker for Functions. Artemis sidecar for Event Hubs AMQP. Redpanda sidecar for Kafka. k3s sidecar for AKS.
 -->
 
 <p align="center">
@@ -51,6 +51,8 @@ Floci AZ is a free, open-source local Azure emulator for development, testing, a
 | Cosmos DB (SQL API) | ✅                         | ❌                                           | ❌                                                                           |
 | Key Vault           | ✅                         | ❌                                           | ❌                                                                           |
 | Event Hubs          | ✅                         | ❌                                           | ❌                                                                           |
+| Azure SQL Database  | ✅                         | ❌                                           | ❌                                                                           |
+| AKS (Kubernetes)    | ✅                         | ❌                                           | ❌                                                                           |
 | Native binary       | ✅                         | ❌                                           | ✅                                                                           |
 | Unified port        | ✅ (4577)                  | ❌                                           | ❌                                                                           |
 | Storage modes       | ✅ (persistent/WAL/Hybrid) | ❌                                           | ❌                                                                           |
@@ -165,6 +167,8 @@ flowchart LR
             E["App Configuration\n/{account}-appconfig/"]
             F["Key Vault\n/{account}-keyvault/"]
             G["Event Hubs\nAMQP :5672 / Kafka :9093"]
+            H["Azure SQL\nMicrosoft.Sql"]
+            I["AKS\nMicrosoft.ContainerService"]
         end
 
         Router --> A
@@ -174,9 +178,13 @@ flowchart LR
         Router --> E
         Router --> F
         Router --> G
+        Router --> H
+        Router --> I
         A & B & C & E & F --> Store[("StorageBackend\nmemory · hybrid\npersistent · wal")]
         D -->|" spawn / proxy "| Docker["🐳 Docker\n(function containers)"]
         G -->|" manages "| Sidecars["🐳 Artemis (AMQP)\n🐳 Redpanda (Kafka)"]
+        H -->|" manages "| SqlContainers["🐳 azure-sql-edge\n(per server)"]
+        I -->|" manages "| K3s["🐳 k3s\n(per cluster)"]
     end
 
     Client -->|" HTTP :4577\nAzure wire protocol "| Router
@@ -195,6 +203,8 @@ flowchart LR
 | **Cosmos DB NoSQL (embedded)** | `/{account}-cosmos-nosql/` | Same embedded SQL engine as above, exposed as a named engine endpoint. Opt-in with `FLOCI_AZ_SERVICES_COSMOS_ENGINES_NOSQL_ENABLED=true`; no Docker required. |
 | **Key Vault**           | `/{account}-keyvault/`       | Secrets CRUD, versioning, soft-delete, properties update                                                                                                                                                              |
 | **Event Hubs**          | AMQP `:5672` / Kafka `:9093` | AMQP 1.0 (Artemis sidecar), Kafka-compatible (Redpanda, opt-in)                                                                                                                                                       |
+| **Azure SQL Database**  | ARM path + `/{account}-sql/` | Servers, databases, firewall rules; Docker-backed `azure-sql-edge` containers; dynamic port allocation                                                                                                               |
+| **Azure Kubernetes Service** | ARM path (`Microsoft.ContainerService`) | CreateOrUpdate, Get, Delete, List, agent pools, kubeconfig (`listClusterAdminCredential`); real k3s containers or mocked |
 
 ## Persistence & Storage Modes
 

--- a/docs/configuration/ports.md
+++ b/docs/configuration/ports.md
@@ -28,6 +28,7 @@ All services share port 4577 and are routed by URL path prefix:
 | Key Vault | `/{account}-keyvault/` |
 | Event Hubs | `/{account}-eventhub/` |
 | **Azure SQL Database** | `/{account}-sql/` or `/subscriptions/.../providers/Microsoft.Sql/...` |
+| **Azure Kubernetes Service** | `/subscriptions/.../providers/Microsoft.ContainerService/...` |
 
 ---
 
@@ -39,6 +40,7 @@ These ports are resolved at runtime via the Docker daemon — you never configur
 | Service | Sidecar container | Protocol | How to discover port |
 |---|---|---|---|
 | Azure SQL Database | `azure-sql-edge` | TDS (SQL Server) | `GET /{account}-sql/servers/{name}/connect` → `port` field |
+| Azure Kubernetes Service | `rancher/k3s` | HTTPS (Kubernetes API) | `POST .../listClusterAdminCredential` → `kubeconfigs[0].value` → `server:` in kubeconfig |
 | Cosmos MongoDB | `mongo` | MongoDB wire | `GET /{account}-cosmosmongo/connect` → `port` field |
 | Cosmos PostgreSQL | `postgres` | PostgreSQL | `GET /{account}-cosmospostgresql/connect` → `port` field |
 | Cosmos Cassandra | `cassandra` | CQL | `GET /{account}-cosmoscassandra/connect` → `port` field |

--- a/docs/services/aks.md
+++ b/docs/services/aks.md
@@ -1,0 +1,286 @@
+# Azure Kubernetes Service (AKS)
+
+Compatible with the `azure-mgmt-containerservice` SDK, the `az aks` CLI, Terraform's `azurerm_kubernetes_cluster`, and any ARM-speaking client.
+
+> **Requires Docker** (in real mode) — each AKS cluster maps to one `rancher/k3s` container.
+> Set `FLOCI_AZ_SERVICES_AKS_MOCKED=true` for a lightweight mock that skips Docker entirely.
+
+---
+
+## Features
+
+- **Clusters** — CreateOrUpdate, Get, Delete, List (by subscription and by resource group), UpdateTags
+- **Agent pools** — List, Get, CreateOrUpdate, Delete
+- **Credentials** — `listClusterAdminCredential`, `listClusterUserCredential` return a base64-encoded kubeconfig
+- **Real k3s mode** — a privileged k3s container starts per cluster; kubeconfig with real CA is extracted and returned
+- **Mocked mode** — clusters transition immediately to `Succeeded` with a synthetic kubeconfig; no Docker required
+- **instanceId-based naming** — each cluster gets an 8-char UUID prefix, preventing container name collisions across resource groups
+
+---
+
+## Endpoints
+
+All operations use ARM paths:
+
+```
+PUT    /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.ContainerService/managedClusters/{name}
+GET    /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.ContainerService/managedClusters/{name}
+DELETE /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.ContainerService/managedClusters/{name}
+PATCH  /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.ContainerService/managedClusters/{name}
+GET    /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.ContainerService/managedClusters
+GET    /subscriptions/{sub}/providers/Microsoft.ContainerService/managedClusters
+POST   .../managedClusters/{name}/listClusterAdminCredential
+POST   .../managedClusters/{name}/listClusterUserCredential
+GET    .../managedClusters/{name}/agentPools
+GET    .../managedClusters/{name}/agentPools/{poolName}
+PUT    .../managedClusters/{name}/agentPools/{poolName}
+DELETE .../managedClusters/{name}/agentPools/{poolName}
+```
+
+---
+
+## Quickstart
+
+### 1 — Create a cluster
+
+```bash
+curl -s -X PUT \
+  "http://localhost:4577/subscriptions/my-sub/resourceGroups/my-rg/providers/Microsoft.ContainerService/managedClusters/my-cluster?api-version=2024-04-01" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "location": "eastus",
+    "properties": {
+      "kubernetesVersion": "1.29",
+      "dnsPrefix": "my-cluster-dns",
+      "agentPoolProfiles": [
+        {
+          "name": "nodepool1",
+          "count": 1,
+          "vmSize": "Standard_DS2_v2",
+          "osType": "Linux",
+          "mode": "System"
+        }
+      ]
+    }
+  }'
+```
+
+In real mode, `provisioningState` is `"Creating"` until k3s is ready (30–90 s). Poll with GET until `"Succeeded"`.
+In mocked mode, the response immediately shows `"Succeeded"`.
+
+### 2 — Poll until ready (real mode only)
+
+```bash
+while true; do
+  STATE=$(curl -s "http://localhost:4577/subscriptions/my-sub/resourceGroups/my-rg/providers/Microsoft.ContainerService/managedClusters/my-cluster?api-version=2024-04-01" \
+          | python3 -c "import sys,json; print(json.load(sys.stdin)['properties']['provisioningState'])")
+  echo "provisioningState: $STATE"
+  [ "$STATE" = "Succeeded" ] && break
+  sleep 5
+done
+```
+
+### 3 — Get the kubeconfig
+
+```bash
+KUBECONFIG_B64=$(curl -s -X POST \
+  "http://localhost:4577/subscriptions/my-sub/resourceGroups/my-rg/providers/Microsoft.ContainerService/managedClusters/my-cluster/listClusterAdminCredential?api-version=2024-04-01" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['kubeconfigs'][0]['value'])")
+
+echo "$KUBECONFIG_B64" | base64 -d > ~/.kube/my-cluster.yaml
+kubectl --kubeconfig ~/.kube/my-cluster.yaml get nodes
+```
+
+In real mode the kubeconfig points to the live k3s API server. In mocked mode it points to `https://localhost:6443` with `insecure-skip-tls-verify: true`.
+
+### 4 — Delete the cluster
+
+```bash
+curl -s -X DELETE \
+  "http://localhost:4577/subscriptions/my-sub/resourceGroups/my-rg/providers/Microsoft.ContainerService/managedClusters/my-cluster?api-version=2024-04-01"
+# returns 202 Accepted; the k3s container and its volume are removed immediately
+```
+
+---
+
+## SDK Integration
+
+=== "Java"
+
+    ```java
+    // pom.xml:
+    // <dependency>
+    //   <groupId>com.azure.resourcemanager</groupId>
+    //   <artifactId>azure-resourcemanager-containerservice</artifactId>
+    //   <version>2.40.0</version>
+    // </dependency>
+
+    import com.azure.core.credential.TokenCredential;
+    import com.azure.core.management.AzureEnvironment;
+    import com.azure.core.management.profile.AzureProfile;
+    import com.azure.identity.DefaultAzureCredentialBuilder;
+    import com.azure.resourcemanager.containerservice.ContainerServiceManager;
+    import com.azure.resourcemanager.containerservice.models.KubernetesCluster;
+
+    AzureProfile profile = new AzureProfile(
+        "tenant-id", "subscription-id", AzureEnvironment.AZURE);
+    TokenCredential credential = new DefaultAzureCredentialBuilder()
+        .authorityHost("http://localhost:4577/")  // point to floci-az
+        .build();
+
+    ContainerServiceManager manager = ContainerServiceManager
+        .authenticate(credential, profile);
+
+    KubernetesCluster cluster = manager.kubernetesClusters()
+        .define("my-cluster")
+        .withRegion("eastus")
+        .withExistingResourceGroup("my-rg")
+        .withDefaultVersion()
+        .withSystemAssignedManagedServiceIdentity()
+        .defineAgentPool("nodepool1")
+            .withVirtualMachineSize(ContainerServiceVMSizeTypes.STANDARD_DS2_V2)
+            .withAgentPoolMode(AgentPoolMode.SYSTEM)
+            .withAgentPoolType(AgentPoolType.VIRTUAL_MACHINE_SCALE_SETS)
+            .withOSType(OSType.LINUX)
+            .withAgentPoolVirtualMachineCount(1)
+            .attach()
+        .create();
+    ```
+
+=== "Python"
+
+    ```python
+    from azure.identity import DefaultAzureCredential
+    from azure.mgmt.containerservice import ContainerServiceClient
+    from azure.mgmt.containerservice.models import (
+        ManagedCluster, ManagedClusterAgentPoolProfile, ContainerServiceVMSizeTypes
+    )
+
+    credential = DefaultAzureCredential()
+    client = ContainerServiceClient(
+        credential=credential,
+        subscription_id="my-sub",
+        base_url="http://localhost:4577",
+    )
+
+    poller = client.managed_clusters.begin_create_or_update(
+        resource_group_name="my-rg",
+        resource_name="my-cluster",
+        parameters=ManagedCluster(
+            location="eastus",
+            kubernetes_version="1.29",
+            dns_prefix="my-cluster-dns",
+            agent_pool_profiles=[
+                ManagedClusterAgentPoolProfile(
+                    name="nodepool1",
+                    count=1,
+                    vm_size=ContainerServiceVMSizeTypes.STANDARD_DS2_V2,
+                    mode="System",
+                )
+            ],
+        ),
+    )
+    cluster = poller.result()
+    print(cluster.provisioning_state)
+    ```
+
+=== "Azure CLI"
+
+    ```bash
+    az aks create \
+      --subscription my-sub \
+      --resource-group my-rg \
+      --name my-cluster \
+      --location eastus \
+      --node-count 1 \
+      --generate-ssh-keys \
+      --output table
+
+    az aks get-credentials \
+      --subscription my-sub \
+      --resource-group my-rg \
+      --name my-cluster \
+      --file ~/.kube/my-cluster.yaml
+    ```
+
+---
+
+## Real vs Mocked Mode
+
+| | Real mode (`mocked=false`) | Mocked mode (`mocked=true`) |
+|---|---|---|
+| Docker required | Yes | No |
+| `provisioningState` after create | `Creating` → polled to `Succeeded` | Immediately `Succeeded` |
+| Kubeconfig | Extracted from k3s — real CA, real server URL | Synthetic — `insecure-skip-tls-verify: true` |
+| `kubectl` connectivity | Yes — points at live k3s API server | No — k3s not running |
+| Container | `floci-az-aks-{instanceId}` (privileged k3s) | None |
+| Use case | Local development, integration tests | Unit tests, CI without Docker |
+
+---
+
+## Configuration
+
+```yaml
+floci-az:
+  services:
+    aks:
+      enabled: true
+      mocked: false             # true = no Docker; false = real k3s (default)
+      default-image: "rancher/k3s:latest"
+      api-server-base-port: 6443
+      api-server-max-port: 7443
+      keep-running-on-shutdown: false
+```
+
+| Environment Variable | Default | Description |
+|---|---|---|
+| `FLOCI_AZ_SERVICES_AKS_ENABLED` | `true` | Enable or disable the AKS service |
+| `FLOCI_AZ_SERVICES_AKS_MOCKED` | `false` | `true` = skip Docker, synthetic kubeconfig |
+| `FLOCI_AZ_SERVICES_AKS_DEFAULT_IMAGE` | `rancher/k3s:latest` | k3s Docker image |
+| `FLOCI_AZ_SERVICES_AKS_API_SERVER_BASE_PORT` | `6443` | Start of host port range for k3s API servers |
+| `FLOCI_AZ_SERVICES_AKS_API_SERVER_MAX_PORT` | `7443` | End of host port range for k3s API servers |
+| `FLOCI_AZ_SERVICES_AKS_KEEP_RUNNING_ON_SHUTDOWN` | `false` | Leave k3s containers running when floci-az stops |
+
+---
+
+## Docker Compose
+
+```yaml
+services:
+  floci-az:
+    image: floci/floci-az:latest
+    ports:
+      - "4577:4577"
+      - "6443-6450:6443-6450"   # k3s API server ports (one per cluster)
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock   # required for real k3s mode
+    environment:
+      FLOCI_AZ_SERVICES_AKS_MOCKED: "false"
+      # k3s containers bind to host ports 6443–7443 via Docker daemon.
+      # Publish the range you need above.
+```
+
+> **Sidecar ports:** k3s containers bind a host port in the `6443–7443` range directly via the Docker daemon.
+> Publish the port range on the `floci-az` service if your application needs to reach the k3s API server from outside Docker.
+
+---
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Your App                                                    │
+│                                                              │
+│  ARM REST calls ──────► floci-az :4577 ──► AksHandler        │
+│  (create cluster,                         (state, routing)   │
+│   list clusters,                                             │
+│   get credentials)                                           │
+│                                                              │
+│  kubectl / k8s client ────────────────────────────────────►  │
+│                               k3s container :6443            │
+│                               (floci-az-aks-{instanceId})    │
+└──────────────────────────────────────────────────────────────┘
+```
+
+The management plane (ARM API) goes through floci-az on port 4577.
+The data plane (kubectl, Kubernetes API) connects **directly** to the k3s container on its allocated port — floci-az is not in the data path.

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -14,6 +14,7 @@ Floci-AZ provides emulation for several core Azure services.
 | **Key Vault** | `/{account}-keyvault/` | ✅ Secrets CRUD, versioning, soft-delete, properties update |
 | **Event Hubs** | AMQP `:5672` / Kafka `:9093` | ✅ AMQP 1.0 (Artemis), Kafka-compatible (Redpanda, opt-in) |
 | **Azure SQL Database** | ARM path + `/{account}-sql/` | ✅ Servers, databases, firewall rules; Docker-backed SQL Server containers |
+| **Azure Kubernetes Service** | ARM path (`Microsoft.ContainerService`) | ✅ Clusters, agent pools, credentials; real k3s containers or mocked |
 
 ## Unified Endpoint
 
@@ -28,5 +29,6 @@ The following services spin up Docker containers on demand and require the Docke
 | **Azure Functions** | User-provided image | HTTP to container |
 | **Azure SQL Database** | `mcr.microsoft.com/azure-sql-edge:latest` | TDS direct to container port |
 | **Cosmos DB engines** | Various (mongo, postgres, cassandra, …) | Protocol direct to container port |
+| **Azure Kubernetes Service** | `rancher/k3s:latest` | kubectl direct to k3s API server port |
 
 > These services **must** have access to the Docker daemon (`/var/run/docker.sock` mount in Docker Compose).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,5 +76,6 @@ nav:
     - Event Hubs: services/event-hub.md
     - Cosmos DB: services/cosmos.md
     - Azure SQL Database: services/sql.md
+    - Azure Kubernetes Service: services/aks.md
   - Contributing: contributing.md
   - Changelog: changelog.md

--- a/src/main/java/io/floci/az/config/EmulatorConfig.java
+++ b/src/main/java/io/floci/az/config/EmulatorConfig.java
@@ -113,9 +113,38 @@ public interface EmulatorConfig {
         EventHubConfig         eventHub();
         SqlServiceConfig       sql();
         ServiceBusConfig       serviceBus();
+        AksConfig              aks();
 
         /** Shared Docker network for sidecar containers (Artemis, Redpanda, etc.). */
         Optional<String> dockerNetwork();
+    }
+
+    interface AksConfig {
+        @WithDefault("true")
+        boolean enabled();
+
+        /**
+         * When {@code true}, no k3s sidecar is started; clusters transition immediately to
+         * "Succeeded" with a synthetic kubeconfig. Useful for tests without Docker.
+         */
+        @WithDefault("true")
+        boolean mocked();
+
+        /** Docker image for the k3s container. */
+        @WithDefault("rancher/k3s:latest")
+        String defaultImage();
+
+        /** Start of the host port range for k3s API servers. */
+        @WithDefault("6443")
+        int apiServerBasePort();
+
+        /** End of the host port range for k3s API servers. */
+        @WithDefault("7443")
+        int apiServerMaxPort();
+
+        /** When {@code true}, k3s containers are left running when floci-az shuts down. */
+        @WithDefault("false")
+        boolean keepRunningOnShutdown();
     }
 
     interface ServiceBusConfig {

--- a/src/main/java/io/floci/az/core/AzureRoutingFilter.java
+++ b/src/main/java/io/floci/az/core/AzureRoutingFilter.java
@@ -87,6 +87,27 @@ public class AzureRoutingFilter {
         }
 
         // ---------------------------------------------------------------
+        // Azure Kubernetes Service — ARM management-plane paths:
+        //   subscriptions/{sub}/[resourceGroups/{rg}/]providers/Microsoft.ContainerService/...
+        // ---------------------------------------------------------------
+        if (path.startsWith("subscriptions/") && path.contains("/providers/Microsoft.ContainerService/")) {
+            Map<String, String> aksQueryParams = new HashMap<>();
+            requestContext.getUriInfo().getQueryParameters().forEach((k, v) -> aksQueryParams.put(k, v.get(0)));
+            AzureRequest aksRequest = new AzureRequest(
+                requestContext.getMethod(), "aks", "aks", path, headers,
+                requestContext.getEntityStream(), aksQueryParams, null);
+            AuthContext aksAuth = authPipeline.resolve(aksRequest);
+            aksRequest = new AzureRequest(
+                requestContext.getMethod(), "aks", "aks", path, headers,
+                requestContext.getEntityStream(), aksQueryParams, aksAuth);
+            Optional<AzureServiceHandler> aksHandler = serviceRegistry.resolve("aks");
+            if (aksHandler.isPresent()) {
+                LOGGER.infof("Dispatching ARM AKS request to AksHandler: %s %s", requestContext.getMethod(), path);
+                return aksHandler.get().handle(aksRequest);
+            }
+        }
+
+        // ---------------------------------------------------------------
         // Azure SQL Database — ARM management-plane paths:
         //   subscriptions/{sub}/[resourceGroups/{rg}/]providers/Microsoft.Sql/...
         //   subscriptions/{sub}/providers/Microsoft.Sql/checkNameAvailability

--- a/src/main/java/io/floci/az/core/AzureServiceRegistry.java
+++ b/src/main/java/io/floci/az/core/AzureServiceRegistry.java
@@ -40,6 +40,7 @@ public class AzureServiceRegistry {
             case "eventhub"   -> config.services().eventHub().enabled();
             case "sql"        -> config.services().sql().enabled();
             case "servicebus" -> config.services().serviceBus().enabled();
+            case "aks"        -> config.services().aks().enabled();
             case "cosmos-mongo", "cosmos-table", "cosmos-cassandra",
                  "cosmos-gremlin", "cosmos-postgresql", "cosmos-nosql" ->
                 config.services().cosmos().enabled() &&

--- a/src/main/java/io/floci/az/core/BannerLogger.java
+++ b/src/main/java/io/floci/az/core/BannerLogger.java
@@ -80,6 +80,14 @@ public class BannerLogger {
                     + "  (on-demand)  storage:" + getStorageMode("servicebus");
             sb.append(serviceStatusDocker("servicebus", true, amqpInfo));
         }
+        if (config.services().aks().enabled()) {
+            String aksInfo = config.services().aks().mocked()
+                    ? "mocked  (no k3s)"
+                    : "k3s:" + config.services().aks().defaultImage()
+                            + "  ports:" + config.services().aks().apiServerBasePort()
+                            + "-" + config.services().aks().apiServerMaxPort();
+            sb.append(serviceStatusDocker("aks", true, aksInfo));
+        }
         LOGGER.info(sb.toString());
         LOGGER.info("=== Local Azure Emulator Ready ===");
     }

--- a/src/main/java/io/floci/az/services/aks/AksClusterManager.java
+++ b/src/main/java/io/floci/az/services/aks/AksClusterManager.java
@@ -1,0 +1,234 @@
+package io.floci.az.services.aks;
+
+import io.floci.az.config.EmulatorConfig;
+import io.floci.az.core.docker.ContainerBuilder;
+import io.floci.az.core.docker.ContainerDetector;
+import io.floci.az.core.docker.ContainerLifecycleManager;
+import io.floci.az.core.docker.ContainerSpec;
+import io.floci.az.core.docker.PortAllocator;
+import io.floci.az.services.aks.AksModels.ManagedCluster;
+import com.github.dockerjava.api.async.ResultCallback;
+import com.github.dockerjava.api.command.ExecCreateCmdResponse;
+import com.github.dockerjava.api.model.Frame;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Manages the Docker lifecycle of k3s containers backing AKS clusters.
+ * Not used when {@code floci-az.services.aks.mocked=true}.
+ */
+@ApplicationScoped
+public class AksClusterManager {
+
+    private static final Logger LOG = Logger.getLogger(AksClusterManager.class);
+    private static final int K3S_API_SERVER_PORT = 6443;
+
+    private final ContainerBuilder containerBuilder;
+    private final ContainerLifecycleManager lifecycleManager;
+    private final ContainerDetector containerDetector;
+    private final PortAllocator portAllocator;
+    private final EmulatorConfig config;
+
+    @Inject
+    public AksClusterManager(ContainerBuilder containerBuilder,
+                              ContainerLifecycleManager lifecycleManager,
+                              ContainerDetector containerDetector,
+                              PortAllocator portAllocator,
+                              EmulatorConfig config) {
+        this.containerBuilder = containerBuilder;
+        this.lifecycleManager = lifecycleManager;
+        this.containerDetector = containerDetector;
+        this.portAllocator = portAllocator;
+        this.config = config;
+    }
+
+    /**
+     * Starts a k3s container for the given cluster. Sets containerId and endpoint on the cluster.
+     * Status remains "Creating" until {@link #isReady} returns true and {@link #finalizeCluster} is called.
+     */
+    public void startCluster(ManagedCluster cluster) {
+        String image = config.services().aks().defaultImage();
+        String containerName = containerName(cluster);
+
+        LOG.infov("Starting k3s container for AKS cluster: {0} using image {1}", cluster.getName(), image);
+
+        int hostPort = portAllocator.allocate(
+                config.services().aks().apiServerBasePort(),
+                config.services().aks().apiServerMaxPort());
+
+        lifecycleManager.removeIfExists(containerName);
+
+        // Named volume for k3s data — prevents macOS APFS chmod(EINVAL) that crashes kine.
+        String volumeName = containerName;
+        ContainerSpec spec = containerBuilder.newContainer(image)
+                .withName(containerName)
+                .withCmd(List.of("server",
+                        "--disable=traefik",
+                        "--tls-san=localhost"))
+                .withEnv("K3S_KUBECONFIG_MODE", "644")
+                .withPortBinding(K3S_API_SERVER_PORT, hostPort)
+                .withNamedVolume(volumeName, "/var/lib/rancher/k3s")
+                .withDockerNetwork(config.services().dockerNetwork())
+                .withPrivileged(true)
+                .withLogRotation()
+                .build();
+
+        ContainerLifecycleManager.ContainerInfo info = lifecycleManager.createAndStart(spec);
+        cluster.setContainerId(info.containerId());
+
+        if (containerDetector.isRunningInContainer()) {
+            cluster.setEndpoint("https://" + containerName + ":" + K3S_API_SERVER_PORT);
+            ContainerLifecycleManager.EndpointInfo ep = info.getEndpoint(K3S_API_SERVER_PORT);
+            cluster.setInternalEndpoint(ep != null
+                    ? "https://" + ep.host() + ":" + ep.port()
+                    : cluster.getEndpoint());
+        } else {
+            cluster.setEndpoint("https://localhost:" + hostPort);
+            cluster.setInternalEndpoint(cluster.getEndpoint());
+        }
+
+        // FQDN reflects the actual API server endpoint for kubectl to use
+        cluster.setFqdn(cluster.getEndpoint().replace("https://", ""));
+
+        LOG.infov("k3s container {0} started for cluster {1} on port {2} (internal: {3})",
+                info.containerId(), cluster.getName(), hostPort, cluster.getInternalEndpoint());
+    }
+
+    /** Polls the k3s /livez endpoint to detect readiness. */
+    public boolean isReady(ManagedCluster cluster) {
+        String endpoint = cluster.getInternalEndpoint() != null
+                ? cluster.getInternalEndpoint()
+                : cluster.getEndpoint();
+        if (endpoint == null || cluster.getContainerId() == null) {
+            return false;
+        }
+        String livezUrl = endpoint + "/livez";
+        try {
+            HttpURLConnection conn = (HttpURLConnection) URI.create(livezUrl).toURL().openConnection();
+            conn.setRequestMethod("GET");
+            conn.setConnectTimeout(2000);
+            conn.setReadTimeout(2000);
+            if (conn instanceof javax.net.ssl.HttpsURLConnection https) {
+                disableSslVerification(https);
+            }
+            int code = conn.getResponseCode();
+            return code == 200 || code == 401 || code == 403;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * Extracts the kubeconfig from the running k3s container,
+     * storing it base64-encoded on the cluster and updating the CA data.
+     */
+    public void finalizeCluster(ManagedCluster cluster) {
+        String containerId = cluster.getContainerId();
+        if (containerId == null) {
+            return;
+        }
+        try {
+            String kubeconfigYaml = execInContainer(containerId,
+                    new String[]{"cat", "/etc/rancher/k3s/k3s.yaml"});
+
+            // Rewrite the server URL to the public endpoint
+            String publicEndpoint = cluster.getEndpoint();
+            String rewritten = kubeconfigYaml.replaceAll(
+                    "server: https://[^\\n]+",
+                    "server: " + publicEndpoint);
+
+            cluster.setKubeconfig(Base64.getEncoder().encodeToString(
+                    rewritten.getBytes(StandardCharsets.UTF_8)));
+
+            String caData = extractYamlField(kubeconfigYaml, "certificate-authority-data");
+            if (caData != null) {
+                cluster.setCaData(caData.trim());
+            }
+
+            LOG.infov("Finalized AKS cluster {0} with kubeconfig and CA data", cluster.getName());
+        } catch (Exception e) {
+            LOG.warnv("Could not extract kubeconfig for cluster {0}: {1}",
+                    cluster.getName(), e.getMessage());
+        }
+    }
+
+    /** Stops and removes the k3s container for the given cluster. */
+    public void stopCluster(ManagedCluster cluster) {
+        if (cluster.getContainerId() == null) {
+            return;
+        }
+        if (config.services().aks().keepRunningOnShutdown()) {
+            LOG.infov("Leaving k3s container for AKS cluster {0} running", cluster.getName());
+            return;
+        }
+        lifecycleManager.stopAndRemove(cluster.getContainerId(), null);
+        lifecycleManager.removeVolume(containerName(cluster));
+        LOG.infov("Stopped k3s container for AKS cluster {0}", cluster.getName());
+    }
+
+    private static String containerName(ManagedCluster cluster) {
+        return "floci-az-aks-" + cluster.getInstanceId();
+    }
+
+    private String execInContainer(String containerId, String[] cmd) throws Exception {
+        var dockerClient = lifecycleManager.getDockerClient();
+        ExecCreateCmdResponse exec = dockerClient
+                .execCreateCmd(containerId)
+                .withCmd(cmd)
+                .withAttachStdout(true)
+                .withAttachStderr(true)
+                .exec();
+
+        StringBuilder output = new StringBuilder();
+        boolean completed = dockerClient.execStartCmd(exec.getId())
+                .exec(new ResultCallback.Adapter<Frame>() {
+                    @Override
+                    public void onNext(Frame frame) {
+                        output.append(new String(frame.getPayload(), StandardCharsets.UTF_8));
+                    }
+                })
+                .awaitCompletion(10, TimeUnit.SECONDS);
+
+        if (!completed) {
+            throw new RuntimeException("exec timed out in container " + containerId);
+        }
+        return output.toString();
+    }
+
+    private static String extractYamlField(String yaml, String fieldName) {
+        for (String line : yaml.split("\n")) {
+            String trimmed = line.trim();
+            if (trimmed.startsWith(fieldName + ":")) {
+                return trimmed.substring(fieldName.length() + 1).trim();
+            }
+        }
+        return null;
+    }
+
+    @SuppressWarnings("java:S4830")
+    private void disableSslVerification(javax.net.ssl.HttpsURLConnection conn) {
+        try {
+            javax.net.ssl.TrustManager[] trustAll = new javax.net.ssl.TrustManager[]{
+                new javax.net.ssl.X509TrustManager() {
+                    public java.security.cert.X509Certificate[] getAcceptedIssuers() { return null; }
+                    public void checkClientTrusted(java.security.cert.X509Certificate[] c, String a) {}
+                    public void checkServerTrusted(java.security.cert.X509Certificate[] c, String a) {}
+                }
+            };
+            javax.net.ssl.SSLContext sc = javax.net.ssl.SSLContext.getInstance("TLS");
+            sc.init(null, trustAll, new java.security.SecureRandom());
+            conn.setSSLSocketFactory(sc.getSocketFactory());
+            conn.setHostnameVerifier((h, s) -> true);
+        } catch (Exception e) {
+            LOG.debugv("Could not disable SSL verification: {0}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/io/floci/az/services/aks/AksHandler.java
+++ b/src/main/java/io/floci/az/services/aks/AksHandler.java
@@ -1,0 +1,636 @@
+package io.floci.az.services.aks;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.floci.az.config.EmulatorConfig;
+import io.floci.az.core.AzureRequest;
+import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.StoredObject;
+import io.floci.az.core.storage.StorageBackend;
+import io.floci.az.core.storage.StorageFactory;
+import io.floci.az.services.aks.AksModels.AgentPoolProfile;
+import io.floci.az.services.aks.AksModels.ManagedCluster;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * HTTP handler for Azure Kubernetes Service (AKS) management-plane requests.
+ *
+ * <h2>Routing</h2>
+ * <p>All requests use ARM paths:</p>
+ * <pre>
+ *   GET    subscriptions/{sub}/providers/Microsoft.ContainerService/managedClusters
+ *   GET    subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.ContainerService/managedClusters
+ *   GET    subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.ContainerService/managedClusters/{name}
+ *   PUT    subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.ContainerService/managedClusters/{name}
+ *   DELETE subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.ContainerService/managedClusters/{name}
+ *   POST   subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.ContainerService/managedClusters/{name}/listClusterAdminCredential
+ *   POST   subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.ContainerService/managedClusters/{name}/listClusterUserCredential
+ * </pre>
+ *
+ * <h2>Mocked mode</h2>
+ * <p>When {@code floci-az.services.aks.mocked=true} (default), no k3s container is started.
+ * Clusters transition immediately to "Succeeded" with a synthetic kubeconfig pointing at localhost.</p>
+ */
+@ApplicationScoped
+public class AksHandler implements AzureServiceHandler {
+
+    private static final Logger LOG = Logger.getLogger(AksHandler.class);
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    private final EmulatorConfig config;
+    private final AksClusterManager clusterManager;
+    private final StorageBackend<String, StoredObject> storage;
+    private final ScheduledExecutorService poller = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread t = new Thread(r, "aks-readiness-poller");
+        t.setDaemon(true);
+        return t;
+    });
+
+    @Inject
+    public AksHandler(EmulatorConfig config,
+                      AksClusterManager clusterManager,
+                      StorageFactory storageFactory) {
+        this.config = config;
+        this.clusterManager = clusterManager;
+        this.storage = storageFactory.create("aks");
+    }
+
+    @PostConstruct
+    public void init() {
+        if (!config.services().aks().mocked()) {
+            startReadinessPoller();
+        }
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        poller.shutdownNow();
+        if (!config.services().aks().mocked()) {
+            scanAll().forEach(cluster -> {
+                try {
+                    clusterManager.stopCluster(cluster);
+                } catch (Exception e) {
+                    LOG.warnv("Error stopping AKS cluster {0}: {1}", cluster.getName(), e.getMessage());
+                }
+            });
+        }
+    }
+
+    @Override
+    public String getServiceType() { return "aks"; }
+
+    @Override
+    public boolean canHandle(AzureRequest req) { return "aks".equals(req.serviceType()); }
+
+    @Override
+    public Response handle(AzureRequest req) {
+        String fullPath = req.resourcePath();
+        String method = req.method();
+
+        LOG.debugf("AksHandler: %s %s", method, fullPath);
+
+        // Extract the path segment after "Microsoft.ContainerService/"
+        String tail = extractAksPath(fullPath);
+
+        // ── LIST all clusters in subscription ──────────────────────────────
+        // subscriptions/{sub}/providers/Microsoft.ContainerService/managedClusters
+        if (tail.equalsIgnoreCase("managedClusters") && !fullPath.contains("/resourceGroups/")) {
+            return handleListSubscription(fullPath);
+        }
+
+        // ── LIST clusters in resource group ────────────────────────────────
+        // subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.ContainerService/managedClusters
+        if (tail.equalsIgnoreCase("managedClusters") && "GET".equals(method)) {
+            return handleListByResourceGroup(fullPath);
+        }
+
+        // ── Credential endpoints ────────────────────────────────────────────
+        // managedClusters/{name}/listClusterAdminCredential
+        // managedClusters/{name}/listClusterUserCredential
+        if (tail.matches("managedClusters/[^/]+/listCluster(?:Admin|User)Credential") && "POST".equals(method)) {
+            String clusterName = segment(tail, 1);
+            String sub = extractSubscriptionId(fullPath);
+            String rg = extractResourceGroup(fullPath);
+            return handleListCredentials(sub, rg, clusterName);
+        }
+
+        // ── Agent pool list ─────────────────────────────────────────────────
+        if (tail.matches("managedClusters/[^/]+/agentPools") && "GET".equals(method)) {
+            String clusterName = segment(tail, 1);
+            String sub = extractSubscriptionId(fullPath);
+            String rg = extractResourceGroup(fullPath);
+            return handleListAgentPools(sub, rg, clusterName);
+        }
+
+        // ── Agent pool CRUD ─────────────────────────────────────────────────
+        if (tail.matches("managedClusters/[^/]+/agentPools/[^/]+")) {
+            String clusterName = segment(tail, 1);
+            String poolName = segment(tail, 3);
+            String sub = extractSubscriptionId(fullPath);
+            String rg = extractResourceGroup(fullPath);
+            return handleAgentPool(method, sub, rg, clusterName, poolName, req);
+        }
+
+        // ── Single cluster CRUD ─────────────────────────────────────────────
+        if (tail.matches("managedClusters/[^/]+")) {
+            String clusterName = segment(tail, 1);
+            String sub = extractSubscriptionId(fullPath);
+            String rg = extractResourceGroup(fullPath);
+            return switch (method) {
+                case "GET"    -> handleGet(sub, rg, clusterName);
+                case "PUT"    -> handleCreateOrUpdate(sub, rg, clusterName, req);
+                case "DELETE" -> handleDelete(sub, rg, clusterName);
+                case "PATCH"  -> handleUpdateTags(sub, rg, clusterName, req);
+                default       -> methodNotAllowed();
+            };
+        }
+
+        return notFound("Unknown AKS path: " + tail);
+    }
+
+    // ── CRUD operations ────────────────────────────────────────────────────────
+
+    private Response handleCreateOrUpdate(String sub, String rg, String clusterName, AzureRequest req) {
+        try {
+            JsonNode body = readBody(req.bodyStream());
+            String location = body.path("location").asText("eastus");
+            JsonNode props = body.path("properties");
+            String k8sVersion = props.path("kubernetesVersion").asText("1.29");
+            String dnsPrefix = props.path("dnsPrefix").asText(clusterName + "-dns");
+            Map<String, String> tags = parseTags(body.path("tags"));
+
+            List<AgentPoolProfile> pools = new ArrayList<>();
+            JsonNode poolsNode = props.path("agentPoolProfiles");
+            if (poolsNode.isArray() && !poolsNode.isEmpty()) {
+                for (JsonNode p : poolsNode) {
+                    AgentPoolProfile pool = new AgentPoolProfile();
+                    pool.setName(p.path("name").asText("nodepool1"));
+                    pool.setCount(p.path("count").asInt(1));
+                    pool.setVmSize(p.path("vmSize").asText("Standard_DS2_v2"));
+                    pool.setOsType(p.path("osType").asText("Linux"));
+                    pool.setMode(p.path("mode").asText("System"));
+                    pool.setProvisioningState("Succeeded");
+                    pools.add(pool);
+                }
+            }
+            if (pools.isEmpty()) {
+                pools.add(AgentPoolProfile.defaultPool());
+            }
+
+            String storageKey = storageKey(sub, rg, clusterName);
+            Optional<ManagedCluster> existing = getCluster(storageKey);
+
+            boolean isNew = existing.isEmpty();
+            ManagedCluster cluster;
+            if (isNew) {
+                cluster = new ManagedCluster();
+                cluster.setInstanceId(UUID.randomUUID().toString().replace("-", "").substring(0, 8));
+                cluster.setSubscriptionId(sub);
+                cluster.setResourceGroup(rg);
+                cluster.setName(clusterName);
+                cluster.setCreatedAt(Instant.now());
+            } else {
+                cluster = existing.get();
+            }
+
+            cluster.setLocation(location);
+            cluster.setKubernetesVersion(k8sVersion);
+            cluster.setDnsPrefix(dnsPrefix);
+            cluster.setFqdn(dnsPrefix + ".hcp." + location + ".azmk8s.io");
+            cluster.setAgentPoolProfiles(pools);
+            cluster.setTags(tags);
+
+            if (config.services().aks().mocked()) {
+                cluster.setProvisioningState("Succeeded");
+                cluster.setEndpoint("https://localhost:" + config.services().aks().apiServerBasePort());
+                cluster.setKubeconfig(mockKubeconfig(cluster));
+            } else {
+                cluster.setProvisioningState("Creating");
+                if (isNew) {
+                    try {
+                        clusterManager.startCluster(cluster);
+                    } catch (Exception e) {
+                        LOG.errorf(e, "Failed to start k3s container for AKS cluster %s", clusterName);
+                        cluster.setProvisioningState("Failed");
+                    }
+                }
+            }
+
+            putCluster(storageKey, cluster);
+
+            int status = isNew ? 201 : 200;
+            return Response.status(status)
+                    .entity(toArmResponse(cluster))
+                    .type("application/json")
+                    .build();
+        } catch (Exception e) {
+            LOG.errorf(e, "Error creating/updating AKS cluster %s", clusterName);
+            return badRequest("Invalid request: " + e.getMessage());
+        }
+    }
+
+    private Response handleGet(String sub, String rg, String clusterName) {
+        return getCluster(storageKey(sub, rg, clusterName))
+                .map(c -> Response.ok(toArmResponse(c)).type("application/json").build())
+                .orElseGet(() -> notFound("Managed cluster '" + clusterName + "' not found."));
+    }
+
+    private Response handleDelete(String sub, String rg, String clusterName) {
+        String key = storageKey(sub, rg, clusterName);
+        Optional<ManagedCluster> found = getCluster(key);
+        if (found.isEmpty()) {
+            return notFound("Managed cluster '" + clusterName + "' not found.");
+        }
+        ManagedCluster cluster = found.get();
+        cluster.setProvisioningState("Deleting");
+        if (!config.services().aks().mocked()) {
+            try {
+                clusterManager.stopCluster(cluster);
+            } catch (Exception e) {
+                LOG.warnv("Error stopping k3s container for cluster {0}: {1}", clusterName, e.getMessage());
+            }
+        }
+        storage.delete(key);
+        return Response.status(202).build();
+    }
+
+    private Response handleUpdateTags(String sub, String rg, String clusterName, AzureRequest req) {
+        String key = storageKey(sub, rg, clusterName);
+        Optional<ManagedCluster> found = getCluster(key);
+        if (found.isEmpty()) {
+            return notFound("Managed cluster '" + clusterName + "' not found.");
+        }
+        try {
+            JsonNode body = readBody(req.bodyStream());
+            ManagedCluster cluster = found.get();
+            cluster.setTags(parseTags(body.path("tags")));
+            putCluster(key, cluster);
+            return Response.ok(toArmResponse(cluster)).type("application/json").build();
+        } catch (Exception e) {
+            return badRequest("Invalid request: " + e.getMessage());
+        }
+    }
+
+    private Response handleListByResourceGroup(String fullPath) {
+        String sub = extractSubscriptionId(fullPath);
+        String rg = extractResourceGroup(fullPath);
+        String prefix = sub + "/" + rg.toLowerCase() + "/";
+        List<Map<String, Object>> items = new ArrayList<>();
+        scanAll().stream()
+                .filter(c -> c.storageKey().toLowerCase().startsWith(prefix))
+                .forEach(c -> items.add(toArmResponse(c)));
+        return Response.ok(Map.of("value", items)).type("application/json").build();
+    }
+
+    private Response handleListSubscription(String fullPath) {
+        String sub = extractSubscriptionId(fullPath);
+        String prefix = sub + "/";
+        List<Map<String, Object>> items = new ArrayList<>();
+        scanAll().stream()
+                .filter(c -> c.storageKey().startsWith(prefix))
+                .forEach(c -> items.add(toArmResponse(c)));
+        return Response.ok(Map.of("value", items)).type("application/json").build();
+    }
+
+    private Response handleListCredentials(String sub, String rg, String clusterName) {
+        Optional<ManagedCluster> found = getCluster(storageKey(sub, rg, clusterName));
+        if (found.isEmpty()) {
+            return notFound("Managed cluster '" + clusterName + "' not found.");
+        }
+        ManagedCluster cluster = found.get();
+        String kubeconfig = cluster.getKubeconfig();
+        if (kubeconfig == null || kubeconfig.isBlank()) {
+            kubeconfig = mockKubeconfig(cluster);
+        }
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("kubeconfigs", List.of(Map.of(
+                "name", "clusterAdmin",
+                "value", kubeconfig)));
+        return Response.ok(result).type("application/json").build();
+    }
+
+    private Response handleListAgentPools(String sub, String rg, String clusterName) {
+        Optional<ManagedCluster> found = getCluster(storageKey(sub, rg, clusterName));
+        if (found.isEmpty()) {
+            return notFound("Managed cluster '" + clusterName + "' not found.");
+        }
+        List<Map<String, Object>> pools = new ArrayList<>();
+        List<AgentPoolProfile> profiles = found.get().getAgentPoolProfiles();
+        if (profiles != null) {
+            for (AgentPoolProfile p : profiles) {
+                pools.add(toAgentPoolArmResponse(sub, rg, clusterName, p));
+            }
+        }
+        return Response.ok(Map.of("value", pools)).type("application/json").build();
+    }
+
+    private Response handleAgentPool(String method, String sub, String rg,
+                                      String clusterName, String poolName, AzureRequest req) {
+        Optional<ManagedCluster> found = getCluster(storageKey(sub, rg, clusterName));
+        if (found.isEmpty()) {
+            return notFound("Managed cluster '" + clusterName + "' not found.");
+        }
+        ManagedCluster cluster = found.get();
+        List<AgentPoolProfile> pools = cluster.getAgentPoolProfiles();
+        if (pools == null) {
+            pools = new ArrayList<>();
+            cluster.setAgentPoolProfiles(pools);
+        }
+
+        if ("GET".equals(method)) {
+            return pools.stream()
+                    .filter(p -> poolName.equals(p.getName()))
+                    .findFirst()
+                    .map(p -> Response.ok(toAgentPoolArmResponse(sub, rg, clusterName, p))
+                            .type("application/json").build())
+                    .orElseGet(() -> notFound("Agent pool '" + poolName + "' not found."));
+        }
+
+        if ("PUT".equals(method)) {
+            try {
+                JsonNode body = readBody(req.bodyStream());
+                JsonNode props = body.path("properties");
+                List<AgentPoolProfile> finalPools = pools;
+                AgentPoolProfile pool = pools.stream()
+                        .filter(p -> poolName.equals(p.getName()))
+                        .findFirst()
+                        .orElseGet(() -> {
+                            AgentPoolProfile np = new AgentPoolProfile();
+                            np.setName(poolName);
+                            finalPools.add(np);
+                            return np;
+                        });
+                pool.setCount(props.path("count").asInt(pool.getCount() > 0 ? pool.getCount() : 1));
+                pool.setVmSize(props.path("vmSize").asText(
+                        pool.getVmSize() != null ? pool.getVmSize() : "Standard_DS2_v2"));
+                pool.setOsType(props.path("osType").asText(
+                        pool.getOsType() != null ? pool.getOsType() : "Linux"));
+                pool.setMode(props.path("mode").asText(
+                        pool.getMode() != null ? pool.getMode() : "System"));
+                pool.setProvisioningState("Succeeded");
+                putCluster(storageKey(sub, rg, clusterName), cluster);
+                return Response.ok(toAgentPoolArmResponse(sub, rg, clusterName, pool))
+                        .type("application/json").build();
+            } catch (Exception e) {
+                return badRequest("Invalid request: " + e.getMessage());
+            }
+        }
+
+        if ("DELETE".equals(method)) {
+            boolean removed = pools.removeIf(p -> poolName.equals(p.getName()));
+            if (!removed) {
+                return notFound("Agent pool '" + poolName + "' not found.");
+            }
+            putCluster(storageKey(sub, rg, clusterName), cluster);
+            return Response.status(202).build();
+        }
+
+        return methodNotAllowed();
+    }
+
+    // ── Readiness poller ───────────────────────────────────────────────────────
+
+    private void startReadinessPoller() {
+        poller.scheduleAtFixedRate(() -> {
+            try {
+                scanAll().forEach(cluster -> {
+                    if ("Creating".equals(cluster.getProvisioningState())) {
+                        if (clusterManager.isReady(cluster)) {
+                            LOG.infov("AKS cluster {0} is now ready", cluster.getName());
+                            clusterManager.finalizeCluster(cluster);
+                            cluster.setProvisioningState("Succeeded");
+                            putCluster(cluster.storageKey(), cluster);
+                        }
+                    }
+                });
+            } catch (Exception e) {
+                LOG.error("Error in AKS readiness poller", e);
+            }
+        }, 2, 3, TimeUnit.SECONDS);
+    }
+
+    // ── Storage helpers ────────────────────────────────────────────────────────
+
+    private Optional<ManagedCluster> getCluster(String key) {
+        return storage.get(key).map(so -> {
+            try {
+                return MAPPER.readValue(so.data(), ManagedCluster.class);
+            } catch (Exception e) {
+                LOG.warnv("Failed to deserialize AKS cluster {0}: {1}", key, e.getMessage());
+                return null;
+            }
+        });
+    }
+
+    private void putCluster(String key, ManagedCluster cluster) {
+        try {
+            byte[] data = MAPPER.writeValueAsBytes(cluster);
+            storage.put(key, new StoredObject(key, data, Map.of(), Instant.now(), key));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to serialize AKS cluster: " + key, e);
+        }
+    }
+
+    private List<ManagedCluster> scanAll() {
+        List<ManagedCluster> result = new ArrayList<>();
+        storage.scan(k -> true).forEach(so -> {
+            try {
+                ManagedCluster c = MAPPER.readValue(so.data(), ManagedCluster.class);
+                if (c != null) { result.add(c); }
+            } catch (Exception e) {
+                LOG.debugv("Skipping unreadable AKS cluster entry: {0}", e.getMessage());
+            }
+        });
+        return result;
+    }
+
+    // ── ARM response builders ──────────────────────────────────────────────────
+
+    private Map<String, Object> toArmResponse(ManagedCluster cluster) {
+        Map<String, Object> props = new LinkedHashMap<>();
+        props.put("provisioningState", cluster.getProvisioningState());
+        props.put("kubernetesVersion", cluster.getKubernetesVersion());
+        props.put("currentKubernetesVersion", cluster.getKubernetesVersion());
+        props.put("dnsPrefix", cluster.getDnsPrefix());
+        props.put("fqdn", cluster.getFqdn());
+        props.put("enableRBAC", true);
+        props.put("nodeResourceGroup",
+                "MC_" + cluster.getResourceGroup() + "_" + cluster.getName() + "_" + cluster.getLocation());
+
+        if (cluster.getAgentPoolProfiles() != null) {
+            List<Map<String, Object>> poolsOut = new ArrayList<>();
+            for (AgentPoolProfile p : cluster.getAgentPoolProfiles()) {
+                Map<String, Object> pm = new LinkedHashMap<>();
+                pm.put("name", p.getName());
+                pm.put("count", p.getCount());
+                pm.put("vmSize", p.getVmSize());
+                pm.put("osType", p.getOsType());
+                pm.put("mode", p.getMode());
+                pm.put("provisioningState", p.getProvisioningState());
+                poolsOut.add(pm);
+            }
+            props.put("agentPoolProfiles", poolsOut);
+        }
+
+        Map<String, Object> out = new LinkedHashMap<>();
+        out.put("id", cluster.armId());
+        out.put("name", cluster.getName());
+        out.put("type", "Microsoft.ContainerService/managedClusters");
+        out.put("location", cluster.getLocation());
+        if (cluster.getTags() != null && !cluster.getTags().isEmpty()) {
+            out.put("tags", cluster.getTags());
+        }
+        out.put("properties", props);
+        return out;
+    }
+
+    private Map<String, Object> toAgentPoolArmResponse(String sub, String rg,
+                                                         String clusterName, AgentPoolProfile pool) {
+        String id = String.format(
+                "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ContainerService" +
+                "/managedClusters/%s/agentPools/%s",
+                sub, rg, clusterName, pool.getName());
+        Map<String, Object> props = new LinkedHashMap<>();
+        props.put("count", pool.getCount());
+        props.put("vmSize", pool.getVmSize());
+        props.put("osType", pool.getOsType());
+        props.put("mode", pool.getMode());
+        props.put("provisioningState", pool.getProvisioningState());
+
+        Map<String, Object> out = new LinkedHashMap<>();
+        out.put("id", id);
+        out.put("name", pool.getName());
+        out.put("type", "Microsoft.ContainerService/managedClusters/agentPools");
+        out.put("properties", props);
+        return out;
+    }
+
+    // ── Mock kubeconfig ────────────────────────────────────────────────────────
+
+    private static String mockKubeconfig(ManagedCluster cluster) {
+        String endpoint = cluster.getEndpoint() != null
+                ? cluster.getEndpoint()
+                : "https://localhost:6443";
+        String yaml = String.format("""
+                apiVersion: v1
+                clusters:
+                - cluster:
+                    server: %s
+                    insecure-skip-tls-verify: true
+                  name: %s
+                contexts:
+                - context:
+                    cluster: %s
+                    user: clusterAdmin_%s
+                  name: %s
+                current-context: %s
+                kind: Config
+                preferences: {}
+                users:
+                - name: clusterAdmin_%s
+                  user:
+                    token: floci-az-mock-token
+                """,
+                endpoint, cluster.getName(), cluster.getName(),
+                cluster.getName(), cluster.getName(), cluster.getName(),
+                cluster.getName());
+        return Base64.getEncoder().encodeToString(yaml.getBytes(StandardCharsets.UTF_8));
+    }
+
+    // ── Path parsing helpers ───────────────────────────────────────────────────
+
+    private static String extractAksPath(String fullPath) {
+        if (fullPath == null) { return ""; }
+        int idx = fullPath.indexOf("/providers/Microsoft.ContainerService/");
+        if (idx >= 0) {
+            return fullPath.substring(idx + "/providers/Microsoft.ContainerService/".length());
+        }
+        return fullPath;
+    }
+
+    private static String extractSubscriptionId(String fullPath) {
+        if (fullPath == null) { return "default"; }
+        String[] parts = fullPath.split("/");
+        for (int i = 0; i < parts.length - 1; i++) {
+            if ("subscriptions".equalsIgnoreCase(parts[i])) { return parts[i + 1]; }
+        }
+        return "default";
+    }
+
+    private static String extractResourceGroup(String fullPath) {
+        if (fullPath == null) { return "default"; }
+        String[] parts = fullPath.split("/");
+        for (int i = 0; i < parts.length - 1; i++) {
+            if ("resourcegroups".equalsIgnoreCase(parts[i])) { return parts[i + 1]; }
+        }
+        return "default";
+    }
+
+    private static String segment(String path, int index) {
+        String[] parts = path.split("/");
+        return index < parts.length ? parts[index] : "";
+    }
+
+    private static String storageKey(String sub, String rg, String clusterName) {
+        return sub + "/" + rg + "/" + clusterName;
+    }
+
+    private static Map<String, String> parseTags(JsonNode tagsNode) {
+        Map<String, String> tags = new LinkedHashMap<>();
+        if (tagsNode != null && tagsNode.isObject()) {
+            tagsNode.fields().forEachRemaining(e -> tags.put(e.getKey(), e.getValue().asText()));
+        }
+        return tags;
+    }
+
+    private JsonNode readBody(java.io.InputStream stream) {
+        try {
+            if (stream == null || stream.available() == 0) { return MAPPER.createObjectNode(); }
+            return MAPPER.readTree(stream);
+        } catch (Exception e) {
+            return MAPPER.createObjectNode();
+        }
+    }
+
+    // ── Standard error responses ───────────────────────────────────────────────
+
+    private static Response notFound(String message) {
+        return Response.status(404).entity(Map.of(
+                "error", Map.of("code", "ResourceNotFound", "message", message)))
+                .type("application/json").build();
+    }
+
+    private static Response badRequest(String message) {
+        return Response.status(400).entity(Map.of(
+                "error", Map.of("code", "InvalidRequest", "message", message)))
+                .type("application/json").build();
+    }
+
+    private static Response methodNotAllowed() {
+        return Response.status(405).entity(Map.of("error", "Method not allowed"))
+                .type("application/json").build();
+    }
+}

--- a/src/main/java/io/floci/az/services/aks/AksModels.java
+++ b/src/main/java/io/floci/az/services/aks/AksModels.java
@@ -1,0 +1,145 @@
+package io.floci.az.services.aks;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class AksModels {
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class ManagedCluster {
+        /** Short unique ID used for Docker container naming: floci-az-aks-{instanceId}. */
+        private String instanceId;
+        private String subscriptionId;
+        private String resourceGroup;
+        private String name;
+        private String location;
+        private String kubernetesVersion;
+        private String provisioningState;
+        private String dnsPrefix;
+        private String fqdn;
+        /** Public API server endpoint (container-DNS resolvable inside Docker, or localhost outside). */
+        private String endpoint;
+        /** Internal endpoint used for readiness polling (IP-based, works on default bridge). */
+        private String internalEndpoint;
+        private String containerId;
+        /** Base64-encoded kubeconfig extracted from k3s (or a mock kubeconfig). */
+        private String kubeconfig;
+        /** Base64-encoded certificate authority data from the cluster. */
+        private String caData;
+        private Instant createdAt;
+        private Map<String, String> tags;
+        private List<AgentPoolProfile> agentPoolProfiles;
+
+        public String getInstanceId() { return instanceId; }
+        public void setInstanceId(String instanceId) { this.instanceId = instanceId; }
+
+        public String getSubscriptionId() { return subscriptionId; }
+        public void setSubscriptionId(String subscriptionId) { this.subscriptionId = subscriptionId; }
+
+        public String getResourceGroup() { return resourceGroup; }
+        public void setResourceGroup(String resourceGroup) { this.resourceGroup = resourceGroup; }
+
+        public String getName() { return name; }
+        public void setName(String name) { this.name = name; }
+
+        public String getLocation() { return location; }
+        public void setLocation(String location) { this.location = location; }
+
+        public String getKubernetesVersion() { return kubernetesVersion; }
+        public void setKubernetesVersion(String kubernetesVersion) { this.kubernetesVersion = kubernetesVersion; }
+
+        public String getProvisioningState() { return provisioningState; }
+        public void setProvisioningState(String provisioningState) { this.provisioningState = provisioningState; }
+
+        public String getDnsPrefix() { return dnsPrefix; }
+        public void setDnsPrefix(String dnsPrefix) { this.dnsPrefix = dnsPrefix; }
+
+        public String getFqdn() { return fqdn; }
+        public void setFqdn(String fqdn) { this.fqdn = fqdn; }
+
+        public String getEndpoint() { return endpoint; }
+        public void setEndpoint(String endpoint) { this.endpoint = endpoint; }
+
+        public String getInternalEndpoint() { return internalEndpoint; }
+        public void setInternalEndpoint(String internalEndpoint) { this.internalEndpoint = internalEndpoint; }
+
+        public String getContainerId() { return containerId; }
+        public void setContainerId(String containerId) { this.containerId = containerId; }
+
+        public String getKubeconfig() { return kubeconfig; }
+        public void setKubeconfig(String kubeconfig) { this.kubeconfig = kubeconfig; }
+
+        public String getCaData() { return caData; }
+        public void setCaData(String caData) { this.caData = caData; }
+
+        public Instant getCreatedAt() { return createdAt; }
+        public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+
+        public Map<String, String> getTags() { return tags; }
+        public void setTags(Map<String, String> tags) { this.tags = tags; }
+
+        public List<AgentPoolProfile> getAgentPoolProfiles() { return agentPoolProfiles; }
+        public void setAgentPoolProfiles(List<AgentPoolProfile> agentPoolProfiles) {
+            this.agentPoolProfiles = agentPoolProfiles;
+        }
+
+        /** ARM resource ID for this cluster. */
+        public String armId() {
+            return String.format(
+                "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.ContainerService/managedClusters/%s",
+                subscriptionId, resourceGroup, name);
+        }
+
+        /** Storage key: subscriptionId/resourceGroup/name */
+        public String storageKey() {
+            return subscriptionId + "/" + resourceGroup + "/" + name;
+        }
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class AgentPoolProfile {
+        private String name;
+        private int count;
+        private String vmSize;
+        private String osType;
+        private String mode;
+        private String provisioningState;
+
+        public String getName() { return name; }
+        public void setName(String name) { this.name = name; }
+
+        public int getCount() { return count; }
+        public void setCount(int count) { this.count = count; }
+
+        public String getVmSize() { return vmSize; }
+        public void setVmSize(String vmSize) { this.vmSize = vmSize; }
+
+        public String getOsType() { return osType; }
+        public void setOsType(String osType) { this.osType = osType; }
+
+        public String getMode() { return mode; }
+        public void setMode(String mode) { this.mode = mode; }
+
+        public String getProvisioningState() { return provisioningState; }
+        public void setProvisioningState(String provisioningState) { this.provisioningState = provisioningState; }
+
+        public static AgentPoolProfile defaultPool() {
+            AgentPoolProfile p = new AgentPoolProfile();
+            p.name = "nodepool1";
+            p.count = 1;
+            p.vmSize = "Standard_DS2_v2";
+            p.osType = "Linux";
+            p.mode = "System";
+            p.provisioningState = "Succeeded";
+            return p;
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -132,6 +132,13 @@ floci-az:
       artemis-image: "apache/activemq-artemis:latest"
       max-delivery-count: 10
       lock-duration-seconds: 60
+    aks:
+      enabled: true
+      mocked: false
+      default-image: "rancher/k3s:latest"
+      api-server-base-port: 6443
+      api-server-max-port: 7443
+      keep-running-on-shutdown: false
     # docker-network:  # optional: shared Docker network for sidecar containers
 
   auth:

--- a/src/test/java/io/floci/az/services/aks/AksDockerTest.java
+++ b/src/test/java/io/floci/az/services/aks/AksDockerTest.java
@@ -1,0 +1,175 @@
+package io.floci.az.services.aks;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.*;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Base64;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * AKS handler tests with {@code mocked=false} — starts a real k3s container.
+ *
+ * <p>Skipped automatically when Docker is unavailable.
+ * k3s can take up to 120 s to reach /livez, so each poll step sleeps 5 s
+ * with a 150 s overall timeout.
+ *
+ * <p>Tests are ordered and share state (cluster created in test 1, verified in 2-4, deleted in 5).
+ * {@code @BeforeAll} only does a filesystem check so it is safe to run before Quarkus is ready;
+ * the HTTP reset is done inside the first {@code @Test} method.
+ */
+@QuarkusTest
+@TestProfile(AksDockerTest.RealModeProfile.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@DisplayName("AksHandler — real k3s mode (Docker required)")
+class AksDockerTest {
+
+    public static class RealModeProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("floci-az.services.aks.mocked", "false");
+        }
+    }
+
+    private static final String SUB  = "test-sub-aks-docker";
+    private static final String RG   = "test-rg-docker";
+    private static final String NAME = "k3s-test-cluster";
+    private static final String BASE =
+            "/subscriptions/" + SUB + "/resourceGroups/" + RG
+            + "/providers/Microsoft.ContainerService";
+    private static final String CLUSTER_PATH = BASE + "/managedClusters/" + NAME;
+
+    /** Pure filesystem check — safe to run before Quarkus is fully ready. */
+    @BeforeAll
+    void checkDockerAvailable() {
+        boolean dockerAvailable = Files.exists(Paths.get("/var/run/docker.sock"))
+                || System.getenv("DOCKER_HOST") != null;
+        assumeTrue(dockerAvailable, "Docker socket not available — skipping real k3s tests");
+    }
+
+    @AfterAll
+    void cleanup() {
+        try {
+            given().delete(CLUSTER_PATH + "?api-version=2024-04-01");
+        } catch (Exception ignored) {}
+    }
+
+    // ── Create cluster ────────────────────────────────────────────────────────
+
+    @Test
+    @Order(1)
+    @DisplayName("PUT cluster returns 201 with provisioningState=Creating")
+    void createClusterReturns201Creating() {
+        // Reset state before first test (safe here — Quarkus is ready by test time)
+        given().post("/_admin/reset").then().statusCode(204);
+
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                  "location": "eastus",
+                  "properties": {
+                    "kubernetesVersion": "1.29",
+                    "dnsPrefix": "k3s-test-dns",
+                    "agentPoolProfiles": [
+                      {"name": "nodepool1", "count": 1, "vmSize": "Standard_DS2_v2",
+                       "osType": "Linux", "mode": "System"}
+                    ]
+                  }
+                }
+                """)
+            .when().put(CLUSTER_PATH + "?api-version=2024-04-01")
+            .then().statusCode(201)
+            .body("name", equalTo(NAME))
+            .body("properties.provisioningState", oneOf("Creating", "Succeeded", "Failed"));
+    }
+
+    // ── Poll until Succeeded ──────────────────────────────────────────────────
+
+    @Test
+    @Order(2)
+    @DisplayName("cluster reaches provisioningState=Succeeded within 150 s")
+    void clusterReachesSucceeded() throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 150_000;
+        String state = "Creating";
+
+        while (!"Succeeded".equals(state) && !"Failed".equals(state)
+                && System.currentTimeMillis() < deadline) {
+            Thread.sleep(5_000);
+            Response r = given()
+                    .when().get(CLUSTER_PATH + "?api-version=2024-04-01");
+            if (r.statusCode() == 200) {
+                state = r.path("properties.provisioningState");
+            }
+        }
+
+        assumeTrue(!"Failed".equals(state),
+                "k3s container failed to start — Docker may lack privileged-container support");
+        assertEquals("Succeeded", state,
+                "Cluster did not reach Succeeded within 150 s; last state=" + state);
+    }
+
+    // ── Verify ARM shape ──────────────────────────────────────────────────────
+
+    @Test
+    @Order(3)
+    @DisplayName("GET cluster returns correct ARM shape after Succeeded")
+    void getClusterArmShape() {
+        given()
+            .when().get(CLUSTER_PATH + "?api-version=2024-04-01")
+            .then().statusCode(200)
+            .body("name", equalTo(NAME))
+            .body("type", equalTo("Microsoft.ContainerService/managedClusters"))
+            .body("location", equalTo("eastus"))
+            .body("properties.provisioningState", equalTo("Succeeded"))
+            .body("properties.kubernetesVersion", equalTo("1.29"))
+            .body("id", containsString("/managedClusters/" + NAME));
+    }
+
+    // ── Kubeconfig contains real server URL ───────────────────────────────────
+
+    @Test
+    @Order(4)
+    @DisplayName("listClusterAdminCredential returns kubeconfig with real k3s server URL")
+    void adminCredentialHasRealServerUrl() {
+        String encoded = given()
+                .contentType("application/json")
+                .when().post(CLUSTER_PATH + "/listClusterAdminCredential?api-version=2024-04-01")
+                .then().statusCode(200)
+                .body("kubeconfigs[0].name", equalTo("clusterAdmin"))
+                .extract().path("kubeconfigs[0].value");
+
+        assertNotNull(encoded, "kubeconfig value must not be null");
+        String kubeconfig = new String(Base64.getDecoder().decode(encoded));
+        assertTrue(kubeconfig.contains("server: https://"),
+                "kubeconfig must contain a server URL; got:\n" + kubeconfig);
+        assertTrue(kubeconfig.contains("certificate-authority-data:")
+                        || kubeconfig.contains("insecure-skip-tls-verify"),
+                "kubeconfig must contain CA data or skip-tls flag");
+    }
+
+    // ── Delete cluster ────────────────────────────────────────────────────────
+
+    @Test
+    @Order(5)
+    @DisplayName("DELETE cluster returns 202 and subsequent GET returns 404")
+    void deleteCluster() {
+        given()
+            .when().delete(CLUSTER_PATH + "?api-version=2024-04-01")
+            .then().statusCode(202);
+
+        given()
+            .when().get(CLUSTER_PATH + "?api-version=2024-04-01")
+            .then().statusCode(404);
+    }
+}

--- a/src/test/java/io/floci/az/services/aks/AksHandlerTest.java
+++ b/src/test/java/io/floci/az/services/aks/AksHandlerTest.java
@@ -1,0 +1,267 @@
+package io.floci.az.services.aks;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Quarkus-level tests for {@link AksHandler}.
+ *
+ * <p>Always runs in mocked mode (no k3s container) regardless of the default in application.yml.
+ * Covers ARM path routing, CRUD, credentials, and agent pools.
+ */
+@QuarkusTest
+@TestProfile(AksHandlerTest.MockedProfile.class)
+@DisplayName("AksHandler — routing and CRUD (mocked mode)")
+@SuppressWarnings("unused")
+class AksHandlerTest {
+
+    public static class MockedProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("floci-az.services.aks.mocked", "true");
+        }
+    }
+
+    private static final String SUB  = "test-sub-aks";
+    private static final String RG   = "test-rg-aks";
+    private static final String BASE =
+            "/subscriptions/" + SUB + "/resourceGroups/" + RG
+            + "/providers/Microsoft.ContainerService";
+
+    @BeforeEach
+    void reset() {
+        given().post("/_admin/reset").then().statusCode(204);
+    }
+
+    // ── GET unknown cluster → 404 ─────────────────────────────────────────────
+
+    @Test
+    @DisplayName("GET unknown cluster returns 404")
+    void getUnknownClusterReturns404() {
+        given()
+            .when().get(BASE + "/managedClusters/no-such-cluster?api-version=2024-04-01")
+            .then().statusCode(404)
+            .body("error.code", equalTo("ResourceNotFound"));
+    }
+
+    // ── CREATE cluster (mocked → 201, provisioningState=Succeeded) ───────────
+
+    @Test
+    @DisplayName("PUT cluster creates cluster and returns 201 with Succeeded state")
+    void createClusterReturns201() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                  "location": "eastus",
+                  "properties": {
+                    "kubernetesVersion": "1.29",
+                    "dnsPrefix": "my-aks-dns",
+                    "agentPoolProfiles": [
+                      {"name": "nodepool1", "count": 2, "vmSize": "Standard_DS2_v2",
+                       "osType": "Linux", "mode": "System"}
+                    ]
+                  }
+                }
+                """)
+            .when().put(BASE + "/managedClusters/my-cluster?api-version=2024-04-01")
+            .then().statusCode(201)
+            .body("name", equalTo("my-cluster"))
+            .body("type", equalTo("Microsoft.ContainerService/managedClusters"))
+            .body("location", equalTo("eastus"))
+            .body("properties.provisioningState", equalTo("Succeeded"))
+            .body("properties.kubernetesVersion", equalTo("1.29"))
+            .body("properties.dnsPrefix", equalTo("my-aks-dns"))
+            .body("properties.agentPoolProfiles", hasSize(1))
+            .body("properties.agentPoolProfiles[0].name", equalTo("nodepool1"))
+            .body("properties.agentPoolProfiles[0].count", equalTo(2))
+            .body("id", containsString("/managedClusters/my-cluster"));
+    }
+
+    // ── GET cluster after create ───────────────────────────────────────────────
+
+    @Test
+    @DisplayName("GET cluster after create returns 200")
+    void getClusterAfterCreate() {
+        given()
+            .contentType("application/json")
+            .body("{\"location\":\"westus\",\"properties\":{\"kubernetesVersion\":\"1.30\"}}")
+            .put(BASE + "/managedClusters/get-test?api-version=2024-04-01")
+            .then().statusCode(201);
+
+        given()
+            .when().get(BASE + "/managedClusters/get-test?api-version=2024-04-01")
+            .then().statusCode(200)
+            .body("name", equalTo("get-test"))
+            .body("location", equalTo("westus"))
+            .body("properties.kubernetesVersion", equalTo("1.30"))
+            .body("properties.provisioningState", equalTo("Succeeded"));
+    }
+
+    // ── DELETE cluster ─────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("DELETE cluster returns 202 and subsequent GET returns 404")
+    void deleteClusterReturns202() {
+        given()
+            .contentType("application/json")
+            .body("{\"location\":\"eastus\",\"properties\":{}}")
+            .put(BASE + "/managedClusters/del-cluster?api-version=2024-04-01")
+            .then().statusCode(201);
+
+        given()
+            .when().delete(BASE + "/managedClusters/del-cluster?api-version=2024-04-01")
+            .then().statusCode(202);
+
+        given()
+            .when().get(BASE + "/managedClusters/del-cluster?api-version=2024-04-01")
+            .then().statusCode(404);
+    }
+
+    // ── LIST by resource group ─────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("LIST clusters by resource group returns value array")
+    void listByResourceGroup() {
+        given()
+            .contentType("application/json")
+            .body("{\"location\":\"eastus\",\"properties\":{}}")
+            .put(BASE + "/managedClusters/list-a?api-version=2024-04-01")
+            .then().statusCode(201);
+
+        given()
+            .contentType("application/json")
+            .body("{\"location\":\"eastus\",\"properties\":{}}")
+            .put(BASE + "/managedClusters/list-b?api-version=2024-04-01")
+            .then().statusCode(201);
+
+        given()
+            .when().get(BASE + "/managedClusters?api-version=2024-04-01")
+            .then().statusCode(200)
+            .body("value", hasSize(greaterThanOrEqualTo(2)));
+    }
+
+    // ── LIST by subscription ───────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("LIST clusters by subscription returns value array")
+    void listBySubscription() {
+        given()
+            .contentType("application/json")
+            .body("{\"location\":\"eastus\",\"properties\":{}}")
+            .put(BASE + "/managedClusters/sub-cluster?api-version=2024-04-01")
+            .then().statusCode(201);
+
+        given()
+            .when().get("/subscriptions/" + SUB
+                        + "/providers/Microsoft.ContainerService/managedClusters?api-version=2024-04-01")
+            .then().statusCode(200)
+            .body("value", hasSize(greaterThanOrEqualTo(1)));
+    }
+
+    // ── PATCH tags ────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("PATCH tags updates cluster tags")
+    void patchTags() {
+        given()
+            .contentType("application/json")
+            .body("{\"location\":\"eastus\",\"properties\":{}}")
+            .put(BASE + "/managedClusters/tag-cluster?api-version=2024-04-01")
+            .then().statusCode(201);
+
+        given()
+            .contentType("application/json")
+            .body("{\"tags\":{\"env\":\"test\"}}")
+            .when().patch(BASE + "/managedClusters/tag-cluster?api-version=2024-04-01")
+            .then().statusCode(200)
+            .body("tags.env", equalTo("test"));
+    }
+
+    // ── listClusterAdminCredential ─────────────────────────────────────────────
+
+    @Test
+    @DisplayName("listClusterAdminCredential returns base64 kubeconfig")
+    void listAdminCredential() {
+        given()
+            .contentType("application/json")
+            .body("{\"location\":\"eastus\",\"properties\":{}}")
+            .put(BASE + "/managedClusters/cred-cluster?api-version=2024-04-01")
+            .then().statusCode(201);
+
+        given()
+            .contentType("application/json")
+            .when().post(BASE + "/managedClusters/cred-cluster/listClusterAdminCredential"
+                         + "?api-version=2024-04-01")
+            .then().statusCode(200)
+            .body("kubeconfigs", hasSize(1))
+            .body("kubeconfigs[0].name", equalTo("clusterAdmin"))
+            .body("kubeconfigs[0].value", notNullValue());
+    }
+
+    // ── Agent pool list ────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("LIST agentPools returns value array")
+    void listAgentPools() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                  "location": "eastus",
+                  "properties": {
+                    "agentPoolProfiles": [
+                      {"name": "pool1", "count": 1, "vmSize": "Standard_DS2_v2",
+                       "osType": "Linux", "mode": "System"}
+                    ]
+                  }
+                }
+                """)
+            .put(BASE + "/managedClusters/pool-cluster?api-version=2024-04-01")
+            .then().statusCode(201);
+
+        given()
+            .when().get(BASE + "/managedClusters/pool-cluster/agentPools?api-version=2024-04-01")
+            .then().statusCode(200)
+            .body("value", hasSize(1))
+            .body("value[0].name", equalTo("pool1"));
+    }
+
+    // ── Agent pool GET ────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("GET agentPool returns pool details")
+    void getAgentPool() {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                  "location": "eastus",
+                  "properties": {
+                    "agentPoolProfiles": [
+                      {"name": "sys", "count": 3, "vmSize": "Standard_D4s_v3",
+                       "osType": "Linux", "mode": "System"}
+                    ]
+                  }
+                }
+                """)
+            .put(BASE + "/managedClusters/ap-get-cluster?api-version=2024-04-01")
+            .then().statusCode(201);
+
+        given()
+            .when().get(BASE + "/managedClusters/ap-get-cluster/agentPools/sys?api-version=2024-04-01")
+            .then().statusCode(200)
+            .body("name", equalTo("sys"))
+            .body("properties.count", equalTo(3))
+            .body("properties.vmSize", equalTo("Standard_D4s_v3"));
+    }
+}


### PR DESCRIPTION
Implements the Azure Kubernetes Service management plane using k3s

- ARM path routing for Microsoft.ContainerService (CreateOrUpdate, Get, Delete, List by subscription and resource group, UpdateTags)
- Agent pool CRUD (List, Get, CreateOrUpdate, Delete)
- listClusterAdminCredential / listClusterUserCredential returning base64-encoded kubeconfig
- Real mode: privileged rancher/k3s container per cluster; background readiness poller transitions provisioningState Creating -> Succeeded; kubeconfig + CA data extracted via exec
- Mocked mode (FLOCI_AZ_SERVICES_AKS_MOCKED=true): no Docker, clusters immediately Succeeded with synthetic kubeconfig
- instanceId-based container naming (floci-az-aks-{instanceId}) prevents collisions across resource groups
- 10 unit tests (mocked mode) + 5 Docker integration tests (real k3s)
- Full documentation: docs/services/aks.md, README, CHANGELOG, mkdocs.yml, ports reference, services index

## Summary

- Adds AKS management-plane emulation backed by real k3s containers (or a lightweight mock for CI/environments without Docker) `listClusterAdminCredential`, `listClusterUserCredential`
- Each cluster gets an `instanceId` (8-char UUID prefix) for stable Docker container naming that survives same-name clusters across resource groups
- Background readiness poller transitions `provisioningState` from `Creating` to `Succeeded` and extracts the real kubeconfig + CA from the k3s container
    
Closes #21 

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
