### PR TITLE
feat(network): Implement Azure Virtual Network (VNet) emulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-06-09
+
 ### Added
 
 - **acr:** Azure Container Registry emulation (`Microsoft.ContainerRegistry/registries`) — registry lifecycle (CreateOrUpdate, Get, Patch, List by subscription and resource group, Delete), `listCredentials` / `regenerateCredential`, `listUsages`, and `checkNameAvailability`. Non-mocked mode backs all registries with a single shared `registry:2` sidecar exposing the Docker Registry HTTP API V2; registries are isolated by an internal repository prefix, so `loginServer` is path-style (`localhost:{port}/{name}`, not `{name}.azurecr.io`) and standard `docker push`/`pull` work against it. The shared registry runs anonymous (admin credentials are issued but not enforced at the data plane). Registries provision asynchronously (`Creating` → `Succeeded` once `GET /v2/` answers); mocked mode (default in tests) is management-plane only. Compatibility: Terraform/OpenTofu `azurerm_container_registry` suites and a Python data-plane push/pull test
@@ -183,7 +185,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Multi-arch Docker image (`linux/amd64`, `linux/arm64`) — native binary (`latest`) and JVM (`latest-jvm`) tags
 - Single unified port `4577` for all services
 
-[Unreleased]: https://github.com/floci-io/floci-az/compare/0.5.0...HEAD
+[Unreleased]: https://github.com/floci-io/floci-az/compare/0.6.0...HEAD
+[0.6.0]: https://github.com/floci-io/floci-az/compare/0.5.0...0.6.0
 [0.5.0]: https://github.com/floci-io/floci-az/compare/0.4.0...0.5.0
 [0.4.0]: https://github.com/floci-io/floci-az/compare/0.3.0...0.4.0
 [0.3.0]: https://github.com/floci-io/floci-az/compare/0.2.0...0.3.0

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,8 @@ compat-run: compat-network
 		-v /var/run/docker.sock:/var/run/docker.sock \
 		-p $(PORT):4577 \
 		-e FLOCI_AZ_SERVICES_DOCKER_NETWORK=$(COMPAT_NETWORK) \
+		-e FLOCI_AZ_TLS_ENABLED=true \
+		-e FLOCI_AZ_HOSTNAME=floci-az \
 		$(FLOCI_AZ_IMAGE)
 	@echo "Waiting for floci-az Docker emulator to start on port $(PORT)..."
 	@until curl -sf http://127.0.0.1:$(PORT)/health > /dev/null; do sleep 1; done

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- 
 AI Context: This is Floci-Az, a lightweight Local Azure Emulator. 
 Identity: It is the Azure equivalent of Floci (AWS). It is NOT LocalStack.
-Protocols: Implements Azure Storage (Blob, Queue, Table), Azure Functions, App Configuration, Key Vault, Event Hubs, Service Bus (Microsoft.ServiceBus), Cosmos DB, Azure SQL Database, Azure Kubernetes Service (AKS), API Management (Microsoft.ApiManagement), Virtual Machines (Microsoft.Compute), Azure Cache for Redis (Microsoft.Cache), and Azure Container Registry (Microsoft.ContainerRegistry).
+Protocols: Implements Azure Storage (Blob, Queue, Table), Azure Functions, App Configuration, Key Vault, Event Hubs, Service Bus (Microsoft.ServiceBus), Cosmos DB, Azure SQL Database, Azure Kubernetes Service (AKS), API Management (Microsoft.ApiManagement), Virtual Network (Microsoft.Network), Virtual Machines (Microsoft.Compute), Azure Cache for Redis (Microsoft.Cache), and Azure Container Registry (Microsoft.ContainerRegistry).
 Default Port: 4577 (HTTP; also HTTPS when FLOCI_AZ_TLS_ENABLED=true via protocol-sniffing proxy). AMQP port: 5672 (Event Hubs). Kafka port: 9093 (Event Hubs, opt-in). k3s API: 6443-7443 (AKS). Redis: 6379-6399 (Azure Cache for Redis).
 Tech Stack: Java, Quarkus, Docker-in-Docker for Functions. Artemis sidecar for Event Hubs AMQP. Redpanda sidecar for Kafka. k3s sidecar for AKS. Redis sidecar for Azure Cache for Redis.
 TLS: Optional. Set FLOCI_AZ_TLS_ENABLED=true. Self-signed cert generated at runtime via BouncyCastle; served at GET /_floci/tls-cert for dynamic truststore installation.
@@ -231,7 +231,8 @@ flowchart LR
 | **Azure SQL Database**  | ARM path + `/{account}-sql/` | Servers, databases, firewall rules; Docker-backed `azure-sql-edge` containers; dynamic port allocation                                                                                                               |
 | **Azure Kubernetes Service** | ARM path (`Microsoft.ContainerService`) | CreateOrUpdate, Get, Delete, List, agent pools, kubeconfig (`listClusterAdminCredential`); real k3s containers or mocked |
 | **API Management**      | ARM path (`Microsoft.ApiManagement`) + `/{account}-apim/{service}/` | In-process APIM emulator for ARM resources, gateway routing, products/subscriptions, named values, backends, OpenAPI import, and a focused policy subset |
