### PR TITLE
feat(vm): add Azure Virtual Machines support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **vm:** Azure Virtual Machines emulation (`Microsoft.Compute/virtualMachines`) — VM lifecycle (CreateOrUpdate, Get, List by subscription and resource group, UpdateTags, Delete), power actions (`start`, `powerOff`, `deallocate`, `restart`, `redeploy`, `reapply`), `instanceView` reporting `ProvisioningState/*` and `PowerState/*`, and `?$expand=instanceView`. Power actions return `202` with an `Azure-AsyncOperation` header and a terminal operation-status endpoint for SDK LRO polling. Mocked mode (default) requires no Docker; container-backed VMs are planned ([#19](https://github.com/floci-io/floci-az/issues/19))
+- **arm:** `Microsoft.Network` dependency stubs — virtual networks, subnets, network interfaces (synthesized private IP), public IP addresses, and network security groups, so Terraform's `azurerm_linux_virtual_machine` and its dependencies apply end-to-end
+- **arm:** Terraform/OpenTofu compatibility suite extended with a Linux virtual machine and its network dependencies
+
 ## [0.5.0] - 2026-05-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- 
 AI Context: This is Floci-Az, a lightweight Local Azure Emulator. 
 Identity: It is the Azure equivalent of Floci (AWS). It is NOT LocalStack.
-Protocols: Implements Azure Storage (Blob, Queue, Table), Azure Functions, App Configuration, Key Vault, Event Hubs, Cosmos DB, Azure SQL Database, and Azure Kubernetes Service (AKS).
+Protocols: Implements Azure Storage (Blob, Queue, Table), Azure Functions, App Configuration, Key Vault, Event Hubs, Cosmos DB, Azure SQL Database, Azure Kubernetes Service (AKS), and Virtual Machines (Microsoft.Compute).
 Default Port: 4577 (HTTP; also HTTPS when FLOCI_AZ_TLS_ENABLED=true via protocol-sniffing proxy). AMQP port: 5672 (Event Hubs). Kafka port: 9093 (Event Hubs, opt-in). k3s API: 6443-7443 (AKS).
 Tech Stack: Java, Quarkus, Docker-in-Docker for Functions. Artemis sidecar for Event Hubs AMQP. Redpanda sidecar for Kafka. k3s sidecar for AKS.
 TLS: Optional. Set FLOCI_AZ_TLS_ENABLED=true. Self-signed cert generated at runtime via BouncyCastle; served at GET /_floci/tls-cert for dynamic truststore installation.
@@ -55,6 +55,7 @@ Floci AZ is a free, open-source local Azure emulator for development, testing, a
 | Event Hubs          | ✅                         | ❌                                           | ❌                                                                           |
 | Azure SQL Database  | ✅                         | ❌                                           | ❌                                                                           |
 | AKS (Kubernetes)    | ✅                         | ❌                                           | ❌                                                                           |
+| Virtual Machines    | ✅                         | ❌                                           | ❌                                                                           |
 | Native binary       | ✅                         | ❌                                           | ✅                                                                           |
 | Unified port        | ✅ (4577)                  | ❌                                           | ❌                                                                           |
 | Storage modes       | ✅ (persistent/WAL/Hybrid) | ❌                                           | ❌                                                                           |
@@ -209,6 +210,7 @@ flowchart LR
 | **Event Hubs**          | AMQP `:5672` / Kafka `:9093` | AMQP 1.0 (Artemis sidecar), Kafka-compatible (Redpanda, opt-in)                                                                                                                                                       |
 | **Azure SQL Database**  | ARM path + `/{account}-sql/` | Servers, databases, firewall rules; Docker-backed `azure-sql-edge` containers; dynamic port allocation                                                                                                               |
 | **Azure Kubernetes Service** | ARM path (`Microsoft.ContainerService`) | CreateOrUpdate, Get, Delete, List, agent pools, kubeconfig (`listClusterAdminCredential`); real k3s containers or mocked |
+| **Virtual Machines**    | ARM path (`Microsoft.Compute` / `Microsoft.Network`) | VM lifecycle (create/start/stop/deallocate/restart/delete/list), instanceView power state, network dependency stubs (vnet/subnet/NIC/public IP/NSG); mocked — no Docker (container backing planned) |
 
 ## Persistence & Storage Modes
 

--- a/compatibility-tests/compat-opentofu/main.tf
+++ b/compatibility-tests/compat-opentofu/main.tf
@@ -43,6 +43,60 @@ resource "azurerm_key_vault_secret" "secret" {
   key_vault_id = azurerm_key_vault.kv.id
 }
 
+resource "azurerm_virtual_network" "vnet" {
+  name                = "floci-test-vnet"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+}
+
+resource "azurerm_subnet" "subnet" {
+  name                 = "floci-test-subnet"
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_network_interface" "nic" {
+  name                = "floci-test-nic"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.subnet.id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+
+resource "azurerm_linux_virtual_machine" "vm" {
+  name                  = "floci-test-vm"
+  resource_group_name   = azurerm_resource_group.rg.name
+  location              = azurerm_resource_group.rg.location
+  size                  = "Standard_B1s"
+  admin_username        = "azureuser"
+  network_interface_ids = [azurerm_network_interface.nic.id]
+
+  admin_password                  = "FlociAz_Strong123!"
+  disable_password_authentication = false
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
+    version   = "latest"
+  }
+}
+
+output "vm_id" {
+  value = azurerm_linux_virtual_machine.vm.id
+}
+
 output "storage_account_name" {
   value = azurerm_storage_account.sa.name
 }

--- a/compatibility-tests/compat-opentofu/test/opentofu.bats
+++ b/compatibility-tests/compat-opentofu/test/opentofu.bats
@@ -95,3 +95,28 @@ setup() {
     assert_success
     assert_output --partial "hello-from-opentofu"
 }
+
+@test "OpenTofu: virtual network created" {
+    run arm_get "subscriptions/${SUB_ID}/resourceGroups/${RG_NAME}/providers/Microsoft.Network/virtualNetworks/${VNET_NAME}"
+    assert_success
+    assert_output --partial "$VNET_NAME"
+}
+
+@test "OpenTofu: network interface has a private IP" {
+    run arm_get "subscriptions/${SUB_ID}/resourceGroups/${RG_NAME}/providers/Microsoft.Network/networkInterfaces/${NIC_NAME}"
+    assert_success
+    assert_output --partial "privateIPAddress"
+}
+
+@test "OpenTofu: linux virtual machine created with Succeeded state" {
+    run arm_get "subscriptions/${SUB_ID}/resourceGroups/${RG_NAME}/providers/Microsoft.Compute/virtualMachines/${VM_NAME}"
+    assert_success
+    assert_output --partial "Microsoft.Compute/virtualMachines"
+    assert_output --partial "Succeeded"
+}
+
+@test "OpenTofu: VM instanceView reports running power state" {
+    run arm_get "subscriptions/${SUB_ID}/resourceGroups/${RG_NAME}/providers/Microsoft.Compute/virtualMachines/${VM_NAME}/instanceView"
+    assert_success
+    assert_output --partial "PowerState/running"
+}

--- a/compatibility-tests/compat-opentofu/test/test_helper/common-setup.bash
+++ b/compatibility-tests/compat-opentofu/test/test_helper/common-setup.bash
@@ -25,6 +25,9 @@ export KV_NAME="floci-test-kv"
 export CONTAINER_NAME="floci-test-container"
 export QUEUE_NAME="floci-test-queue"
 export SECRET_NAME="floci-test-secret"
+export VNET_NAME="floci-test-vnet"
+export NIC_NAME="floci-test-nic"
+export VM_NAME="floci-test-vm"
 export SUB_ID="${TF_VAR_subscription_id}"
 
 arm_get() {

--- a/compatibility-tests/compat-terraform/main.tf
+++ b/compatibility-tests/compat-terraform/main.tf
@@ -43,6 +43,60 @@ resource "azurerm_key_vault_secret" "secret" {
   key_vault_id = azurerm_key_vault.kv.id
 }
 
+resource "azurerm_virtual_network" "vnet" {
+  name                = "floci-test-vnet"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+}
+
+resource "azurerm_subnet" "subnet" {
+  name                 = "floci-test-subnet"
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_network_interface" "nic" {
+  name                = "floci-test-nic"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.subnet.id
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+
+resource "azurerm_linux_virtual_machine" "vm" {
+  name                  = "floci-test-vm"
+  resource_group_name   = azurerm_resource_group.rg.name
+  location              = azurerm_resource_group.rg.location
+  size                  = "Standard_B1s"
+  admin_username        = "azureuser"
+  network_interface_ids = [azurerm_network_interface.nic.id]
+
+  admin_password                  = "FlociAz_Strong123!"
+  disable_password_authentication = false
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts"
+    version   = "latest"
+  }
+}
+
+output "vm_id" {
+  value = azurerm_linux_virtual_machine.vm.id
+}
+
 output "storage_account_name" {
   value = azurerm_storage_account.sa.name
 }

--- a/compatibility-tests/compat-terraform/test/terraform.bats
+++ b/compatibility-tests/compat-terraform/test/terraform.bats
@@ -95,3 +95,28 @@ setup() {
     assert_success
     assert_output --partial "hello-from-terraform"
 }
+
+@test "Terraform: virtual network created" {
+    run arm_get "subscriptions/${SUB_ID}/resourceGroups/${RG_NAME}/providers/Microsoft.Network/virtualNetworks/${VNET_NAME}"
+    assert_success
+    assert_output --partial "$VNET_NAME"
+}
+
+@test "Terraform: network interface has a private IP" {
+    run arm_get "subscriptions/${SUB_ID}/resourceGroups/${RG_NAME}/providers/Microsoft.Network/networkInterfaces/${NIC_NAME}"
+    assert_success
+    assert_output --partial "privateIPAddress"
+}
+
+@test "Terraform: linux virtual machine created with Succeeded state" {
+    run arm_get "subscriptions/${SUB_ID}/resourceGroups/${RG_NAME}/providers/Microsoft.Compute/virtualMachines/${VM_NAME}"
+    assert_success
+    assert_output --partial "Microsoft.Compute/virtualMachines"
+    assert_output --partial "Succeeded"
+}
+
+@test "Terraform: VM instanceView reports running power state" {
+    run arm_get "subscriptions/${SUB_ID}/resourceGroups/${RG_NAME}/providers/Microsoft.Compute/virtualMachines/${VM_NAME}/instanceView"
+    assert_success
+    assert_output --partial "PowerState/running"
+}

--- a/compatibility-tests/compat-terraform/test/test_helper/common-setup.bash
+++ b/compatibility-tests/compat-terraform/test/test_helper/common-setup.bash
@@ -25,6 +25,9 @@ export KV_NAME="floci-test-kv"
 export CONTAINER_NAME="floci-test-container"
 export QUEUE_NAME="floci-test-queue"
 export SECRET_NAME="floci-test-secret"
+export VNET_NAME="floci-test-vnet"
+export NIC_NAME="floci-test-nic"
+export VM_NAME="floci-test-vm"
 export SUB_ID="${TF_VAR_subscription_id}"
 
 arm_get() {

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -15,6 +15,7 @@ Floci-AZ provides emulation for several core Azure services.
 | **Event Hubs** | AMQP `:5672` / Kafka `:9093` | ✅ AMQP 1.0 (Artemis), Kafka-compatible (Redpanda, opt-in) |
 | **Azure SQL Database** | ARM path + `/{account}-sql/` | ✅ Servers, databases, firewall rules; Docker-backed SQL Server containers |
 | **Azure Kubernetes Service** | ARM path (`Microsoft.ContainerService`) | ✅ Clusters, agent pools, credentials; real k3s containers or mocked |
+| **Virtual Machines** | ARM path (`Microsoft.Compute` / `Microsoft.Network`) | ✅ VM lifecycle (create/start/stop/deallocate/restart/delete/list), instanceView, network dependency stubs; mocked (Docker backing planned) |
 
 ## Unified Endpoint
 

--- a/docs/services/vm.md
+++ b/docs/services/vm.md
@@ -1,0 +1,124 @@
+# Azure Virtual Machines (VM)
+
+Compatible with the `azure-mgmt-compute` SDK, the `az vm` CLI, Terraform's `azurerm_linux_virtual_machine`, and any ARM-speaking client.
+
+> **No Docker required** (mocked mode, the default). VMs are emulated as pure ARM control-plane
+> resources: they provision instantly and report power state. Real Docker-backed VMs are planned
+> (set `FLOCI_AZ_SERVICES_VM_MOCKED=false` once available).
+
+---
+
+## Features
+
+- **Lifecycle** — CreateOrUpdate, Get, Delete, List (by subscription and by resource group), UpdateTags
+- **Power actions** — `start`, `powerOff`, `deallocate`, `restart`, `redeploy`, `reapply`
+- **instanceView** — reports `ProvisioningState/*` and `PowerState/*` statuses
+- **Network dependency stubs** — `Microsoft.Network` shells (virtual networks, subnets, network
+  interfaces, public IPs, network security groups) so `azurerm_linux_virtual_machine` and its
+  dependencies apply end-to-end. Network interfaces get a synthesized private IP.
+- **Long-running operations** — power actions return `202` with an `Azure-AsyncOperation` header
+  pointing at an operation-status endpoint, so SDK pollers complete cleanly.
+
+---
+
+## Endpoints
+
+All operations use ARM paths:
+
+```
+PUT    /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Compute/virtualMachines/{name}
+GET    /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Compute/virtualMachines/{name}
+PATCH  /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Compute/virtualMachines/{name}
+DELETE /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Compute/virtualMachines/{name}
+GET    .../virtualMachines/{name}/instanceView
+POST   .../virtualMachines/{name}/{start|powerOff|deallocate|restart|redeploy|reapply}
+GET    /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Compute/virtualMachines
+GET    /subscriptions/{sub}/providers/Microsoft.Compute/virtualMachines
+
+# Network dependency shells
+PUT/GET/DELETE  .../providers/Microsoft.Network/virtualNetworks/{name}
+PUT/GET/DELETE  .../providers/Microsoft.Network/virtualNetworks/{vnet}/subnets/{name}
+PUT/GET/DELETE  .../providers/Microsoft.Network/networkInterfaces/{name}
+PUT/GET/DELETE  .../providers/Microsoft.Network/publicIPAddresses/{name}
+PUT/GET/DELETE  .../providers/Microsoft.Network/networkSecurityGroups/{name}
+```
+
+Use `?$expand=instanceView` on a Get to embed the instance view under `properties.instanceView`.
+
+---
+
+## Quickstart
+
+### 1 — Create a VM
+
+```bash
+curl -s -X PUT \
+  "http://localhost:4577/subscriptions/my-sub/resourceGroups/my-rg/providers/Microsoft.Compute/virtualMachines/my-vm?api-version=2024-11-01" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "location": "eastus",
+    "properties": {
+      "hardwareProfile": {"vmSize": "Standard_B1s"},
+      "storageProfile": {
+        "imageReference": {
+          "publisher": "Canonical",
+          "offer": "0001-com-ubuntu-server-jammy",
+          "sku": "22_04-lts",
+          "version": "latest"
+        },
+        "osDisk": {"createOption": "FromImage", "caching": "ReadWrite"}
+      },
+      "osProfile": {"adminUsername": "azureuser", "computerName": "my-vm"},
+      "networkProfile": {"networkInterfaces": [{"id": ".../networkInterfaces/my-nic"}]}
+    }
+  }'
+```
+
+The VM is returned with `properties.provisioningState = "Succeeded"` and starts in the
+`PowerState/running` state.
+
+### 2 — Power actions
+
+```bash
+BASE="http://localhost:4577/subscriptions/my-sub/resourceGroups/my-rg/providers/Microsoft.Compute/virtualMachines/my-vm"
+curl -s -X POST "$BASE/powerOff?api-version=2024-11-01"     # -> PowerState/stopped
+curl -s -X POST "$BASE/start?api-version=2024-11-01"        # -> PowerState/running
+curl -s -X POST "$BASE/deallocate?api-version=2024-11-01"   # -> PowerState/deallocated
+```
+
+### 3 — Read power state
+
+```bash
+curl -s "$BASE/instanceView?api-version=2024-11-01"
+# { "computerName": "my-vm", "osName": "Linux",
+#   "statuses": [ {"code":"ProvisioningState/succeeded",...}, {"code":"PowerState/running",...} ] }
+```
+
+---
+
+## Configuration
+
+```yaml
+floci-az:
+  services:
+    vm:
+      enabled: true
+      mocked: true              # true = no Docker, pure ARM state. false = container-backed (planned)
+      default-image: "ubuntu:22.04"
+```
+
+| Env var | Default | Description |
+|---|---|---|
+| `FLOCI_AZ_SERVICES_VM_ENABLED` | `true` | Enable/disable the service |
+| `FLOCI_AZ_SERVICES_VM_MOCKED` | `true` | Mocked mode (no Docker) |
+| `FLOCI_AZ_SERVICES_VM_DEFAULT_IMAGE` | `ubuntu:22.04` | Fallback Docker image for unresolved image references |
+
+---
+
+## Notes & limitations
+
+- Mocked mode does not run a real OS — there is no SSH, no guest agent, and `runCommand` is not executed.
+- Network dependency shells echo submitted properties with `provisioningState = "Succeeded"`;
+  NIC private IPs and public IPs are synthesized, not allocated from a real address pool.
+- Real container-backed VMs (image resolution via `imageReference`, `docker start/stop/restart`)
+  are planned for a follow-up.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,5 +77,6 @@ nav:
     - Cosmos DB: services/cosmos.md
     - Azure SQL Database: services/sql.md
     - Azure Kubernetes Service: services/aks.md
+    - Virtual Machines: services/vm.md
   - Contributing: contributing.md
   - Changelog: changelog.md

--- a/src/main/java/io/floci/az/config/EmulatorConfig.java
+++ b/src/main/java/io/floci/az/config/EmulatorConfig.java
@@ -117,9 +117,27 @@ public interface EmulatorConfig {
         SqlServiceConfig       sql();
         ServiceBusConfig       serviceBus();
         AksConfig              aks();
+        VmConfig               vm();
 
         /** Shared Docker network for sidecar containers (Artemis, Redpanda, etc.). */
         Optional<String> dockerNetwork();
+    }
+
+    interface VmConfig {
+        @WithDefault("true")
+        boolean enabled();
+
+        /**
+         * When {@code true}, no Docker container is started; virtual machines transition
+         * immediately to {@code Succeeded} / {@code PowerState/running} and power actions are
+         * pure state transitions. Useful for tests without Docker.
+         */
+        @WithDefault("true")
+        boolean mocked();
+
+        /** Default Docker image used when an imageReference cannot be resolved (non-mocked mode). */
+        @WithDefault("ubuntu:22.04")
+        String defaultImage();
     }
 
     interface AksConfig {

--- a/src/main/java/io/floci/az/core/AdminController.java
+++ b/src/main/java/io/floci/az/core/AdminController.java
@@ -11,6 +11,7 @@ import io.floci.az.services.queue.QueueServiceHandler;
 import io.floci.az.services.servicebus.ServiceBusHandler;
 import io.floci.az.services.sql.SqlHandler;
 import io.floci.az.services.table.TableServiceHandler;
+import io.floci.az.services.vm.VmHandler;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
@@ -32,6 +33,7 @@ public class AdminController {
     @Inject ServiceBusHandler       serviceBusHandler;
     @Inject SqlHandler              sqlHandler;
     @Inject TableServiceHandler     tableHandler;
+    @Inject VmHandler               vmHandler;
 
     @GET
     @Path("/accounts")
@@ -63,6 +65,7 @@ public class AdminController {
         queueHandler.clearAll();
         serviceBusHandler.clearAll();
         tableHandler.clearAll();
+        vmHandler.clearAll();
 
         // Docker-backed services — stop containers first, then clear state
         sqlHandler.clearAll();

--- a/src/main/java/io/floci/az/core/AzureIdentityController.java
+++ b/src/main/java/io/floci/az/core/AzureIdentityController.java
@@ -50,7 +50,12 @@ public class AzureIdentityController {
         String baseUrl = uriInfo.getBaseUri().toString().replaceAll("/+$", "");
         return Response.ok(Map.of(
             "name",                     "floci-az",
-            "resourceManager",          baseUrl + "/",
+            // No trailing slash: in Azure Stack mode the go-azure-sdk concatenates this
+            // endpoint with leading-slash resource paths, so a trailing slash yields
+            // "//subscriptions/..." — a network-path reference that breaks the SDK's LRO
+            // poller URL resolution (it drops the resource name and polls the collection
+            // forever, e.g. hanging `terraform destroy` of a virtual machine).
+            "resourceManager",          baseUrl,
             "microsoftGraphResourceId", baseUrl + "/",
             "portal",                   baseUrl + "/",
             "gallery",                  baseUrl + "/",

--- a/src/main/java/io/floci/az/core/AzureRoutingFilter.java
+++ b/src/main/java/io/floci/az/core/AzureRoutingFilter.java
@@ -249,6 +249,28 @@ public class AzureRoutingFilter {
         }
 
         // ---------------------------------------------------------------
+        // Azure Virtual Machines — ARM management-plane paths:
+        //   subscriptions/{sub}/[resourceGroups/{rg}/]providers/Microsoft.Compute/virtualMachines/...
+        //   subscriptions/{sub}/providers/Microsoft.Compute/locations/{loc}/operations/{opId}
+        // ---------------------------------------------------------------
+        if (path.startsWith("subscriptions/") && path.contains("/providers/Microsoft.Compute/")) {
+            Map<String, String> vmQueryParams = new HashMap<>();
+            requestContext.getUriInfo().getQueryParameters().forEach((k, v) -> vmQueryParams.put(k, v.get(0)));
+            AzureRequest vmRequest = new AzureRequest(
+                requestContext.getMethod(), "vm", "vm", path, headers,
+                requestContext.getEntityStream(), vmQueryParams, null, secure);
+            AuthContext vmAuth = authPipeline.resolve(vmRequest);
+            vmRequest = new AzureRequest(
+                requestContext.getMethod(), "vm", "vm", path, headers,
+                requestContext.getEntityStream(), vmQueryParams, vmAuth, secure);
+            Optional<AzureServiceHandler> vmHandler = serviceRegistry.resolve("vm");
+            if (vmHandler.isPresent()) {
+                LOGGER.infof("Dispatching ARM VM request to VmHandler: %s %s", requestContext.getMethod(), path);
+                return vmHandler.get().handle(vmRequest);
+            }
+        }
+
+        // ---------------------------------------------------------------
         // ARM general management-plane paths: subscriptions/{sub}/...
         // (resource groups, storage accounts, key vaults, etc. not served
         //  by the more-specific AKS and SQL handlers above)

--- a/src/main/java/io/floci/az/core/AzureServiceRegistry.java
+++ b/src/main/java/io/floci/az/core/AzureServiceRegistry.java
@@ -41,6 +41,7 @@ public class AzureServiceRegistry {
             case "sql"        -> config.services().sql().enabled();
             case "servicebus" -> config.services().serviceBus().enabled();
             case "aks"        -> config.services().aks().enabled();
+            case "vm"         -> config.services().vm().enabled();
             case "cosmos-mongo", "cosmos-table", "cosmos-cassandra",
                  "cosmos-gremlin", "cosmos-postgresql", "cosmos-nosql" ->
                 config.services().cosmos().enabled() &&

--- a/src/main/java/io/floci/az/core/BannerLogger.java
+++ b/src/main/java/io/floci/az/core/BannerLogger.java
@@ -88,6 +88,12 @@ public class BannerLogger {
                             + "-" + config.services().aks().apiServerMaxPort();
             sb.append(serviceStatusDocker("aks", true, aksInfo));
         }
+        if (config.services().vm().enabled()) {
+            String vmInfo = config.services().vm().mocked()
+                    ? "mocked  (no docker)"
+                    : "image:" + config.services().vm().defaultImage();
+            sb.append(serviceStatusDocker("vm", true, vmInfo));
+        }
         LOGGER.info(sb.toString());
         LOGGER.info("=== Local Azure Emulator Ready ===");
     }

--- a/src/main/java/io/floci/az/services/arm/ArmHandler.java
+++ b/src/main/java/io/floci/az/services/arm/ArmHandler.java
@@ -52,6 +52,7 @@ public class ArmHandler implements AzureServiceHandler {
     private final Map<String, Map<String, Object>> storageAccounts  = new ConcurrentHashMap<>();
     private final Map<String, Map<String, Object>> keyVaults        = new ConcurrentHashMap<>();
     private final Map<String, Map<String, Object>> webApps          = new ConcurrentHashMap<>();
+    private final Map<String, Map<String, Object>> networkResources = new ConcurrentHashMap<>();
 
     private final EmulatorConfig config;
     private final BlobServiceHandler blobHandler;
@@ -175,6 +176,10 @@ public class ArmHandler implements AzureServiceHandler {
                     .filter(v -> sub.equals(v.get("_sub")) && rg.equals(v.get("_rg")))
                     .map(ArmHandler::stripInternal)
                     .forEach(resources::add);
+            networkResources.values().stream()
+                    .filter(v -> sub.equals(v.get("_sub")) && rg.equals(v.get("_rg")))
+                    .map(ArmHandler::stripInternal)
+                    .forEach(resources::add);
             return Response.ok(Map.of("value", resources)).build();
         }
 
@@ -197,6 +202,9 @@ public class ArmHandler implements AzureServiceHandler {
         }
         if (path.contains("/providers/Microsoft.Web/")) {
             return handleWeb(req, path, method, sub);
+        }
+        if (path.contains("/providers/Microsoft.Network/")) {
+            return handleNetwork(req, path, method, sub);
         }
         return armNotFound(path);
     }
@@ -314,6 +322,128 @@ public class ArmHandler implements AzureServiceHandler {
         resource.put("kind", "functionapp,linux");
         resource.put("properties", properties);
         return resource;
+    }
+
+    // ── Network resources (VM dependencies) ───────────────────────────────────
+    //
+    // Lightweight ARM shells for the resources an azurerm_linux_virtual_machine needs:
+    // virtualNetworks (+ subnets), networkInterfaces, publicIPAddresses,
+    // networkSecurityGroups. Submitted properties are echoed back with
+    // provisioningState=Succeeded; NIC private IPs and public IPs are synthesised so the
+    // provider can read them back after apply.
+
+    private Response handleNetwork(AzureRequest req, String path, String method, String sub) {
+        String rg   = extractRg(path);
+        String tail = extractAfter(path, "/providers/Microsoft.Network/");
+
+        // LIST: tail is a single resource-type segment (e.g. "virtualNetworks").
+        if (tail.matches("[^/]+")) {
+            return listNetworkResources(sub, rg, "Microsoft.Network/" + tail);
+        }
+        // LIST subnets of a vnet: "virtualNetworks/{vnet}/subnets".
+        if (tail.matches("virtualNetworks/[^/]+/subnets")) {
+            return listNetworkResources(sub, rg, "Microsoft.Network/virtualNetworks/subnets");
+        }
+
+        String resourceType = networkResourceType(tail);
+        String name         = networkResourceName(tail);
+        String key          = netKey(sub, rg, tail);
+
+        return switch (method) {
+            case "PUT"    -> createOrUpdateNetworkResource(req, sub, rg, tail, resourceType, name, key);
+            case "GET"    -> {
+                Map<String, Object> resource = networkResources.get(key);
+                yield resource == null ? armNotFound(tail) : Response.ok(stripInternal(resource)).build();
+            }
+            case "DELETE" -> { networkResources.remove(key); yield Response.ok().build(); }
+            default       -> Response.status(405).build();
+        };
+    }
+
+    private Response listNetworkResources(String sub, String rg, String type) {
+        List<Map<String, Object>> items = networkResources.values().stream()
+                .filter(r -> sub.equals(r.get("_sub")) && rg.equals(r.get("_rg")) && type.equals(r.get("type")))
+                .map(ArmHandler::stripInternal)
+                .toList();
+        return Response.ok(Map.of("value", items)).build();
+    }
+
+    private Response createOrUpdateNetworkResource(AzureRequest req, String sub, String rg, String tail,
+                                                   String resourceType, String name, String key) {
+        Map<String, Object> body       = parseBody(req);
+        Map<String, Object> properties = new LinkedHashMap<>(cast(body.get("properties")));
+        synthesizeNetworkProperties(resourceType, properties);
+        properties.put("provisioningState", "Succeeded");
+
+        Map<String, Object> resource = new LinkedHashMap<>();
+        resource.put("_sub", sub);
+        resource.put("_rg", rg);
+        resource.put("id", "/subscriptions/" + sub + "/resourceGroups/" + rg
+                + "/providers/Microsoft.Network/" + tail);
+        resource.put("name", name);
+        resource.put("type", resourceType);
+        String location = bodyString(body, "location", null);
+        if (location != null) {
+            resource.put("location", location);
+        }
+        if (body.get("tags") instanceof Map<?, ?> tags && !tags.isEmpty()) {
+            resource.put("tags", tags);
+        }
+        resource.put("properties", properties);
+        networkResources.put(key, resource);
+        return Response.ok(stripInternal(resource)).build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void synthesizeNetworkProperties(String resourceType, Map<String, Object> properties) {
+        switch (resourceType) {
+            case "Microsoft.Network/networkInterfaces" -> {
+                Object cfgs = properties.get("ipConfigurations");
+                List<Object> configs = cfgs instanceof List<?> l && !l.isEmpty()
+                        ? new ArrayList<>((List<Object>) l)
+                        : new ArrayList<>(List.of(new LinkedHashMap<String, Object>(Map.of("name", "ipconfig1"))));
+                boolean[] first = {true};
+                configs.replaceAll(c -> {
+                    Map<String, Object> cfg = new LinkedHashMap<>(cast(c));
+                    Map<String, Object> cp = new LinkedHashMap<>(cast(cfg.get("properties")));
+                    cp.putIfAbsent("privateIPAddress", "10.0.0.4");
+                    cp.putIfAbsent("privateIPAllocationMethod", "Dynamic");
+                    cp.put("primary", first[0]);
+                    cp.put("provisioningState", "Succeeded");
+                    cfg.put("properties", cp);
+                    cfg.putIfAbsent("name", "ipconfig1");
+                    first[0] = false;
+                    return cfg;
+                });
+                properties.put("ipConfigurations", configs);
+            }
+            case "Microsoft.Network/publicIPAddresses" -> {
+                properties.putIfAbsent("ipAddress", "20.0.0.4");
+                properties.putIfAbsent("publicIPAllocationMethod", "Dynamic");
+            }
+            default -> { /* virtualNetworks, subnets, networkSecurityGroups: echo as-is */ }
+        }
+    }
+
+    private static String networkResourceType(String tail) {
+        // "networkInterfaces/{name}" -> "Microsoft.Network/networkInterfaces"
+        // "virtualNetworks/{v}/subnets/{s}" -> "Microsoft.Network/virtualNetworks/subnets"
+        String[] parts = tail.split("/");
+        if (parts.length >= 4 && "subnets".equals(parts[2])) {
+            return "Microsoft.Network/virtualNetworks/subnets";
+        }
+        return "Microsoft.Network/" + parts[0];
+    }
+
+    private static String networkResourceName(String tail) {
+        String[] parts = tail.split("[/?]");
+        return parts.length > 0 ? parts[parts.length - 1] : tail;
+    }
+
+    private static String netKey(String sub, String rg, String tail) {
+        int q = tail.indexOf('?');
+        String clean = q >= 0 ? tail.substring(0, q) : tail;
+        return sub + "/" + rg + "/net/" + clean;
     }
 
     // ── Storage Accounts ─────────────────────────────────────────────────────

--- a/src/main/java/io/floci/az/services/vm/VmHandler.java
+++ b/src/main/java/io/floci/az/services/vm/VmHandler.java
@@ -198,12 +198,12 @@ public class VmHandler implements AzureServiceHandler {
     }
 
     private Response handleDelete(String sub, String rg, String vmName) {
-        String key = storageKey(sub, rg, vmName);
-        if (getVm(key).isEmpty()) {
-            return Response.status(204).build();
-        }
-        storage.delete(key);
-        return acceptedWithAsync(sub, null);
+        storage.delete(storageKey(sub, rg, vmName));
+        // Delete synchronously with 204 No Content. The azurerm provider's virtualmachines
+        // DeleteThenPoll treats a 202/200 as a long-running operation and polls the collection
+        // forever against the emulator; a terminal 204 signals the delete is complete so
+        // `terraform destroy` proceeds. 204 is also idempotent for an already-absent VM.
+        return Response.status(204).build();
     }
 
     private Response handleListSubscription(String sub, boolean expandInstanceView) {

--- a/src/main/java/io/floci/az/services/vm/VmHandler.java
+++ b/src/main/java/io/floci/az/services/vm/VmHandler.java
@@ -1,0 +1,452 @@
+package io.floci.az.services.vm;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.floci.az.config.EmulatorConfig;
+import io.floci.az.core.AzureRequest;
+import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.StoredObject;
+import io.floci.az.core.storage.StorageBackend;
+import io.floci.az.core.storage.StorageFactory;
+import io.floci.az.services.vm.VmModels.PowerState;
+import io.floci.az.services.vm.VmModels.VirtualMachine;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * HTTP handler for Azure Virtual Machines (Microsoft.Compute/virtualMachines) management-plane
+ * requests.
+ *
+ * <h2>Routing</h2>
+ * <pre>
+ *   GET    subscriptions/{sub}/providers/Microsoft.Compute/virtualMachines                       (list all)
+ *   GET    subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Compute/virtualMachines    (list in rg)
+ *   PUT    .../virtualMachines/{vm}            create/update
+ *   GET    .../virtualMachines/{vm}            (?$expand=instanceView)
+ *   PATCH  .../virtualMachines/{vm}            update tags
+ *   DELETE .../virtualMachines/{vm}
+ *   GET    .../virtualMachines/{vm}/instanceView
+ *   POST   .../virtualMachines/{vm}/{start|powerOff|deallocate|restart|redeploy|reapply}
+ *   GET    subscriptions/{sub}/providers/Microsoft.Compute/locations/{loc}/operations/{opId}   (LRO status)
+ * </pre>
+ *
+ * <h2>Mocked mode</h2>
+ * <p>When {@code floci-az.services.vm.mocked=true} (default), no Docker container is started.
+ * VMs transition immediately to {@code provisioningState=Succeeded} / {@code PowerState/running}.
+ * Power actions are pure state transitions. This keeps the service usable in CI without Docker.</p>
+ */
+@ApplicationScoped
+public class VmHandler implements AzureServiceHandler {
+
+    private static final Logger LOG = Logger.getLogger(VmHandler.class);
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    private static final String COMPUTE_MARKER = "/providers/Microsoft.Compute/";
+    private static final String API_VERSION = "2024-11-01";
+
+    private final EmulatorConfig config;
+    private final StorageBackend<String, StoredObject> storage;
+
+    @Inject
+    public VmHandler(EmulatorConfig config, StorageFactory storageFactory) {
+        this.config = config;
+        this.storage = storageFactory.create("vm");
+    }
+
+    @Override
+    public String getServiceType() { return "vm"; }
+
+    @Override
+    public boolean canHandle(AzureRequest req) { return "vm".equals(req.serviceType()); }
+
+    @Override
+    public Response handle(AzureRequest req) {
+        String fullPath = req.resourcePath();
+        String method = req.method().toUpperCase();
+        String tail = extractComputePath(fullPath);
+
+        LOG.debugf("VmHandler: %s %s (tail=%s)", method, fullPath, tail);
+
+        // ── LRO operation status (returns terminal Succeeded immediately) ──────
+        if (tail.matches("locations/[^/]+/operation(?:s|Results)/[^/?]+.*")) {
+            return Response.ok(Map.of("status", "Succeeded")).type("application/json").build();
+        }
+
+        // ── List in subscription ───────────────────────────────────────────────
+        if (tail.matches("virtualMachines(?:[?].*)?") && !fullPath.contains("/resourceGroups/")) {
+            return handleListSubscription(extractSubscriptionId(fullPath), expandsInstanceView(req));
+        }
+
+        // ── List in resource group ──────────────────────────────────────────────
+        if (tail.matches("virtualMachines(?:[?].*)?") && "GET".equals(method)) {
+            return handleListByResourceGroup(extractSubscriptionId(fullPath),
+                    extractResourceGroup(fullPath), expandsInstanceView(req));
+        }
+
+        String sub = extractSubscriptionId(fullPath);
+        String rg = extractResourceGroup(fullPath);
+
+        // ── instanceView ──────────────────────────────────────────────────────
+        if (tail.matches("virtualMachines/[^/]+/instanceView(?:[?].*)?") && "GET".equals(method)) {
+            return handleInstanceView(sub, rg, segment(tail, 1));
+        }
+
+        // ── Power actions ───────────────────────────────────────────────────────
+        if (tail.matches("virtualMachines/[^/]+/(start|powerOff|deallocate|restart|redeploy|reapply)(?:[?].*)?")
+                && "POST".equals(method)) {
+            return handlePowerAction(sub, rg, segment(tail, 1), segment(tail, 2));
+        }
+
+        // ── Single VM CRUD ────────────────────────────────────────────────────────
+        if (tail.matches("virtualMachines/[^/]+(?:[?].*)?")) {
+            String vmName = segment(tail, 1);
+            return switch (method) {
+                case "GET"    -> handleGet(sub, rg, vmName, expandsInstanceView(req));
+                case "PUT"    -> handleCreateOrUpdate(sub, rg, vmName, req);
+                case "PATCH"  -> handleUpdateTags(sub, rg, vmName, req);
+                case "DELETE" -> handleDelete(sub, rg, vmName);
+                default       -> methodNotAllowed();
+            };
+        }
+
+        return armNotFound("Unsupported Microsoft.Compute path: " + tail);
+    }
+
+    // ── CRUD ───────────────────────────────────────────────────────────────────
+
+    private Response handleCreateOrUpdate(String sub, String rg, String vmName, AzureRequest req) {
+        try {
+            JsonNode body = readBody(req.bodyStream());
+            String location = body.path("location").asText("eastus");
+            Map<String, String> tags = parseTags(body.path("tags"));
+            Map<String, Object> properties = objectToMap(body.path("properties"));
+
+            String key = storageKey(sub, rg, vmName);
+            Optional<VirtualMachine> existing = getVm(key);
+            boolean isNew = existing.isEmpty();
+
+            VirtualMachine vm = existing.orElseGet(VirtualMachine::new);
+            if (isNew) {
+                vm.setSubscriptionId(sub);
+                vm.setResourceGroup(rg);
+                vm.setName(vmName);
+                vm.setVmId(UUID.randomUUID().toString());
+                vm.setTimeCreated(Instant.now());
+            }
+            vm.setLocation(location);
+            vm.setTags(tags.isEmpty() ? null : tags);
+            vm.setProperties(properties);
+
+            // Mocked mode: VM is provisioned and powered on immediately. Non-mocked Docker
+            // backing is wired in phase 2 (would set "Creating" + launch a container here).
+            vm.setProvisioningState("Succeeded");
+            if (isNew || vm.getPowerState() == null) {
+                vm.setPowerState(PowerState.RUNNING.code());
+            }
+
+            putVm(key, vm);
+            return Response.status(isNew ? 201 : 200)
+                    .entity(toArmResponse(vm, false))
+                    .type("application/json")
+                    .build();
+        } catch (Exception e) {
+            LOG.errorf(e, "Error creating/updating VM %s", vmName);
+            return badRequest("Invalid request: " + e.getMessage());
+        }
+    }
+
+    private Response handleGet(String sub, String rg, String vmName, boolean expandInstanceView) {
+        return getVm(storageKey(sub, rg, vmName))
+                .map(vm -> Response.ok(toArmResponse(vm, expandInstanceView)).type("application/json").build())
+                .orElseGet(() -> armNotFound("The Resource 'Microsoft.Compute/virtualMachines/" + vmName
+                        + "' under resource group '" + rg + "' was not found."));
+    }
+
+    private Response handleUpdateTags(String sub, String rg, String vmName, AzureRequest req) {
+        String key = storageKey(sub, rg, vmName);
+        Optional<VirtualMachine> found = getVm(key);
+        if (found.isEmpty()) {
+            return armNotFound("Virtual machine '" + vmName + "' not found.");
+        }
+        try {
+            JsonNode body = readBody(req.bodyStream());
+            VirtualMachine vm = found.get();
+            Map<String, String> tags = parseTags(body.path("tags"));
+            vm.setTags(tags.isEmpty() ? null : tags);
+            putVm(key, vm);
+            return Response.ok(toArmResponse(vm, false)).type("application/json").build();
+        } catch (Exception e) {
+            return badRequest("Invalid request: " + e.getMessage());
+        }
+    }
+
+    private Response handleDelete(String sub, String rg, String vmName) {
+        String key = storageKey(sub, rg, vmName);
+        if (getVm(key).isEmpty()) {
+            return Response.status(204).build();
+        }
+        storage.delete(key);
+        return acceptedWithAsync(sub, null);
+    }
+
+    private Response handleListSubscription(String sub, boolean expandInstanceView) {
+        String prefix = sub + "/";
+        List<Map<String, Object>> items = new ArrayList<>();
+        scanAll().stream()
+                .filter(vm -> vm.storageKey().startsWith(prefix))
+                .forEach(vm -> items.add(toArmResponse(vm, expandInstanceView)));
+        return Response.ok(Map.of("value", items)).type("application/json").build();
+    }
+
+    private Response handleListByResourceGroup(String sub, String rg, boolean expandInstanceView) {
+        String prefix = (sub + "/" + rg + "/").toLowerCase();
+        List<Map<String, Object>> items = new ArrayList<>();
+        scanAll().stream()
+                .filter(vm -> vm.storageKey().toLowerCase().startsWith(prefix))
+                .forEach(vm -> items.add(toArmResponse(vm, expandInstanceView)));
+        return Response.ok(Map.of("value", items)).type("application/json").build();
+    }
+
+    private Response handleInstanceView(String sub, String rg, String vmName) {
+        // The instanceView endpoint returns the bare VirtualMachineInstanceView object
+        // (no id/name/type wrapper) — see Compute spec VirtualMachine_Get_InstanceView.
+        return getVm(storageKey(sub, rg, vmName))
+                .map(vm -> Response.ok(instanceViewBody(vm)).type("application/json").build())
+                .orElseGet(() -> armNotFound("Virtual machine '" + vmName + "' not found."));
+    }
+
+    private Response handlePowerAction(String sub, String rg, String vmName, String action) {
+        String key = storageKey(sub, rg, vmName);
+        Optional<VirtualMachine> found = getVm(key);
+        if (found.isEmpty()) {
+            return armNotFound("Virtual machine '" + vmName + "' not found.");
+        }
+        VirtualMachine vm = found.get();
+        PowerState target = switch (action) {
+            case "powerOff"   -> PowerState.STOPPED;
+            case "deallocate" -> PowerState.DEALLOCATED;
+            default           -> PowerState.RUNNING;  // start, restart, redeploy, reapply
+        };
+        vm.setPowerState(target.code());
+        vm.setProvisioningState("Succeeded");
+        putVm(key, vm);
+        return acceptedWithAsync(sub, vm.getLocation());
+    }
+
+    // ── ARM response builders ────────────────────────────────────────────────────
+
+    private Map<String, Object> toArmResponse(VirtualMachine vm, boolean expandInstanceView) {
+        Map<String, Object> props = vm.getProperties() != null
+                ? new LinkedHashMap<>(vm.getProperties())
+                : new LinkedHashMap<>();
+        props.put("vmId", vm.getVmId());
+        props.put("provisioningState", vm.getProvisioningState());
+        if (vm.getTimeCreated() != null) {
+            props.put("timeCreated", OffsetDateTime.ofInstant(vm.getTimeCreated(), ZoneOffset.UTC).toString());
+        }
+        if (expandInstanceView) {
+            props.put("instanceView", instanceViewBody(vm));
+        }
+
+        Map<String, Object> out = new LinkedHashMap<>();
+        out.put("id", vm.armId());
+        out.put("name", vm.getName());
+        out.put("type", "Microsoft.Compute/virtualMachines");
+        out.put("location", vm.getLocation());
+        if (vm.getTags() != null && !vm.getTags().isEmpty()) {
+            out.put("tags", vm.getTags());
+        }
+        out.put("properties", props);
+        return out;
+    }
+
+    private Map<String, Object> instanceViewBody(VirtualMachine vm) {
+        PowerState power = PowerState.fromCode(vm.getPowerState());
+        String computerName = osProfileComputerName(vm);
+
+        List<Map<String, Object>> statuses = new ArrayList<>();
+        statuses.add(Map.of(
+                "code", "ProvisioningState/" + lower(vm.getProvisioningState()),
+                "level", "Info",
+                "displayStatus", "Provisioning succeeded"));
+        statuses.add(Map.of(
+                "code", power.statusCode(),
+                "level", "Info",
+                "displayStatus", power.displayStatus()));
+
+        Map<String, Object> view = new LinkedHashMap<>();
+        if (computerName != null) {
+            view.put("computerName", computerName);
+        }
+        view.put("osName", "Linux");
+        view.put("statuses", statuses);
+        return view;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static String osProfileComputerName(VirtualMachine vm) {
+        if (vm.getProperties() == null) { return vm.getName(); }
+        Object osProfile = vm.getProperties().get("osProfile");
+        if (osProfile instanceof Map<?, ?> m) {
+            Object cn = ((Map<String, Object>) m).get("computerName");
+            if (cn != null) { return cn.toString(); }
+        }
+        return vm.getName();
+    }
+
+    private Response acceptedWithAsync(String sub, String location) {
+        String loc = (location == null || location.isBlank()) ? "eastus" : location;
+        String url = config.effectiveBaseUrl() + "/subscriptions/" + sub
+                + "/providers/Microsoft.Compute/locations/" + loc
+                + "/operations/" + UUID.randomUUID() + "?api-version=" + API_VERSION + "&monitor=true";
+        return Response.status(202)
+                .header("Azure-AsyncOperation", url)
+                .header("Location", url)
+                .build();
+    }
+
+    // ── Storage helpers ────────────────────────────────────────────────────────
+
+    private Optional<VirtualMachine> getVm(String key) {
+        return storage.get(key).map(so -> {
+            try {
+                return MAPPER.readValue(so.data(), VirtualMachine.class);
+            } catch (Exception e) {
+                LOG.warnv("Failed to deserialize VM {0}: {1}", key, e.getMessage());
+                return null;
+            }
+        });
+    }
+
+    private void putVm(String key, VirtualMachine vm) {
+        try {
+            byte[] data = MAPPER.writeValueAsBytes(vm);
+            storage.put(key, new StoredObject(key, data, Map.of(), Instant.now(), key));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to serialize VM: " + key, e);
+        }
+    }
+
+    private List<VirtualMachine> scanAll() {
+        List<VirtualMachine> result = new ArrayList<>();
+        storage.scan(k -> true).forEach(so -> {
+            try {
+                VirtualMachine vm = MAPPER.readValue(so.data(), VirtualMachine.class);
+                if (vm != null) { result.add(vm); }
+            } catch (Exception e) {
+                LOG.debugv("Skipping unreadable VM entry: {0}", e.getMessage());
+            }
+        });
+        return result;
+    }
+
+    // ── Path / body parsing helpers ──────────────────────────────────────────────
+
+    private static String extractComputePath(String fullPath) {
+        if (fullPath == null) { return ""; }
+        int idx = fullPath.indexOf(COMPUTE_MARKER);
+        return idx >= 0 ? fullPath.substring(idx + COMPUTE_MARKER.length()) : fullPath;
+    }
+
+    private static String extractSubscriptionId(String fullPath) {
+        return segmentAfter(fullPath, "subscriptions");
+    }
+
+    private static String extractResourceGroup(String fullPath) {
+        return segmentAfter(fullPath, "resourcegroups");
+    }
+
+    private static String segmentAfter(String fullPath, String marker) {
+        if (fullPath == null) { return "default"; }
+        String[] parts = fullPath.split("/");
+        for (int i = 0; i < parts.length - 1; i++) {
+            if (marker.equalsIgnoreCase(parts[i])) { return parts[i + 1]; }
+        }
+        return "default";
+    }
+
+    private static String segment(String path, int index) {
+        String[] parts = path.split("[/?]");
+        return index < parts.length ? parts[index] : "";
+    }
+
+    private static boolean expandsInstanceView(AzureRequest req) {
+        String expand = req.queryParams() == null ? null : req.queryParams().get("$expand");
+        return expand != null && expand.toLowerCase().contains("instanceview");
+    }
+
+    private static String lower(String s) {
+        return s == null ? "" : s.toLowerCase();
+    }
+
+    private static String storageKey(String sub, String rg, String vmName) {
+        return sub + "/" + rg + "/" + vmName;
+    }
+
+    private static Map<String, String> parseTags(JsonNode tagsNode) {
+        Map<String, String> tags = new LinkedHashMap<>();
+        if (tagsNode != null && tagsNode.isObject()) {
+            tagsNode.fields().forEachRemaining(e -> tags.put(e.getKey(), e.getValue().asText()));
+        }
+        return tags;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> objectToMap(JsonNode node) {
+        if (node == null || node.isMissingNode() || node.isNull()) {
+            return new LinkedHashMap<>();
+        }
+        return MAPPER.convertValue(node, Map.class);
+    }
+
+    private JsonNode readBody(java.io.InputStream stream) {
+        try {
+            if (stream == null || stream.available() == 0) { return MAPPER.createObjectNode(); }
+            return MAPPER.readTree(stream);
+        } catch (Exception e) {
+            return MAPPER.createObjectNode();
+        }
+    }
+
+    // ── Standard ARM error responses ──────────────────────────────────────────────
+
+    private static Response armNotFound(String message) {
+        return Response.status(404).entity(Map.of(
+                "error", Map.of("code", "ResourceNotFound", "message", message)))
+                .type("application/json").build();
+    }
+
+    private static Response badRequest(String message) {
+        return Response.status(400).entity(Map.of(
+                "error", Map.of("code", "InvalidRequest", "message", message)))
+                .type("application/json").build();
+    }
+
+    private static Response methodNotAllowed() {
+        return Response.status(405).entity(Map.of(
+                "error", Map.of("code", "MethodNotAllowed", "message", "Method not allowed")))
+                .type("application/json").build();
+    }
+
+    /** Wipes all VM data — used by {@code POST /_admin/reset}. */
+    public void clearAll() {
+        storage.clear();
+    }
+}

--- a/src/main/java/io/floci/az/services/vm/VmImageResolver.java
+++ b/src/main/java/io/floci/az/services/vm/VmImageResolver.java
@@ -1,0 +1,85 @@
+package io.floci.az.services.vm;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.jboss.logging.Logger;
+
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Resolves an Azure {@code storageProfile.imageReference} (publisher / offer / sku) to a
+ * Docker image URI, used when running VMs in non-mocked mode (phase 2).
+ *
+ * <p>Recognises the common Linux marketplace images; unknown references fall back to
+ * {@code ubuntu:22.04}. Windows images are not supported locally and also fall back.</p>
+ */
+@ApplicationScoped
+public class VmImageResolver {
+
+    private static final Logger LOG = Logger.getLogger(VmImageResolver.class);
+
+    private static final String DEFAULT_IMAGE = "ubuntu:22.04";
+
+    // Keyed by "<publisher>/<offer>/<sku>" lower-cased. Kept small and explicit, mirroring
+    // the AWS sibling's AmiImageResolver; the heuristic below covers the long tail.
+    private static final Map<String, String> BUILTIN_MAPPINGS = Map.ofEntries(
+            Map.entry("canonical/0001-com-ubuntu-server-jammy/22_04-lts",  "ubuntu:22.04"),
+            Map.entry("canonical/0001-com-ubuntu-server-jammy/22_04-lts-gen2", "ubuntu:22.04"),
+            Map.entry("canonical/0001-com-ubuntu-server-noble/24_04-lts",  "ubuntu:24.04"),
+            Map.entry("canonical/0001-com-ubuntu-server-focal/20_04-lts",  "ubuntu:20.04"),
+            Map.entry("canonical/ubuntuserver/18.04-lts",                  "ubuntu:18.04"),
+            Map.entry("debian/debian-12/12",                               "debian:12"),
+            Map.entry("debian/debian-11/11",                               "debian:11"),
+            Map.entry("almalinux/almalinux/9-gen2",                        "almalinux:9"),
+            Map.entry("rockylinux/rockylinux/9-base",                      "rockylinux:9")
+    );
+
+    /** Resolves a typed publisher/offer/sku triple to a Docker image URI. */
+    public String resolve(String publisher, String offer, String sku) {
+        String pub = lower(publisher);
+        String off = lower(offer);
+        String s = lower(sku);
+
+        String key = pub + "/" + off + "/" + s;
+        String mapped = BUILTIN_MAPPINGS.get(key);
+        if (mapped != null) {
+            return mapped;
+        }
+
+        // Heuristic fall-through for the long tail of marketplace SKUs.
+        if (off.contains("ubuntu") || pub.contains("canonical")) {
+            if (s.startsWith("24") || off.contains("noble")) { return "ubuntu:24.04"; }
+            if (s.startsWith("20") || off.contains("focal")) { return "ubuntu:20.04"; }
+            if (s.startsWith("18")) { return "ubuntu:18.04"; }
+            return "ubuntu:22.04";
+        }
+        if (off.contains("debian") || pub.contains("debian")) {
+            return s.startsWith("11") ? "debian:11" : "debian:12";
+        }
+        if (off.contains("alpine") || s.contains("alpine")) {
+            return "alpine:latest";
+        }
+
+        LOG.warnv("Unknown imageReference {0}/{1}/{2}; falling back to {3}",
+                publisher, offer, sku, DEFAULT_IMAGE);
+        return DEFAULT_IMAGE;
+    }
+
+    /** Convenience overload that resolves directly from a parsed imageReference map. */
+    @SuppressWarnings("unchecked")
+    public String resolve(Map<String, Object> imageReference) {
+        if (imageReference == null) {
+            return DEFAULT_IMAGE;
+        }
+        return resolve(
+                str(imageReference.get("publisher")),
+                str(imageReference.get("offer")),
+                str(imageReference.get("sku")));
+    }
+
+    private static String str(Object o) { return o == null ? "" : o.toString(); }
+
+    private static String lower(String s) {
+        return s == null ? "" : s.trim().toLowerCase(Locale.ROOT);
+    }
+}

--- a/src/main/java/io/floci/az/services/vm/VmModels.java
+++ b/src/main/java/io/floci/az/services/vm/VmModels.java
@@ -1,0 +1,115 @@
+package io.floci.az.services.vm;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.time.Instant;
+import java.util.Map;
+
+public class VmModels {
+
+    /**
+     * Persisted Azure Virtual Machine (Microsoft.Compute/virtualMachines).
+     *
+     * <p>The submitted {@code properties} block (hardwareProfile, storageProfile, osProfile,
+     * networkProfile, …) is stored verbatim so GET round-trips faithfully for SDKs and Terraform.
+     * {@code provisioningState}, {@code vmId} and power state are managed by the emulator.</p>
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class VirtualMachine {
+        private String subscriptionId;
+        private String resourceGroup;
+        private String name;
+        private String location;
+        private String vmId;
+        private String provisioningState;
+        /** Power state code: running | stopped | deallocated | starting | stopping | deallocating. */
+        private String powerState;
+        private Instant timeCreated;
+        private Map<String, String> tags;
+        private Map<String, Object> properties;
+        /** Docker container id when running in non-mocked mode (phase 2). */
+        private String containerId;
+
+        public String getSubscriptionId() { return subscriptionId; }
+        public void setSubscriptionId(String subscriptionId) { this.subscriptionId = subscriptionId; }
+
+        public String getResourceGroup() { return resourceGroup; }
+        public void setResourceGroup(String resourceGroup) { this.resourceGroup = resourceGroup; }
+
+        public String getName() { return name; }
+        public void setName(String name) { this.name = name; }
+
+        public String getLocation() { return location; }
+        public void setLocation(String location) { this.location = location; }
+
+        public String getVmId() { return vmId; }
+        public void setVmId(String vmId) { this.vmId = vmId; }
+
+        public String getProvisioningState() { return provisioningState; }
+        public void setProvisioningState(String provisioningState) { this.provisioningState = provisioningState; }
+
+        public String getPowerState() { return powerState; }
+        public void setPowerState(String powerState) { this.powerState = powerState; }
+
+        public Instant getTimeCreated() { return timeCreated; }
+        public void setTimeCreated(Instant timeCreated) { this.timeCreated = timeCreated; }
+
+        public Map<String, String> getTags() { return tags; }
+        public void setTags(Map<String, String> tags) { this.tags = tags; }
+
+        public Map<String, Object> getProperties() { return properties; }
+        public void setProperties(Map<String, Object> properties) { this.properties = properties; }
+
+        public String getContainerId() { return containerId; }
+        public void setContainerId(String containerId) { this.containerId = containerId; }
+
+        /** ARM resource ID for this virtual machine. */
+        public String armId() {
+            return "/subscriptions/" + subscriptionId + "/resourceGroups/" + resourceGroup
+                    + "/providers/Microsoft.Compute/virtualMachines/" + name;
+        }
+
+        /** Storage key: subscriptionId/resourceGroup/name. */
+        public String storageKey() {
+            return subscriptionId + "/" + resourceGroup + "/" + name;
+        }
+    }
+
+    /**
+     * Azure VM power-state codes, surfaced in {@code instanceView.statuses} as
+     * {@code PowerState/<code>}.
+     */
+    public enum PowerState {
+        RUNNING("running", "VM running"),
+        STOPPED("stopped", "VM stopped"),
+        DEALLOCATED("deallocated", "VM deallocated"),
+        STARTING("starting", "VM starting"),
+        STOPPING("stopping", "VM stopping"),
+        DEALLOCATING("deallocating", "VM deallocating");
+
+        private final String code;
+        private final String displayStatus;
+
+        PowerState(String code, String displayStatus) {
+            this.code = code;
+            this.displayStatus = displayStatus;
+        }
+
+        public String code() { return code; }
+        public String displayStatus() { return displayStatus; }
+        public String statusCode() { return "PowerState/" + code; }
+
+        public static PowerState fromCode(String code) {
+            if (code != null) {
+                for (PowerState p : values()) {
+                    if (p.code.equals(code)) { return p; }
+                }
+            }
+            return RUNNING;
+        }
+    }
+
+    private VmModels() {}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -140,6 +140,10 @@ floci-az:
       api-server-base-port: 6443
       api-server-max-port: 7443
       keep-running-on-shutdown: false
+    vm:
+      enabled: true
+      mocked: true          # true = no Docker; VMs are pure ARM state. false = back VMs with containers (phase 2)
+      default-image: "ubuntu:22.04"
     # docker-network:  # optional: shared Docker network for sidecar containers
 
   auth:

--- a/src/test/java/io/floci/az/services/vm/VmHandlerTest.java
+++ b/src/test/java/io/floci/az/services/vm/VmHandlerTest.java
@@ -1,0 +1,187 @@
+package io.floci.az.services.vm;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Quarkus-level tests for {@link VmHandler}, exercising the Microsoft.Compute/virtualMachines
+ * ARM surface in mocked mode (no Docker).
+ */
+@QuarkusTest
+@TestProfile(VmHandlerTest.MockedProfile.class)
+@DisplayName("VmHandler — lifecycle and power state (mocked mode)")
+@SuppressWarnings("unused")
+class VmHandlerTest {
+
+    public static class MockedProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("floci-az.services.vm.mocked", "true");
+        }
+    }
+
+    private static final String SUB  = "test-sub-vm";
+    private static final String RG   = "test-rg-vm";
+    private static final String API  = "?api-version=2024-11-01";
+    private static final String BASE =
+            "/subscriptions/" + SUB + "/resourceGroups/" + RG + "/providers/Microsoft.Compute";
+
+    private static final String CREATE_BODY = """
+            {
+              "location": "eastus",
+              "tags": {"env": "test"},
+              "properties": {
+                "hardwareProfile": {"vmSize": "Standard_D2s_v3"},
+                "storageProfile": {
+                  "imageReference": {
+                    "publisher": "Canonical",
+                    "offer": "0001-com-ubuntu-server-jammy",
+                    "sku": "22_04-lts",
+                    "version": "latest"
+                  },
+                  "osDisk": {"createOption": "FromImage", "name": "myOsDisk"}
+                },
+                "osProfile": {"adminUsername": "azureuser", "computerName": "myvm"},
+                "networkProfile": {
+                  "networkInterfaces": [
+                    {"id": "/subscriptions/test-sub-vm/resourceGroups/test-rg-vm/providers/Microsoft.Network/networkInterfaces/myvm-nic"}
+                  ]
+                }
+              }
+            }
+            """;
+
+    @BeforeEach
+    void reset() {
+        given().post("/_admin/reset").then().statusCode(204);
+    }
+
+    private void createVm(String vmName) {
+        given().contentType("application/json").body(CREATE_BODY)
+                .when().put(BASE + "/virtualMachines/" + vmName + API)
+                .then().statusCode(201);
+    }
+
+    @Test
+    @DisplayName("GET unknown VM returns 404 ResourceNotFound")
+    void getUnknownVmReturns404() {
+        given().when().get(BASE + "/virtualMachines/no-such-vm" + API)
+                .then().statusCode(404)
+                .body("error.code", equalTo("ResourceNotFound"));
+    }
+
+    @Test
+    @DisplayName("PUT creates VM (201) with Succeeded state and echoed properties")
+    void createVmReturns201() {
+        given().contentType("application/json").body(CREATE_BODY)
+                .when().put(BASE + "/virtualMachines/vm1" + API)
+                .then().statusCode(201)
+                .body("name", equalTo("vm1"))
+                .body("type", equalTo("Microsoft.Compute/virtualMachines"))
+                .body("location", equalTo("eastus"))
+                .body("tags.env", equalTo("test"))
+                .body("properties.provisioningState", equalTo("Succeeded"))
+                .body("properties.vmId", not(emptyOrNullString()))
+                .body("properties.hardwareProfile.vmSize", equalTo("Standard_D2s_v3"))
+                .body("properties.osProfile.adminUsername", equalTo("azureuser"));
+    }
+
+    @Test
+    @DisplayName("PUT existing VM returns 200 (update)")
+    void updateVmReturns200() {
+        createVm("vm1");
+        given().contentType("application/json").body(CREATE_BODY)
+                .when().put(BASE + "/virtualMachines/vm1" + API)
+                .then().statusCode(200);
+    }
+
+    @Test
+    @DisplayName("GET VM with $expand=instanceView includes power state running")
+    void getWithInstanceViewExpand() {
+        createVm("vm1");
+        given().when().get(BASE + "/virtualMachines/vm1?api-version=2024-11-01&$expand=instanceView")
+                .then().statusCode(200)
+                .body("properties.instanceView.statuses.code", hasItem("PowerState/running"));
+    }
+
+    @Test
+    @DisplayName("GET instanceView returns ProvisioningState and PowerState statuses")
+    void instanceViewStatuses() {
+        createVm("vm1");
+        given().when().get(BASE + "/virtualMachines/vm1/instanceView" + API)
+                .then().statusCode(200)
+                .body("computerName", equalTo("myvm"))
+                .body("statuses.code", hasItems("ProvisioningState/succeeded", "PowerState/running"));
+    }
+
+    @Test
+    @DisplayName("powerOff -> stopped, start -> running, deallocate -> deallocated")
+    void powerTransitions() {
+        createVm("vm1");
+
+        given().when().post(BASE + "/virtualMachines/vm1/powerOff" + API).then().statusCode(202);
+        given().when().get(BASE + "/virtualMachines/vm1/instanceView" + API)
+                .then().body("statuses.code", hasItem("PowerState/stopped"));
+
+        given().when().post(BASE + "/virtualMachines/vm1/start" + API).then().statusCode(202);
+        given().when().get(BASE + "/virtualMachines/vm1/instanceView" + API)
+                .then().body("statuses.code", hasItem("PowerState/running"));
+
+        given().when().post(BASE + "/virtualMachines/vm1/deallocate" + API).then().statusCode(202);
+        given().when().get(BASE + "/virtualMachines/vm1/instanceView" + API)
+                .then().body("statuses.code", hasItem("PowerState/deallocated"));
+    }
+
+    @Test
+    @DisplayName("power action returns Azure-AsyncOperation header for SDK LRO polling")
+    void powerActionEmitsAsyncHeader() {
+        createVm("vm1");
+        given().when().post(BASE + "/virtualMachines/vm1/restart" + API)
+                .then().statusCode(202)
+                .header("Azure-AsyncOperation", containsString("/operations/"));
+    }
+
+    @Test
+    @DisplayName("List by resource group returns created VMs")
+    void listByResourceGroup() {
+        createVm("vm1");
+        createVm("vm2");
+        given().when().get(BASE + "/virtualMachines" + API)
+                .then().statusCode(200)
+                .body("value.name", hasItems("vm1", "vm2"));
+    }
+
+    @Test
+    @DisplayName("DELETE removes the VM (then GET 404)")
+    void deleteVm() {
+        createVm("vm1");
+        given().when().delete(BASE + "/virtualMachines/vm1" + API).then().statusCode(202);
+        given().when().get(BASE + "/virtualMachines/vm1" + API).then().statusCode(404);
+    }
+
+    @Test
+    @DisplayName("Network interface stub synthesizes a private IP and Succeeded state")
+    void networkInterfaceStub() {
+        String nicPath = "/subscriptions/" + SUB + "/resourceGroups/" + RG
+                + "/providers/Microsoft.Network/networkInterfaces/myvm-nic";
+        given().contentType("application/json")
+                .body("""
+                    {"location":"eastus","properties":{"ipConfigurations":[
+                      {"name":"ipconfig1","properties":{"subnet":{"id":"/subscriptions/x/.../subnets/default"}}}
+                    ]}}
+                    """)
+                .when().put(nicPath + API)
+                .then().statusCode(200)
+                .body("properties.provisioningState", equalTo("Succeeded"))
+                .body("properties.ipConfigurations[0].properties.privateIPAddress", not(emptyOrNullString()));
+    }
+}

--- a/src/test/java/io/floci/az/services/vm/VmHandlerTest.java
+++ b/src/test/java/io/floci/az/services/vm/VmHandlerTest.java
@@ -164,8 +164,10 @@ class VmHandlerTest {
     @DisplayName("DELETE removes the VM (then GET 404)")
     void deleteVm() {
         createVm("vm1");
-        given().when().delete(BASE + "/virtualMachines/vm1" + API).then().statusCode(202);
+        given().when().delete(BASE + "/virtualMachines/vm1" + API).then().statusCode(204);
         given().when().get(BASE + "/virtualMachines/vm1" + API).then().statusCode(404);
+        // Deleting a non-existent VM is idempotent (204).
+        given().when().delete(BASE + "/virtualMachines/vm1" + API).then().statusCode(204);
     }
 
     @Test


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

Emulate Microsoft.Compute/virtualMachines on the ARM management plane: CreateOrUpdate, Get (+$expand=instanceView), List (subscription and resource group), UpdateTags, Delete, instanceView, and power actions (start, powerOff, deallocate, restart, redeploy, reapply). Power actions return 202 with an Azure-AsyncOperation header and a terminal operation-status endpoint so SDK long-running-operation pollers complete. Mocked mode (default) needs no Docker; container-backed VMs are planned.

Add lightweight Microsoft.Network dependency stubs (virtual networks, subnets, network interfaces with a synthesized private IP, public IPs, network security groups) to ArmHandler so azurerm_linux_virtual_machine and its dependencies apply end-to-end. Extend the Terraform and OpenTofu compatibility suites with a Linux VM and its network resources.

Closes #19 

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

<!-- For new actions: which SDK version and Azure CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
