### PR TITLE
docs: list all services (Service Bus, API Management) and add Umami analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- 
 AI Context: This is Floci-Az, a lightweight Local Azure Emulator. 
 Identity: It is the Azure equivalent of Floci (AWS). It is NOT LocalStack.
-Protocols: Implements Azure Storage (Blob, Queue, Table), Azure Functions, App Configuration, Key Vault, Event Hubs, Cosmos DB, Azure SQL Database, Azure Kubernetes Service (AKS), API Management (Microsoft.ApiManagement), Virtual Machines (Microsoft.Compute), Azure Cache for Redis (Microsoft.Cache), and Azure Container Registry (Microsoft.ContainerRegistry).
+Protocols: Implements Azure Storage (Blob, Queue, Table), Azure Functions, App Configuration, Key Vault, Event Hubs, Service Bus (Microsoft.ServiceBus), Cosmos DB, Azure SQL Database, Azure Kubernetes Service (AKS), API Management (Microsoft.ApiManagement), Virtual Machines (Microsoft.Compute), Azure Cache for Redis (Microsoft.Cache), and Azure Container Registry (Microsoft.ContainerRegistry).
 Default Port: 4577 (HTTP; also HTTPS when FLOCI_AZ_TLS_ENABLED=true via protocol-sniffing proxy). AMQP port: 5672 (Event Hubs). Kafka port: 9093 (Event Hubs, opt-in). k3s API: 6443-7443 (AKS). Redis: 6379-6399 (Azure Cache for Redis).
 Tech Stack: Java, Quarkus, Docker-in-Docker for Functions. Artemis sidecar for Event Hubs AMQP. Redpanda sidecar for Kafka. k3s sidecar for AKS. Redis sidecar for Azure Cache for Redis.
 TLS: Optional. Set FLOCI_AZ_TLS_ENABLED=true. Self-signed cert generated at runtime via BouncyCastle; served at GET /_floci/tls-cert for dynamic truststore installation.
@@ -53,6 +53,7 @@ Floci AZ is a free, open-source local Azure emulator for development, testing, a
 | Cosmos DB (SQL API) | ✅                         | ❌                                           | ❌                                                                           |
 | Key Vault           | ✅                         | ❌                                           | ❌                                                                           |
 | Event Hubs          | ✅                         | ❌                                           | ❌                                                                           |
+| Service Bus         | ✅                         | ❌                                           | ❌                                                                           |
 | Azure SQL Database  | ✅                         | ❌                                           | ❌                                                                           |
 | AKS (Kubernetes)    | ✅                         | ❌                                           | ❌                                                                           |
 | API Management      | ✅                         | ❌                                           | ❌                                                                           |
@@ -177,6 +178,11 @@ flowchart LR
             H["Azure SQL\nMicrosoft.Sql"]
             I["AKS\nMicrosoft.ContainerService"]
             J["API Management\nMicrosoft.ApiManagement"]
+            K["Cosmos DB\n/{account}-cosmos/"]
+            L["Service Bus\n/{account}-servicebus/"]
+            M["Virtual Machines\nMicrosoft.Compute"]
+            N["Azure Cache for Redis\nMicrosoft.Cache"]
+            O["Container Registry\nMicrosoft.ContainerRegistry"]
         end
 
         Proxy -->|" route "| Router
@@ -190,11 +196,19 @@ flowchart LR
         Router --> H
         Router --> I
         Router --> J
-        A & B & C & E & F --> Store[("StorageBackend\nmemory · hybrid\npersistent · wal")]
+        Router --> K
+        Router --> L
+        Router --> M
+        Router --> N
+        Router --> O
+        A & B & C & E & F & K --> Store[("StorageBackend\nmemory · hybrid\npersistent · wal")]
         D -->|" spawn / proxy "| Docker["🐳 Docker\n(function containers)"]
-        G -->|" manages "| Sidecars["🐳 Artemis (AMQP)\n🐳 Redpanda (Kafka)"]
+        G & L -->|" manages "| Sidecars["🐳 Artemis (AMQP)\n🐳 Redpanda (Kafka)"]
         H -->|" manages "| SqlContainers["🐳 azure-sql-edge\n(per server)"]
         I -->|" manages "| K3s["🐳 k3s\n(per cluster)"]
+        K -->|" engines "| CosmosEngines["🐳 Cosmos engines\n(mongo · citus · scylla · …)"]
+        N -->|" manages "| RedisC["🐳 valkey\n(per cache)"]
+        O -->|" manages "| RegistryC["🐳 registry:2\n(shared)"]
     end
 
     Client -->|" HTTP/HTTPS :4577\nAzure wire protocol "| Proxy
