### PR TITLE
feat(docker): Copy certificates from src/main/resources/certs/ into container images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,11 +44,13 @@ RUN mkdir -p /app/data \
 COPY --from=build /build/target/quarkus-app/ quarkus-app/
 RUN chown -R 1001:root /app/quarkus-app
 
+COPY --from=build --chown=1001:root /build/src/main/resources/certs/ certs/
+
 COPY --chmod=755 docker/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 VOLUME /app/data
 
-EXPOSE 4577
+EXPOSE 4577 4578
 
 HEALTHCHECK --interval=5s --timeout=3s --retries=5 \
     CMD wget -q --spider http://localhost:4577/_floci/health || exit 1

--- a/docker/Dockerfile.jvm-package
+++ b/docker/Dockerfile.jvm-package
@@ -32,6 +32,7 @@ RUN mkdir -p /app/data \
     && chown 1001:root /app/data
 
 COPY --chown=1001:root target/quarkus-app quarkus-app/
+COPY --chown=1001:root src/main/resources/certs/ certs/
 
 COPY --chmod=755 docker/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
@@ -54,7 +55,7 @@ LABEL org.opencontainers.image.title="Floci AZ" \
       url="https://floci.io" \
       vendor="Floci"
 
-EXPOSE 4577
+EXPOSE 4577 4578
 
 HEALTHCHECK --interval=5s --timeout=3s --retries=5 \
     CMD wget -q --spider http://localhost:4577/_floci/health || exit 1

--- a/docker/Dockerfile.native
+++ b/docker/Dockerfile.native
@@ -57,7 +57,7 @@ RUN mkdir -p /app/data \
 
 VOLUME /app/data
 
-EXPOSE 4577
+EXPOSE 4577 4578
 
 HEALTHCHECK --interval=5s --timeout=3s --retries=10 \
     CMD bash -c 'echo -e "GET /_floci/health HTTP/1.0\r\nHost: localhost\r\n\r\n" > /dev/tcp/localhost/4577' || exit 1
@@ -69,6 +69,8 @@ ENV FLOCI_AZ_SERVICES_FUNCTIONS_CODE_PATH=/app/data/functions
 
 COPY --from=build /app/target/*-runner /app/application
 RUN chmod +x /app/application
+
+COPY --from=build --chown=1001:root /app/src/main/resources/certs/ certs/
 
 COPY --chmod=755 docker/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 

--- a/docker/Dockerfile.native-package
+++ b/docker/Dockerfile.native-package
@@ -38,6 +38,7 @@ VOLUME /app/data
 
 COPY --chown=1001:root native/${TARGETARCH}/ /app/
 RUN mv /app/*-runner /app/application && chmod +x /app/application
+COPY --chown=1001:root src/main/resources/certs/ certs/
 
 COPY --chmod=755 docker/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
@@ -58,7 +59,7 @@ LABEL org.opencontainers.image.title="Floci AZ" \
       url="https://floci.io" \
       vendor="Floci"
 
-EXPOSE 4577
+EXPOSE 4577 4578
 
 HEALTHCHECK --interval=5s --timeout=3s --retries=10 \
     CMD curl -f http://localhost:4577/_floci/health || exit 1


### PR DESCRIPTION
## Summary

feat(docker): Copy certificates from src/main/resources/certs/ into container images

close #33 

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

<!-- For new actions: which SDK version and Azure CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
