### PR TITLE
chore(acr,redis): back registries and caches with Docker by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **arm:** `Microsoft.Network` dependency stubs — virtual networks, subnets, network interfaces (synthesized private IP), public IP addresses, and network security groups, so Terraform's `azurerm_linux_virtual_machine` and its dependencies apply end-to-end
 - **arm:** Terraform/OpenTofu compatibility suite extended with a Linux virtual machine and its network dependencies
 
+### Changed
+
+- **acr, redis:** Docker backing is now **on by default** (`mocked: false`) — creating a registry or cache starts a real container (a shared `registry:2` for ACR, a `valkey/valkey:8-alpine` container per cache for Redis). Set `FLOCI_AZ_SERVICES_ACR_MOCKED=true` / `FLOCI_AZ_SERVICES_REDIS_MOCKED=true` to restore management-plane-only mode. Unit tests pin `mocked=true` via test profiles and remain Docker-free.
+
 ## [0.5.0] - 2026-05-28
 
 ### Added

--- a/compatibility-tests/sdk-test-python/tests/test_redis.py
+++ b/compatibility-tests/sdk-test-python/tests/test_redis.py
@@ -99,5 +99,7 @@ def test_wrong_password_rejected(provisioned_cache):
     except redis.exceptions.RedisError:
         pytest.skip("Redis sidecar not reachable (mocked mode or no Docker)")
 
-    with pytest.raises(redis.exceptions.ResponseError):
+    # A wrong password raises AuthenticationError (newer redis-py) or a ResponseError "WRONGPASS"
+    # (older); accept either.
+    with pytest.raises((redis.exceptions.AuthenticationError, redis.exceptions.ResponseError)):
         _client(props, "wrong-password").ping()