-| **Virtual Machines**    | ARM path (`Microsoft.Compute` / `Microsoft.Network`) | VM lifecycle (create/start/stop/deallocate/restart/delete/list), instanceView power state, network dependency stubs (vnet/subnet/NIC/public IP/NSG); mocked — no Docker (container backing planned) |
+| **Virtual Network**     | ARM path (`Microsoft.Network`) | VNet, subnet, NIC, public IP, and NSG ARM resources; subnet listing is scoped to the parent VNet; NIC private IPs are synthesized for VM/Terraform compatibility |
+| **Virtual Machines**    | ARM path (`Microsoft.Compute`) | VM lifecycle (create/start/stop/deallocate/restart/delete/list), instanceView power state; mocked — no Docker (container backing planned) |
 | **Azure Cache for Redis** | ARM path (`Microsoft.Cache`) | Cache CRUD, `listKeys`/`regenerateKey`; real `valkey/valkey:8-alpine` containers (data plane, primary key as password) or mocked; non-SSL port |
 | **Azure Container Registry** | ARM path (`Microsoft.ContainerRegistry`) | Registry CRUD, `listCredentials`/`regenerateCredential`, `checkNameAvailability`; one shared `registry:2` (Docker Registry V2 push/pull, path-style `loginServer`, anonymous) or mocked |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@
 
 ---
 
-Floci-AZ is a fast, free, and open-source local Azure service emulator — providing Blob Storage, Queues, Tables, Azure Functions, App Configuration, Cosmos DB (all APIs), Key Vault, and Event Hubs in a single native binary.
+Floci-AZ is a fast, free, and open-source local Azure service emulator — providing Blob Storage, Queues, Tables, Azure Functions, App Configuration, Cosmos DB (all APIs), Key Vault, Event Hubs, API Management, Virtual Network, Virtual Machines, Azure Cache for Redis, and Azure Container Registry in a single native binary.
 
 ## Why floci-az?
 
@@ -48,6 +48,7 @@ flowchart LR
             F["Cosmos DB\n/{account}-cosmos(-*)/"]
             G["Key Vault\n/{account}-keyvault/"]
             H["Event Hubs\nAMQP :5672 / Kafka :9093"]
+            I["ARM Services\nAPIM · Network · VM · Redis · ACR"]
         end
 
         Router --> A
@@ -58,7 +59,9 @@ flowchart LR
         Router --> F
         Router --> G
         Router --> H
+        Router --> I
         A & B & C & E & F & G --> Store[("StorageBackend\nmemory · hybrid\npersistent · wal")]
+        I --> Store
         D -->|"spawn / proxy"| Docker["🐳 Docker\n(function containers)"]
         F -->|"optional engines"| DockerEngines["🐳 MongoDB · PostgreSQL\nCassandra · Gremlin"]
         H -->|"manages"| Sidecars["🐳 Artemis (AMQP)\n🐳 Redpanda (Kafka)"]
@@ -80,6 +83,11 @@ flowchart LR
 | **Cosmos DB engines** | `/{account}-cosmos-{api}/` | MongoDB · PostgreSQL · Cassandra · Gremlin (Docker-backed, opt-in) · Table · NoSQL (embedded, opt-in) |
 | **Key Vault** | `/{account}-keyvault/` | Secrets CRUD, versioning, soft-delete, properties update |
 | **Event Hubs** | AMQP `:5672` / Kafka `:9093` | AMQP 1.0 (Artemis sidecar), Kafka-compatible (Redpanda, opt-in) |
+| **API Management** | ARM path + `/{account}-apim/` | APIs, operations, products, subscriptions, gateway routing, focused policy subset |
+| **Virtual Network** | ARM path (`Microsoft.Network`) | VNets, subnets, NICs, public IPs, NSGs for Terraform/OpenTofu and VM dependencies |
+| **Virtual Machines** | ARM path (`Microsoft.Compute`) | VM lifecycle, power actions, instanceView; mocked control plane |
+| **Azure Cache for Redis** | ARM path (`Microsoft.Cache`) | Cache CRUD, keys, real Redis-compatible containers or mocked mode |
+| **Azure Container Registry** | ARM path (`Microsoft.ContainerRegistry`) | Registry CRUD, credentials, Docker Registry V2 push/pull support |
 
 ## Quick Start
 

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -17,7 +17,8 @@ Floci-AZ provides emulation for several core Azure services.
 | **Azure SQL Database** | ARM path + `/{account}-sql/` | ✅ Servers, databases, firewall rules; Docker-backed SQL Server containers |
 | **Azure Kubernetes Service** | ARM path (`Microsoft.ContainerService`) | ✅ Clusters, agent pools, credentials; real k3s containers or mocked |
 | **API Management** | ARM path (`Microsoft.ApiManagement`) + `/{account}-apim/` | ✅ APIs, operations, products, subscriptions, named values, backends, OpenAPI import; gateway routing + policy subset |
-| **Virtual Machines** | ARM path (`Microsoft.Compute` / `Microsoft.Network`) | ✅ VM lifecycle (create/start/stop/deallocate/restart/delete/list), instanceView, network dependency stubs; mocked (Docker backing planned) |
+| **Virtual Network** | ARM path (`Microsoft.Network`) | ✅ VNets, subnets, NICs, public IPs, NSGs; in-process ARM state for Terraform/OpenTofu and VM dependencies |
+| **Virtual Machines** | ARM path (`Microsoft.Compute`) | ✅ VM lifecycle (create/start/stop/deallocate/restart/delete/list), instanceView; mocked (Docker backing planned) |
 | **Azure Cache for Redis** | ARM path (`Microsoft.Cache`) | ✅ Cache CRUD, listKeys/regenerateKey; real Redis containers (data plane) or mocked |
 | **Azure Container Registry** | ARM path (`Microsoft.ContainerRegistry`) | ✅ Registry CRUD, admin credentials, checkNameAvailability; one shared `registry:2` (Docker Registry V2 push/pull) or mocked |
 

