### PR TITLE
fix(blob): support large blob uploads beyond 20 MB

### DIFF
--- a/compatibility-tests/sdk-test-python/tests/test_blob.py
+++ b/compatibility-tests/sdk-test-python/tests/test_blob.py
@@ -100,3 +100,41 @@ def test_blob_overwrite(blob_service_client):
     assert blob.download_blob().readall() == b"updated"
 
     blob_service_client.delete_container(container_name)
+
+
+# --- Large payload tests (regression for Jackson StreamConstraintsException > 20 MB) ---
+
+def test_large_blob_single_put(blob_service_client):
+    """25 MB blob via PutBlob — just above the old 20 MB Jackson string-length default."""
+    container_name = make_container_name()
+    blob_service_client.create_container(container_name)
+    container = blob_service_client.get_container_client(container_name)
+
+    size = 25 * 1024 * 1024  # 25 MB
+    data = b"x" * size
+
+    blob = container.get_blob_client("large-single.bin")
+    blob.upload_blob(data, overwrite=True, max_concurrency=1)
+
+    props = blob.get_blob_properties()
+    assert props.size == size
+
+    blob_service_client.delete_container(container_name)
+
+
+def test_large_blob_block_upload(blob_service_client):
+    """100 MB blob — SDK switches to Put Block / Put Block List chunked upload."""
+    container_name = make_container_name()
+    blob_service_client.create_container(container_name)
+    container = blob_service_client.get_container_client(container_name)
+
+    size = 100 * 1024 * 1024  # 100 MB
+    data = b"y" * size
+
+    blob = container.get_blob_client("large-chunked.bin")
+    blob.upload_blob(data, overwrite=True)
+
+    props = blob.get_blob_properties()
+    assert props.size == size
+
+    blob_service_client.delete_container(container_name)

--- a/src/main/java/io/floci/az/core/JacksonConfig.java
+++ b/src/main/java/io/floci/az/core/JacksonConfig.java
@@ -1,0 +1,22 @@
+package io.floci.az.core;
+
+import com.fasterxml.jackson.core.StreamReadConstraints;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.jackson.ObjectMapperCustomizer;
+import jakarta.inject.Singleton;
+
+// Raises Jackson's string-length limit so large payloads (blob uploads, function ZIPs) are accepted.
+// Azure Storage allows PutBlob up to 5000 MiB; Functions ZIPs can reach several hundred MB.
+@Singleton
+public class JacksonConfig implements ObjectMapperCustomizer {
+
+    private static final int MAX_STRING_LENGTH = 512 * 1024 * 1024; // 512 MB
+
+    @Override
+    public void customize(ObjectMapper mapper) {
+        mapper.getFactory().setStreamReadConstraints(
+                StreamReadConstraints.builder()
+                        .maxStringLength(MAX_STRING_LENGTH)
+                        .build());
+    }
+}

--- a/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
+++ b/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
@@ -5,6 +5,7 @@ import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
 import io.floci.az.core.StoredObject;
 import io.floci.az.core.XmlBuilder;
+import io.floci.az.core.XmlParser;
 import io.floci.az.core.XmlUtils;
 import io.floci.az.core.storage.StorageBackend;
 import io.floci.az.core.storage.StorageFactory;
@@ -15,7 +16,9 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Arrays;
 import java.time.ZoneId;
