### PR TITLE
feat(arm): ARM management-plane emulation with Terraform and OpenTofu compatibility

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -71,6 +71,8 @@ jobs:
               -e SERVICEBUS_AMQPS_PORT=5671
               -e SERVICEBUS_NAMESPACE=default
           - test: sdk-test-node
+          - test: compat-terraform
+          - test: compat-opentofu
 
     steps:
       - name: Download floci-az image

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build run run-cosmos-mongo run-cosmos-postgresql run-cosmos-cassandra run-cosmos-gremlin run-cosmos-table run-cosmos-nosql run-sql stop \
         test test-python test-java-compat test-node-compat test-servicebus-compat test-appconfig test-cosmos \
         test-cosmos-mongo test-cosmos-postgresql test-cosmos-cassandra test-cosmos-gremlin test-cosmos-table test-cosmos-nosql test-cosmos-all \
-        test-sql compat-docker clean
+        test-sql test-terraform test-opentofu test-iac compat-docker clean
 
 MVN            = ./mvnw
 PORT           = 4577
@@ -9,6 +9,8 @@ PID_FILE       = emulator.pid
 PYTHON_DIR     = compatibility-tests/sdk-test-python
 JAVA_DIR       = compatibility-tests/sdk-test-java
 NODE_DIR       = compatibility-tests/sdk-test-node
+TERRAFORM_DIR  = compatibility-tests/compat-terraform
+OPENTOFU_DIR   = compatibility-tests/compat-opentofu
 
 # ── Build ─────────────────────────────────────────────────────────────────────
 
@@ -163,6 +165,24 @@ test-sql:
 	cd $(JAVA_DIR) && mvn test -Dtest=SqlCompatibilityTest; \
 	EXIT=$$?; $(MAKE) -C $(CURDIR) stop; exit $$EXIT
 
+test-terraform:
+	@echo "==> Terraform IaC compatibility tests"
+	@docker build -q -t floci-az-compat-terraform -f $(TERRAFORM_DIR)/Dockerfile $(TERRAFORM_DIR)/
+	docker run --rm --network floci_az_default \
+		-e FLOCI_AZ_ENDPOINT=http://floci-az:$(PORT) \
+		-v "$(CURDIR)/test-results:/results" \
+		floci-az-compat-terraform
+
+test-opentofu:
+	@echo "==> OpenTofu IaC compatibility tests"
+	@docker build -q -t floci-az-compat-opentofu -f $(OPENTOFU_DIR)/Dockerfile $(OPENTOFU_DIR)/
+	docker run --rm --network floci_az_default \
+		-e FLOCI_AZ_ENDPOINT=http://floci-az:$(PORT) \
+		-v "$(CURDIR)/test-results:/results" \
+		floci-az-compat-opentofu
+
+test-iac: test-terraform test-opentofu
+
 # ── Full test suite ────────────────────────────────────────────────────────────
 
 # Run all compatibility tests in Docker containers against the running floci-az.
@@ -172,6 +192,8 @@ compat-docker:
 	@docker build -q --platform linux/amd64 -t floci-az-compat-python -f $(PYTHON_DIR)/Dockerfile $(PYTHON_DIR)/
 	@docker build -q -t floci-az-compat-node -f $(NODE_DIR)/Dockerfile $(NODE_DIR)/
 	@docker build -q -t floci-az-compat-java -f $(JAVA_DIR)/Dockerfile $(JAVA_DIR)/
+	@docker build -q -t floci-az-compat-terraform -f $(TERRAFORM_DIR)/Dockerfile $(TERRAFORM_DIR)/
+	@docker build -q -t floci-az-compat-opentofu -f $(OPENTOFU_DIR)/Dockerfile $(OPENTOFU_DIR)/
 	@echo "==> Python SDK tests (blob, queue, table, appconfig, keyvault, eventhub)"
 	docker run --rm --platform linux/amd64 --network floci_az_default \
 		-e FLOCI_AZ_ENDPOINT=http://floci-az:4577 \
@@ -192,6 +214,14 @@ compat-docker:
 		-e SERVICEBUS_NAMESPACE=default \
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		floci-az-compat-java
+	@echo "==> Terraform IaC tests"
+	docker run --rm --network floci_az_default \
+		-e FLOCI_AZ_ENDPOINT=http://floci-az:4577 \
+		floci-az-compat-terraform
+	@echo "==> OpenTofu IaC tests"
+	docker run --rm --network floci_az_default \
+		-e FLOCI_AZ_ENDPOINT=http://floci-az:4577 \
+		floci-az-compat-opentofu
 
 test-compat:
 	@echo "==> Running all SDK compatibility tests (emulator must be running)"

--- a/compatibility-tests/compat-opentofu/Dockerfile
+++ b/compatibility-tests/compat-opentofu/Dockerfile
@@ -1,0 +1,26 @@
+FROM ghcr.io/opentofu/opentofu:1.8 AS opentofu
+
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends bash curl git jq ca-certificates socat \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=opentofu /usr/local/bin/tofu /usr/local/bin/tofu
+
+WORKDIR /app
+
+RUN git clone --depth 1 https://github.com/bats-core/bats-core.git /opt/bats-core \
+    && git clone --depth 1 https://github.com/bats-core/bats-support.git /opt/bats-support \
+    && git clone --depth 1 https://github.com/bats-core/bats-assert.git /opt/bats-assert
+
+COPY . .
+
+ENV FLOCI_AZ_ENDPOINT=http://floci-az:4577
+ENV BATS_LIB_PATH=/opt
+ENV TF_VAR_subscription_id=00000000-0000-0000-0000-000000000001
+ENV TF_VAR_tenant_id=00000000-0000-0000-0000-000000000002
+
+RUN chmod +x /app/run-bats-in-container.sh && mkdir -p /results
+
+ENTRYPOINT ["./run-bats-in-container.sh"]

--- a/compatibility-tests/compat-opentofu/main.tf
+++ b/compatibility-tests/compat-opentofu/main.tf
@@ -1,0 +1,56 @@
+variable "location" {
+  type    = string
+  default = "eastus"
+}
+
+resource "azurerm_resource_group" "rg" {
+  name     = "floci-test-rg"
+  location = var.location
+}
+
+resource "azurerm_storage_account" "sa" {
+  name                     = "flocitestsa"
+  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = azurerm_resource_group.rg.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_container" "sc" {
+  name                 = "floci-test-container"
+  storage_account_name = azurerm_storage_account.sa.name
+}
+
+resource "azurerm_storage_queue" "sq" {
+  name                 = "floci-test-queue"
+  storage_account_name = azurerm_storage_account.sa.name
+}
+
+resource "azurerm_key_vault" "kv" {
+  name                = "floci-test-kv"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  tenant_id           = var.tenant_id
+  sku_name            = "standard"
+
+  soft_delete_retention_days = 7
+  purge_protection_enabled   = false
+}
+
+resource "azurerm_key_vault_secret" "secret" {
+  name         = "floci-test-secret"
+  value        = "hello-from-opentofu"
+  key_vault_id = azurerm_key_vault.kv.id
+}
+
+output "storage_account_name" {
+  value = azurerm_storage_account.sa.name
+}
+
+output "key_vault_name" {
+  value = azurerm_key_vault.kv.name
+}
+
+output "key_vault_uri" {
+  value = azurerm_key_vault.kv.vault_uri
+}

--- a/compatibility-tests/compat-opentofu/provider.tf
+++ b/compatibility-tests/compat-opentofu/provider.tf
@@ -1,0 +1,37 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+  }
+}
+
+variable "subscription_id" {
+  type    = string
+  default = "00000000-0000-0000-0000-000000000001"
+}
+
+variable "tenant_id" {
+  type    = string
+  default = "00000000-0000-0000-0000-000000000002"
+}
+
+variable "metadata_host" {
+  type    = string
+  default = "localhost:4577"
+}
+
+provider "azurerm" {
+  features {}
+  skip_provider_registration = true
+  use_cli                    = false
+
+  environment   = "stack"
+  metadata_host = var.metadata_host
+
+  subscription_id = var.subscription_id
+  tenant_id       = var.tenant_id
+  client_id       = "00000000-0000-0000-0000-000000000003"
+  client_secret   = "fake-secret"
+}

--- a/compatibility-tests/compat-opentofu/run-bats-in-container.sh
+++ b/compatibility-tests/compat-opentofu/run-bats-in-container.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Derive host:port from FLOCI_AZ_ENDPOINT (strip scheme and trailing slash)
+_raw="${FLOCI_AZ_ENDPOINT#http://}"
+_raw="${_raw#https://}"
+FLOCI_AZ_HOST="${_raw%/}"
+
+# Install TLS cert so go-azure-sdk (used by azurerm provider) trusts floci-az HTTPS.
+# Fetch via HTTP since the port accepts both HTTP and HTTPS.
+echo "Waiting for floci-az and installing TLS certificate..."
+for i in $(seq 1 30); do
+    if curl -sf "http://${FLOCI_AZ_HOST}/_floci/tls-cert" \
+            -o /usr/local/share/ca-certificates/floci-az.crt 2>/dev/null; then
+        update-ca-certificates 2>/dev/null
+        echo "TLS certificate installed."
+        break
+    fi
+    echo "  Attempt $i/30: floci-az not ready, retrying..."
+    sleep 2
+done
+
+# Pass host:port to azurerm provider for Azure Stack endpoint discovery
+export TF_VAR_metadata_host="$FLOCI_AZ_HOST"
+
+# Add /etc/hosts entries so *.vault.azure.net resolves to floci-az.
+# The azurerm provider validates vault URIs as name.vault.azure.net and calls data-plane there.
+FLOCI_AZ_HOST_ONLY="${FLOCI_AZ_HOST%%:*}"
+FLOCI_AZ_HOST_IP=$(getent hosts "$FLOCI_AZ_HOST_ONLY" 2>/dev/null | awk '{print $1}' | head -1 || echo "127.0.0.1")
+# Map all domain-based endpoints to loopback so socat can intercept and forward to floci-az.
+# Blob/queue use standard HTTP port 80; Key Vault uses standard HTTPS port 443.
+# kv-default is the fixed account name used when the azurerm provider sends KV data-plane
+# requests to the ARM base URL (metadata/endpoints returns 404).
+echo "127.0.0.1 floci-test-kv.vault.azure.net" >> /etc/hosts
+echo "127.0.0.1 kv-default.vault.azure.net" >> /etc/hosts
+echo "127.0.0.1 flocitestsa.blob.core.windows.net" >> /etc/hosts
+echo "127.0.0.1 flocitestsa.queue.core.windows.net" >> /etc/hosts
+
+# Forward port 80 (HTTP) for storage data-plane and port 443 (HTTPS) for Key Vault
+# data-plane to the emulator so azurerm provider can use standard domain-based endpoints.
+socat TCP-LISTEN:80,bind=127.0.0.1,fork,reuseaddr TCP:"${FLOCI_AZ_HOST}" &
+socat TCP-LISTEN:443,bind=127.0.0.1,fork,reuseaddr TCP:"${FLOCI_AZ_HOST}" &
+sleep 1
+
+report_dir="$(mktemp -d /tmp/bats-junit-XXXXXX)"
+trap 'rm -rf "$report_dir"' EXIT
+
+set +e
+/opt/bats-core/bin/bats --report-formatter junit -o "$report_dir" test/
+status=$?
+set -e
+
+if [ -f "$report_dir/report.xml" ]; then
+    mv "$report_dir/report.xml" /results/junit.xml
+fi
+
+exit "$status"