--- a/docs/services/network.md
+++ b/docs/services/network.md
@@ -1,0 +1,86 @@
+# Azure Virtual Network
+
+Compatible with ARM-speaking clients, Terraform's AzureRM provider, and OpenTofu resources that provision basic `Microsoft.Network` dependencies for local VM workflows.
+
+> **No Docker required.** Network is an in-process ARM control-plane emulator. It stores resource state and returns Azure-shaped responses, but it does not create real routing, packet isolation, firewall enforcement, or IP allocation.
+
+---
+
+## Features
+
+- **Virtual networks** — CreateOrUpdate, Get, Delete, and List by resource group
+- **Subnets** — CreateOrUpdate, Get, Delete, and List under a virtual network
+- **Network interfaces** — CreateOrUpdate, Get, Delete, and List by resource group
+- **Public IP addresses** — CreateOrUpdate, Get, Delete, and List by resource group
+- **Network security groups** — CreateOrUpdate, Get, Delete, and List by resource group
+- **Terraform/OpenTofu compatibility** — supports the Network resources needed by `azurerm_linux_virtual_machine`
+- **Resource group listing** — Network resources appear in ARM resource group resource listings
+
+Created resources return `properties.provisioningState = "Succeeded"`. NICs synthesize a dynamic private IP (`10.0.0.4`) when no private IP is supplied, and public IP resources synthesize a dynamic public IP (`20.0.0.4`) when no address is supplied.
+
+---
+
+## Endpoints
+
+All operations use ARM paths:
+
+```text
+GET    /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/virtualNetworks
+PUT    /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/virtualNetworks/{name}
+GET    /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/virtualNetworks/{name}
+DELETE /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/virtualNetworks/{name}
+
+GET    /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/virtualNetworks/{vnet}/subnets
+PUT    /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/virtualNetworks/{vnet}/subnets/{name}
+GET    /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/virtualNetworks/{vnet}/subnets/{name}
+DELETE /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/virtualNetworks/{vnet}/subnets/{name}
+
+PUT    /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/networkInterfaces/{name}
+GET    /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/networkInterfaces/{name}
+DELETE /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/networkInterfaces/{name}
+
+PUT    /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/publicIPAddresses/{name}
+GET    /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/publicIPAddresses/{name}
+DELETE /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/publicIPAddresses/{name}
+
+PUT    /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/networkSecurityGroups/{name}
+GET    /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/networkSecurityGroups/{name}
+DELETE /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Network/networkSecurityGroups/{name}
+```
+
+---
+
+## Terraform And OpenTofu
+
+The compatibility suites exercise Network through the same local emulator path used in CI:
+
+```bash
+make test-terraform
+make test-opentofu
+```
+
+If port `4577` is already in use, run the suites against another emulator port:
+
+```bash
+make PORT=4578 test-terraform
+make PORT=4578 test-opentofu
+```
+
+The Network coverage lives in:
+
+- `compatibility-tests/compat-terraform`
+- `compatibility-tests/compat-opentofu`
+
+The current Network scope is enough for Terraform/OpenTofu to create and destroy a resource group with VNet, subnet, NIC, public IP, NSG, and a VM that references the NIC.
+
+---
+
+## Scope And Limitations
+
+- No real L2/L3 networking, routing, peering, DNS, packet forwarding, or service endpoints
+- No NSG rule enforcement; NSG resources are stored as ARM state only
+- No private endpoint, route table, NAT gateway, load balancer, or application gateway behavior
+- No real IP address management; default private and public IPs are synthesized for SDK and provider compatibility
+- Deletes are state-only; deleting a VNet also removes its child subnets from the in-memory store
+
+The goal is API parity for local provisioning workflows, especially SDK, Azure CLI, Terraform, and OpenTofu flows that need Network dependencies before creating other Azure resources.

--- a/docs/services/vm.md
+++ b/docs/services/vm.md
@@ -13,9 +13,9 @@ Compatible with the `azure-mgmt-compute` SDK, the `az vm` CLI, Terraform's `azur
 - **Lifecycle** — CreateOrUpdate, Get, Delete, List (by subscription and by resource group), UpdateTags
 - **Power actions** — `start`, `powerOff`, `deallocate`, `restart`, `redeploy`, `reapply`
 - **instanceView** — reports `ProvisioningState/*` and `PowerState/*` statuses
-- **Network dependency stubs** — `Microsoft.Network` shells (virtual networks, subnets, network
-  interfaces, public IPs, network security groups) so `azurerm_linux_virtual_machine` and its
-  dependencies apply end-to-end. Network interfaces get a synthesized private IP.
+- **Network integration** — VM ARM resources can reference `Microsoft.Network` network
+  interfaces. The Network emulator supplies VNet, subnet, NIC, public IP, and NSG ARM resources
+  so `azurerm_linux_virtual_machine` and its dependencies apply end-to-end.
 - **Long-running operations** — power actions return `202` with an `Azure-AsyncOperation` header
   pointing at an operation-status endpoint, so SDK pollers complete cleanly.
 