@@ -213,6 +227,7 @@ flowchart LR
 | **Cosmos DB NoSQL (embedded)** | `/{account}-cosmos-nosql/` | Same embedded SQL engine as above, exposed as a named engine endpoint. Opt-in with `FLOCI_AZ_SERVICES_COSMOS_ENGINES_NOSQL_ENABLED=true`; no Docker required. |
 | **Key Vault**           | `/{account}-keyvault/`       | Secrets CRUD, versioning, soft-delete, properties update                                                                                                                                                              |
 | **Event Hubs**          | AMQP `:5672` / Kafka `:9093` | AMQP 1.0 (Artemis sidecar), Kafka-compatible (Redpanda, opt-in)                                                                                                                                                       |
+| **Service Bus**         | `/{account}-servicebus/` + AMQP `:5673` | Queues, topics, subscriptions (created dynamically); AMQP 1.0 data plane via Artemis sidecar, or mocked (management plane only)                                                                             |
 | **Azure SQL Database**  | ARM path + `/{account}-sql/` | Servers, databases, firewall rules; Docker-backed `azure-sql-edge` containers; dynamic port allocation                                                                                                               |
 | **Azure Kubernetes Service** | ARM path (`Microsoft.ContainerService`) | CreateOrUpdate, Get, Delete, List, agent pools, kubeconfig (`listClusterAdminCredential`); real k3s containers or mocked |
 | **API Management**      | ARM path (`Microsoft.ApiManagement`) + `/{account}-apim/{service}/` | In-process APIM emulator for ARM resources, gateway routing, products/subscriptions, named values, backends, OpenAPI import, and a focused policy subset |

--- a/docs/services/apim.md
+++ b/docs/services/apim.md
@@ -1,0 +1,57 @@
+# API Management
+
+floci-az includes an **in-process API Management emulator** intended for local development, SDK
+compatibility tests, and CI workflows that need APIM-shaped ARM resources plus a lightweight gateway.
+It is **not** a full Azure APIM gateway implementation — no sidecar is started; everything runs
+in-process.
+
+## Endpoints
+
+| Plane | Path |
+|---|---|
+| Management (ARM) | `Microsoft.ApiManagement/service/...` |
+| Gateway | `/{account}-apim/{serviceName}/{apiPath...}` — e.g. `http://localhost:4577/devstoreaccount1-apim/{serviceName}/...` |
+
+## Supported
+
+- **Management service** resources: create, get, list, delete.
+- **API** resources: create, get, list, delete.
+- **Operation** resources: create, get, list, delete.
+- **Policy** resources at service, API, and operation scope.
+- **Product** resources and product-to-API links.
+- **Subscription** resources with gateway subscription-key enforcement.
+- **Named values**, including secret named values whose `properties.value` is not exposed in ARM responses.
+- **Backends** and `<set-backend-service backend-id="...">`.
+- **OpenAPI JSON import** for APIs (operation generation from `paths`); reimport replaces previously generated operations.
+- **Gateway routing** for API paths and operation URL templates, with backend proxying when an API `serviceUrl` or backend policy is configured.
+
+### Supported policy subset
+
+The policy engine intentionally supports a focused subset:
+
+- `<set-header>` with `exists-action="override" | skip | append | delete`
+- `<set-query-parameter>` with `exists-action="override" | skip | delete`
+- `<rewrite-uri template="...">`
+- `<set-backend-service base-url="...">` and `<set-backend-service backend-id="...">`
+- `<return-response>` with nested `<set-status code="...">` and `<set-body>`
+- Named-value interpolation with `{{name}}` in supported policy values
+
+## Configuration
+
+```yaml
+floci-az:
+  services:
+    apim:
+      enabled: true
+```
+
+| Variable | Default | Description |
+|---|---|---|
+| `FLOCI_AZ_SERVICES_APIM_ENABLED` | `true` | Enable/disable the service |
+
+## Out of scope
+
+- The full Azure policy language (only the subset above is interpreted)
+- Developer portal, products workflow approvals, and analytics
+- Self-hosted gateways, multi-region deployment, and custom domains
+- Rate-limiting/quota, JWT validation, and caching policies

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -13,8 +13,10 @@ Floci-AZ provides emulation for several core Azure services.
 | **Cosmos DB multi-API** | _(engine sidecars)_ | ✅ MongoDB, PostgreSQL, Cassandra, Gremlin, Table, NoSQL (opt-in Docker engines) |
 | **Key Vault** | `/{account}-keyvault/` | ✅ Secrets CRUD, versioning, soft-delete, properties update |
 | **Event Hubs** | AMQP `:5672` / Kafka `:9093` | ✅ AMQP 1.0 (Artemis), Kafka-compatible (Redpanda, opt-in) |