--- a/compatibility-tests/compat-opentofu/test/opentofu.bats
+++ b/compatibility-tests/compat-opentofu/test/opentofu.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+# OpenTofu compatibility tests for floci-az
+
+setup_file() {
+    load 'test_helper/common-setup'
+
+    cd "$TOFU_DIR"
+
+    echo "# === OpenTofu Compatibility Test ===" >&3
+    echo "# Endpoint: $FLOCI_AZ_ENDPOINT" >&3
+    echo "# Metadata host: $TF_VAR_metadata_host" >&3
+
+    # Clean any previous state
+    rm -rf .terraform .terraform.lock.hcl terraform.tfstate* 2>/dev/null || true
+
+    echo "# --- tofu init ---" >&3
+    run tofu init -input=false -no-color
+    if [ "$status" -ne 0 ]; then
+        echo "# tofu init failed: $output" >&3
+        return 1
+    fi
+
+    echo "# --- tofu validate ---" >&3
+    run tofu validate -no-color
+    if [ "$status" -ne 0 ]; then
+        echo "# tofu validate failed: $output" >&3
+        return 1
+    fi
+
+    echo "# --- tofu plan ---" >&3
+    run tofu plan -input=false -no-color
+    if [ "$status" -ne 0 ]; then
+        echo "# tofu plan failed: $output" >&3
+        return 1
+    fi
+
+    echo "# --- tofu apply ---" >&3
+    run tofu apply -input=false -auto-approve -no-color
+    if [ "$status" -ne 0 ]; then
+        echo "# tofu apply failed: $output" >&3
+        return 1
+    fi
+}
+
+teardown_file() {
+    load 'test_helper/common-setup'
+
+    cd "$TOFU_DIR"
+
+    echo "# --- tofu destroy ---" >&3
+    tofu destroy -input=false -auto-approve -no-color || true
+}
+
+setup() {
+    load 'test_helper/common-setup'
+}
+
+# --- Spot Checks ---
+
+@test "OpenTofu: resource group created" {
+    run arm_get "subscriptions/${SUB_ID}/resourceGroups/${RG_NAME}"
+    assert_success
+    assert_output --partial "\"name\""
+    assert_output --partial "$RG_NAME"
+}
+
+@test "OpenTofu: storage account created with blob endpoint" {
+    run arm_get "subscriptions/${SUB_ID}/resourceGroups/${RG_NAME}/providers/Microsoft.Storage/storageAccounts/${SA_NAME}"
+    assert_success
+    assert_output --partial "primaryEndpoints"
+    assert_output --partial "blob"
+}
+
+@test "OpenTofu: storage container listed in blob API" {
+    run curl -sf "${FLOCI_AZ_ENDPOINT}/${SA_NAME}?comp=list&restype=container"
+    assert_success
+    assert_output --partial "$CONTAINER_NAME"
+}
+
+@test "OpenTofu: storage queue listed in queue API" {
+    run curl -sf "${FLOCI_AZ_ENDPOINT}/${SA_NAME}-queue?comp=list"
+    assert_success
+    assert_output --partial "$QUEUE_NAME"
+}
+
+@test "OpenTofu: key vault created with vault URI" {
+    run arm_get "subscriptions/${SUB_ID}/resourceGroups/${RG_NAME}/providers/Microsoft.KeyVault/vaults/${KV_NAME}"
+    assert_success
+    assert_output --partial "vaultUri"
+    assert_output --partial "${KV_NAME}.vault.azure.net"
+}
+
+@test "OpenTofu: key vault secret readable via data plane" {
+    run kv_get "secrets/${SECRET_NAME}"
+    assert_success
+    assert_output --partial "hello-from-opentofu"
+}

--- a/compatibility-tests/compat-opentofu/test/test_helper/common-setup.bash
+++ b/compatibility-tests/compat-opentofu/test/test_helper/common-setup.bash
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Common setup for floci-az OpenTofu bats tests
+
+TOFU_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# Load bats helpers
+if [[ -n "${BATS_LIB_PATH:-}" ]]; then
+    load "${BATS_LIB_PATH}/bats-support/load"
+    load "${BATS_LIB_PATH}/bats-assert/load"
+else
+    echo "Error: BATS_LIB_PATH not set" >&2
+    exit 1
+fi
+
+export FLOCI_AZ_ENDPOINT="${FLOCI_AZ_ENDPOINT:-http://localhost:4577}"
+export TF_VAR_subscription_id="${TF_VAR_subscription_id:-00000000-0000-0000-0000-000000000001}"
+export TF_VAR_tenant_id="${TF_VAR_tenant_id:-00000000-0000-0000-0000-000000000002}"
+# TF_VAR_metadata_host is set by run-bats-in-container.sh; default for local runs
+export TF_VAR_metadata_host="${TF_VAR_metadata_host:-localhost:4577}"
+
+# Resource names that match main.tf
+export SA_NAME="flocitestsa"
+export RG_NAME="floci-test-rg"
+export KV_NAME="floci-test-kv"
+export CONTAINER_NAME="floci-test-container"
+export QUEUE_NAME="floci-test-queue"
+export SECRET_NAME="floci-test-secret"
+export SUB_ID="${TF_VAR_subscription_id}"
+
+arm_get() {
+    curl -sf -H "Authorization: Bearer fake" \
+        "${FLOCI_AZ_ENDPOINT}/$1"
+}
+
+kv_get() {
+    # azurerm v3 provider sends key vault data-plane to the ARM base URL when
+    # metadata/endpoints returns 404. Read from the same path so the account
+    # namespace matches what the provider wrote.
+    curl -sf -H "Authorization: Bearer fake" \
+        "${FLOCI_AZ_ENDPOINT}/$1?api-version=7.4"
+}

--- a/compatibility-tests/compat-terraform/Dockerfile
+++ b/compatibility-tests/compat-terraform/Dockerfile
@@ -1,0 +1,26 @@
+FROM hashicorp/terraform:1.10 AS terraform
+
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends bash curl git jq ca-certificates socat \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=terraform /bin/terraform /usr/local/bin/terraform
+
+WORKDIR /app
+
+RUN git clone --depth 1 https://github.com/bats-core/bats-core.git /opt/bats-core \
+    && git clone --depth 1 https://github.com/bats-core/bats-support.git /opt/bats-support \
+    && git clone --depth 1 https://github.com/bats-core/bats-assert.git /opt/bats-assert
+
+COPY . .
+
+ENV FLOCI_AZ_ENDPOINT=http://floci-az:4577
+ENV BATS_LIB_PATH=/opt
+ENV TF_VAR_subscription_id=00000000-0000-0000-0000-000000000001
+ENV TF_VAR_tenant_id=00000000-0000-0000-0000-000000000002
+
+RUN chmod +x /app/run-bats-in-container.sh && mkdir -p /results
+
+ENTRYPOINT ["./run-bats-in-container.sh"]

--- a/compatibility-tests/compat-terraform/main.tf
+++ b/compatibility-tests/compat-terraform/main.tf
@@ -1,0 +1,56 @@
+variable "location" {
+  type    = string
+  default = "eastus"
+}
+
+resource "azurerm_resource_group" "rg" {
+  name     = "floci-test-rg"
+  location = var.location
+}
+
+resource "azurerm_storage_account" "sa" {
+  name                     = "flocitestsa"
+  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = azurerm_resource_group.rg.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS"
+}
+
+resource "azurerm_storage_container" "sc" {
+  name                 = "floci-test-container"
+  storage_account_name = azurerm_storage_account.sa.name
+}
+
+resource "azurerm_storage_queue" "sq" {
+  name                 = "floci-test-queue"
+  storage_account_name = azurerm_storage_account.sa.name
+}
+
+resource "azurerm_key_vault" "kv" {
+  name                = "floci-test-kv"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  tenant_id           = var.tenant_id
+  sku_name            = "standard"
+
+  soft_delete_retention_days = 7
+  purge_protection_enabled   = false
+}
+
+resource "azurerm_key_vault_secret" "secret" {
+  name         = "floci-test-secret"
+  value        = "hello-from-terraform"
+  key_vault_id = azurerm_key_vault.kv.id
+}
+
+output "storage_account_name" {
+  value = azurerm_storage_account.sa.name
+}
+
+output "key_vault_name" {
+  value = azurerm_key_vault.kv.name
+}
+
+output "key_vault_uri" {
+  value = azurerm_key_vault.kv.vault_uri
+}

--- a/compatibility-tests/compat-terraform/provider.tf
+++ b/compatibility-tests/compat-terraform/provider.tf
@@ -1,0 +1,37 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+  }
+}
+
+variable "subscription_id" {
+  type    = string
+  default = "00000000-0000-0000-0000-000000000001"
+}
+
+variable "tenant_id" {
+  type    = string
+  default = "00000000-0000-0000-0000-000000000002"
+}
+
+variable "metadata_host" {
+  type    = string
+  default = "localhost:4577"
+}
+
+provider "azurerm" {
+  features {}
+  skip_provider_registration = true
+  use_cli                    = false
+
+  environment   = "stack"
+  metadata_host = var.metadata_host
+
+  subscription_id = var.subscription_id
+  tenant_id       = var.tenant_id
+  client_id       = "00000000-0000-0000-0000-000000000003"
+  client_secret   = "fake-secret"
+}

