### PR TITLE
fix(functions): share one container per app across all functions

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/FunctionsCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/FunctionsCompatibilityTest.java
@@ -249,17 +249,17 @@ class FunctionsCompatibilityTest {
     }
 
     /**
-     * Builds a minimal Azure Functions v3 Node.js ZIP in-memory and returns it as base64.
-     * Structure:
-     *   host.json
-     *   hello/function.json   (HTTP trigger)
-     *   hello/index.js        (handler)
+     * Builds a minimal Azure Functions Node.js ZIP in-memory and returns it as base64.
+     * Flat structure — ContainerLauncher injects at wwwroot/{funcName}/ and separately
+     * provides host.json at wwwroot/host.json, so ZIPs must NOT include host.json or
+     * a {funcName}/ subdirectory.
+     *   function.json   (HTTP trigger binding)
+     *   index.js        (handler)
      */
     private static String buildNodeZipBase64() throws Exception {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (ZipOutputStream zos = new ZipOutputStream(baos)) {
-            addZipEntry(zos, "host.json", "{\"version\":\"2.0\"}");
-            addZipEntry(zos, "hello/function.json", """
+            addZipEntry(zos, "function.json", """
                     {
                       "bindings": [
                         {"authLevel":"anonymous","type":"httpTrigger","direction":"in",
@@ -268,7 +268,7 @@ class FunctionsCompatibilityTest {
                       ]
                     }
                     """);
-            addZipEntry(zos, "hello/index.js", """
+            addZipEntry(zos, "index.js", """
                     module.exports = async function(context, req) {
                         const msg = (req.query && req.query.msg) || "world";
                         context.res = { status: 200, body: "Hello, " + msg + "!" };

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/FunctionsMultiFunctionTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/FunctionsMultiFunctionTest.java
@@ -1,0 +1,212 @@
+package io.floci.az.compat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.*;
+
+import java.io.ByteArrayOutputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.UUID;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Verifies that multiple functions deployed to the same app share a single container.
+ *
+ * Management tests (create/deploy/list) run without Docker.
+ * Invocation and container-count tests require Docker and are skipped when unavailable.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class FunctionsMultiFunctionTest {
+
+    private static final String BASE =
+            System.getenv().getOrDefault("FLOCI_AZ_ENDPOINT", "http://localhost:4577");
+    private static final String ACCOUNT = EmulatorConfig.ACCOUNT;
+    private static final String FUNCTIONS_BASE = BASE + "/" + ACCOUNT + "-functions";
+
+    private static final HttpClient http = HttpClient.newHttpClient();
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private static final String APP_NAME     = "multiapp-" + UUID.randomUUID().toString().substring(0, 8);
+    private static final String FUNC_GREET   = "greet";
+    private static final String FUNC_FAREWELL = "farewell";
+
+    private static boolean dockerAvailable = false;
+
+    @BeforeAll
+    static void setUp() {
+        EmulatorConfig.assumeEmulatorRunning();
+        try {
+            ProcessBuilder pb = new ProcessBuilder("docker", "info");
+            pb.redirectErrorStream(true);
+            Process p = pb.start();
+            dockerAvailable = p.waitFor() == 0;
+        } catch (Exception e) {
+            dockerAvailable = false;
+        }
+    }
+
+    // ── App and function setup ────────────────────────────────────────────────
+
+    @Test @Order(1)
+    void createApp_returns201() throws Exception {
+        HttpResponse<String> resp = put(FUNCTIONS_BASE + "/admin/apps/" + APP_NAME,
+                "{\"runtime\":\"node\"}");
+        assertEquals(201, resp.statusCode(), "createApp: " + resp.body());
+        assertEquals(APP_NAME, mapper.readTree(resp.body()).get("name").asText());
+    }
+
+    @Test @Order(2)
+    void deployGreetFunction_returns201() throws Exception {
+        String body = buildDeployBody("index.handler", 60, buildFunctionZip("Hello, World!"));
+        HttpResponse<String> resp = put(
+                FUNCTIONS_BASE + "/admin/apps/" + APP_NAME + "/functions/" + FUNC_GREET, body);
+        assertEquals(201, resp.statusCode(), "deployGreet: " + resp.body());
+        assertEquals("Ready", mapper.readTree(resp.body()).get("status").asText());
+    }
+
+    @Test @Order(3)
+    void deployFarewellFunction_returns201() throws Exception {
+        String body = buildDeployBody("index.handler", 60, buildFunctionZip("Goodbye, World!"));
+        HttpResponse<String> resp = put(
+                FUNCTIONS_BASE + "/admin/apps/" + APP_NAME + "/functions/" + FUNC_FAREWELL, body);
+        assertEquals(201, resp.statusCode(), "deployFarewell: " + resp.body());
+        assertEquals("Ready", mapper.readTree(resp.body()).get("status").asText());
+    }
+
+    @Test @Order(4)
+    void listFunctions_containsBothFunctions() throws Exception {
+        HttpResponse<String> resp = get(
+                FUNCTIONS_BASE + "/admin/apps/" + APP_NAME + "/functions");
+        assertEquals(200, resp.statusCode());
+        JsonNode value = mapper.readTree(resp.body()).get("value");
+        assertTrue(value.isArray(), "Expected array in response");
+        assertEquals(2, value.size(), "Expected exactly 2 functions");
+        List<String> names = new ArrayList<>();
+        for (JsonNode fn : value) {
+            names.add(fn.get("name").asText());
+        }
+        assertTrue(names.contains(FUNC_GREET),    "greet missing from list: " + names);
+        assertTrue(names.contains(FUNC_FAREWELL),  "farewell missing from list: " + names);
+    }
+
+    // ── Invocation (Docker required) ──────────────────────────────────────────
+
+    @Test @Order(5)
+    void invokeGreetFunction_returns200() throws Exception {
+        assumeTrue(dockerAvailable, "Docker not available — skipping invocation test");
+        HttpResponse<String> resp = get(
+                FUNCTIONS_BASE + "/api/" + APP_NAME + "/" + FUNC_GREET);
+        assertEquals(200, resp.statusCode(), "invoke greet: " + resp.body());
+        assertTrue(resp.body().contains("Hello"), "Unexpected body: " + resp.body());
+    }
+
+    @Test @Order(6)
+    void invokeFarewellFunction_returns200() throws Exception {
+        assumeTrue(dockerAvailable, "Docker not available — skipping invocation test");
+        HttpResponse<String> resp = get(
+                FUNCTIONS_BASE + "/api/" + APP_NAME + "/" + FUNC_FAREWELL);
+        assertEquals(200, resp.statusCode(), "invoke farewell: " + resp.body());
+        assertTrue(resp.body().contains("Goodbye"), "Unexpected body: " + resp.body());
+    }
+
+    // ── Single container per app (Docker required) ────────────────────────────
+
+    @Test @Order(7)
+    void onlyOneContainerRunningForApp() throws Exception {
+        assumeTrue(dockerAvailable, "Docker not available — skipping container-count test");
+        // Both functions were invoked above; the warm pool should hold exactly one container.
+        ProcessBuilder pb = new ProcessBuilder(
+                "docker", "ps", "--filter", "name=floci-az-fn-" + APP_NAME, "--format", "{{.ID}}");
+        pb.redirectErrorStream(true);
+        Process p = pb.start();
+        String output = new String(p.getInputStream().readAllBytes(), StandardCharsets.UTF_8).trim();
+        p.waitFor();
+
+        long count = output.isBlank() ? 0L : output.lines().filter(l -> !l.isBlank()).count();
+        assertEquals(1L, count,
+                "Expected exactly 1 container for app '" + APP_NAME + "', found " + count
+                        + ".\nRunning containers:\n" + output);
+    }
+
+    // ── Cleanup ───────────────────────────────────────────────────────────────
+
+    @Test @Order(8)
+    void deleteApp_returns204() throws Exception {
+        HttpResponse<String> resp = delete(FUNCTIONS_BASE + "/admin/apps/" + APP_NAME);
+        assertEquals(204, resp.statusCode());
+    }
+
+    @Test @Order(9)
+    void getApp_afterDelete_returns404() throws Exception {
+        HttpResponse<String> resp = get(FUNCTIONS_BASE + "/admin/apps/" + APP_NAME);
+        assertEquals(404, resp.statusCode());
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static HttpResponse<String> get(String url) throws Exception {
+        return http.send(HttpRequest.newBuilder(URI.create(url)).GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    private static HttpResponse<String> put(String url, String json) throws Exception {
+        return http.send(HttpRequest.newBuilder(URI.create(url))
+                        .PUT(HttpRequest.BodyPublishers.ofString(json))
+                        .header("Content-Type", "application/json")
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    private static HttpResponse<String> delete(String url) throws Exception {
+        return http.send(HttpRequest.newBuilder(URI.create(url)).DELETE().build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    private static String buildDeployBody(String handler, int timeoutSeconds, String zipBase64) {
+        return String.format(
+                "{\"handler\":\"%s\",\"timeoutSeconds\":%d,\"zipBase64\":\"%s\"}",
+                handler, timeoutSeconds, zipBase64);
+    }
+
+    /**
+     * Builds a flat Azure Functions Node.js ZIP (function.json + index.js only).
+     * ContainerLauncher injects files at wwwroot/{funcName}/ and manages host.json
+     * separately, so ZIPs must not include host.json or a function-name subdirectory.
+     */
+    private static String buildFunctionZip(String responseMessage) throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            addZipEntry(zos, "function.json", """
+                    {
+                      "bindings": [
+                        {"authLevel":"anonymous","type":"httpTrigger","direction":"in",
+                         "name":"req","methods":["get","post"]},
+                        {"type":"http","direction":"out","name":"res"}
+                      ]
+                    }
+                    """);
+            addZipEntry(zos, "index.js",
+                    "module.exports = async function(context, req) {\n"
+                    + "  context.res = { status: 200, body: \"" + responseMessage + "\" };\n"
+                    + "};\n");
+        }
+        return Base64.getEncoder().encodeToString(baos.toByteArray());
+    }
+
+    private static void addZipEntry(ZipOutputStream zos, String name, String content) throws Exception {
+        zos.putNextEntry(new ZipEntry(name));
+        zos.write(content.getBytes(StandardCharsets.UTF_8));
+        zos.closeEntry();
+    }
+}

--- a/src/main/java/io/floci/az/services/functions/ContainerHandle.java
+++ b/src/main/java/io/floci/az/services/functions/ContainerHandle.java
@@ -8,15 +8,15 @@ public class ContainerHandle {
     public enum State { WARM, BUSY, STOPPED }
 
     private final String containerId;
-    private final String functionKey;   // "{account}/{appName}/{funcName}"
+    private final String appKey;        // "{account}/{appName}" — all functions in one app share one container
     private final String host;
     private final int port;             // host-mapped port for container's port 80
     private volatile long lastUsedMs;
     private volatile State state;
 
-    public ContainerHandle(String containerId, String functionKey, String host, int port) {
+    public ContainerHandle(String containerId, String appKey, String host, int port) {
         this.containerId  = containerId;
-        this.functionKey  = functionKey;
+        this.appKey       = appKey;
         this.host         = host;
         this.port         = port;
         this.lastUsedMs   = System.currentTimeMillis();
@@ -24,7 +24,7 @@ public class ContainerHandle {
     }
 
     public String containerId()  { return containerId; }
-    public String functionKey()  { return functionKey; }
+    public String appKey()       { return appKey; }
     public String host()         { return host; }
     public int    port()         { return port; }
     public State  state()        { return state; }

--- a/src/main/java/io/floci/az/services/functions/ContainerLauncher.java
+++ b/src/main/java/io/floci/az/services/functions/ContainerLauncher.java
@@ -14,6 +14,7 @@ import io.floci.az.core.dns.EmbeddedDnsServer;
 import io.floci.az.core.docker.ContainerDetector;
 import io.floci.az.core.docker.DockerHostResolver;
 import io.floci.az.services.functions.FunctionModels.FunctionDefinition;
+import java.util.List;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
@@ -24,6 +25,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -87,21 +89,27 @@ public class ContainerLauncher {
                 .build();
     }
 
-    public ContainerHandle launch(FunctionDefinition def) {
-        LOG.infov("Launching container for function: {0}/{1}", def.appName(), def.funcName());
+    /**
+     * Launches a single container for an entire function app.
+     * All deployed functions in {@code appDefs} have their code injected into
+     * the container under {@code /home/site/wwwroot/{funcName}/} so the
+     * Azure Functions host discovers and loads them all at startup.
+     */
+    public ContainerHandle launch(List<FunctionDefinition> appDefs) {
+        FunctionDefinition primary = appDefs.get(0);
+        LOG.infov("Launching app container for: {0} ({1} function(s))",
+                primary.appName(), appDefs.size());
 
-        if (def.codeLocalPath() != null && !Files.exists(Path.of(def.codeLocalPath()))) {
-            throw new RuntimeException("Code directory not found for " + def.funcName()
-                    + ": " + def.codeLocalPath());
-        }
-
-        String image = resolveImage(def.runtime());
+        String image = resolveImage(primary.runtime());
         ensureImage(image);
 
-        List<String> env = buildEnv(def);
+        List<String> env = buildEnv(primary);
 
         String shortId = UUID.randomUUID().toString().replace("-", "").substring(0, 8);
-        String containerName = "floci-az-fn-" + def.appName() + "-" + def.funcName() + "-" + shortId;
+        String containerName = "floci-az-fn-" + primary.appName() + "-" + shortId;
+
+        // Use primary as `def` alias for the remainder of the method
+        FunctionDefinition def = primary;
 
         // Create container with port 80 bound to a dynamic host port
         ExposedPort exposed  = ExposedPort.tcp(FUNCTIONS_PORT);
@@ -144,9 +152,16 @@ public class ContainerLauncher {
         String containerId = created.getId();
         LOG.infov("Created container {0} ({1})", containerName, containerId.substring(0, 12));
 
-        // Inject function code before starting so the Functions host finds it on startup
-        if (def.codeLocalPath() != null) {
-            copyCodeToContainer(containerId, Path.of(def.codeLocalPath()), def.funcName());
+        // Inject a shared host.json at the wwwroot root so the Functions host starts
+        // correctly when each function's code is in its own subdirectory.
+        injectHostJson(containerId);
+
+        // Inject code for every function in the app before starting so the Functions
+        // host finds them all at /home/site/wwwroot/{funcName}/ on startup.
+        for (FunctionDefinition fn : appDefs) {
+            if (fn.codeLocalPath() != null && Files.exists(Path.of(fn.codeLocalPath()))) {
+                copyCodeToContainer(containerId, Path.of(fn.codeLocalPath()), fn.funcName());
+            }
         }
 
         dockerClient.startContainerCmd(containerId).exec();
@@ -172,7 +187,7 @@ public class ContainerLauncher {
         int targetPort = targetHost.equals("localhost") ? hostPort : 80;
         waitForReady(targetHost, targetPort, 60);
 
-        return new ContainerHandle(containerId, def.functionKey(), targetHost, targetPort);
+        return new ContainerHandle(containerId, def.appKey(), targetHost, targetPort);
     }
 
     public void stop(ContainerHandle handle) {
@@ -270,13 +285,44 @@ public class ContainerLauncher {
         return Integer.parseInt(binding[0].getHostPortSpec());
     }
 
+    private void injectHostJson(String containerId) {
+        byte[] content = "{\"version\":\"2.0\"}".getBytes(StandardCharsets.UTF_8);
+        try (PipedOutputStream pos = new PipedOutputStream();
+             PipedInputStream pis = new PipedInputStream(pos, 65536)) {
+            Thread tarThread = new Thread(() -> {
+                try (pos; TarArchiveOutputStream tar = newTar(pos)) {
+                    TarArchiveEntry entry = new TarArchiveEntry("home/site/wwwroot/host.json");
+                    entry.setSize(content.length);
+                    entry.setMode(0644);
+                    tar.putArchiveEntry(entry);
+                    tar.write(content);
+                    tar.closeArchiveEntry();
+                } catch (IOException e) {
+                    LOG.errorv("Failed to stream host.json TAR: {0}", e.getMessage());
+                }
+            }, "tar-host-json");
+            tarThread.setDaemon(true);
+            tarThread.start();
+            dockerClient.copyArchiveToContainerCmd(containerId)
+                    .withRemotePath("/")
+                    .withTarInputStream(pis)
+                    .exec();
+            LOG.debugv("Injected host.json into {0}", WWWROOT);
+        } catch (Exception e) {
+            LOG.warnv("Failed to inject host.json: {0}", e.getMessage());
+        }
+    }
+
     private void copyCodeToContainer(String containerId, Path codeDir, String funcName) {
         try (PipedOutputStream pos = new PipedOutputStream();
              PipedInputStream  pis = new PipedInputStream(pos, 256 * 1024)) {
 
+            // Each function lives at /home/site/wwwroot/{funcName}/ so the Azure
+            // Functions host discovers all functions in the app from one container.
+            String prefix = "home/site/wwwroot/" + funcName + "/";
             Thread tarThread = new Thread(() -> {
                 try (pos) {
-                    createTarWithPrefix(codeDir, pos, "home/site/wwwroot/");
+                    createTarWithPrefix(codeDir, pos, prefix);
                 } catch (IOException e) {
                     LOG.errorv("Failed to stream TAR for {0}: {1}", funcName, e.getMessage());
                 }

--- a/src/main/java/io/floci/az/services/functions/FunctionModels.java
+++ b/src/main/java/io/floci/az/services/functions/FunctionModels.java
@@ -32,6 +32,11 @@ public class FunctionModels {
             @JsonInclude(JsonInclude.Include.NON_NULL) String codeLocalPath,
             Instant createdAt
     ) {
+        /** Pool key — all functions in one app share one container. */
+        public String appKey() {
+            return accountName + "/" + appName;
+        }
+
         public String functionKey() {
             return accountName + "/" + appName + "/" + funcName;
         }

--- a/src/main/java/io/floci/az/services/functions/FunctionsExecutorService.java
+++ b/src/main/java/io/floci/az/services/functions/FunctionsExecutorService.java
@@ -3,6 +3,7 @@ package io.floci.az.services.functions;
 import io.floci.az.core.AzureErrorResponse;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.services.functions.FunctionModels.FunctionDefinition;
+import java.util.List;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
@@ -45,7 +46,7 @@ public class FunctionsExecutorService {
                 .build();
     }
 
-    public Response invoke(FunctionDefinition def, AzureRequest request) {
+    public Response invoke(FunctionDefinition def, List<FunctionDefinition> appDefs, AzureRequest request) {
         if (def.codeLocalPath() == null) {
             return new AzureErrorResponse("FunctionCodeNotDeployed",
                     "No code has been deployed for function '" + def.funcName() + "'. "
@@ -55,12 +56,12 @@ public class FunctionsExecutorService {
 
         ContainerHandle handle = null;
         try {
-            handle = warmPool.acquire(def);
+            handle = warmPool.acquire(def, appDefs);
             return proxy(handle, request, def.funcName(), def.timeoutSeconds());
         } catch (Exception e) {
-            LOG.errorv("Invocation failed for {0}: {1}", def.functionKey(), e.getMessage());
+            LOG.errorv("Invocation failed for {0}: {1}", def.appKey(), e.getMessage());
             if (handle != null) {
-                warmPool.drain(def.functionKey());
+                warmPool.drain(def.appKey());
                 handle = null;
             }
             return new AzureErrorResponse("FunctionInvocationError", e.getMessage())

--- a/src/main/java/io/floci/az/services/functions/FunctionsServiceHandler.java
+++ b/src/main/java/io/floci/az/services/functions/FunctionsServiceHandler.java
@@ -168,14 +168,9 @@ public class FunctionsServiceHandler implements AzureServiceHandler {
     }
 
     private Response deleteApp(AzureRequest request, String appName) {
-        // Drain all warm containers for every function in the app
+        // Drain the shared app container pool before removing all functions.
+        warmPool.drain(request.accountName() + "/" + appName);
         String fnPrefix = fnScanPrefix(request.accountName(), appName);
-        store.scan(k -> k.startsWith(fnPrefix)).forEach(so -> {
-            try {
-                FunctionDefinition def = mapper.readValue(so.data(), FunctionDefinition.class);
-                warmPool.drain(def.functionKey());
-            } catch (IOException ignored) {}
-        });
         // Delete all function entries
         store.keys().stream()
                 .filter(k -> k.startsWith(fnPrefix))
@@ -226,8 +221,8 @@ public class FunctionsServiceHandler implements AzureServiceHandler {
                     codePath,
                     Instant.now());
 
-            // Drain stale warm containers on redeploy
-            warmPool.drain(def.functionKey());
+            // Drain the app container on redeploy — container must restart with updated code.
+            warmPool.drain(def.appKey());
             store.put(fnKey(request.accountName(), appName, funcName), toStoredObject(def));
 
             return Response.status(201).type(MediaType.APPLICATION_JSON)
@@ -267,12 +262,8 @@ public class FunctionsServiceHandler implements AzureServiceHandler {
 
     private Response deleteFunction(AzureRequest request, String appName, String funcName) {
         String key = fnKey(request.accountName(), appName, funcName);
-        store.get(key).ifPresent(so -> {
-            try {
-                FunctionDefinition def = mapper.readValue(so.data(), FunctionDefinition.class);
-                warmPool.drain(def.functionKey());
-            } catch (IOException ignored) {}
-        });
+        // Drain the app container — it must restart without the removed function.
+        warmPool.drain(request.accountName() + "/" + appName);
         store.delete(key);
         codeStore.deleteCode(request.accountName(), appName, funcName);
         return Response.noContent().build();
@@ -298,7 +289,19 @@ public class FunctionsServiceHandler implements AzureServiceHandler {
 
         try {
             FunctionDefinition def = mapper.readValue(fnSo.get().data(), FunctionDefinition.class);
-            return executor.invoke(def, request);
+
+            // All functions in the app share one container — collect them all so the
+            // launcher can inject every function's code before starting the host.
+            String fnPrefix = fnScanPrefix(request.accountName(), appName);
+            List<FunctionModels.FunctionDefinition> appDefs = store.scan(k -> k.startsWith(fnPrefix)).stream()
+                    .map(so -> {
+                        try { return mapper.readValue(so.data(), FunctionDefinition.class); }
+                        catch (IOException e) { return null; }
+                    })
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
+
+            return executor.invoke(def, appDefs, request);
         } catch (IOException e) {
             return Response.serverError().build();
         }

--- a/src/main/java/io/floci/az/services/functions/WarmPool.java
+++ b/src/main/java/io/floci/az/services/functions/WarmPool.java
@@ -2,6 +2,7 @@ package io.floci.az.services.functions;
 
 import io.floci.az.config.EmulatorConfig;
 import io.floci.az.services.functions.FunctionModels.FunctionDefinition;
+import java.util.List;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -76,24 +77,25 @@ public class WarmPool {
     }
 
     /**
-     * Returns a warm container for the function, cold-starting one if necessary.
+     * Returns a warm container for the app, cold-starting one if necessary.
+     * All functions in the app share the same container pool slot.
      */
-    public ContainerHandle acquire(FunctionDefinition def) {
+    public ContainerHandle acquire(FunctionDefinition def, List<FunctionDefinition> appDefs) {
         boolean ephemeral = config.services().functions().ephemeral();
         ContainerHandle handle = null;
 
         if (!ephemeral) {
-            ArrayDeque<ContainerHandle> q = pool.computeIfAbsent(def.functionKey(), k -> new ArrayDeque<>());
+            ArrayDeque<ContainerHandle> q = pool.computeIfAbsent(def.appKey(), k -> new ArrayDeque<>());
             synchronized (q) {
                 handle = q.pollFirst();
             }
         }
 
         if (handle == null) {
-            LOG.debugv(ephemeral ? "Ephemeral start: {0}" : "Cold start: {0}", def.functionKey());
-            handle = launcher.launch(def);
+            LOG.debugv(ephemeral ? "Ephemeral start: {0}" : "Cold start: {0}", def.appKey());
+            handle = launcher.launch(appDefs);
         } else {
-            LOG.debugv("Warm container reused: {0}", def.functionKey());
+            LOG.debugv("Warm container reused: {0}", def.appKey());
         }
 
         handle.setState(ContainerHandle.State.BUSY);
@@ -112,16 +114,16 @@ public class WarmPool {
         handle.setState(ContainerHandle.State.WARM);
         handle.touchLastUsed();
 
-        ArrayDeque<ContainerHandle> q = pool.computeIfAbsent(handle.functionKey(), k -> new ArrayDeque<>());
+        ArrayDeque<ContainerHandle> q = pool.computeIfAbsent(handle.appKey(), k -> new ArrayDeque<>());
         boolean returned;
         synchronized (q) {
             returned = q.size() < maxPoolSizePerFunction;
             if (returned) q.addFirst(handle);
         }
         if (returned) {
-            LOG.debugv("Container returned to pool: {0}", handle.functionKey());
+            LOG.debugv("Container returned to pool: {0}", handle.appKey());
         } else {
-            LOG.debugv("Pool full for {0}, discarding container", handle.functionKey());
+            LOG.debugv("Pool full for {0}, discarding container", handle.appKey());
             stopQuietly(handle);
         }
     }


### PR DESCRIPTION
## Summary

Each function in a Function App used its own container, meaning N functions in one app started N containers. Azure Functions hosts all functions of an app in a single process, so the emulator should match.

- Pool containers by appKey (account/appName) instead of per-function
- ContainerLauncher.launch() now accepts all app functions and injects each function's code at wwwroot/{funcName}/ before the container starts
- Injects a shared host.json at wwwroot/host.json so the Functions host discovers all functions on startup
- WarmPool.acquire() takes appDefs and passes them to the launcher; pool keyed on def.appKey()
- FunctionsExecutorService.invoke() accepts appDefs and forwards them
- FunctionsServiceHandler collects all functions in the app on invocation and passes the list to the executor

Fixes #39

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

<!-- For new actions: which SDK version and Azure CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