+| **Service Bus** | `/{account}-servicebus/` + AMQP `:5673` | ✅ Queues, topics, subscriptions (dynamic); AMQP 1.0 via Artemis sidecar or mocked |
 | **Azure SQL Database** | ARM path + `/{account}-sql/` | ✅ Servers, databases, firewall rules; Docker-backed SQL Server containers |
 | **Azure Kubernetes Service** | ARM path (`Microsoft.ContainerService`) | ✅ Clusters, agent pools, credentials; real k3s containers or mocked |
+| **API Management** | ARM path (`Microsoft.ApiManagement`) + `/{account}-apim/` | ✅ APIs, operations, products, subscriptions, named values, backends, OpenAPI import; gateway routing + policy subset |
 | **Virtual Machines** | ARM path (`Microsoft.Compute` / `Microsoft.Network`) | ✅ VM lifecycle (create/start/stop/deallocate/restart/delete/list), instanceView, network dependency stubs; mocked (Docker backing planned) |
 | **Azure Cache for Redis** | ARM path (`Microsoft.Cache`) | ✅ Cache CRUD, listKeys/regenerateKey; real Redis containers (data plane) or mocked |
 | **Azure Container Registry** | ARM path (`Microsoft.ContainerRegistry`) | ✅ Registry CRUD, admin credentials, checkNameAvailability; one shared `registry:2` (Docker Registry V2 push/pull) or mocked |