--- a/compatibility-tests/compat-terraform/run-bats-in-container.sh
+++ b/compatibility-tests/compat-terraform/run-bats-in-container.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Derive host:port from FLOCI_AZ_ENDPOINT (strip scheme and trailing slash)
+_raw="${FLOCI_AZ_ENDPOINT#http://}"
+_raw="${_raw#https://}"
+FLOCI_AZ_HOST="${_raw%/}"
+
+# Install TLS cert so go-azure-sdk (used by azurerm provider) trusts floci-az HTTPS.
+# Fetch via HTTP since the port accepts both HTTP and HTTPS.
+echo "Waiting for floci-az and installing TLS certificate..."
+for i in $(seq 1 30); do
+    if curl -sf "http://${FLOCI_AZ_HOST}/_floci/tls-cert" \
+            -o /usr/local/share/ca-certificates/floci-az.crt 2>/dev/null; then
+        update-ca-certificates 2>/dev/null
+        echo "TLS certificate installed."
+        break
+    fi
+    echo "  Attempt $i/30: floci-az not ready, retrying..."
+    sleep 2
+done
+
+# Pass host:port to azurerm provider for Azure Stack endpoint discovery
+export TF_VAR_metadata_host="$FLOCI_AZ_HOST"
+
+# Add /etc/hosts entries so *.vault.azure.net resolves to floci-az.
+# The azurerm provider validates vault URIs as name.vault.azure.net and calls data-plane there.
+FLOCI_AZ_HOST_ONLY="${FLOCI_AZ_HOST%%:*}"
+FLOCI_AZ_HOST_IP=$(getent hosts "$FLOCI_AZ_HOST_ONLY" 2>/dev/null | awk '{print $1}' | head -1 || echo "127.0.0.1")
+# Map all domain-based endpoints to loopback so socat can intercept and forward to floci-az.
+# Blob/queue use standard HTTP port 80; Key Vault uses standard HTTPS port 443.
+# kv-default is the fixed account name used when the azurerm provider sends KV data-plane
+# requests to the ARM base URL (metadata/endpoints returns 404).
+echo "127.0.0.1 floci-test-kv.vault.azure.net" >> /etc/hosts
+echo "127.0.0.1 kv-default.vault.azure.net" >> /etc/hosts
+echo "127.0.0.1 flocitestsa.blob.core.windows.net" >> /etc/hosts
+echo "127.0.0.1 flocitestsa.queue.core.windows.net" >> /etc/hosts
+
+# Forward port 80 (HTTP) for storage data-plane and port 443 (HTTPS) for Key Vault
+# data-plane to the emulator so azurerm provider can use standard domain-based endpoints.
+socat TCP-LISTEN:80,bind=127.0.0.1,fork,reuseaddr TCP:"${FLOCI_AZ_HOST}" &
+socat TCP-LISTEN:443,bind=127.0.0.1,fork,reuseaddr TCP:"${FLOCI_AZ_HOST}" &
+sleep 1
+
+report_dir="$(mktemp -d /tmp/bats-junit-XXXXXX)"
+trap 'rm -rf "$report_dir"' EXIT
+
+set +e
+/opt/bats-core/bin/bats --report-formatter junit -o "$report_dir" test/
+status=$?
+set -e
+
+if [ -f "$report_dir/report.xml" ]; then
+    mv "$report_dir/report.xml" /results/junit.xml
+fi
+
+exit "$status"

--- a/compatibility-tests/compat-terraform/test/terraform.bats
+++ b/compatibility-tests/compat-terraform/test/terraform.bats
@@ -1,0 +1,97 @@
+#!/usr/bin/env bats
+# Terraform compatibility tests for floci-az
+
+setup_file() {
+    load 'test_helper/common-setup'
+
+    cd "$TF_DIR"
+
+    echo "# === Terraform Compatibility Test ===" >&3
+    echo "# Endpoint: $FLOCI_AZ_ENDPOINT" >&3
+    echo "# Metadata host: $TF_VAR_metadata_host" >&3
+
+    # Clean any previous state
+    rm -rf .terraform .terraform.lock.hcl terraform.tfstate* 2>/dev/null || true
+
+    echo "# --- terraform init ---" >&3
+    run terraform init -input=false -no-color
+    if [ "$status" -ne 0 ]; then
+        echo "# terraform init failed: $output" >&3
+        return 1
+    fi
+
+    echo "# --- terraform validate ---" >&3
+    run terraform validate -no-color
+    if [ "$status" -ne 0 ]; then
+        echo "# terraform validate failed: $output" >&3
+        return 1
+    fi
+
+    echo "# --- terraform plan ---" >&3
+    run terraform plan -input=false -no-color
+    if [ "$status" -ne 0 ]; then
+        echo "# terraform plan failed: $output" >&3
+        return 1
+    fi
+
+    echo "# --- terraform apply ---" >&3
+    run terraform apply -input=false -auto-approve -no-color
+    if [ "$status" -ne 0 ]; then
+        echo "# terraform apply failed: $output" >&3
+        return 1
+    fi
+}
+
+teardown_file() {
+    load 'test_helper/common-setup'
+
+    cd "$TF_DIR"
+
+    echo "# --- terraform destroy ---" >&3
+    terraform destroy -input=false -auto-approve -no-color || true
+}
+
+setup() {
+    load 'test_helper/common-setup'
+}
+
+# --- Spot Checks ---
+
+@test "Terraform: resource group created" {
+    run arm_get "subscriptions/${SUB_ID}/resourceGroups/${RG_NAME}"
+    assert_success
+    assert_output --partial "\"name\""
+    assert_output --partial "$RG_NAME"
+}
+
+@test "Terraform: storage account created with blob endpoint" {
+    run arm_get "subscriptions/${SUB_ID}/resourceGroups/${RG_NAME}/providers/Microsoft.Storage/storageAccounts/${SA_NAME}"
+    assert_success
+    assert_output --partial "primaryEndpoints"
+    assert_output --partial "blob"
+}
+
+@test "Terraform: storage container listed in blob API" {
+    run curl -sf "${FLOCI_AZ_ENDPOINT}/${SA_NAME}?comp=list&restype=container"
+    assert_success
+    assert_output --partial "$CONTAINER_NAME"
+}
+
+@test "Terraform: storage queue listed in queue API" {
+    run curl -sf "${FLOCI_AZ_ENDPOINT}/${SA_NAME}-queue?comp=list"
+    assert_success
+    assert_output --partial "$QUEUE_NAME"
+}
+
+@test "Terraform: key vault created with vault URI" {
+    run arm_get "subscriptions/${SUB_ID}/resourceGroups/${RG_NAME}/providers/Microsoft.KeyVault/vaults/${KV_NAME}"
+    assert_success
+    assert_output --partial "vaultUri"
+    assert_output --partial "${KV_NAME}.vault.azure.net"
+}
+
+@test "Terraform: key vault secret readable via data plane" {
+    run kv_get "secrets/${SECRET_NAME}"
+    assert_success
+    assert_output --partial "hello-from-terraform"
+}