@@ -35,13 +35,10 @@ POST   .../virtualMachines/{name}/{start|powerOff|deallocate|restart|redeploy|re
 GET    /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Compute/virtualMachines
 GET    /subscriptions/{sub}/providers/Microsoft.Compute/virtualMachines
 
-# Network dependency shells
-PUT/GET/DELETE  .../providers/Microsoft.Network/virtualNetworks/{name}
-PUT/GET/DELETE  .../providers/Microsoft.Network/virtualNetworks/{vnet}/subnets/{name}
-PUT/GET/DELETE  .../providers/Microsoft.Network/networkInterfaces/{name}
-PUT/GET/DELETE  .../providers/Microsoft.Network/publicIPAddresses/{name}
-PUT/GET/DELETE  .../providers/Microsoft.Network/networkSecurityGroups/{name}
+# Network resources are handled by the Microsoft.Network emulator.
 ```
+
+See [Azure Virtual Network](network.md) for VNet, subnet, NIC, public IP, and NSG scope.
 
 Use `?$expand=instanceView` on a Get to embed the instance view under `properties.instanceView`.
 
@@ -118,7 +115,7 @@ floci-az:
 ## Notes & limitations
 
 - Mocked mode does not run a real OS — there is no SSH, no guest agent, and `runCommand` is not executed.
-- Network dependency shells echo submitted properties with `provisioningState = "Succeeded"`;
-  NIC private IPs and public IPs are synthesized, not allocated from a real address pool.
+- Network resources are ARM control-plane emulation only. NIC private IPs and public IPs are
+  synthesized by the Network emulator, not allocated from a real address pool.
 - Real container-backed VMs (image resolution via `imageReference`, `docker start/stop/restart`)
   are planned for a follow-up.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -80,6 +80,7 @@ nav:
     - Azure SQL Database: services/sql.md
     - Azure Kubernetes Service: services/aks.md
     - API Management: services/apim.md
+    - Virtual Network: services/network.md
     - Virtual Machines: services/vm.md
     - Azure Cache for Redis: services/redis.md
     - Azure Container Registry: services/acr.md

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.floci.az</groupId>
     <artifactId>floci-az</artifactId>
-    <version>0.5.0</version>
+    <version>0.6.0</version>
 
     <properties>
         <compiler-plugin.version>3.15.0</compiler-plugin.version>

--- a/src/main/java/io/floci/az/core/AdminController.java
+++ b/src/main/java/io/floci/az/core/AdminController.java
@@ -8,6 +8,7 @@ import io.floci.az.services.cosmos.CosmosHandler;
 import io.floci.az.services.eventhub.EventHubHandler;
 import io.floci.az.services.functions.FunctionsServiceHandler;
 import io.floci.az.services.keyvault.KeyVaultHandler;
+import io.floci.az.services.network.NetworkHandler;
 import io.floci.az.services.queue.QueueServiceHandler;
 import io.floci.az.services.redis.RedisHandler;
 import io.floci.az.services.servicebus.ServiceBusHandler;
@@ -32,6 +33,7 @@ public class AdminController {
     @Inject EventHubHandler         eventHubHandler;
     @Inject FunctionsServiceHandler functionsHandler;
     @Inject KeyVaultHandler         keyVaultHandler;
+    @Inject NetworkHandler          networkHandler;
     @Inject QueueServiceHandler     queueHandler;
     @Inject ServiceBusHandler       serviceBusHandler;
     @Inject SqlHandler              sqlHandler;
@@ -67,6 +69,7 @@ public class AdminController {
         cosmosHandler.clearAll();
         functionsHandler.clearAll();
         keyVaultHandler.clearAll();
+        networkHandler.clearAll();
         queueHandler.clearAll();
         serviceBusHandler.clearAll();
         tableHandler.clearAll();

--- a/src/main/java/io/floci/az/services/arm/ArmHandler.java
+++ b/src/main/java/io/floci/az/services/arm/ArmHandler.java
@@ -8,6 +8,7 @@ import io.floci.az.services.apim.ApiManagementHandler;
 import io.floci.az.services.blob.BlobServiceHandler;
 import io.floci.az.services.functions.FunctionRuntime;
 import io.floci.az.services.functions.FunctionsServiceHandler;
+import io.floci.az.services.network.NetworkHandler;
 import io.floci.az.services.queue.QueueServiceHandler;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -53,22 +54,23 @@ public class ArmHandler implements AzureServiceHandler {
     private final Map<String, Map<String, Object>> storageAccounts  = new ConcurrentHashMap<>();
     private final Map<String, Map<String, Object>> keyVaults        = new ConcurrentHashMap<>();
     private final Map<String, Map<String, Object>> webApps          = new ConcurrentHashMap<>();
-    private final Map<String, Map<String, Object>> networkResources = new ConcurrentHashMap<>();
-
     private final EmulatorConfig config;
     private final BlobServiceHandler blobHandler;
     private final QueueServiceHandler queueHandler;
     private final FunctionsServiceHandler functionsHandler;
     private final ApiManagementHandler apiManagementHandler;
+    private final NetworkHandler networkHandler;
 
     @Inject
     public ArmHandler(EmulatorConfig config, BlobServiceHandler blobHandler, QueueServiceHandler queueHandler,
-                      FunctionsServiceHandler functionsHandler, ApiManagementHandler apiManagementHandler) {
+                      FunctionsServiceHandler functionsHandler, ApiManagementHandler apiManagementHandler,
+                      NetworkHandler networkHandler) {
         this.config               = config;
         this.blobHandler          = blobHandler;
         this.queueHandler         = queueHandler;
         this.functionsHandler     = functionsHandler;
         this.apiManagementHandler = apiManagementHandler;
+        this.networkHandler       = networkHandler;
     }
 
     @Override
@@ -180,10 +182,7 @@ public class ArmHandler implements AzureServiceHandler {
                     .filter(v -> sub.equals(v.get("_sub")) && rg.equals(v.get("_rg")))
                     .map(ArmHandler::stripInternal)
                     .forEach(resources::add);
-            networkResources.values().stream()
-                    .filter(v -> sub.equals(v.get("_sub")) && rg.equals(v.get("_rg")))
-                    .map(ArmHandler::stripInternal)
-                    .forEach(resources::add);
+            resources.addAll(networkHandler.listResources(sub, rg));
             resources.addAll(apiManagementHandler.listServices(sub, rg));
             return Response.ok(Map.of("value", resources)).build();
         }
@@ -209,7 +208,7 @@ public class ArmHandler implements AzureServiceHandler {
             return handleWeb(req, path, method, sub);
         }
         if (path.contains("/providers/Microsoft.Network/")) {
-            return handleNetwork(req, path, method, sub);
+            return networkHandler.handleArm(req, path, method, sub);
         }
         if (path.contains("/providers/Microsoft.ApiManagement/")) {
             return apiManagementHandler.handleArm(req, path, method, sub);
@@ -330,128 +329,6 @@ public class ArmHandler implements AzureServiceHandler {
         resource.put("kind", "functionapp,linux");
         resource.put("properties", properties);
         return resource;
-    }
-
-    // ── Network resources (VM dependencies) ───────────────────────────────────
-    //
-    // Lightweight ARM shells for the resources an azurerm_linux_virtual_machine needs:
-    // virtualNetworks (+ subnets), networkInterfaces, publicIPAddresses,
-    // networkSecurityGroups. Submitted properties are echoed back with
-    // provisioningState=Succeeded; NIC private IPs and public IPs are synthesised so the
-    // provider can read them back after apply.
-
-    private Response handleNetwork(AzureRequest req, String path, String method, String sub) {
-        String rg   = extractRg(path);
-        String tail = extractAfter(path, "/providers/Microsoft.Network/");
-
-        // LIST: tail is a single resource-type segment (e.g. "virtualNetworks").
-        if (tail.matches("[^/]+")) {
-            return listNetworkResources(sub, rg, "Microsoft.Network/" + tail);
-        }
-        // LIST subnets of a vnet: "virtualNetworks/{vnet}/subnets".
-        if (tail.matches("virtualNetworks/[^/]+/subnets")) {
-            return listNetworkResources(sub, rg, "Microsoft.Network/virtualNetworks/subnets");
-        }
-
-        String resourceType = networkResourceType(tail);
-        String name         = networkResourceName(tail);
-        String key          = netKey(sub, rg, tail);
-
-        return switch (method) {
-            case "PUT"    -> createOrUpdateNetworkResource(req, sub, rg, tail, resourceType, name, key);
-            case "GET"    -> {
-                Map<String, Object> resource = networkResources.get(key);
-                yield resource == null ? armNotFound(tail) : Response.ok(stripInternal(resource)).build();
-            }
-            case "DELETE" -> { networkResources.remove(key); yield Response.ok().build(); }
-            default       -> Response.status(405).build();
-        };
-    }
-
-    private Response listNetworkResources(String sub, String rg, String type) {
-        List<Map<String, Object>> items = networkResources.values().stream()
-                .filter(r -> sub.equals(r.get("_sub")) && rg.equals(r.get("_rg")) && type.equals(r.get("type")))
-                .map(ArmHandler::stripInternal)
-                .toList();
-        return Response.ok(Map.of("value", items)).build();
-    }
-
-    private Response createOrUpdateNetworkResource(AzureRequest req, String sub, String rg, String tail,
-                                                   String resourceType, String name, String key) {
-        Map<String, Object> body       = parseBody(req);
-        Map<String, Object> properties = new LinkedHashMap<>(cast(body.get("properties")));
-        synthesizeNetworkProperties(resourceType, properties);
-        properties.put("provisioningState", "Succeeded");
-
-        Map<String, Object> resource = new LinkedHashMap<>();
-        resource.put("_sub", sub);
-        resource.put("_rg", rg);
-        resource.put("id", "/subscriptions/" + sub + "/resourceGroups/" + rg
-                + "/providers/Microsoft.Network/" + tail);
-        resource.put("name", name);
-        resource.put("type", resourceType);
-        String location = bodyString(body, "location", null);
-        if (location != null) {
-            resource.put("location", location);
-        }
-        if (body.get("tags") instanceof Map<?, ?> tags && !tags.isEmpty()) {
-            resource.put("tags", tags);
-        }
-        resource.put("properties", properties);
-        networkResources.put(key, resource);
-        return Response.ok(stripInternal(resource)).build();
-    }
-
-    @SuppressWarnings("unchecked")
-    private static void synthesizeNetworkProperties(String resourceType, Map<String, Object> properties) {
-        switch (resourceType) {
-            case "Microsoft.Network/networkInterfaces" -> {
-                Object cfgs = properties.get("ipConfigurations");
-                List<Object> configs = cfgs instanceof List<?> l && !l.isEmpty()
-                        ? new ArrayList<>((List<Object>) l)
-                        : new ArrayList<>(List.of(new LinkedHashMap<String, Object>(Map.of("name", "ipconfig1"))));
-                boolean[] first = {true};
-                configs.replaceAll(c -> {
-                    Map<String, Object> cfg = new LinkedHashMap<>(cast(c));
-                    Map<String, Object> cp = new LinkedHashMap<>(cast(cfg.get("properties")));
-                    cp.putIfAbsent("privateIPAddress", "10.0.0.4");
-                    cp.putIfAbsent("privateIPAllocationMethod", "Dynamic");
-                    cp.put("primary", first[0]);
-                    cp.put("provisioningState", "Succeeded");
-                    cfg.put("properties", cp);
-                    cfg.putIfAbsent("name", "ipconfig1");
-                    first[0] = false;
-                    return cfg;
-                });
-                properties.put("ipConfigurations", configs);
-            }
-            case "Microsoft.Network/publicIPAddresses" -> {
-                properties.putIfAbsent("ipAddress", "20.0.0.4");
-                properties.putIfAbsent("publicIPAllocationMethod", "Dynamic");
-            }
-            default -> { /* virtualNetworks, subnets, networkSecurityGroups: echo as-is */ }
-        }
-    }
-
-    private static String networkResourceType(String tail) {
-        // "networkInterfaces/{name}" -> "Microsoft.Network/networkInterfaces"
-        // "virtualNetworks/{v}/subnets/{s}" -> "Microsoft.Network/virtualNetworks/subnets"
-        String[] parts = tail.split("/");
-        if (parts.length >= 4 && "subnets".equals(parts[2])) {
-            return "Microsoft.Network/virtualNetworks/subnets";
-        }
-        return "Microsoft.Network/" + parts[0];
-    }
-
-    private static String networkResourceName(String tail) {
-        String[] parts = tail.split("[/?]");
-        return parts.length > 0 ? parts[parts.length - 1] : tail;
-    }
-
-    private static String netKey(String sub, String rg, String tail) {
-        int q = tail.indexOf('?');
-        String clean = q >= 0 ? tail.substring(0, q) : tail;
-        return sub + "/" + rg + "/net/" + clean;
     }
 
     // ── Storage Accounts ─────────────────────────────────────────────────────

--- a/src/main/java/io/floci/az/services/network/NetworkHandler.java
+++ b/src/main/java/io/floci/az/services/network/NetworkHandler.java
@@ -1,0 +1,32 @@
+package io.floci.az.services.network;
+
+import io.floci.az.core.AzureRequest;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+
+import java.util.List;
+import java.util.Map;
+
+@ApplicationScoped
+public class NetworkHandler {
+
+    private final NetworkService service;
+
+    @Inject
+    public NetworkHandler(NetworkService service) {
+        this.service = service;
+    }
+
+    public Response handleArm(AzureRequest request, String path, String method, String sub) {
+        return service.handleArm(request, path, method, sub);
+    }
+
+    public List<Map<String, Object>> listResources(String sub, String rg) {
+        return service.listResources(sub, rg);
+    }
+
+    public void clearAll() {
+        service.clearAll();
+    }
+}

--- a/src/main/java/io/floci/az/services/network/NetworkService.java
+++ b/src/main/java/io/floci/az/services/network/NetworkService.java
@@ -1,0 +1,224 @@
+package io.floci.az.services.network;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.floci.az.core.AzureRequest;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@ApplicationScoped
+public class NetworkService {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final Map<String, Map<String, Object>> resources;
+
+    @Inject
+    public NetworkService(NetworkStore store) {
+        this.resources = store.resources;
+    }
+
+    public Response handleArm(AzureRequest request, String path, String method, String sub) {
+        String rg = extractRg(path);
+        String tail = extractAfter(path, "/providers/Microsoft.Network/");
+
+        if (tail.matches("[^/]+")) {
+            return Response.ok(Map.of("value", listResources(sub, rg, "Microsoft.Network/" + tail))).build();
+        }
+        if (tail.matches("virtualNetworks/[^/]+/subnets")) {
+            String vnetName = tail.split("/")[1];
+            return Response.ok(Map.of("value", listSubnets(sub, rg, vnetName))).build();
+        }
+
+        String resourceType = resourceType(tail);
+        String name = resourceName(tail);
+        String key = key(sub, rg, tail);
+
+        return switch (method) {
+            case "PUT" -> createOrUpdateResource(request, sub, rg, tail, resourceType, name, key);
+            case "GET" -> {
+                Map<String, Object> resource = resources.get(key);
+                yield resource == null ? notFound(tail) : Response.ok(stripInternal(resource)).build();
+            }
+            case "DELETE" -> {
+                resources.remove(key);
+                deleteChildren(sub, rg, tail);
+                yield Response.ok().build();
+            }
+            default -> Response.status(405).build();
+        };
+    }
+
+    public List<Map<String, Object>> listResources(String sub, String rg) {
+        return resources.values().stream()
+                .filter(r -> sub.equals(r.get("_sub")) && rg.equals(r.get("_rg")))
+                .map(NetworkService::stripInternal)
+                .toList();
+    }
+
+    public List<Map<String, Object>> listResources(String sub, String rg, String type) {
+        return resources.values().stream()
+                .filter(r -> sub.equals(r.get("_sub")) && rg.equals(r.get("_rg")) && type.equals(r.get("type")))
+                .map(NetworkService::stripInternal)
+                .toList();
+    }
+
+    public List<Map<String, Object>> listSubnets(String sub, String rg, String vnetName) {
+        String prefix = key(sub, rg, "virtualNetworks/" + vnetName + "/subnets/");
+        return resources.entrySet().stream()
+                .filter(e -> e.getKey().startsWith(prefix))
+                .map(Map.Entry::getValue)
+                .map(NetworkService::stripInternal)
+                .toList();
+    }
+
+    public void clearAll() {
+        resources.clear();
+    }
+
+    private Response createOrUpdateResource(AzureRequest request, String sub, String rg, String tail,
+                                            String resourceType, String name, String key) {
+        Map<String, Object> body = parseBody(request);
+        Map<String, Object> properties = new LinkedHashMap<>(cast(body.get("properties")));
+        synthesizeProperties(resourceType, properties);
+        properties.put("provisioningState", "Succeeded");
+
+        Map<String, Object> resource = new LinkedHashMap<>();
+        resource.put("_sub", sub);
+        resource.put("_rg", rg);
+        resource.put("id", "/subscriptions/" + sub + "/resourceGroups/" + rg
+                + "/providers/Microsoft.Network/" + tail);
+        resource.put("name", name);
+        resource.put("type", resourceType);
+        String location = bodyString(body, "location", null);
+        if (location != null) {
+            resource.put("location", location);
+        }
+        if (body.get("tags") instanceof Map<?, ?> tags && !tags.isEmpty()) {
+            resource.put("tags", tags);
+        }
+        resource.put("properties", properties);
+        resources.put(key, resource);
+        return Response.ok(stripInternal(resource)).build();
+    }
+
+    private void deleteChildren(String sub, String rg, String tail) {
+        String[] parts = tail.split("/");
+        if (parts.length == 2 && "virtualNetworks".equals(parts[0])) {
+            String prefix = key(sub, rg, "virtualNetworks/" + parts[1] + "/subnets/");
+            resources.keySet().removeIf(k -> k.startsWith(prefix));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void synthesizeProperties(String resourceType, Map<String, Object> properties) {
+        switch (resourceType) {
+            case "Microsoft.Network/networkInterfaces" -> {
+                Object cfgs = properties.get("ipConfigurations");
+                List<Object> configs = cfgs instanceof List<?> l && !l.isEmpty()
+                        ? new ArrayList<>((List<Object>) l)
+                        : new ArrayList<>(List.of(new LinkedHashMap<String, Object>(Map.of("name", "ipconfig1"))));
+                boolean[] first = {true};
+                configs.replaceAll(c -> {
+                    Map<String, Object> cfg = new LinkedHashMap<>(cast(c));
+                    Map<String, Object> cp = new LinkedHashMap<>(cast(cfg.get("properties")));
+                    cp.putIfAbsent("privateIPAddress", "10.0.0.4");
+                    cp.putIfAbsent("privateIPAllocationMethod", "Dynamic");
+                    cp.put("primary", first[0]);
+                    cp.put("provisioningState", "Succeeded");
+                    cfg.put("properties", cp);
+                    cfg.putIfAbsent("name", "ipconfig1");
+                    first[0] = false;
+                    return cfg;
+                });
+                properties.put("ipConfigurations", configs);
+            }
+            case "Microsoft.Network/publicIPAddresses" -> {
+                properties.putIfAbsent("ipAddress", "20.0.0.4");
+                properties.putIfAbsent("publicIPAllocationMethod", "Dynamic");
+            }
+            default -> { }
+        }
+    }
+
+    private static String resourceType(String tail) {
+        String[] parts = tail.split("/");
+        if (parts.length >= 4 && "subnets".equals(parts[2])) {
+            return "Microsoft.Network/virtualNetworks/subnets";
+        }
+        return "Microsoft.Network/" + parts[0];
+    }
+
+    private static String resourceName(String tail) {
+        String[] parts = tail.split("[/?]");
+        return parts.length > 0 ? parts[parts.length - 1] : tail;
+    }
+
+    private static String key(String sub, String rg, String tail) {
+        int q = tail.indexOf('?');
+        String clean = q >= 0 ? tail.substring(0, q) : tail;
+        return sub + "/" + rg + "/net/" + clean;
+    }
+
+    private static String extractRg(String path) {
+        String[] parts = path.split("/");
+        for (int i = 0; i < parts.length - 1; i++) {
+            if ("resourcegroups".equalsIgnoreCase(parts[i])) {
+                return parts[i + 1];
+            }
+        }
+        return "unknown";
+    }
+
+    private static String extractAfter(String path, String marker) {
+        int idx = path.lastIndexOf(marker);
+        if (idx < 0) {
+            return "unknown";
+        }
+        String rest = path.substring(idx + marker.length());
+        int q = rest.indexOf('?');
+        return q >= 0 ? rest.substring(0, q) : rest;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> parseBody(AzureRequest request) {
+        try {
+            if (request.bodyStream() == null || request.bodyStream().available() == 0) {
+                return Map.of();
+            }
+            return MAPPER.readValue(request.bodyStream(), Map.class);
+        } catch (IOException e) {
+            return Map.of();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> cast(Object o) {
+        return o instanceof Map<?, ?> m ? (Map<String, Object>) m : Map.of();
+    }
+
+    private static String bodyString(Map<String, Object> map, String key, String defaultValue) {
+        Object v = map.get(key);
+        return v instanceof String s ? s : defaultValue;
+    }
+
+    private static Map<String, Object> stripInternal(Map<String, Object> resource) {
+        Map<String, Object> copy = new LinkedHashMap<>(resource);
+        copy.remove("_sub");
+        copy.remove("_rg");
+        return copy;
+    }
+
+    private Response notFound(String path) {
+        return Response.status(404).entity(Map.of("error", Map.of(
+                "code", "ResourceNotFound",
+                "message", "Resource not found: " + path
+        ))).build();
+    }
+}

--- a/src/main/java/io/floci/az/services/network/NetworkStore.java
+++ b/src/main/java/io/floci/az/services/network/NetworkStore.java
@@ -1,0 +1,12 @@
+package io.floci.az.services.network;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@ApplicationScoped
+public class NetworkStore {
+
+    final Map<String, Map<String, Object>> resources = new ConcurrentHashMap<>();
+}

--- a/src/test/java/io/floci/az/services/network/NetworkHandlerTest.java
+++ b/src/test/java/io/floci/az/services/network/NetworkHandlerTest.java
@@ -1,0 +1,116 @@
+package io.floci.az.services.network;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
+
+@QuarkusTest
+@DisplayName("NetworkHandler - ARM Virtual Network compatibility")
+class NetworkHandlerTest {
+
+    private static final String SUB = "test-sub-net";
+    private static final String RG = "test-rg-net";
+    private static final String API = "?api-version=2024-05-01";
+    private static final String BASE =
+            "/subscriptions/" + SUB + "/resourceGroups/" + RG + "/providers/Microsoft.Network";
+
+    @BeforeEach
+    void reset() {
+        given().when().post("/_admin/reset").then().statusCode(204);
+    }
+
+    @Test
+    void virtualNetworkLifecycleAndSubnetListing() {
+        String vnetBody = """
+                {
+                  "location": "eastus",
+                  "tags": {"env": "test"},
+                  "properties": {
+                    "addressSpace": {
+                      "addressPrefixes": ["10.10.0.0/16"]
+                    }
+                  }
+                }
+                """;
+
+        given().contentType("application/json").body(vnetBody)
+                .when().put(BASE + "/virtualNetworks/vnet1" + API)
+                .then().statusCode(200)
+                .body("name", equalTo("vnet1"))
+                .body("type", equalTo("Microsoft.Network/virtualNetworks"))
+                .body("location", equalTo("eastus"))
+                .body("tags.env", equalTo("test"))
+                .body("properties.provisioningState", equalTo("Succeeded"))
+                .body("properties.addressSpace.addressPrefixes", hasItem("10.10.0.0/16"));
+
+        given().when().get(BASE + "/virtualNetworks" + API)
+                .then().statusCode(200)
+                .body("value", hasSize(1))
+                .body("value[0].name", equalTo("vnet1"));
+
+        String subnetBody = """
+                {
+                  "properties": {
+                    "addressPrefix": "10.10.1.0/24"
+                  }
+                }
+                """;
+
+        given().contentType("application/json").body(subnetBody)
+                .when().put(BASE + "/virtualNetworks/vnet1/subnets/default" + API)
+                .then().statusCode(200)
+                .body("name", equalTo("default"))
+                .body("type", equalTo("Microsoft.Network/virtualNetworks/subnets"))
+                .body("properties.addressPrefix", equalTo("10.10.1.0/24"))
+                .body("properties.provisioningState", equalTo("Succeeded"));
+
+        given().when().get(BASE + "/virtualNetworks/vnet1/subnets" + API)
+                .then().statusCode(200)
+                .body("value", hasSize(1))
+                .body("value[0].name", equalTo("default"));
+
+        given().when().delete(BASE + "/virtualNetworks/vnet1" + API)
+                .then().statusCode(200);
+
+        given().when().get(BASE + "/virtualNetworks/vnet1" + API)
+                .then().statusCode(404)
+                .body("error.code", equalTo("ResourceNotFound"));
+    }
+
+    @Test
+    void networkInterfaceSynthesizesPrivateIpForVmCompatibility() {
+        String nicBody = """
+                {
+                  "location": "eastus",
+                  "properties": {
+                    "ipConfigurations": [
+                      {
+                        "name": "ipconfig1",
+                        "properties": {
+                          "subnet": {
+                            "id": "/subscriptions/test-sub-net/resourceGroups/test-rg-net/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/default"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+                """;
+
+        given().contentType("application/json").body(nicBody)
+                .when().put(BASE + "/networkInterfaces/nic1" + API)
+                .then().statusCode(200)
+                .body("name", equalTo("nic1"))
+                .body("type", equalTo("Microsoft.Network/networkInterfaces"))
+                .body("properties.ipConfigurations[0].properties.privateIPAddress", equalTo("10.0.0.4"))
+                .body("properties.ipConfigurations[0].properties.privateIPAllocationMethod", equalTo("Dynamic"))
+                .body("properties.ipConfigurations[0].properties.primary", equalTo(true))
+                .body("properties.ipConfigurations[0].properties.provisioningState", equalTo("Succeeded"));
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds initial Azure Virtual Network emulation support under `Microsoft.Network`.

The implementation moves Network resources out of the VM fallback/stub path and gives them their own in-process ARM emulator, closer to how Azure exposes networking resources. This allows VM-related IaC flows to provision their required network dependencies through normal ARM paths.

## What changed

- Added dedicated `Microsoft.Network` handling for:
  - Virtual Networks
  - Subnets
  - Network Interfaces
  - Public IP Addresses
  - Network Security Groups
- Added in-memory Network state management.
- Integrated Network resources with ARM resource group listings.
- Updated VM behavior to rely on the Network emulator instead of internal network stubs.
- Added compatibility coverage through Terraform/OpenTofu flows.
- Updated project documentation to describe the real Network scope and limitations.

## Current scope

This is ARM control-plane emulation only.

It supports local provisioning workflows, but does not implement real networking behavior such as routing, packet isolation, DNS, NSG enforcement, peering, private endpoints, or actual IP allocation.

NIC private IPs and public IPs are synthesized for SDK/provider compatibility.

## How to test

From the repository root:

```bash
./mvnw -q -Dtest=NetworkHandlerTest test
./mvnw -q -Dtest=VmHandlerTest test
./mvnw -q -DskipTests compile
```

To run the broader compatibility flows:

```bash
make test-terraform
make test-opentofu
```

If port `4577` is already in use:

```bash
make PORT=4578 test-terraform
make PORT=4578 test-opentofu
```

## Notes from local validation

Network resources were successfully created and destroyed through Terraform/OpenTofu using the local emulator path, including:

- Resource group
- Virtual network
- Subnet
- Network interface
- Public IP
- Network security group
- VM referencing the NIC

One broader IaC run may still fail later in unrelated ACR polling behavior, but the Network portion applies and destroys correctly.

close #22 

## Type of change

- [ ] Bug fix (`fix:`)
- [X] New feature (`feat:`)
- [X] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

<!-- For new actions: which SDK version and Azure CLI version were used to verify the wire protocol? -->
<!-- For bug fixes: what was the incorrect behavior? -->

## Checklist

- [X] `./mvnw test` passes locally
- [X] New or updated integration test added
- [X] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
