### PR TITLE
refactor(service-bus): Streamline Artemis TLS generation and testing

### DIFF
--- a/src/main/java/io/floci/az/services/eventhub/ArtemisTlsGenerator.java
+++ b/src/main/java/io/floci/az/services/eventhub/ArtemisTlsGenerator.java
@@ -10,7 +10,6 @@ import org.bouncycastle.asn1.x509.GeneralNames;
 import org.bouncycastle.asn1.x509.KeyUsage;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
@@ -23,7 +22,6 @@ import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.KeyStore;
 import java.security.SecureRandom;
-import java.security.Security;
 import java.security.cert.X509Certificate;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -39,12 +37,7 @@ public class ArtemisTlsGenerator {
 
     public static final String KEYSTORE_PASSWORD = "artemis-tls";
     private static final String CONTAINER_ALIAS = "artemis";
-
-    static {
-        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
-            Security.addProvider(new BouncyCastleProvider());
-        }
-    }
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     public record TlsBundle(byte[] pkcs12Bytes, String certPem) {}
 
@@ -54,13 +47,13 @@ public class ArtemisTlsGenerator {
      * DNS names passed in (e.g. the Docker container name for the sidecar).
      */
     public TlsBundle generate(String... additionalDnsNames) throws Exception {
-        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA", BouncyCastleProvider.PROVIDER_NAME);
-        keyGen.initialize(2048, new SecureRandom());
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(2048, SECURE_RANDOM);
         KeyPair keyPair = keyGen.generateKeyPair();
 
         Instant now = Instant.now();
         X500Name name = new X500Name("CN=floci-az-artemis");
-        BigInteger serial = new BigInteger(128, new SecureRandom());
+        BigInteger serial = new BigInteger(128, SECURE_RANDOM);
 
         var certBuilder = new JcaX509v3CertificateBuilder(
                 name, serial,
@@ -82,12 +75,9 @@ public class ArtemisTlsGenerator {
                 new KeyUsage(KeyUsage.digitalSignature | KeyUsage.keyEncipherment));
 
         ContentSigner signer = new JcaContentSignerBuilder("SHA256WithRSA")
-                .setProvider(BouncyCastleProvider.PROVIDER_NAME)
                 .build(keyPair.getPrivate());
 
-        X509Certificate cert = new JcaX509CertificateConverter()
-                .setProvider(BouncyCastleProvider.PROVIDER_NAME)
-                .getCertificate(certBuilder.build(signer));
+        X509Certificate cert = new JcaX509CertificateConverter().getCertificate(certBuilder.build(signer));
 
         KeyStore ks = KeyStore.getInstance("PKCS12");
         ks.load(null, null);

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -90,7 +90,8 @@ public class ServiceBusNamespaceManager {
             tls = tlsGenerator.generate(containerName);
         } catch (Exception e) {
             throw new RuntimeException(
-                    "Failed to generate TLS certificate for Service Bus namespace: " + namespaceName, e);
+                    "Failed to generate TLS certificate for Service Bus namespace '" + namespaceName
+                            + "': " + rootMessage(e), e);
         }
 
         String brokerXml = configGenerator.generate(namespaceName);
@@ -251,6 +252,15 @@ public class ServiceBusNamespaceManager {
 
     static String containerName(String namespaceName) {
         return "floci-az-servicebus-" + namespaceName;
+    }
+
+    private static String rootMessage(Throwable error) {
+        Throwable root = error;
+        while (root.getCause() != null) {
+            root = root.getCause();
+        }
+        String message = root.getMessage();
+        return root.getClass().getSimpleName() + (message == null || message.isBlank() ? "" : ": " + message);
     }
 
     @FunctionalInterface

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,7 @@ quarkus:
       --initialize-at-run-time=org.bouncycastle.jcajce.provider.asymmetric.x509.CertificateFactory,
       --initialize-at-run-time=io.floci.az.core.tls.TlsConfigSource,
       --initialize-at-run-time=io.floci.az.core.tls.CertificateGenerator,
+      --initialize-at-run-time=io.floci.az.services.eventhub.ArtemisTlsGenerator,
       --initialize-at-run-time=io.floci.az.services.acr.AcrHandler,
       --initialize-at-run-time=io.floci.az.services.redis.RedisHandler
 

--- a/src/test/java/io/floci/az/services/eventhub/ArtemisTlsGeneratorTest.java
+++ b/src/test/java/io/floci/az/services/eventhub/ArtemisTlsGeneratorTest.java
@@ -1,0 +1,38 @@
+package io.floci.az.services.eventhub;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.security.KeyStore;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ArtemisTlsGeneratorTest {
+
+    @Test
+    void generatesPemCertificateAndPkcs12Keystore() throws Exception {
+        ArtemisTlsGenerator.TlsBundle bundle =
+                new ArtemisTlsGenerator().generate("floci-az-servicebus-default");
+
+        assertTrue(bundle.certPem().contains("BEGIN CERTIFICATE"));
+        assertTrue(bundle.pkcs12Bytes().length > 0);
+
+        KeyStore keyStore = KeyStore.getInstance("PKCS12");
+        keyStore.load(new ByteArrayInputStream(bundle.pkcs12Bytes()),
+                ArtemisTlsGenerator.KEYSTORE_PASSWORD.toCharArray());
+        assertTrue(keyStore.containsAlias("artemis"));
+
+        CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
+        X509Certificate certificate = (X509Certificate) certificateFactory.generateCertificate(
+                new ByteArrayInputStream(bundle.certPem().getBytes()));
+        Collection<List<?>> sans = certificate.getSubjectAlternativeNames();
+        assertNotNull(sans);
+        assertTrue(sans.stream().anyMatch(san -> san.contains("localhost")));
+        assertTrue(sans.stream().anyMatch(san -> san.contains("floci-az-servicebus-default")));
+    }
+}


### PR DESCRIPTION
Remove explicit Bouncy Castle provider registration and usage. Initialize SecureRandom once for improved efficiency. Add unit tests to validate TLS bundle generation. Improve error reporting for TLS generation failures by including root cause. Configure ArtemisTlsGenerator for GraalVM native image runtime initialization.

close #55 

## Service Bus native release validation

I validated this fix against a local native Docker image, which is the closest path to the published release image.

### Build native image locally

```bash
docker build \
  -f docker/Dockerfile.native \
  -t floci-az:native-local \
  --build-arg VERSION=0.6.0-local \
  .
```

The native image built successfully.

### Run the native image with Service Bus non-mocked

```bash
docker run -d --name floci-sb-test \
  -p 4577:4577 \
  -v /var/run/docker.sock:/var/run/docker.sock \
  -e FLOCI_AZ_STORAGE_MODE=memory \
  -e FLOCI_AZ_SERVICES_SERVICE_BUS_MOCKED=false \
  floci-az:native-local
```

Note: I intentionally did not publish `5673` from the main container because the Service Bus sidecar owns the AMQP host port.

### Create Service Bus namespace

```bash
curl -X PUT "http://localhost:4577/devstoreaccount1-servicebus/namespaces/default" \
  -H "Content-Type: application/json" \
  -d '{}'
```

### Result

The namespace is created successfully in non-mocked mode, and TLS certificate generation works in the native image:

```json
{
  "name": "default",
  "amqpPort": 5672,
  "amqpsPort": 5671,
  "tlsCertPem": "-----BEGIN CERTIFICATE-----...",
  "mocked": false
}
```

This confirms that the native/release-like image no longer fails with:

```text
Failed to generate TLS certificate for Service Bus namespace
```

### Additional validation

```bash
./mvnw -q -Dtest=ArtemisTlsGeneratorTest test
./mvnw -q -DskipTests compile
```

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [x] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

<!-- For new actions: which SDK version and Azure CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