--- a/compatibility-tests/compat-terraform/test/test_helper/common-setup.bash
+++ b/compatibility-tests/compat-terraform/test/test_helper/common-setup.bash
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Common setup for floci-az Terraform bats tests
+
+TF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# Load bats helpers
+if [[ -n "${BATS_LIB_PATH:-}" ]]; then
+    load "${BATS_LIB_PATH}/bats-support/load"
+    load "${BATS_LIB_PATH}/bats-assert/load"
+else
+    echo "Error: BATS_LIB_PATH not set" >&2
+    exit 1
+fi
+
+export FLOCI_AZ_ENDPOINT="${FLOCI_AZ_ENDPOINT:-http://localhost:4577}"
+export TF_VAR_subscription_id="${TF_VAR_subscription_id:-00000000-0000-0000-0000-000000000001}"
+export TF_VAR_tenant_id="${TF_VAR_tenant_id:-00000000-0000-0000-0000-000000000002}"
+# TF_VAR_metadata_host is set by run-bats-in-container.sh; default for local runs
+export TF_VAR_metadata_host="${TF_VAR_metadata_host:-localhost:4577}"
+
+# Resource names that match main.tf
+export SA_NAME="flocitestsa"
+export RG_NAME="floci-test-rg"
+export KV_NAME="floci-test-kv"
+export CONTAINER_NAME="floci-test-container"
+export QUEUE_NAME="floci-test-queue"
+export SECRET_NAME="floci-test-secret"
+export SUB_ID="${TF_VAR_subscription_id}"
+
+arm_get() {
+    curl -sf -H "Authorization: Bearer fake" \
+        "${FLOCI_AZ_ENDPOINT}/$1"
+}
+
+kv_get() {
+    # azurerm v3 provider sends key vault data-plane to the ARM base URL when
+    # metadata/endpoints returns 404. Read from the same path so the account
+    # namespace matches what the provider wrote.
+    curl -sf -H "Authorization: Bearer fake" \
+        "${FLOCI_AZ_ENDPOINT}/$1?api-version=7.4"
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
     environment:
       FLOCI_AZ_STORAGE_MODE: memory
       FLOCI_AZ_SERVICES_DOCKER_NETWORK: floci_az_default
+      FLOCI_AZ_TLS_ENABLED: "true"
+      FLOCI_AZ_HOSTNAME: floci-az
     networks:
       floci_az_default:
         aliases:

--- a/src/main/java/io/floci/az/core/AzureIdentityController.java
+++ b/src/main/java/io/floci/az/core/AzureIdentityController.java
@@ -1,23 +1,78 @@
 package io.floci.az.core;
 
+import io.floci.az.config.EmulatorConfig;
+import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.UriInfo;
+import java.util.List;
 import java.util.Map;
 
-@Path("/common/oauth2/v2.0/token")
+@Path("/")
 public class AzureIdentityController {
 
+    private final EmulatorConfig config;
+
+    @Inject
+    public AzureIdentityController(EmulatorConfig config) {
+        this.config = config;
+    }
+
     @POST
+    @Path("common/oauth2/v2.0/token")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     @Produces(MediaType.APPLICATION_JSON)
-    public Response token() {
-        // Return a static JWT mock
+    public Response tokenCommon() {
+        return tokenResponse();
+    }
+
+    // AzureRM Terraform provider calls /{tenantId}/oauth2/v2.0/token
+    @POST
+    @Path("{tenantId}/oauth2/v2.0/token")
+    @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response tokenByTenant(@PathParam("tenantId") String tenantId) {
+        return tokenResponse();
+    }
+
+    // ARM environment discovery — called by go-azure-sdk (Azure Stack mode via metadata_host).
+    // Format follows the 2022-09-01 metadata schema used by hashicorp/go-azure-sdk.
+    // Suffixes are required so go-azure-sdk populates env.Storage/env.KeyVault with a
+    // resource identifier; the actual data-plane URLs come from ARM primaryEndpoints/vaultUri.
+    @GET
+    @Path("metadata/endpoints")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response metadataEndpoints(@Context UriInfo uriInfo) {
+        // Derive base URL from the incoming request so the returned endpoints are
+        // always reachable by the caller (host-network, Docker bridge, or TLS).
+        String baseUrl = uriInfo.getBaseUri().toString().replaceAll("/+$", "");
         return Response.ok(Map.of(
-            "token_type", "Bearer",
-            "expires_in", 3599,
+            "name",                     "floci-az",
+            "resourceManager",          baseUrl + "/",
+            "microsoftGraphResourceId", baseUrl + "/",
+            "portal",                   baseUrl + "/",
+            "gallery",                  baseUrl + "/",
+            "authentication", Map.of(
+                "loginEndpoint",    baseUrl + "/",
+                "audiences",        List.of(baseUrl + "/"),
+                "identityProvider", "AAD",
+                "tenant",           "common"
+            ),
+            "suffixes", Map.of(
+                "storage",     "core.windows.net",
+                "keyVaultDns", "vault.azure.net"
+            )
+        )).build();
+    }
+
+    private Response tokenResponse() {
+        return Response.ok(Map.of(
+            "token_type",     "Bearer",
+            "expires_in",     3599,
             "ext_expires_in", 3599,
-            "access_token", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.t-46OS_I4B9mBqMzdN49xH16p02Y56K1YF_3-m2-y-U"
+            "access_token",   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.t-46OS_I4B9mBqMzdN49xH16p02Y56K1YF_3-m2-y-U"
         )).build();
     }
 }

--- a/src/main/java/io/floci/az/core/AzureRoutingFilter.java
+++ b/src/main/java/io/floci/az/core/AzureRoutingFilter.java
@@ -1,6 +1,8 @@
 package io.floci.az.core;
 
+import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.auth.AuthPipeline;
+import io.floci.az.services.arm.ArmHandler;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Vertx;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -8,8 +10,8 @@ import jakarta.inject.Inject;
 import jakarta.ws.rs.container.ContainerRequestContext;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import jakarta.ws.rs.core.UriInfo;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.server.ServerRequestFilter;
 
@@ -23,20 +25,21 @@ public class AzureRoutingFilter {
 
     private static final Logger LOGGER = Logger.getLogger(AzureRoutingFilter.class);
 
-    @Inject
-    AuthPipeline authPipeline;
+    private final AuthPipeline authPipeline;
+    private final AzureServiceRegistry serviceRegistry;
+    private final EmulatorConfig config;
+    private final ArmHandler armHandler;
+    private final Vertx vertx;
 
     @Inject
-    AzureServiceRegistry serviceRegistry;
-
-    @Inject
-    Vertx vertx;
-
-    @Context
-    UriInfo uriInfo;
-
-    @Context
-    HttpHeaders httpHeaders;
+    public AzureRoutingFilter(AuthPipeline authPipeline, AzureServiceRegistry serviceRegistry,
+            EmulatorConfig config, ArmHandler armHandler, Vertx vertx) {
+        this.authPipeline = authPipeline;
+        this.serviceRegistry = serviceRegistry;
+        this.config = config;
+        this.armHandler = armHandler;
+        this.vertx = vertx;
+    }
 
     /**
      * Cosmos DB top-level path segments that are used by the Java SDK when it
@@ -55,19 +58,24 @@ public class AzureRoutingFilter {
     );
 
     @ServerRequestFilter(preMatching = true)
-    public Uni<Response> filter(ContainerRequestContext requestContext) {
+    public Uni<Response> filter(ContainerRequestContext requestContext, @Context HttpHeaders httpHeaders) {
         // Capture context before switching threads
         String path0 = requestContext.getUriInfo().getPath();
         HttpHeaders headers = httpHeaders;
+        // Capture Host header now (JAX-RS request scope may not propagate to the blocking thread).
+        // Try both canonical and lowercase forms since HTTP header names are case-insensitive.
+        String h = requestContext.getHeaders().getFirst("Host");
+        if (h == null) h = requestContext.getHeaders().getFirst("host");
+        final String capturedHost = h;
 
         return Uni.createFrom().completionStage(
-            vertx.executeBlocking(() -> doFilter(requestContext, path0, headers))
+            vertx.executeBlocking(() -> doFilter(requestContext, path0, headers, capturedHost))
                  .toCompletionStage()
         );
     }
 
 
-    private Response doFilter(ContainerRequestContext requestContext, String rawPath, HttpHeaders headers) {
+    private Response doFilter(ContainerRequestContext requestContext, String rawPath, HttpHeaders headers, String capturedHost) {
         boolean secure = requestContext.getSecurityContext().isSecure();
         String path = rawPath;
 
@@ -82,9 +90,117 @@ public class AzureRoutingFilter {
 
         LOGGER.infof("Incoming request: %s %s", requestContext.getMethod(), path);
 
+        // Host-based routing for Azure data-plane services.
+        // capturedHost is extracted in filter() before executeBlocking because the JAX-RS
+        // request scope may not propagate to the Vert.x blocking thread.
+        String hostOnly = null;
+        if (capturedHost != null) {
+            hostOnly = capturedHost.contains(":") ? capturedHost.split(":")[0] : capturedHost;
+        }
+
+        // Key Vault: {vaultName}.vault.azure.net
+        if (hostOnly != null && hostOnly.endsWith(".vault.azure.net")) {
+            String kvAccount = hostOnly.substring(0, hostOnly.length() - ".vault.azure.net".length());
+            Map<String, String> kvQueryParams = new HashMap<>();
+            requestContext.getUriInfo().getQueryParameters().forEach((k, v) -> kvQueryParams.put(k, v.get(0)));
+            AzureRequest kvRequest = new AzureRequest(
+                requestContext.getMethod(), kvAccount, "keyvault",
+                path, headers, requestContext.getEntityStream(), kvQueryParams, null, secure);
+            AuthContext kvAuth = authPipeline.resolve(kvRequest);
+            kvRequest = new AzureRequest(
+                requestContext.getMethod(), kvAccount, "keyvault",
+                path, headers, requestContext.getEntityStream(), kvQueryParams, kvAuth, secure);
+            Optional<AzureServiceHandler> kvHandler = serviceRegistry.resolve("keyvault");
+            if (kvHandler.isPresent()) {
+                LOGGER.infof("Dispatching vault.azure.net request to KeyVaultHandler: %s %s (account=%s)",
+                    requestContext.getMethod(), path, kvAccount);
+                return kvHandler.get().handle(kvRequest);
+            }
+        }
+
+        // Blob Storage: {account}.blob.core.windows.net
+        if (hostOnly != null && hostOnly.endsWith(".blob.core.windows.net")) {
+            String blobAccount = hostOnly.substring(0, hostOnly.length() - ".blob.core.windows.net".length());
+            Map<String, String> blobQueryParams = new HashMap<>();
+            requestContext.getUriInfo().getQueryParameters().forEach((k, v) -> blobQueryParams.put(k, v.get(0)));
+            AzureRequest blobRequest = new AzureRequest(
+                requestContext.getMethod(), blobAccount, "blob",
+                path, headers, requestContext.getEntityStream(), blobQueryParams, null, secure);
+            AuthContext blobAuth = authPipeline.resolve(blobRequest);
+            blobRequest = new AzureRequest(
+                requestContext.getMethod(), blobAccount, "blob",
+                path, headers, requestContext.getEntityStream(), blobQueryParams, blobAuth, secure);
+            Optional<AzureServiceHandler> blobHandler = serviceRegistry.resolve("blob");
+            if (blobHandler.isPresent()) {
+                LOGGER.infof("Dispatching blob.core.windows.net request to BlobServiceHandler: %s %s (account=%s)",
+                    requestContext.getMethod(), path, blobAccount);
+                return blobHandler.get().handle(blobRequest);
+            }
+        }
+
+        // Queue Storage: {account}.queue.core.windows.net
+        if (hostOnly != null && hostOnly.endsWith(".queue.core.windows.net")) {
+            String queueAccount = hostOnly.substring(0, hostOnly.length() - ".queue.core.windows.net".length());
+            Map<String, String> queueQueryParams = new HashMap<>();
+            requestContext.getUriInfo().getQueryParameters().forEach((k, v) -> queueQueryParams.put(k, v.get(0)));
+            AzureRequest queueRequest = new AzureRequest(
+                requestContext.getMethod(), queueAccount, "queue",
+                path, headers, requestContext.getEntityStream(), queueQueryParams, null, secure);
+            AuthContext queueAuth = authPipeline.resolve(queueRequest);
+            queueRequest = new AzureRequest(
+                requestContext.getMethod(), queueAccount, "queue",
+                path, headers, requestContext.getEntityStream(), queueQueryParams, queueAuth, secure);
+            Optional<AzureServiceHandler> queueHandler = serviceRegistry.resolve("queue");
+            if (queueHandler.isPresent()) {
+                LOGGER.infof("Dispatching queue.core.windows.net request to QueueServiceHandler: %s %s (account=%s)",
+                    requestContext.getMethod(), path, queueAccount);
+                return queueHandler.get().handle(queueRequest);
+            }
+        }
+
         // Identity bypass
         if (path.contains("oauth2/v2.0/token")) {
             return null;
+        }
+
+        // ARM metadata endpoint — called by go-azure-sdk for environment discovery.
+        // Return null so JAX-RS returns 404; the azurerm provider falls back to defaults.
+        // Implementing the metadata response causes the provider to detect Azure Stack
+        // and reject the configuration with an unsupported-environment error.
+        if (path.startsWith("metadata/endpoints")) {
+            return null;
+        }
+
+        // Microsoft Graph API — called by azurerm provider for service principal discovery
+        if (path.startsWith("v1.0/")) {
+            return null;
+        }
+
+        // Key Vault data-plane paths arriving at the ARM base URL.
+        // The azurerm v3 provider (when metadata/endpoints returns 404) sends all key vault
+        // data-plane requests directly to the ARM base URL rather than to *.vault.azure.net.
+        // Intercept well-known KV API path prefixes and route to KeyVaultHandler with a fixed
+        // account name so both the provider and kv_get in BATS tests use the same namespace.
+        if (path.startsWith("secrets/") || path.equals("secrets")
+                || path.startsWith("certificates/") || path.equals("certificates")
+                || path.startsWith("keys/") || path.equals("keys")
+                || path.startsWith("deletedsecrets/") || path.startsWith("deletedcertificates/")
+                || path.startsWith("deletedkeys/")) {
+            String kvAccount = armHandler.getDefaultKvAccount();
+            Map<String, String> kvQueryParams = new HashMap<>();
+            requestContext.getUriInfo().getQueryParameters().forEach((k, v) -> kvQueryParams.put(k, v.get(0)));
+            AzureRequest kvRequest = new AzureRequest(
+                requestContext.getMethod(), kvAccount, "keyvault",
+                path, headers, requestContext.getEntityStream(), kvQueryParams, null, secure);
+            AuthContext kvAuth = authPipeline.resolve(kvRequest);
+            kvRequest = new AzureRequest(
+                requestContext.getMethod(), kvAccount, "keyvault",
+                path, headers, requestContext.getEntityStream(), kvQueryParams, kvAuth, secure);
+            Optional<AzureServiceHandler> kvHandler = serviceRegistry.resolve("keyvault");
+            if (kvHandler.isPresent()) {
+                LOGGER.infof("Routing ARM-base KV path to KeyVaultHandler: %s %s", requestContext.getMethod(), path);
+                return kvHandler.get().handle(kvRequest);
+            }
         }
 
         // ---------------------------------------------------------------
@@ -129,6 +245,28 @@ public class AzureRoutingFilter {
             if (sqlHandler.isPresent()) {
                 LOGGER.infof("Dispatching ARM SQL request to SqlHandler: %s %s", requestContext.getMethod(), path);
                 return sqlHandler.get().handle(sqlRequest);
+            }
+        }
+
+        // ---------------------------------------------------------------
+        // ARM general management-plane paths: subscriptions/{sub}/...
+        // (resource groups, storage accounts, key vaults, etc. not served
+        //  by the more-specific AKS and SQL handlers above)
+        // ---------------------------------------------------------------
+        if (path.startsWith("subscriptions/")) {
+            Map<String, String> armQueryParams = new HashMap<>();
+            requestContext.getUriInfo().getQueryParameters().forEach((k, v) -> armQueryParams.put(k, v.get(0)));
+            AzureRequest armRequest = new AzureRequest(
+                requestContext.getMethod(), "arm", "arm", path, headers,
+                requestContext.getEntityStream(), armQueryParams, null, secure);
+            AuthContext armAuth = authPipeline.resolve(armRequest);
+            armRequest = new AzureRequest(
+                requestContext.getMethod(), "arm", "arm", path, headers,
+                requestContext.getEntityStream(), armQueryParams, armAuth, secure);
+            Optional<AzureServiceHandler> armHandler = serviceRegistry.resolve("arm");
+            if (armHandler.isPresent()) {
+                LOGGER.infof("Dispatching ARM request to ArmHandler: %s %s", requestContext.getMethod(), path);
+                return armHandler.get().handle(armRequest);
             }
         }
 

--- a/src/main/java/io/floci/az/core/MicrosoftGraphController.java
+++ b/src/main/java/io/floci/az/core/MicrosoftGraphController.java
@@ -1,0 +1,36 @@
+package io.floci.az.core;
+
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import java.util.Map;
+
+@Path("/v1.0")
+public class MicrosoftGraphController {
+
+    // azurerm provider calls GET /v1.0/servicePrincipals?$filter=appId eq '{clientId}'
+    // to discover the service principal object ID during provider initialization.
+    @GET
+    @Path("servicePrincipals")
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response servicePrincipals(@QueryParam("$filter") String filter) {
+        String appId = extractAppId(filter);
+        return Response.ok(Map.of(
+            "value", List.of(Map.of(
+                "id",    "00000000-0000-0000-0000-000000000010",
+                "appId", appId
+            ))
+        )).build();
+    }
+
+    private String extractAppId(String filter) {
+        if (filter != null) {
+            String[] parts = filter.split("'");
+            if (parts.length >= 2) {
+                return parts[1];
+            }
+        }
+        return "00000000-0000-0000-0000-000000000003";
+    }
+}

--- a/src/main/java/io/floci/az/core/tls/TlsConfigSource.java
+++ b/src/main/java/io/floci/az/core/tls/TlsConfigSource.java
@@ -159,7 +159,8 @@ public class TlsConfigSource implements ConfigSource {
     private static List<String> buildSanList(List<String> customHostnames) {
         List<String> all = new ArrayList<>();
         all.addAll(List.of("localhost", "127.0.0.1", "0.0.0.0", "*.localhost",
-                "localhost.floci-az.io", "*.localhost.floci-az.io"));
+                "localhost.floci-az.io", "*.localhost.floci-az.io",
+                "*.vault.azure.net"));
         all.addAll(customHostnames);
         return all;
     }

--- a/src/main/java/io/floci/az/services/arm/ArmHandler.java
+++ b/src/main/java/io/floci/az/services/arm/ArmHandler.java
@@ -1,0 +1,570 @@
+package io.floci.az.services.arm;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.floci.az.config.EmulatorConfig;
+import io.floci.az.core.AzureRequest;
+import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.services.blob.BlobServiceHandler;
+import io.floci.az.services.queue.QueueServiceHandler;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * ARM management-plane handler for Azure Resource Manager paths that are not
+ * served by more-specific handlers (AKS, SQL).
+ *
+ * <p>Handles the minimal ARM surface required by the {@code hashicorp/azurerm}
+ * Terraform provider v4+:
+ *
+ * <ul>
+ *   <li>Subscription — {@code GET /subscriptions/{sub}}</li>
+ *   <li>Resource Groups — {@code PUT/GET/DELETE /subscriptions/{sub}/resourceGroups/{rg}}</li>
+ *   <li>Storage Accounts — ARM shell that bridges container/queue creation to the
+ *       existing Blob and Queue storage backends</li>
+ *   <li>Key Vaults — ARM shell whose vault URI points at the existing Key Vault handler</li>
+ * </ul>
+ */
+@ApplicationScoped
+public class ArmHandler implements AzureServiceHandler {
+
+    private static final Logger LOG = Logger.getLogger(ArmHandler.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    static final String FAKE_STORAGE_KEY =
+            "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMh0==";
+
+    private static final String SUBSCRIPTION_ID = "00000000-0000-0000-0000-000000000001";
+    private static final String TENANT_ID       = "00000000-0000-0000-0000-000000000002";
+
+    // In-memory ARM resource state — no StorageBackend needed, these are ephemeral
+    private final Map<String, Map<String, Object>> resourceGroups   = new ConcurrentHashMap<>();
+    private final Map<String, Map<String, Object>> storageAccounts  = new ConcurrentHashMap<>();
+    private final Map<String, Map<String, Object>> keyVaults        = new ConcurrentHashMap<>();
+
+    private final EmulatorConfig config;
+    private final BlobServiceHandler blobHandler;
+    private final QueueServiceHandler queueHandler;
+
+    @Inject
+    public ArmHandler(EmulatorConfig config, BlobServiceHandler blobHandler, QueueServiceHandler queueHandler) {
+        this.config       = config;
+        this.blobHandler  = blobHandler;
+        this.queueHandler = queueHandler;
+    }
+
+    @Override
+    public String getServiceType() { return "arm"; }
+
+    @Override
+    public boolean canHandle(AzureRequest req) { return "arm".equals(req.serviceType()); }
+
+    @Override
+    public Response handle(AzureRequest req) {
+        String path   = req.resourcePath();
+        String method = req.method().toUpperCase();
+
+        LOG.debugf("ArmHandler %s %s", method, path);
+
+        // ── Subscription ──────────────────────────────────────────────────────
+        if (path.matches("subscriptions/[^/?]+") ||
+            path.matches("subscriptions/[^/?]+\\?.*")) {
+            return subscriptionResponse(extractSub(path));
+        }
+
+        // ── Cross-subscription storage account listing ─────────────────────────
+        // azurerm provider calls this during state refresh/destroy to verify that
+        // storage accounts still exist. Return real data so destroy plans correctly.
+        if (path.matches("subscriptions/[^/?]+/providers/Microsoft\\.Storage/storageAccounts([?].*)?")) {
+            String sub = extractSub(path);
+            List<Map<String, Object>> accounts = storageAccounts.values().stream()
+                    .filter(a -> sub.equals(a.get("_sub")))
+                    .map(ArmHandler::stripInternal)
+                    .toList();
+            return Response.ok(Map.of("value", accounts)).build();
+        }
+
+        // ── Cross-subscription key vault listing ───────────────────────────────
+        if (path.matches("subscriptions/[^/?]+/providers/Microsoft\\.KeyVault/vaults([?].*)?")) {
+            String sub = extractSub(path);
+            List<Map<String, Object>> vaults = keyVaults.values().stream()
+                    .filter(v -> sub.equals(v.get("_sub")))
+                    .map(ArmHandler::stripInternal)
+                    .toList();
+            return Response.ok(Map.of("value", vaults)).build();
+        }
+
+        // ── Provider registration check (skip_provider_registration=true still calls this) ──
+        // Only matches /subscriptions/{sub}/providers or /subscriptions/{sub}/providers/{namespace}
+        // (no resource type segment), so the more-specific handlers above take precedence.
+        if (path.matches("subscriptions/[^/]+/providers(/[^/]+)?([?].*)?")) {
+            return Response.ok(Map.of("value", List.of())).build();
+        }
+
+        // ── Subscription-level resource listing ──────────────────────────────
+        // azurerm provider calls this to populate its Key Vault cache so it can
+        // look up a vault by its vaultUri. Return all key vaults for the subscription.
+        if (path.matches("subscriptions/[^/?]+/resources([?].*)?")) {
+            String sub = extractSub(path);
+            List<Map<String, Object>> resources = keyVaults.values().stream()
+                    .filter(v -> sub.equals(v.get("_sub")))
+                    .map(ArmHandler::stripInternal)
+                    .toList();
+            return Response.ok(Map.of("value", resources)).build();
+        }
+
+        // ── Resource Groups ───────────────────────────────────────────────────
+        // Azure spec uses lowercase "resourcegroups" but convention uses "resourceGroups"; accept both.
+        if (path.startsWith("subscriptions/") && path.toLowerCase().contains("/resourcegroups")) {
+            return handleResourceGroupBranch(req, path, method);
+        }
+
+        return armNotFound(path);
+    }
+
+    // ── Resource Group routing ────────────────────────────────────────────────
+
+    private Response handleResourceGroupBranch(AzureRequest req, String path, String method) {
+        String sub = extractSub(path);
+        String lc  = path.toLowerCase();
+
+        // GET subscriptions/{sub}/resourceGroups  (list)
+        if (lc.matches("subscriptions/[^/]+/resourcegroups([?].*)?")) {
+            return Response.ok(Map.of("value", new ArrayList<>(resourceGroups.values()))).build();
+        }
+
+        // subscriptions/{sub}/resourceGroups/{rg}  (no trailing segments)
+        if (lc.matches("subscriptions/[^/]+/resourcegroups/[^/]+([?].*)?")) {
+            String rg = extractRg(path);
+            return switch (method) {
+                case "PUT"    -> createOrUpdateResourceGroup(sub, rg, req);
+                case "GET"    -> getResourceGroup(sub, rg);
+                case "DELETE" -> { resourceGroups.remove(rgKey(sub, rg)); yield Response.ok().build(); }
+                default       -> Response.status(405).build();
+            };
+        }
+
+        // subscriptions/{sub}/resourceGroups/{rg}/resources  (list resources in RG)
+        // azurerm provider calls this before deleting a resource group to verify it is empty.
+        if (lc.matches("subscriptions/[^/]+/resourcegroups/[^/]+/resources([?].*)?")) {
+            String rg = extractRg(path);
+            List<Map<String, Object>> resources = new ArrayList<>();
+            storageAccounts.values().stream()
+                    .filter(a -> sub.equals(a.get("_sub")) && rg.equals(a.get("_rg")))
+                    .map(ArmHandler::stripInternal)
+                    .forEach(resources::add);
+            keyVaults.values().stream()
+                    .filter(v -> sub.equals(v.get("_sub")) && rg.equals(v.get("_rg")))
+                    .map(ArmHandler::stripInternal)
+                    .forEach(resources::add);
+            return Response.ok(Map.of("value", resources)).build();
+        }
+
+        // subscriptions/{sub}/resourceGroups/{rg}/providers/...
+        if (path.contains("/providers/")) {
+            return handleProviders(req, path, method, sub);
+        }
+
+        return armNotFound(path);
+    }
+
+    // ── Provider-level routing ────────────────────────────────────────────────
+
+    private Response handleProviders(AzureRequest req, String path, String method, String sub) {
+        if (path.contains("/providers/Microsoft.Storage/")) {
+            return handleStorage(req, path, method, sub);
+        }
+        if (path.contains("/providers/Microsoft.KeyVault/")) {
+            return handleKeyVault(req, path, method, sub);
+        }
+        return armNotFound(path);
+    }
+
+    // ── Storage Accounts ─────────────────────────────────────────────────────
+
+    private Response handleStorage(AzureRequest req, String path, String method, String sub) {
+        String rg = extractRg(path);
+
+        // POST .../storageAccounts/{name}/listKeys
+        if (path.contains("/storageAccounts/") && path.endsWith("/listKeys")) {
+            String account = extractResourceName(path, "storageAccounts");
+            return listKeys(account);
+        }
+
+        // .../storageAccounts/{name}/blobServices/default/containers/{container}
+        if (path.contains("/blobServices/default/containers/")) {
+            return handleBlobContainer(req, path, method, sub, rg);
+        }
+
+        // .../storageAccounts/{name}/blobServices/default  (blobServices properties)
+        if (path.contains("/blobServices/default") && !path.contains("/containers/")) {
+            return Response.ok(Map.of("id", path, "name", "default",
+                    "type", "Microsoft.Storage/storageAccounts/blobServices",
+                    "properties", Map.of())).build();
+        }
+
+        // .../storageAccounts/{name}/queueServices/default/queues/{queue}
+        if (path.contains("/queueServices/default/queues/")) {
+            return handleQueueResource(req, path, method, sub, rg);
+        }
+
+        // .../storageAccounts/{name}/queueServices/default  (queueServices properties)
+        if (path.contains("/queueServices/default") && !path.contains("/queues/")) {
+            return Response.ok(Map.of("id", path, "name", "default",
+                    "type", "Microsoft.Storage/storageAccounts/queueServices",
+                    "properties", Map.of())).build();
+        }
+
+        // GET .../storageAccounts  (list in RG)
+        if (path.matches(".*/providers/Microsoft\\.Storage/storageAccounts([?].*)?")) {
+            List<Map<String, Object>> accounts = storageAccounts.values().stream()
+                    .filter(a -> sub.equals(a.get("_sub")) && rg.equals(a.get("_rg")))
+                    .map(ArmHandler::stripInternal)
+                    .toList();
+            return Response.ok(Map.of("value", accounts)).build();
+        }
+
+        // PUT/GET/DELETE .../storageAccounts/{name}
+        if (path.contains("/storageAccounts/")) {
+            String account = extractResourceName(path, "storageAccounts");
+            return switch (method) {
+                case "PUT"    -> createOrUpdateStorageAccount(req, sub, rg, account);
+                case "GET"    -> getStorageAccount(sub, rg, account);
+                case "DELETE" -> { storageAccounts.remove(saKey(sub, rg, account)); yield Response.ok().build(); }
+                default       -> Response.status(405).build();
+            };
+        }
+
+        return armNotFound(path);
+    }
+
+    private Response createOrUpdateStorageAccount(AzureRequest req, String sub, String rg, String account) {
+        Map<String, Object> body = parseBody(req);
+        String location = bodyString(body, "location", "eastus");
+        // Return domain-based storage endpoints so the azurerm provider can parse the account name.
+        // The port is taken from the configured base URL so data-plane requests reach our emulator.
+        String portStr = storagePortString();
+
+        Map<String, Object> resource = new LinkedHashMap<>();
+        resource.put("_sub", sub);
+        resource.put("_rg", rg);
+        resource.put("id", "/subscriptions/" + sub + "/resourceGroups/" + rg
+                + "/providers/Microsoft.Storage/storageAccounts/" + account);
+        resource.put("name", account);
+        resource.put("type", "Microsoft.Storage/storageAccounts");
+        resource.put("location", location);
+        resource.put("sku", Map.of("name", "Standard_LRS", "tier", "Standard"));
+        resource.put("kind", "StorageV2");
+        resource.put("properties", Map.of(
+                "provisioningState", "Succeeded",
+                "primaryEndpoints", Map.of(
+                        "blob",  "http://" + account + ".blob.core.windows.net" + portStr + "/",
+                        "queue", "http://" + account + ".queue.core.windows.net" + portStr + "/",
+                        "table", "http://" + account + ".table.core.windows.net" + portStr + "/"),
+                "primaryLocation", location,
+                "statusOfPrimary", "available",
+                "supportsHttpsTrafficOnly", false,
+                "accessTier", "Hot",
+                "encryption", Map.of(
+                        "services", Map.of(
+                                "blob",  Map.of("enabled", true, "keyType", "Account"),
+                                "file",  Map.of("enabled", true, "keyType", "Account"),
+                                "queue", Map.of("enabled", true, "keyType", "Account"),
+                                "table", Map.of("enabled", true, "keyType", "Account")),
+                        "keySource", "Microsoft.Storage")
+        ));
+
+        storageAccounts.put(saKey(sub, rg, account), resource);
+        LOG.infof("ARM: created storage account %s", account);
+        return Response.ok(stripInternal(resource)).build();
+    }
+
+    private Response getStorageAccount(String sub, String rg, String account) {
+        Map<String, Object> resource = storageAccounts.get(saKey(sub, rg, account));
+        if (resource == null) {
+            return armNotFound("storageAccounts/" + account);
+        }
+        return Response.ok(stripInternal(resource)).build();
+    }
+
+    private Response listKeys(String account) {
+        return Response.ok(Map.of("keys", List.of(
+                Map.of("keyName", "key1", "value", FAKE_STORAGE_KEY, "permissions", "FULL"),
+                Map.of("keyName", "key2", "value", FAKE_STORAGE_KEY, "permissions", "FULL")
+        ))).build();
+    }
+
+    // ── Blob Container (via ARM) ──────────────────────────────────────────────
+
+    private Response handleBlobContainer(AzureRequest req, String path, String method, String sub, String rg) {
+        String account   = extractResourceName(path, "storageAccounts");
+        String container = extractAfter(path, "/containers/");
+
+        return switch (method) {
+            case "PUT" -> {
+                blobHandler.ensureContainer(account, container);
+                Map<String, Object> body = parseBody(req);
+                Map<String, Object> props = Map.of(
+                        "publicAccess",      "None",
+                        "leaseStatus",       "Unlocked",
+                        "leaseState",        "Available",
+                        "lastModifiedTime",  java.time.Instant.now().toString(),
+                        "etag",              "\"" + UUID.randomUUID() + "\"");
+                yield Response.status(201).entity(Map.of(
+                        "id",         path,
+                        "name",       container,
+                        "type",       "Microsoft.Storage/storageAccounts/blobServices/containers",
+                        "properties", props
+                )).build();
+            }
+            case "GET" -> Response.ok(Map.of(
+                    "id",         path,
+                    "name",       container,
+                    "type",       "Microsoft.Storage/storageAccounts/blobServices/containers",
+                    "properties", Map.of("publicAccess", "None")
+            )).build();
+            case "DELETE" -> Response.ok().build();
+            default -> Response.status(405).build();
+        };
+    }
+
+    // ── Queue Resource (via ARM) ──────────────────────────────────────────────
+
+    private Response handleQueueResource(AzureRequest req, String path, String method, String sub, String rg) {
+        String account = extractResourceName(path, "storageAccounts");
+        String queue   = extractAfter(path, "/queues/");
+
+        return switch (method) {
+            case "PUT" -> {
+                queueHandler.ensureQueue(account, queue);
+                yield Response.status(201).entity(Map.of(
+                        "id",         path,
+                        "name",       queue,
+                        "type",       "Microsoft.Storage/storageAccounts/queueServices/queues",
+                        "properties", Map.of()
+                )).build();
+            }
+            case "GET" -> Response.ok(Map.of(
+                    "id",         path,
+                    "name",       queue,
+                    "type",       "Microsoft.Storage/storageAccounts/queueServices/queues",
+                    "properties", Map.of()
+            )).build();
+            case "DELETE" -> Response.ok().build();
+            default -> Response.status(405).build();
+        };
+    }
+
+    // ── Key Vault ─────────────────────────────────────────────────────────────
+
+    private Response handleKeyVault(AzureRequest req, String path, String method, String sub) {
+        String rg = extractRg(path);
+
+        // GET list
+        if (path.matches(".*/providers/Microsoft\\.KeyVault/vaults([?].*)?")) {
+            List<Map<String, Object>> vaults = keyVaults.values().stream()
+                    .filter(v -> sub.equals(v.get("_sub")) && rg.equals(v.get("_rg")))
+                    .map(ArmHandler::stripInternal)
+                    .toList();
+            return Response.ok(Map.of("value", vaults)).build();
+        }
+
+        // Single vault
+        if (path.contains("/vaults/")) {
+            String vaultName = extractResourceName(path, "vaults");
+            return switch (method) {
+                case "PUT"    -> createOrUpdateKeyVault(req, sub, rg, vaultName);
+                case "GET"    -> getKeyVault(sub, rg, vaultName);
+                case "DELETE" -> { keyVaults.remove(kvKey(sub, rg, vaultName)); yield Response.ok().build(); }
+                default       -> Response.status(405).build();
+            };
+        }
+
+        return armNotFound(path);
+    }
+
+    private Response createOrUpdateKeyVault(AzureRequest req, String sub, String rg, String vaultName) {
+        Map<String, Object> body     = parseBody(req);
+        String location              = bodyString(body, "location", "eastus");
+        // Use vault.azure.net domain format so the azurerm provider accepts the URI.
+        // Port is derived from the configured base URL so data-plane calls reach our emulator.
+        String vaultUri              = vaultUri(vaultName);
+        Map<String, Object> bodyProps = body.containsKey("properties")
+                ? cast(body.get("properties")) : Map.of();
+        String tenantId = bodyString(bodyProps, "tenantId", TENANT_ID);
+
+        Map<String, Object> resource = new LinkedHashMap<>();
+        resource.put("_sub",  sub);
+        resource.put("_rg",   rg);
+        resource.put("id",    "/subscriptions/" + sub + "/resourceGroups/" + rg
+                + "/providers/Microsoft.KeyVault/vaults/" + vaultName);
+        resource.put("name",     vaultName);
+        resource.put("type",     "Microsoft.KeyVault/vaults");
+        resource.put("location", location);
+        resource.put("properties", Map.of(
+                "vaultUri",          vaultUri,
+                "tenantId",          tenantId,
+                "sku",               Map.of("family", "A", "name", "standard"),
+                "provisioningState", "Succeeded",
+                "enableSoftDelete",  false,
+                "accessPolicies",    List.of()
+        ));
+
+        keyVaults.put(kvKey(sub, rg, vaultName), resource);
+        LOG.infof("ARM: created key vault %s (vaultUri=%s)", vaultName, vaultUri);
+        return Response.ok(stripInternal(resource)).build();
+    }
+
+    private Response getKeyVault(String sub, String rg, String vaultName) {
+        Map<String, Object> resource = keyVaults.get(kvKey(sub, rg, vaultName));
+        if (resource == null) {
+            return armNotFound("vaults/" + vaultName);
+        }
+        return Response.ok(stripInternal(resource)).build();
+    }
+
+    // ── Resource Groups ───────────────────────────────────────────────────────
+
+    private Response createOrUpdateResourceGroup(String sub, String rg, AzureRequest req) {
+        Map<String, Object> body     = parseBody(req);
+        String location              = bodyString(body, "location", "eastus");
+
+        Map<String, Object> resource = new LinkedHashMap<>();
+        resource.put("id",       "/subscriptions/" + sub + "/resourceGroups/" + rg);
+        resource.put("name",     rg);
+        resource.put("type",     "Microsoft.Resources/resourceGroups");
+        resource.put("location", location);
+        resource.put("properties", Map.of("provisioningState", "Succeeded"));
+
+        resourceGroups.put(rgKey(sub, rg), resource);
+        LOG.infof("ARM: created resource group %s", rg);
+        return Response.status(201).entity(resource).build();
+    }
+
+    private Response getResourceGroup(String sub, String rg) {
+        Map<String, Object> resource = resourceGroups.get(rgKey(sub, rg));
+        if (resource == null) {
+            return armNotFound("resourceGroups/" + rg);
+        }
+        return Response.ok(resource).build();
+    }
+
+    // ── Subscription ─────────────────────────────────────────────────────────
+
+    private Response subscriptionResponse(String sub) {
+        return Response.ok(Map.of(
+                "id",             "/subscriptions/" + sub,
+                "subscriptionId", sub,
+                "displayName",    "floci-az local",
+                "state",          "Enabled",
+                "tenantId",       TENANT_ID
+        )).build();
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static String extractSub(String path) {
+        String[] parts = path.split("/");
+        for (int i = 0; i < parts.length - 1; i++) {
+            if ("subscriptions".equals(parts[i])) return parts[i + 1];
+        }
+        return "unknown";
+    }
+
+    private static String extractRg(String path) {
+        String[] parts = path.split("/");
+        for (int i = 0; i < parts.length - 1; i++) {
+            if ("resourcegroups".equalsIgnoreCase(parts[i])) return parts[i + 1];
+        }
+        return "unknown";
+    }
+
+    private static String extractResourceName(String path, String resourceType) {
+        Pattern p = Pattern.compile("/" + Pattern.quote(resourceType) + "/([^/?]+)");
+        Matcher m = p.matcher(path);
+        return m.find() ? m.group(1) : "unknown";
+    }
+
+    private static String extractAfter(String path, String marker) {
+        int idx = path.lastIndexOf(marker);
+        if (idx < 0) return "unknown";
+        String rest = path.substring(idx + marker.length());
+        int q = rest.indexOf('?');
+        return q >= 0 ? rest.substring(0, q) : rest;
+    }
+
+    private static String rgKey(String sub, String rg)               { return sub + "/" + rg; }
+    private static String saKey(String sub, String rg, String name)  { return sub + "/" + rg + "/" + name; }
+    private static String kvKey(String sub, String rg, String name)  { return sub + "/" + rg + "/kv/" + name; }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> cast(Object o) {
+        return o instanceof Map<?, ?> m ? (Map<String, Object>) m : Map.of();
+    }
+
+    private static String bodyString(Map<String, Object> map, String key, String defaultValue) {
+        Object v = map.get(key);
+        return v instanceof String s ? s : defaultValue;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> parseBody(AzureRequest req) {
+        try {
+            if (req.bodyStream() == null || req.bodyStream().available() == 0) {
+                return Map.of();
+            }
+            return MAPPER.readValue(req.bodyStream(), Map.class);
+        } catch (IOException e) {
+            return Map.of();
+        }
+    }
+
+    private static Map<String, Object> stripInternal(Map<String, Object> resource) {
+        Map<String, Object> copy = new LinkedHashMap<>(resource);
+        copy.remove("_sub");
+        copy.remove("_rg");
+        return copy;
+    }
+
+    /**
+     * Returns the account name to use for ARM-base-URL key vault data-plane fallback.
+     * When there is exactly one vault registered, returns its name so that KV data-plane
+     * responses carry the correct vault.azure.net URI and the provider's vault cache lookup
+     * succeeds. Falls back to "kv-default" when zero or multiple vaults are present.
+     */
+    public String getDefaultKvAccount() {
+        if (keyVaults.size() == 1) {
+            Object name = keyVaults.values().iterator().next().get("name");
+            if (name instanceof String s) return s;
+        }
+        return "kv-default";
+    }
+
+    private String storagePortString() {
+        // Return no port so storage URLs use standard HTTP port 80.
+        // Test containers forward port 80 → emulator via socat.
+        return "";
+    }
+
+    private String vaultUri(String vaultName) {
+        // Use vault.azure.net domain format on standard port 443 (no explicit port).
+        // azurerm validates the URI matches *.vault.* pattern. In the test container a
+        // socat listener on 443 forwards to the emulator so the azurerm provider can
+        // reach the vault; host-based routing then dispatches to KeyVaultHandler.
+        return "https://" + vaultName + ".vault.azure.net/";
+    }
+
+    private Response armNotFound(String path) {
+        return Response.status(404).entity(Map.of("error", Map.of(
+                "code",    "ResourceNotFound",
+                "message", "Resource not found: " + path
+        ))).build();
+    }
+}

--- a/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
+++ b/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
@@ -4,6 +4,7 @@ import io.floci.az.core.AzureErrorResponse;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
 import io.floci.az.core.StoredObject;
+import io.floci.az.core.XmlBuilder;
 import io.floci.az.core.XmlUtils;
 import io.floci.az.core.storage.StorageBackend;
 import io.floci.az.core.storage.StorageFactory;
@@ -63,6 +64,12 @@ public class BlobServiceHandler implements AzureServiceHandler {
         if (path.isEmpty() || path.equals("/")) {
             if ("GET".equalsIgnoreCase(method) && "list".equals(query.get("comp"))) {
                 response = listContainers(request);
+            } else if ("service".equals(query.get("restype")) && "properties".equals(query.get("comp"))) {
+                if ("GET".equalsIgnoreCase(method) || "HEAD".equalsIgnoreCase(method)) {
+                    response = getBlobServiceProperties();
+                } else {
+                    response = Response.ok().build();
+                }
             } else {
                 response = new AzureErrorResponse("NotImplemented", "The requested operation is not implemented.")
                         .toXmlResponse(501);
@@ -104,6 +111,32 @@ public class BlobServiceHandler implements AzureServiceHandler {
                 .header("x-ms-version", request.headers().getHeaderString("x-ms-version"))
                 .header("Date", RFC1123_DATE_TIME.format(Instant.now()))
                 .build();
+    }
+
+    private Response getBlobServiceProperties() {
+        String xml = new XmlBuilder()
+            .start("StorageServiceProperties")
+                .start("Logging")
+                    .elem("Version", "1.0")
+                    .elem("Delete", "false")
+                    .elem("Read", "false")
+                    .elem("Write", "false")
+                    .start("RetentionPolicy").elem("Enabled", "false").end("RetentionPolicy")
+                .end("Logging")
+                .start("HourMetrics")
+                    .elem("Version", "1.0")
+                    .elem("Enabled", "false")
+                    .start("RetentionPolicy").elem("Enabled", "false").end("RetentionPolicy")
+                .end("HourMetrics")
+                .start("MinuteMetrics")
+                    .elem("Version", "1.0")
+                    .elem("Enabled", "false")
+                    .start("RetentionPolicy").elem("Enabled", "false").end("RetentionPolicy")
+                .end("MinuteMetrics")
+                .start("StaticWebsite").elem("Enabled", "false").end("StaticWebsite")
+            .end("StorageServiceProperties")
+            .toString();
+        return Response.ok(xml, "application/xml").build();
     }
 
     private Response getContainer(AzureRequest request, String containerName, boolean headOnly) {
@@ -278,6 +311,10 @@ public class BlobServiceHandler implements AzureServiceHandler {
 
     public void clearAll() {
         store.clear();
+    }
+
+    public void ensureContainer(String accountName, String containerName) {
+        store.put(nsKey(accountName, containerName), NS_SENTINEL);
     }
 
     private static String nsKey(String accountName, String containerName) {

--- a/src/main/java/io/floci/az/services/keyvault/KeyVaultHandler.java
+++ b/src/main/java/io/floci/az/services/keyvault/KeyVaultHandler.java
@@ -67,6 +67,14 @@ public class KeyVaultHandler implements AzureServiceHandler {
                     .build();
         }
 
+        // Root probe — azurerm provider polls this to confirm the vault is reachable.
+        if (path.isEmpty() || path.equals("/")) {
+            return Response.ok(java.util.Map.of(
+                "type", "Microsoft.KeyVault/vaults",
+                "id",   "https://" + account + ".vault.azure.net/"
+            )).build();
+        }
+
         if ("secrets".equals(path)) {
             return "GET".equals(method) ? listSecrets(account) : methodNotAllowed();
         }
@@ -78,6 +86,18 @@ public class KeyVaultHandler implements AzureServiceHandler {
         }
         if (path.startsWith("deletedsecrets/")) {
             return handleDeletedSecrets(req, method, account, path.substring("deletedsecrets/".length()));
+        }
+
+        // Certificate contacts — azurerm provider reads this after key vault creation.
+        // Return an empty contacts list so the provider sees no contacts configured.
+        if ("certificates/contacts".equals(path)) {
+            if ("GET".equals(method)) {
+                return Response.ok(java.util.Map.of(
+                    "id", "https://" + account + ".vault.azure.net/certificates/contacts",
+                    "contacts", java.util.List.of()
+                )).build();
+            }
+            return methodNotAllowed();
         }
 
         return kvError(404, "BadRequest", "Resource not found: " + path);
@@ -517,7 +537,7 @@ public class KeyVaultHandler implements AzureServiceHandler {
     // -------------------------------------------------------------------------
 
     private String vaultHost(String account) {
-        return "https://" + account + "-keyvault";
+        return "https://" + account + ".vault.azure.net";
     }
 
     private String secretVersionId(String account, String name, String version) {

--- a/src/main/java/io/floci/az/services/queue/QueueServiceHandler.java
+++ b/src/main/java/io/floci/az/services/queue/QueueServiceHandler.java
@@ -5,6 +5,7 @@ import io.floci.az.core.AzureErrorResponse;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
 import io.floci.az.core.StoredObject;
+import io.floci.az.core.XmlBuilder;
 import io.floci.az.core.XmlUtils;
 import io.floci.az.core.storage.StorageBackend;
 import io.floci.az.core.storage.StorageFactory;
@@ -63,6 +64,12 @@ public class QueueServiceHandler implements AzureServiceHandler {
         if (path.isEmpty() || path.equals("/")) {
             if ("GET".equalsIgnoreCase(method) && "list".equals(query.get("comp"))) {
                 response = listQueues(request);
+            } else if ("service".equals(query.get("restype")) && "properties".equals(query.get("comp"))) {
+                if ("GET".equalsIgnoreCase(method) || "HEAD".equalsIgnoreCase(method)) {
+                    response = getQueueServiceProperties();
+                } else {
+                    response = Response.ok().build();
+                }
             } else {
                 response = new AzureErrorResponse("NotImplemented", "The requested operation is not implemented.")
                         .toXmlResponse(501);
@@ -77,6 +84,8 @@ public class QueueServiceHandler implements AzureServiceHandler {
                     response = createQueue(request, queueName);
                 } else if ("DELETE".equalsIgnoreCase(method)) {
                     response = deleteQueue(request, queueName);
+                } else if ("GET".equalsIgnoreCase(method) || "HEAD".equalsIgnoreCase(method)) {
+                    response = getQueue(request, queueName);
                 } else {
                     response = new AzureErrorResponse("NotImplemented", "The requested operation is not implemented.")
                             .toXmlResponse(501);
@@ -107,6 +116,32 @@ public class QueueServiceHandler implements AzureServiceHandler {
                 .header("x-ms-version", request.headers().getHeaderString("x-ms-version"))
                 .header("Date", RFC1123_DATE_TIME.format(Instant.now()))
                 .build();
+    }
+
+    private Response getQueueServiceProperties() {
+        String xml = new XmlBuilder()
+            .start("StorageServiceProperties")
+                .start("Logging")
+                    .elem("Version", "1.0")
+                    .elem("Delete", "false")
+                    .elem("Read", "false")
+                    .elem("Write", "false")
+                    .start("RetentionPolicy").elem("Enabled", "false").end("RetentionPolicy")
+                .end("Logging")
+                .start("HourMetrics")
+                    .elem("Version", "1.0")
+                    .elem("Enabled", "false")
+                    .start("RetentionPolicy").elem("Enabled", "false").end("RetentionPolicy")
+                .end("HourMetrics")
+                .start("MinuteMetrics")
+                    .elem("Version", "1.0")
+                    .elem("Enabled", "false")
+                    .start("RetentionPolicy").elem("Enabled", "false").end("RetentionPolicy")
+                .end("MinuteMetrics")
+                .selfClose("Cors")
+            .end("StorageServiceProperties")
+            .toString();
+        return Response.ok(xml, "application/xml").build();
     }
 
     private Response createQueue(AzureRequest request, String queueName) {
@@ -140,6 +175,14 @@ public class QueueServiceHandler implements AzureServiceHandler {
         );
 
         return Response.ok(XmlUtils.toXml(response)).type(MediaType.APPLICATION_XML).build();
+    }
+
+    private Response getQueue(AzureRequest request, String queueName) {
+        if (store.get(nsKey(request.accountName(), queueName)).isEmpty()) {
+            return new AzureErrorResponse("QueueNotFound", "The specified queue does not exist.")
+                    .toXmlResponse(Response.Status.NOT_FOUND.getStatusCode());
+        }
+        return Response.ok().build();
     }
 
     private Response putMessage(AzureRequest request, String queueName) {
@@ -270,6 +313,10 @@ public class QueueServiceHandler implements AzureServiceHandler {
 
     public void clearAll() {
         store.clear();
+    }
+
+    public void ensureQueue(String accountName, String queueName) {
+        store.put(nsKey(accountName, queueName), NS_SENTINEL);
     }
 
     private static String nsKey(String accountName, String queueName) {

--- a/src/test/java/io/floci/az/core/tls/TlsConfigSourceCertificateGenerationTest.java
+++ b/src/test/java/io/floci/az/core/tls/TlsConfigSourceCertificateGenerationTest.java
@@ -84,8 +84,8 @@ class TlsConfigSourceCertificateGenerationTest {
         assertTrue(sans.contains("localhost"));
         assertTrue(sans.contains("127.0.0.1"));
         assertTrue(sans.contains("0.0.0.0"));
-        assertEquals(6, sans.size(),
-            "Default cert should have exactly 6 SANs (localhost, 127.0.0.1, 0.0.0.0, *.localhost, localhost.floci-az.io, *.localhost.floci-az.io)");
+        assertEquals(7, sans.size(),
+            "Default cert should have exactly 7 SANs (localhost, 127.0.0.1, 0.0.0.0, *.localhost, localhost.floci-az.io, *.localhost.floci-az.io, *.vault.azure.net)");
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Adds `ArmHandler` — the ARM management-plane surface needed by the azurerm Terraform and OpenTofu providers: subscription, resource groups, storage accounts, and key vaults with accurate cross-subscription listing so `terraform destroy` cleans up completely without orphaning state
- Adds two new BATS compatibility suites (`compat-terraform`, `compat-opentofu`) covering full apply + destroy lifecycle; both run in CI and via `make compat-docker`
- Fixes Key Vault secret IDs to use `*.vault.azure.net` format (required by azurerm provider URI validation)
- Adds `*.vault.azure.net` to the self-signed TLS certificate SANs so vault data-plane requests proxied via socat pass TLS validation inside test containers
- Replaces XML string concatenation in `BlobServiceHandler` and `QueueServiceHandler` with `XmlBuilder`
- Converts field injection to constructor injection in `AzureRoutingFilter` and `AzureIdentityController`

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

<!-- For new actions: which SDK version and Azure CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