--- a/docs/services/acr.md
+++ b/docs/services/acr.md
@@ -33,8 +33,8 @@ The **data plane** is served directly by the registry sidecar (not proxied throu
 > Docker handles this transparently: `docker login localhost:{port}` ignores the path, and an image
 > ref like `localhost:{port}/{registryName}/app` parses as registry `localhost:{port}` + repo
 > `{registryName}/app`. Docker treats `localhost:PORT` as insecure (plain-HTTP) automatically, so no
-> daemon config is needed. In **mocked** mode (default, no Docker) `loginServer` is the cosmetic
-> `{name}.azurecr.io` for management-plane fidelity.
+> daemon config is needed. The data plane is on by default (`mocked: false`). In **mocked** mode
+> (no Docker) `loginServer` is the cosmetic `{name}.azurecr.io` for management-plane fidelity.
 
 ## Authentication
 
@@ -61,7 +61,7 @@ floci-az:
   services:
     acr:
       enabled: true
-      mocked: true              # true = no Docker, management plane only. false = one shared registry:2 for all registries
+      mocked: false             # false (default) = one shared registry:2 for all registries. true = management plane only, no Docker
       default-image: "registry:2"
       base-port: 5000           # host port range start for registry containers
       max-port: 5099            # host port range end
@@ -70,7 +70,7 @@ floci-az:
 | Env var | Default | Description |
 |---|---|---|
 | `FLOCI_AZ_SERVICES_ACR_ENABLED` | `true` | Enable/disable the service |
-| `FLOCI_AZ_SERVICES_ACR_MOCKED` | `true` | Mocked mode (no Docker) |
+| `FLOCI_AZ_SERVICES_ACR_MOCKED` | `false` | Mocked mode (management plane only, no Docker) |
 | `FLOCI_AZ_SERVICES_ACR_DEFAULT_IMAGE` | `registry:2` | Registry container image |
 | `FLOCI_AZ_SERVICES_ACR_BASE_PORT` | `5000` | Host port range start |
 | `FLOCI_AZ_SERVICES_ACR_MAX_PORT` | `5099` | Host port range end |

--- a/docs/services/redis.md
+++ b/docs/services/redis.md
@@ -4,9 +4,9 @@ Compatible with the `azure-mgmt-redis` SDK, the `az redis` CLI, Terraform's `azu
 and any ARM-speaking client for the management plane — plus **any standard Redis client**
 (redis-py, StackExchange.Redis, Jedis, `redis-cli`, …) for the data plane.
 
-> **Real sidecar.** When `mocked=false`, each cache is backed by a real container
+> **Real sidecar (default).** With `mocked=false` (the default), each cache is backed by a real container
 > (`valkey/valkey:8-alpine` — a drop-in, RESP-compatible Redis fork) that clients connect to with
-> the Redis protocol. The default in unit-test profiles is `mocked=true` (management plane only, no
+> the Redis protocol. Unit-test profiles force `mocked=true` (management plane only, no
 > Docker).
 
 ---
@@ -106,7 +106,7 @@ floci-az:
   services:
     redis:
       enabled: true
-      mocked: true              # true = no Docker, management plane only. false = real cache container per cache
+      mocked: false             # false (default) = real cache container per cache. true = no Docker, management plane only
       default-image: "valkey/valkey:8-alpine"
       base-port: 6379           # host port range start for cache containers
       max-port: 6399            # host port range end
@@ -116,7 +116,7 @@ floci-az:
 | Env var | Default | Description |
 |---|---|---|
 | `FLOCI_AZ_SERVICES_REDIS_ENABLED` | `true` | Enable/disable the service |
-| `FLOCI_AZ_SERVICES_REDIS_MOCKED` | `true` | Mocked mode (no Docker) |
+| `FLOCI_AZ_SERVICES_REDIS_MOCKED` | `false` | Mocked mode (management plane only, no Docker) |
 | `FLOCI_AZ_SERVICES_REDIS_DEFAULT_IMAGE` | `valkey/valkey:8-alpine` | Cache container image (RESP-compatible) |
 | `FLOCI_AZ_SERVICES_REDIS_BASE_PORT` | `6379` | Host port range start |
 | `FLOCI_AZ_SERVICES_REDIS_MAX_PORT` | `6399` | Host port range end |

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -148,14 +148,14 @@ floci-az:
       enabled: true
     redis:
       enabled: true
-      mocked: true          # true = no Docker; caches are pure ARM state. false = back caches with real Redis containers
+      mocked: false         # false = back caches with real Valkey containers (default). true = no Docker; pure ARM state
       default-image: "valkey/valkey:8-alpine"   # RESP-compatible Redis fork (BSD-licensed)
       base-port: 6379
       max-port: 6399
       max-memory: "256mb"
     acr:
       enabled: true
-      mocked: true          # true = no Docker; registries are pure ARM state. false = back with real registry:2 containers
+      mocked: false         # false = back registries with a shared registry:2 container (default). true = no Docker; pure ARM state
       default-image: "registry:2"
       base-port: 5000
       max-port: 5099

--- a/src/test/java/io/floci/az/services/acr/AcrHandlerTest.java
+++ b/src/test/java/io/floci/az/services/acr/AcrHandlerTest.java
@@ -1,9 +1,13 @@
 package io.floci.az.services.acr;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.Map;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.endsWith;
@@ -15,9 +19,19 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 /**
  * Management-plane coverage for Azure Container Registry in mocked mode (no Docker):
  * registry CRUD, listCredentials / regenerateCredential, and checkNameAvailability.
+ *
+ * <p>Always runs in mocked mode (no registry container) regardless of the default in application.yml.
  */
 @QuarkusTest
+@TestProfile(AcrHandlerTest.MockedProfile.class)
 public class AcrHandlerTest {
+
+    public static class MockedProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("floci-az.services.acr.mocked", "true");
+        }
+    }
 
     private static final String SUB = "00000000-0000-0000-0000-000000000001";
     private static final String RG = "test-rg";


### PR DESCRIPTION
## Summary

Enable Docker backing **by default** for Azure Container Registry and Azure Cache for Redis: flip the shipped default to `mocked: false`, so creating a registry or cache starts a real container (a shared `registry:2` for ACR, a `valkey/valkey:8-alpine` container per cache for Redis) instead of returning synthetic ARM state — matching how AKS already defaults to a real k3s container. Set `FLOCI_AZ_SERVICES_ACR_MOCKED=true` / `FLOCI_AZ_SERVICES_REDIS_MOCKED=true` to restore management-plane-only mode.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## Azure Compatibility

No wire-protocol change — only the default `mocked` flag. The real ACR/Redis sidecars are already verified (Terraform/OpenTofu `azurerm_container_registry` / `azurerm_redis_cache` suites + Python data-plane tests). Unit tests pin `mocked=true` via `@TestProfile` and remain Docker-free.

## Checklist

- [x] `./mvnw test` passes locally (156/156)
- [x] New or updated integration test added — N/A; existing suites cover both modes (`AcrHandlerTest`/`RedisHandlerTest` pin `mocked=true`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
