### PR TITLE
feat(functions): Allow specifying runtime versions with linuxFxVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,9 @@ curl "$BASE/api/my-app/hello?msg=world"
 
 Supported runtimes: `node`, `python`, `java`, `dotnet`.
 
+To select a Linux language version, pass the Azure-compatible `linuxFxVersion`.
+For example, Python 3.12 uses `{"runtime":"python","linuxFxVersion":"Python|3.12"}`.
+
 </details>
 
 <details>

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/FunctionsLinuxFxVersionCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/FunctionsLinuxFxVersionCompatibilityTest.java
@@ -1,0 +1,91 @@
+package io.floci.az.compat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class FunctionsLinuxFxVersionCompatibilityTest {
+
+    private static final String BASE =
+            System.getenv().getOrDefault("FLOCI_AZ_ENDPOINT", "http://localhost:4577");
+    private static final String ACCOUNT = EmulatorConfig.ACCOUNT;
+    private static final String FUNCTIONS_BASE = BASE + "/" + ACCOUNT + "-functions";
+    private static final String SUBSCRIPTION = "00000000-0000-0000-0000-000000000001";
+    private static final String RESOURCE_GROUP = "linuxfx-rg";
+    private static final HttpClient http = HttpClient.newHttpClient();
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeAll
+    static void checkEmulator() {
+        EmulatorConfig.assumeEmulatorRunning();
+    }
+
+    @Test
+    void adminApiPersistsPythonLinuxFxVersion() throws Exception {
+        String appName = "linuxfx-admin-" + UUID.randomUUID().toString().substring(0, 8);
+        HttpResponse<String> create = put(FUNCTIONS_BASE + "/admin/apps/" + appName,
+                "{\"runtime\":\"python\",\"linuxFxVersion\":\"Python|3.12\"}");
+        assertEquals(201, create.statusCode(), create.body());
+        assertEquals("Python|3.12", mapper.readTree(create.body()).get("linuxFxVersion").asText());
+    }
+
+    @Test
+    void armSiteConfigPersistsAndBridgesPythonLinuxFxVersion() throws Exception {
+        String appName = "linuxfx-arm-" + UUID.randomUUID().toString().substring(0, 8);
+        String sitePath = BASE + "/subscriptions/" + SUBSCRIPTION
+                + "/resourceGroups/" + RESOURCE_GROUP
+                + "/providers/Microsoft.Web/sites/" + appName;
+        String siteUrl = sitePath + "?api-version=2024-11-01";
+
+        HttpResponse<String> create = put(siteUrl, """
+                {"location":"eastus","properties":{"siteConfig":{"linuxFxVersion":"Python|3.12"}}}
+                """);
+        assertEquals(200, create.statusCode(), create.body());
+
+        HttpResponse<String> config = get(sitePath + "/config/web?api-version=2024-11-01");
+        assertEquals(200, config.statusCode(), config.body());
+        JsonNode properties = mapper.readTree(config.body()).get("properties");
+        assertEquals("Python|3.12", properties.get("linuxFxVersion").asText());
+
+        HttpResponse<String> app = get(FUNCTIONS_BASE + "/admin/apps/" + appName);
+        assertEquals(200, app.statusCode(), app.body());
+        assertEquals("python", mapper.readTree(app.body()).get("runtime").asText());
+        assertEquals("Python|3.12", mapper.readTree(app.body()).get("linuxFxVersion").asText());
+    }
+
+    @Test
+    void armRejectsMalformedLinuxFxVersion() throws Exception {
+        String appName = "linuxfx-invalid-" + UUID.randomUUID().toString().substring(0, 8);
+        String siteUrl = BASE + "/subscriptions/" + SUBSCRIPTION
+                + "/resourceGroups/" + RESOURCE_GROUP
+                + "/providers/Microsoft.Web/sites/" + appName
+                + "?api-version=2024-11-01";
+
+        HttpResponse<String> create = put(siteUrl, """
+                {"properties":{"siteConfig":{"linuxFxVersion":"python-3.12"}}}
+                """);
+        assertEquals(400, create.statusCode(), create.body());
+    }
+
+    private static HttpResponse<String> get(String url) throws Exception {
+        return http.send(HttpRequest.newBuilder(URI.create(url)).GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    private static HttpResponse<String> put(String url, String json) throws Exception {
+        return http.send(HttpRequest.newBuilder(URI.create(url))
+                        .PUT(HttpRequest.BodyPublishers.ofString(json))
+                        .header("Content-Type", "application/json")
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+}

--- a/docs/services/functions.md
+++ b/docs/services/functions.md
@@ -41,12 +41,19 @@ Default account: `devstoreaccount1`
 **Create app request body:**
 ```json
 {
-  "runtime": "node",
+  "runtime": "python",
+  "linuxFxVersion": "Python|3.12",
   "environment": {
     "MY_VAR": "hello"
   }
 }
 ```
+
+`linuxFxVersion` is optional. When set, floci-az selects the matching Azure Functions
+Linux image, such as `mcr.microsoft.com/azure-functions/python:4-python3.12`.
+The ARM-compatible `Microsoft.Web/sites` and `Microsoft.Web/sites/{name}/config/web`
+paths accept the same setting under `properties.siteConfig.linuxFxVersion` and
+`properties.linuxFxVersion`, respectively.
 
 ### Functions
 

--- a/src/main/java/io/floci/az/services/arm/ArmHandler.java
+++ b/src/main/java/io/floci/az/services/arm/ArmHandler.java
@@ -5,6 +5,8 @@ import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
 import io.floci.az.services.blob.BlobServiceHandler;
+import io.floci.az.services.functions.FunctionRuntime;
+import io.floci.az.services.functions.FunctionsServiceHandler;
 import io.floci.az.services.queue.QueueServiceHandler;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -43,21 +45,26 @@ public class ArmHandler implements AzureServiceHandler {
 
     private static final String SUBSCRIPTION_ID = "00000000-0000-0000-0000-000000000001";
     private static final String TENANT_ID       = "00000000-0000-0000-0000-000000000002";
+    private static final String DEFAULT_FUNCTIONS_ACCOUNT = "devstoreaccount1";
 
     // In-memory ARM resource state — no StorageBackend needed, these are ephemeral
     private final Map<String, Map<String, Object>> resourceGroups   = new ConcurrentHashMap<>();
     private final Map<String, Map<String, Object>> storageAccounts  = new ConcurrentHashMap<>();
     private final Map<String, Map<String, Object>> keyVaults        = new ConcurrentHashMap<>();
+    private final Map<String, Map<String, Object>> webApps          = new ConcurrentHashMap<>();
 
     private final EmulatorConfig config;
     private final BlobServiceHandler blobHandler;
     private final QueueServiceHandler queueHandler;
+    private final FunctionsServiceHandler functionsHandler;
 
     @Inject
-    public ArmHandler(EmulatorConfig config, BlobServiceHandler blobHandler, QueueServiceHandler queueHandler) {
-        this.config       = config;
-        this.blobHandler  = blobHandler;
-        this.queueHandler = queueHandler;
+    public ArmHandler(EmulatorConfig config, BlobServiceHandler blobHandler, QueueServiceHandler queueHandler,
+                      FunctionsServiceHandler functionsHandler) {
+        this.config           = config;
+        this.blobHandler      = blobHandler;
+        this.queueHandler     = queueHandler;
+        this.functionsHandler = functionsHandler;
     }
 
     @Override
@@ -164,6 +171,10 @@ public class ArmHandler implements AzureServiceHandler {
                     .filter(v -> sub.equals(v.get("_sub")) && rg.equals(v.get("_rg")))
                     .map(ArmHandler::stripInternal)
                     .forEach(resources::add);
+            webApps.values().stream()
+                    .filter(v -> sub.equals(v.get("_sub")) && rg.equals(v.get("_rg")))
+                    .map(ArmHandler::stripInternal)
+                    .forEach(resources::add);
             return Response.ok(Map.of("value", resources)).build();
         }
 
@@ -184,7 +195,125 @@ public class ArmHandler implements AzureServiceHandler {
         if (path.contains("/providers/Microsoft.KeyVault/")) {
             return handleKeyVault(req, path, method, sub);
         }
+        if (path.contains("/providers/Microsoft.Web/")) {
+            return handleWeb(req, path, method, sub);
+        }
         return armNotFound(path);
+    }
+
+    // ── Function Apps ────────────────────────────────────────────────────────
+
+    private Response handleWeb(AzureRequest req, String path, String method, String sub) {
+        String rg = extractRg(path);
+
+        if (path.matches(".*/providers/Microsoft\\.Web/sites([?].*)?")) {
+            List<Map<String, Object>> apps = webApps.values().stream()
+                    .filter(a -> sub.equals(a.get("_sub")) && rg.equals(a.get("_rg")))
+                    .map(ArmHandler::stripInternal)
+                    .toList();
+            return Response.ok(Map.of("value", apps)).build();
+        }
+
+        if (path.contains("/sites/")) {
+            String appName = extractResourceName(path, "sites");
+            if (path.contains("/config/web")) {
+                return handleWebConfig(req, path, method, sub, rg, appName);
+            }
+            return switch (method) {
+                case "PUT"    -> createOrUpdateWebApp(req, sub, rg, appName);
+                case "GET"    -> getWebApp(sub, rg, appName);
+                case "DELETE" -> { webApps.remove(webAppKey(sub, rg, appName)); yield Response.ok().build(); }
+                default       -> Response.status(405).build();
+            };
+        }
+
+        return armNotFound(path);
+    }
+
+    private Response createOrUpdateWebApp(AzureRequest req, String sub, String rg, String appName) {
+        Map<String, Object> body = parseBody(req);
+        Map<String, Object> properties = cast(body.get("properties"));
+        Map<String, Object> siteConfig = cast(properties.get("siteConfig"));
+        String linuxFxVersion = bodyString(siteConfig, "linuxFxVersion", null);
+        try {
+            Map<String, Object> resource = webAppResource(sub, rg, appName,
+                    bodyString(body, "location", "eastus"), linuxFxVersion);
+            syncFunctionApp(appName, linuxFxVersion);
+            webApps.put(webAppKey(sub, rg, appName), resource);
+            return Response.ok(stripInternal(resource)).build();
+        } catch (IllegalArgumentException e) {
+            return Response.status(400).entity(Map.of("error", Map.of(
+                    "code", "InvalidLinuxFxVersion", "message", e.getMessage()))).build();
+        }
+    }
+
+    private Response getWebApp(String sub, String rg, String appName) {
+        Map<String, Object> resource = webApps.get(webAppKey(sub, rg, appName));
+        return resource == null ? armNotFound("sites/" + appName)
+                : Response.ok(stripInternal(resource)).build();
+    }
+
+    private Response handleWebConfig(AzureRequest req, String path, String method, String sub,
+                                     String rg, String appName) {
+        Map<String, Object> resource = webApps.get(webAppKey(sub, rg, appName));
+        if (resource == null) {
+            return armNotFound("sites/" + appName);
+        }
+        if ("GET".equals(method)) {
+            return Response.ok(Map.of("id", path, "name", "web",
+                    "type", "Microsoft.Web/sites/config",
+                    "properties", cast(resource.get("properties")).get("siteConfig"))).build();
+        }
+        if (!"PUT".equals(method)) {
+            return Response.status(405).build();
+        }
+
+        Map<String, Object> body = parseBody(req);
+        Map<String, Object> config = body.containsKey("properties") ? cast(body.get("properties")) : body;
+        String linuxFxVersion = bodyString(config, "linuxFxVersion", null);
+        try {
+            Map<String, Object> updated = webAppResource(sub, rg, appName,
+                    bodyString(resource, "location", "eastus"), linuxFxVersion);
+            syncFunctionApp(appName, linuxFxVersion);
+            webApps.put(webAppKey(sub, rg, appName), updated);
+            return Response.ok(Map.of("id", path, "name", "web",
+                    "type", "Microsoft.Web/sites/config",
+                    "properties", cast(updated.get("properties")).get("siteConfig"))).build();
+        } catch (IllegalArgumentException e) {
+            return Response.status(400).entity(Map.of("error", Map.of(
+                    "code", "InvalidLinuxFxVersion", "message", e.getMessage()))).build();
+        }
+    }
+
+    private void syncFunctionApp(String appName, String linuxFxVersion) {
+        if (linuxFxVersion == null || linuxFxVersion.isBlank()) {
+            return;
+        }
+        String runtime = FunctionRuntime.runtimeFromLinuxFxVersion(linuxFxVersion);
+        functionsHandler.upsertApp(DEFAULT_FUNCTIONS_ACCOUNT, appName, runtime, linuxFxVersion, null);
+    }
+
+    private static Map<String, Object> webAppResource(String sub, String rg, String appName,
+                                                       String location, String linuxFxVersion) {
+        Map<String, Object> siteConfig = new LinkedHashMap<>();
+        if (linuxFxVersion != null) {
+            siteConfig.put("linuxFxVersion", linuxFxVersion);
+        }
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("state", "Running");
+        properties.put("siteConfig", siteConfig);
+
+        Map<String, Object> resource = new LinkedHashMap<>();
+        resource.put("_sub", sub);
+        resource.put("_rg", rg);
+        resource.put("id", "/subscriptions/" + sub + "/resourceGroups/" + rg
+                + "/providers/Microsoft.Web/sites/" + appName);
+        resource.put("name", appName);
+        resource.put("type", "Microsoft.Web/sites");
+        resource.put("location", location);
+        resource.put("kind", "functionapp,linux");
+        resource.put("properties", properties);
+        return resource;
     }
 
     // ── Storage Accounts ─────────────────────────────────────────────────────
@@ -503,6 +632,7 @@ public class ArmHandler implements AzureServiceHandler {
     private static String rgKey(String sub, String rg)               { return sub + "/" + rg; }
     private static String saKey(String sub, String rg, String name)  { return sub + "/" + rg + "/" + name; }
     private static String kvKey(String sub, String rg, String name)  { return sub + "/" + rg + "/kv/" + name; }
+    private static String webAppKey(String sub, String rg, String name) { return sub + "/" + rg + "/web/" + name; }
 
     @SuppressWarnings("unchecked")
     private static Map<String, Object> cast(Object o) {

--- a/src/main/java/io/floci/az/services/functions/ContainerLauncher.java
+++ b/src/main/java/io/floci/az/services/functions/ContainerLauncher.java
@@ -58,13 +58,6 @@ public class ContainerLauncher {
     private static final String WWWROOT = "/home/site/wwwroot";
     private static final int FUNCTIONS_PORT = 80;
 
-    private static final Map<String, String> RUNTIME_IMAGES = Map.of(
-            "node",   "mcr.microsoft.com/azure-functions/node:4",
-            "python", "mcr.microsoft.com/azure-functions/python:4",
-            "java",   "mcr.microsoft.com/azure-functions/java:4",
-            "dotnet", "mcr.microsoft.com/azure-functions/dotnet-isolated:4"
-    );
-
     private final DockerClient dockerClient;
     private final DockerHostResolver hostResolver;
     private final ContainerDetector containerDetector;
@@ -100,7 +93,7 @@ public class ContainerLauncher {
         LOG.infov("Launching app container for: {0} ({1} function(s))",
                 primary.appName(), appDefs.size());
 
-        String image = resolveImage(primary.runtime());
+        String image = FunctionRuntime.resolveImage(primary.runtime(), primary.linuxFxVersion());
         ensureImage(image);
 
         List<String> env = buildEnv(primary);
@@ -225,15 +218,6 @@ public class ContainerLauncher {
             LOG.warnv("Failed to detect self network, falling back to bridge: {0}", e.getMessage());
         }
         return "bridge";
-    }
-
-    private String resolveImage(String runtime) {
-        String image = RUNTIME_IMAGES.get(runtime != null ? runtime.toLowerCase() : "node");
-        if (image == null) {
-            throw new RuntimeException("Unsupported runtime: " + runtime
-                    + ". Supported: " + RUNTIME_IMAGES.keySet());
-        }
-        return image;
     }
 
     private void ensureImage(String image) {

--- a/src/main/java/io/floci/az/services/functions/FunctionModels.java
+++ b/src/main/java/io/floci/az/services/functions/FunctionModels.java
@@ -16,6 +16,7 @@ public class FunctionModels {
             String appName,
             String accountName,
             String runtime,
+            @JsonInclude(JsonInclude.Include.NON_NULL) String linuxFxVersion,
             @JsonInclude(JsonInclude.Include.NON_NULL) Map<String, String> environment,
             Instant createdAt
     ) {}
@@ -26,6 +27,7 @@ public class FunctionModels {
             String funcName,
             String accountName,
             String runtime,
+            @JsonInclude(JsonInclude.Include.NON_NULL) String linuxFxVersion,
             String handler,
             int timeoutSeconds,
             @JsonInclude(JsonInclude.Include.NON_NULL) Map<String, String> environment,
@@ -47,6 +49,7 @@ public class FunctionModels {
     @RegisterForReflection
     public record CreateAppRequest(
             String runtime,
+            @JsonInclude(JsonInclude.Include.NON_NULL) String linuxFxVersion,
             @JsonInclude(JsonInclude.Include.NON_NULL) Map<String, String> environment
     ) {}
 
@@ -64,6 +67,7 @@ public class FunctionModels {
     public record AppResponse(
             String name,
             String runtime,
+            @JsonInclude(JsonInclude.Include.NON_NULL) String linuxFxVersion,
             String status,
             Instant createdAt
     ) {}
@@ -73,6 +77,7 @@ public class FunctionModels {
             String name,
             String appName,
             String runtime,
+            @JsonInclude(JsonInclude.Include.NON_NULL) String linuxFxVersion,
             String handler,
             int timeoutSeconds,
             String invokeUrl,

--- a/src/main/java/io/floci/az/services/functions/FunctionRuntime.java
+++ b/src/main/java/io/floci/az/services/functions/FunctionRuntime.java
@@ -1,0 +1,69 @@
+package io.floci.az.services.functions;
+
+import java.util.Locale;
+import java.util.Map;
+
+public final class FunctionRuntime {
+
+    private static final Map<String, String> DEFAULT_IMAGES = Map.of(
+            "node",   "mcr.microsoft.com/azure-functions/node:4",
+            "python", "mcr.microsoft.com/azure-functions/python:4",
+            "java",   "mcr.microsoft.com/azure-functions/java:4",
+            "dotnet", "mcr.microsoft.com/azure-functions/dotnet-isolated:4"
+    );
+
+    private FunctionRuntime() {}
+
+    public static String resolveImage(String runtime, String linuxFxVersion) {
+        String normalizedRuntime = normalizeRuntime(runtime);
+        if (linuxFxVersion == null || linuxFxVersion.isBlank()) {
+            return defaultImage(normalizedRuntime);
+        }
+
+        String[] parts = linuxFxVersion.split("\\|", 2);
+        if (parts.length != 2 || parts[0].isBlank() || parts[1].isBlank()) {
+            throw new IllegalArgumentException("Invalid linuxFxVersion: " + linuxFxVersion
+                    + ". Expected a value such as Python|3.12.");
+        }
+
+        String stack = normalizeRuntime(parts[0]);
+        String version = parts[1].trim();
+        if (!stack.equals(normalizedRuntime)) {
+            throw new IllegalArgumentException("linuxFxVersion stack '" + parts[0]
+                    + "' does not match runtime '" + runtime + "'.");
+        }
+
+        return switch (normalizedRuntime) {
+            case "python" -> "mcr.microsoft.com/azure-functions/python:4-python" + version;
+            case "node"   -> "mcr.microsoft.com/azure-functions/node:4-node" + version;
+            case "java"   -> "mcr.microsoft.com/azure-functions/java:4-java" + version;
+            default       -> defaultImage(normalizedRuntime);
+        };
+    }
+
+    public static String runtimeFromLinuxFxVersion(String linuxFxVersion) {
+        if (linuxFxVersion == null || linuxFxVersion.isBlank()) {
+            return null;
+        }
+        String[] parts = linuxFxVersion.split("\\|", 2);
+        if (parts.length != 2 || parts[0].isBlank() || parts[1].isBlank()) {
+            throw new IllegalArgumentException("Invalid linuxFxVersion: " + linuxFxVersion
+                    + ". Expected a value such as Python|3.12.");
+        }
+        return normalizeRuntime(parts[0]);
+    }
+
+    private static String normalizeRuntime(String runtime) {
+        String normalized = runtime == null ? "" : runtime.trim().toLowerCase(Locale.ROOT);
+        return "dotnet-isolated".equals(normalized) ? "dotnet" : normalized;
+    }
+
+    private static String defaultImage(String runtime) {
+        String image = DEFAULT_IMAGES.get(runtime);
+        if (image == null) {
+            throw new IllegalArgumentException("Unsupported runtime: " + runtime
+                    + ". Supported: " + DEFAULT_IMAGES.keySet());
+        }
+        return image;
+    }
+}

--- a/src/main/java/io/floci/az/services/functions/FunctionsServiceHandler.java
+++ b/src/main/java/io/floci/az/services/functions/FunctionsServiceHandler.java
@@ -127,18 +127,31 @@ public class FunctionsServiceHandler implements AzureServiceHandler {
     private Response createApp(AzureRequest request, String appName) {
         try {
             CreateAppRequest body = mapper.readValue(request.bodyStream(), CreateAppRequest.class);
-            if (body.runtime() == null || body.runtime().isBlank()) {
+            String runtime = body.runtime();
+            if ((runtime == null || runtime.isBlank()) && body.linuxFxVersion() != null) {
+                runtime = FunctionRuntime.runtimeFromLinuxFxVersion(body.linuxFxVersion());
+            }
+            if (runtime == null || runtime.isBlank()) {
                 return error("InvalidInput", "runtime is required", 400);
             }
+            FunctionRuntime.resolveImage(runtime, body.linuxFxVersion());
             String key = appKey(request.accountName(), appName);
             FunctionApp app = new FunctionApp(appName, request.accountName(),
-                    body.runtime(), body.environment(), Instant.now());
+                    runtime, body.linuxFxVersion(), body.environment(), Instant.now());
             store.put(key, toStoredObject(app));
             return Response.status(201).type(MediaType.APPLICATION_JSON)
                     .entity(toAppResponse(app)).build();
-        } catch (IOException e) {
+        } catch (IOException | IllegalArgumentException e) {
             return error("InvalidInput", "Invalid request body: " + e.getMessage(), 400);
         }
+    }
+
+    public void upsertApp(String accountName, String appName, String runtime, String linuxFxVersion,
+                          Map<String, String> environment) {
+        FunctionRuntime.resolveImage(runtime, linuxFxVersion);
+        FunctionApp app = new FunctionApp(appName, accountName, runtime, linuxFxVersion,
+                environment, Instant.now());
+        store.put(appKey(accountName, appName), toStoredObject(app));
     }
 
     private Response getApp(AzureRequest request, String appName) {
@@ -215,6 +228,7 @@ public class FunctionsServiceHandler implements AzureServiceHandler {
             FunctionDefinition def = new FunctionDefinition(
                     appName, funcName, request.accountName(),
                     app.runtime(),
+                    app.linuxFxVersion(),
                     body.handler() != null ? body.handler() : "index.handler",
                     body.timeoutSeconds() > 0 ? body.timeoutSeconds() : 230,
                     env.isEmpty() ? null : env,
@@ -326,14 +340,15 @@ public class FunctionsServiceHandler implements AzureServiceHandler {
     }
 
     private AppResponse toAppResponse(FunctionApp app) {
-        return new AppResponse(app.appName(), app.runtime(), "Running", app.createdAt());
+        return new AppResponse(app.appName(), app.runtime(), app.linuxFxVersion(),
+                "Running", app.createdAt());
     }
 
     private FunctionResponse toFunctionResponse(FunctionDefinition def, String accountName) {
         String invokeUrl = config.effectiveBaseUrl() + "/" + accountName
                 + "-functions/api/" + def.appName() + "/" + def.funcName();
         return new FunctionResponse(
-                def.funcName(), def.appName(), def.runtime(), def.handler(),
+                def.funcName(), def.appName(), def.runtime(), def.linuxFxVersion(), def.handler(),
                 def.timeoutSeconds(), invokeUrl,
                 def.codeLocalPath() != null ? "Ready" : "AwaitingDeploy",
                 def.createdAt());

--- a/src/test/java/io/floci/az/services/functions/FunctionRuntimeTest.java
+++ b/src/test/java/io/floci/az/services/functions/FunctionRuntimeTest.java
@@ -1,0 +1,32 @@
+package io.floci.az.services.functions;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class FunctionRuntimeTest {
+
+    @Test
+    void pythonLinuxFxVersionSelectsVersionedImage() {
+        assertEquals("mcr.microsoft.com/azure-functions/python:4-python3.12",
+                FunctionRuntime.resolveImage("python", "Python|3.12"));
+    }
+
+    @Test
+    void missingLinuxFxVersionKeepsDefaultImage() {
+        assertEquals("mcr.microsoft.com/azure-functions/python:4",
+                FunctionRuntime.resolveImage("python", null));
+    }
+
+    @Test
+    void linuxFxVersionStackMustMatchRuntime() {
+        assertThrows(IllegalArgumentException.class,
+                () -> FunctionRuntime.resolveImage("python", "Node|22"));
+    }
+
+    @Test
+    void runtimeCanBeDerivedFromLinuxFxVersion() {
+        assertEquals("python", FunctionRuntime.runtimeFromLinuxFxVersion("Python|3.12"));
+    }
+}


### PR DESCRIPTION
Introduce FunctionRuntime utility to resolve Docker images based on runtime and linuxFxVersion. Update Functions service to store and use linuxFxVersion in app and function definitions. Integrate Microsoft.Web/sites ARM resources to persist linuxFxVersion and bridge to internal function app definitions. Add unit and compatibility tests.
Update documentation.

close #38 

## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [X] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

<!-- For new actions: which SDK version and Azure CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [X] `./mvnw test` passes locally
- [X] New or updated integration test added
- [X] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