--- a/docs/services/service-bus.md
+++ b/docs/services/service-bus.md
@@ -1,0 +1,113 @@
+# Service Bus
+
+Azure Service Bus emulation with a **management plane** for entity topology (queues, topics,
+subscriptions) over HTTP, and an **AMQP 1.0 data plane** backed by an Apache ActiveMQ Artemis sidecar
+managed automatically by floci-az.
+
+| Plane | Protocol | Transport | Port |
+|---|---|---|---|
+| Management | HTTP | `/{account}-servicebus/` on `:4577` | `4577` |
+| Data | AMQP 1.0 | Apache ActiveMQ Artemis sidecar | `5673` (AMQP) / `5674` (AMQPS) |
+
+Unlike Event Hubs, entity topology is **not** pre-configured — queues, topics and subscriptions are
+created dynamically through the management API (or auto-created on first use by the SDK).
+
+> **Mocked mode (default).** With `mocked: true` the Artemis sidecar is not started: the management
+> API responds, but the AMQP data plane is unavailable. Set `mocked: false` (and expose the AMQP
+> ports) to send and receive messages.
+
+## Management plane
+
+Entity CRUD is served over HTTP at `/{account}-servicebus/`:
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/{account}-servicebus/$Resources/queues` | List queues |
+| `PUT` / `DELETE` | `/{account}-servicebus/{queue}` | Create / delete a queue |
+| `GET` | `/{account}-servicebus/$Resources/topics` | List topics |
+| `PUT` / `DELETE` | `/{account}-servicebus/{topic}` | Create / delete a topic |
+| `GET` | `/{account}-servicebus/{topic}/subscriptions` | List subscriptions |
+| `PUT` / `GET` / `DELETE` | `/{account}-servicebus/{topic}/subscriptions/{sub}` | Manage a subscription |
+
+## Connection String
+
+```
+Endpoint=sb://localhost:5673;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=devkey;UseDevelopmentEmulator=true;
+```
+
+`UseDevelopmentEmulator=true` tells the SDK to use plain AMQP (no TLS). The `SharedAccessKey` value is
+ignored — Artemis runs without authentication in dev mode.
+
+## Python SDK
+
+```python
+from azure.servicebus import ServiceBusClient, ServiceBusMessage
+
+CONN = (
+    "Endpoint=sb://localhost:5673;"
+    "SharedAccessKeyName=RootManageSharedAccessKey;"
+    "SharedAccessKey=devkey;"
+    "UseDevelopmentEmulator=true;"
+)
+
+with ServiceBusClient.from_connection_string(CONN) as client:
+    with client.get_queue_sender("myqueue") as sender:
+        sender.send_messages(ServiceBusMessage("hello world"))
+
+    with client.get_queue_receiver("myqueue", max_wait_time=5) as receiver:
+        for msg in receiver:
+            print(str(msg))
+            receiver.complete_message(msg)
+```
+
+## Configuration
+
+### Docker Compose
+
+```yaml
+services:
+  floci-az:
+    image: floci/floci-az:latest
+    ports:
+      - "4577:4577"   # floci-az HTTP (management plane)
+      - "5673:5673"   # Service Bus AMQP (Artemis)
+      - "5674:5674"   # Service Bus AMQPS (Artemis)
+    environment:
+      FLOCI_AZ_SERVICES_SERVICE_BUS_ENABLED: "true"
+      FLOCI_AZ_SERVICES_SERVICE_BUS_MOCKED: "false"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+```
+
+### Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `FLOCI_AZ_SERVICES_SERVICE_BUS_ENABLED` | `true` | Enable/disable the service |
+| `FLOCI_AZ_SERVICES_SERVICE_BUS_MOCKED` | `true` | Mocked mode (management plane only, no Artemis) |
+| `FLOCI_AZ_SERVICES_SERVICE_BUS_AMQP_PORT` | `5673` | Host port for AMQP (Artemis) |
+| `FLOCI_AZ_SERVICES_SERVICE_BUS_AMQP_TLS_PORT` | `5674` | Host port for AMQPS |
+| `FLOCI_AZ_SERVICES_SERVICE_BUS_ARTEMIS_IMAGE` | `apache/activemq-artemis:latest` | Artemis image |
+| `FLOCI_AZ_SERVICES_SERVICE_BUS_MAX_DELIVERY_COUNT` | `10` | Max delivery attempts before dead-lettering |
+| `FLOCI_AZ_SERVICES_SERVICE_BUS_LOCK_DURATION_SECONDS` | `60` | Peek-lock duration |
+
+### application.yml
+
+```yaml
+floci-az:
+  services:
+    service-bus:
+      enabled: true
+      mocked: true              # true = management plane only, no Docker. false = real Artemis sidecar
+      amqp-port: 5673
+      amqp-tls-port: 5674
+      artemis-image: "apache/activemq-artemis:latest"
+      max-delivery-count: 10
+      lock-duration-seconds: 60
+```
+
+## Out of scope (future work)
+
+- Sessions, scheduled/deferred messages, and auto-forwarding
+- Duplicate detection and message transactions
+- Geo-disaster recovery and partitioned entities

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ edit_uri: edit/main/docs/
 
 theme:
   name: material
+  custom_dir: overrides
   logo: assets/floci-header.svg
   favicon: assets/floci.svg
   palette:
@@ -74,9 +75,11 @@ nav:
     - App Configuration: services/app-config.md
     - Key Vault: services/key-vault.md
     - Event Hubs: services/event-hub.md
+    - Service Bus: services/service-bus.md
     - Cosmos DB: services/cosmos.md
     - Azure SQL Database: services/sql.md
     - Azure Kubernetes Service: services/aks.md
+    - API Management: services/apim.md
     - Virtual Machines: services/vm.md
     - Azure Cache for Redis: services/redis.md
     - Azure Container Registry: services/acr.md

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,7 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+  {{ super() }}
+  <!-- Umami analytics — tracks docs visits (privacy-friendly, cookieless) -->
+  <script defer src="https://cloud.umami.is/script.js" data-website-id="b2ab8ccd-4619-4b94-bfa6-e8870961d6eb"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary

Documentation-site updates to make sure **every implemented service is listed and documented**:

- **New pages:** `docs/services/service-bus.md` and `docs/services/apim.md` (Service Bus and API Management had no pages).
- **Listed everywhere they were missing:** Service Bus + API Management added to the README comparison/service tables, the AI-context line, `docs/services/index.md`, and the mkdocs nav.
- **Architecture diagram fixed:** the mermaid graph stopped at API Management — added the missing nodes (Cosmos DB, Service Bus, Virtual Machines, Azure Cache for Redis, Container Registry) with their router/sidecar/store edges.
- **Umami analytics:** added to the docs site via a Material theme override (`overrides/main.html` → `theme.custom_dir`), cookieless + `defer`. Verified with `mkdocs build --strict`.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## Azure Compatibility

N/A — documentation and docs-site only; no emulator behavior or wire protocol changes.

## Checklist

- [x] `./mvnw test` passes locally — N/A, docs-only (no code changed)
- [ ] New or updated integration test added — N/A, docs-only
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