@@ -32,6 +35,7 @@ public class BlobServiceHandler implements AzureServiceHandler {
             .withZone(ZoneId.of("GMT"));
 
     private static final String NS_PREFIX = "__ns__:";
+    private static final String BLOCK_PREFIX = "__blk__:";
     private static final StoredObject NS_SENTINEL =
             new StoredObject("", new byte[0], Map.of(), Instant.EPOCH, "");
 
@@ -94,7 +98,14 @@ public class BlobServiceHandler implements AzureServiceHandler {
                 }
             } else {
                 if ("PUT".equalsIgnoreCase(method)) {
-                    response = putBlob(request, containerName, blobName);
+                    String comp = query.get("comp");
+                    if ("block".equals(comp)) {
+                        response = putBlock(request, containerName, blobName);
+                    } else if ("blocklist".equals(comp)) {
+                        response = putBlockList(request, containerName, blobName);
+                    } else {
+                        response = putBlob(request, containerName, blobName);
+                    }
                 } else if ("GET".equalsIgnoreCase(method) || "HEAD".equalsIgnoreCase(method)) {
                     response = getBlob(request, containerName, blobName, "HEAD".equalsIgnoreCase(method));
                 } else if ("DELETE".equalsIgnoreCase(method)) {
@@ -208,6 +219,72 @@ public class BlobServiceHandler implements AzureServiceHandler {
 
             store.put(objKey(request.accountName(), containerName, blobName),
                     new StoredObject(blobName, data, metadata, Instant.now(), UUID.randomUUID().toString()));
+
+            return Response.status(Response.Status.CREATED)
+                    .header("Last-Modified", RFC1123_DATE_TIME.format(Instant.now()))
+                    .header("ETag", UUID.randomUUID().toString())
+                    .header("x-ms-request-server-encrypted", "true")
+                    .header("Content-Length", 0)
+                    .build();
+        } catch (IOException e) {
+            return Response.serverError().build();
+        }
+    }
+
+    private String blockKey(String account, String container, String blob, String blockId) {
+        return BLOCK_PREFIX + account + "/" + container + "/" + blob + "/" + blockId;
+    }
+
+    private Response putBlock(AzureRequest request, String containerName, String blobName) {
+        String blockId = request.queryParams().get("blockid");
+        if (blockId == null || blockId.isBlank()) {
+            return new AzureErrorResponse("InvalidQueryParameterValue",
+                    "The blockid query parameter is required.").toXmlResponse(400);
+        }
+        try {
+            byte[] data = request.bodyStream().readAllBytes();
+            store.put(blockKey(request.accountName(), containerName, blobName, blockId),
+                    new StoredObject(blockId, data, Map.of(), Instant.now(), UUID.randomUUID().toString()));
+            return Response.status(Response.Status.CREATED)
+                    .header("x-ms-request-server-encrypted", "true")
+                    .header("Content-Length", 0)
+                    .build();
+        } catch (IOException e) {
+            return Response.serverError().build();
+        }
+    }
+
+    private Response putBlockList(AzureRequest request, String containerName, String blobName) {
+        try {
+            String xml = new String(request.bodyStream().readAllBytes(), StandardCharsets.UTF_8);
+            // <BlockList> contains <Latest>, <Committed>, or <Uncommitted> elements in commit order.
+            // The SDK uses <Latest> for fresh uploads; collect all three preserving per-type order.
+            List<String> blockIds = new ArrayList<>();
+            blockIds.addAll(XmlParser.extractAll(xml, "Latest"));
+            blockIds.addAll(XmlParser.extractAll(xml, "Committed"));
+            blockIds.addAll(XmlParser.extractAll(xml, "Uncommitted"));
+
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            for (String blockId : blockIds) {
+                Optional<StoredObject> block = store.get(
+                        blockKey(request.accountName(), containerName, blobName, blockId));
+                if (block.isEmpty()) {
+                    return new AzureErrorResponse("InvalidBlockList",
+                            "The specified block list is invalid.").toXmlResponse(400);
+                }
+                out.write(block.get().data());
+                store.delete(blockKey(request.accountName(), containerName, blobName, blockId));
+            }
+
+            Map<String, String> metadata = new HashMap<>();
+            metadata.put("BlobType", "BlockBlob");
+            String ct = request.headers().getHeaderString(HttpHeaders.CONTENT_TYPE);
+            metadata.put("Content-Type", ct != null ? ct : "application/octet-stream");
+            metadata.put("Name", blobName);
+
+            store.put(objKey(request.accountName(), containerName, blobName),
+                    new StoredObject(blobName, out.toByteArray(), metadata, Instant.now(),
+                            UUID.randomUUID().toString()));
 
             return Response.status(Response.Status.CREATED)
                     .header("Last-Modified", RFC1123_DATE_TIME.format(Instant.now()))

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,6 +5,8 @@ quarkus:
   http:
     port: ${floci-az.port}
     host: 0.0.0.0
+    limits:
+      max-body-size: 2G
   native:
     additional-build-args: >-
       --initialize-at-run-time=org.apache.hc.client5.http.impl.auth.NTLMEngineImpl,


### PR DESCRIPTION
## Summary

Three changes required to accept payloads above Jackson's 2.15+ default limit:

- JacksonConfig: register ObjectMapperCustomizer to raise Jackson's StreamReadConstraints.maxStringLength from 20 MB to 512 MB, preventing StreamConstraintsException on large inline payloads (functions ZIPs, blobs)
- application.yml: set quarkus.http.limits.max-body-size to 2G; Quarkus defaults to 10 MB and returns 413 before the request reaches any handler
- BlobServiceHandler: implement block blob upload protocol (Put Block via comp=block, Put Block List via comp=blocklist); the Azure Storage SDK switches to chunked upload for blobs above ~64 MB and the emulator was storing the XML commit body as the blob content instead of assembling blocks

Fixes #37
## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

<!-- For new actions: which SDK version and Azure CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
