### PR TITLE
fix(native): register ARM models for reflection and init handlers at run time

### DIFF
--- a/src/main/java/io/floci/az/services/acr/AcrModels.java
+++ b/src/main/java/io/floci/az/services/acr/AcrModels.java
@@ -2,12 +2,14 @@ package io.floci.az.services.acr;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.time.Instant;
 import java.util.Map;
 
 public class AcrModels {
 
+    @RegisterForReflection
     @JsonIgnoreProperties(ignoreUnknown = true)
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class Registry {

--- a/src/main/java/io/floci/az/services/aks/AksModels.java
+++ b/src/main/java/io/floci/az/services/aks/AksModels.java
@@ -2,6 +2,7 @@ package io.floci.az.services.aks;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -11,6 +12,7 @@ import java.util.Map;
 
 public class AksModels {
 
+    @RegisterForReflection
     @JsonIgnoreProperties(ignoreUnknown = true)
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class ManagedCluster {
@@ -103,6 +105,7 @@ public class AksModels {
         }
     }
 
+    @RegisterForReflection
     @JsonIgnoreProperties(ignoreUnknown = true)
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class AgentPoolProfile {

--- a/src/main/java/io/floci/az/services/appconfig/AppConfigModels.java
+++ b/src/main/java/io/floci/az/services/appconfig/AppConfigModels.java
@@ -1,5 +1,7 @@
 package io.floci.az.services.appconfig;
 
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
 import java.util.List;
 import java.util.Map;
 
@@ -32,10 +34,12 @@ public final class AppConfigModels {
     public static final String STATUS_FAILED       = "failed";
 
     /** A single page of list results plus the optional relative continuation link. */
+    @RegisterForReflection
     public record Page(List<Map<String, Object>> items, String nextLink) {
     }
 
     /** Response body for {@code GET /operations?snapshot=...}. */
+    @RegisterForReflection
     public record OperationDetails(String id, String status, Object error) {
     }
 }

--- a/src/main/java/io/floci/az/services/redis/RedisModels.java
+++ b/src/main/java/io/floci/az/services/redis/RedisModels.java
@@ -2,12 +2,14 @@ package io.floci.az.services.redis;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.time.Instant;
 import java.util.Map;
 
 public class RedisModels {
 
+    @RegisterForReflection
     @JsonIgnoreProperties(ignoreUnknown = true)
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class RedisCache {

--- a/src/main/java/io/floci/az/services/vm/VmModels.java
+++ b/src/main/java/io/floci/az/services/vm/VmModels.java
@@ -2,6 +2,7 @@ package io.floci.az.services.vm;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.time.Instant;
 import java.util.Map;
@@ -15,6 +16,7 @@ public class VmModels {
      * networkProfile, …) is stored verbatim so GET round-trips faithfully for SDKs and Terraform.
      * {@code provisioningState}, {@code vmId} and power state are managed by the emulator.</p>
      */
+    @RegisterForReflection
     @JsonIgnoreProperties(ignoreUnknown = true)
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public static class VirtualMachine {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,7 +18,9 @@ quarkus:
       --initialize-at-run-time=org.bouncycastle.jcajce.provider.asymmetric.rsa.KeyPairGeneratorSpi,
       --initialize-at-run-time=org.bouncycastle.jcajce.provider.asymmetric.x509.CertificateFactory,
       --initialize-at-run-time=io.floci.az.core.tls.TlsConfigSource,
-      --initialize-at-run-time=io.floci.az.core.tls.CertificateGenerator
+      --initialize-at-run-time=io.floci.az.core.tls.CertificateGenerator,
+      --initialize-at-run-time=io.floci.az.services.acr.AcrHandler,
+      --initialize-at-run-time=io.floci.az.services.redis.RedisHandler
 
 floci-az:
   port: 4577


### PR DESCRIPTION
## Summary

Fix the **GraalVM native image** (the release/nightly artifact), which was broken: ARM resources **404'd right after create** and App Configuration **snapshots 500'd**. Two native-only causes:

- `AcrHandler`/`RedisHandler` hold a static `SecureRandom`, which GraalVM bakes into the image heap (disallowed) → native build failed in analysis. Added both to `--initialize-at-run-time` (mirroring `CertificateGenerator`).
- The `redis`/`acr`/`vm`/`aks` model POJOs and the appconfig `OperationDetails`/`Page` records lacked `@RegisterForReflection`, so native stripped the metadata Jackson needs and serialize/deserialize round-trips silently failed. Registered them (mirroring the blob/queue/table models).

Invisible until now because CI builds native only at release/nightly and **never runs it**.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

No wire-protocol change. Verified by rebuilding the native image (`docker/Dockerfile.native`) and re-running the **full compat suite against the native container** — terraform, opentofu, python (121 passed), node (72/72), java (151, 0 errors) — all green where they previously 404'd / 500'd. JVM build unaffected (`./mvnw test` 156/156).

## Checklist

- [x] `./mvnw test` passes locally (156/156)
- [x] New or updated integration test added — N/A; reflection-only fix, validated by the existing compat suite run against the native image
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
