### PR TITLE
feat: add Azure DNS support (zones + record sets)

### DIFF
--- a/src/main/java/io/floci/az/services/arm/ArmHandler.java
+++ b/src/main/java/io/floci/az/services/arm/ArmHandler.java
@@ -86,6 +86,11 @@ public class ArmHandler implements AzureServiceHandler {
 
         LOG.debugf("ArmHandler %s %s", method, path);
 
+        // ── Network Provider (subscription & resource-group levels) ───────────
+        if (path.contains("/providers/Microsoft.Network/")) {
+            return networkHandler.handleArm(req, path, method, extractSub(path));
+        }
+
         // ── Subscription ──────────────────────────────────────────────────────
         if (path.matches("subscriptions/[^/?]+") ||
             path.matches("subscriptions/[^/?]+\\?.*")) {

--- a/src/main/java/io/floci/az/services/network/NetworkService.java
+++ b/src/main/java/io/floci/az/services/network/NetworkService.java
@@ -28,6 +28,10 @@ public class NetworkService {
         String rg = extractRg(path);
         String tail = extractAfter(path, "/providers/Microsoft.Network/");
 
+        if (tail.startsWith("dnsZones") || tail.startsWith("dnszones")) {
+            return handleDnsZones(request, path, method, sub, rg, tail);
+        }
+
         if (tail.matches("[^/]+")) {
             return Response.ok(Map.of("value", listResources(sub, rg, "Microsoft.Network/" + tail))).build();
         }
@@ -219,6 +223,364 @@ public class NetworkService {
         return Response.status(404).entity(Map.of("error", Map.of(
                 "code", "ResourceNotFound",
                 "message", "Resource not found: " + path
+        ))).build();
+    }
+
+    // ── Azure DNS Support ───────────────────────────────────────────────────
+
+    private Response handleDnsZones(AzureRequest request, String path, String method, String sub, String rg, String tail) {
+        String[] parts = tail.split("/");
+
+        // 1. List zones
+        if (parts.length == 1) {
+            return Response.ok(Map.of("value", listDnsZones(sub, rg))).build();
+        }
+
+        // 2. Zone CRUD
+        if (parts.length == 2) {
+            String zoneName = parts[1];
+            return switch (method) {
+                case "PUT"    -> createOrUpdateDnsZone(request, sub, rg, zoneName);
+                case "GET"    -> getDnsZone(sub, rg, zoneName);
+                case "DELETE" -> deleteDnsZone(sub, rg, zoneName);
+                default       -> Response.status(405).build();
+            };
+        }
+
+        // 3. List all record sets
+        if (parts.length == 3 && ("recordsets".equalsIgnoreCase(parts[2]) || "all".equalsIgnoreCase(parts[2]))) {
+            String zoneName = parts[1];
+            return Response.ok(Map.of("value", listAllRecordSets(sub, rg, zoneName))).build();
+        }
+
+        // 4. List record sets by type
+        if (parts.length == 3 && isRecordType(parts[2])) {
+            String zoneName = parts[1];
+            String recordType = parts[2];
+            return Response.ok(Map.of("value", listRecordSetsByType(sub, rg, zoneName, recordType))).build();
+        }
+
+        // 5. Record Set CRUD
+        if (parts.length >= 4 && isRecordType(parts[2])) {
+            String zoneName = parts[1];
+            String recordType = parts[2];
+            StringBuilder nameBuilder = new StringBuilder(parts[3]);
+            for (int i = 4; i < parts.length; i++) {
+                nameBuilder.append("/").append(parts[i]);
+            }
+            String relativeRecordSetName = nameBuilder.toString();
+
+            return switch (method) {
+                case "PUT"    -> createOrUpdateRecordSet(request, sub, rg, zoneName, recordType, relativeRecordSetName);
+                case "GET"    -> getRecordSet(sub, rg, zoneName, recordType, relativeRecordSetName);
+                case "DELETE" -> deleteRecordSet(sub, rg, zoneName, recordType, relativeRecordSetName);
+                default       -> Response.status(405).build();
+            };
+        }
+
+        return notFound(tail);
+    }
+
+    private static boolean isRecordType(String part) {
+        String u = part.toUpperCase();
+        return "A".equals(u) || "AAAA".equals(u) || "CNAME".equals(u) ||
+               "TXT".equals(u) || "MX".equals(u) || "NS".equals(u) ||
+               "SOA".equals(u) || "SRV".equals(u) || "CAA".equals(u);
+    }
+
+    private List<Map<String, Object>> listDnsZones(String sub, String rg) {
+        return resources.values().stream()
+                .filter(r -> sub.equals(r.get("_sub"))
+                        && ("unknown".equals(rg) || rg.equals(r.get("_rg")))
+                        && "Microsoft.Network/dnsZones".equals(r.get("type")))
+                .map(NetworkService::stripInternal)
+                .toList();
+    }
+
+    private Response getDnsZone(String sub, String rg, String zoneName) {
+        String key = sub + "/" + rg + "/net/dnsZones/" + zoneName;
+        Map<String, Object> zone = resources.get(key);
+        if (zone == null) {
+            return notFound("dnsZones/" + zoneName);
+        }
+        return Response.ok(stripInternal(zone)).build();
+    }
+
+    private Response createOrUpdateDnsZone(AzureRequest request, String sub, String rg, String zoneName) {
+        String key = sub + "/" + rg + "/net/dnsZones/" + zoneName;
+        Map<String, Object> body = parseBody(request);
+        Map<String, Object> properties = new LinkedHashMap<>(cast(body.get("properties")));
+
+        Map<String, Object> existingZone = resources.get(key);
+        String etag = existingZone != null ? (String) existingZone.get("etag") : "\"" + java.util.UUID.randomUUID() + "\"";
+        int numberOfRecordSets = existingZone != null ? ((Number) cast(existingZone.get("properties")).getOrDefault("numberOfRecordSets", 2)).intValue() : 2;
+
+        properties.putIfAbsent("maxNumberOfRecordSets", 10000);
+        properties.putIfAbsent("numberOfRecordSets", numberOfRecordSets);
+        properties.putIfAbsent("zoneType", "Public");
+        properties.putIfAbsent("nameServers", List.of(
+                "ns1-01.azure-dns.com.",
+                "ns2-01.azure-dns.net.",
+                "ns3-01.azure-dns.org.",
+                "ns4-01.azure-dns.info."
+        ));
+
+        Map<String, Object> zone = new LinkedHashMap<>();
+        zone.put("_sub", sub);
+        zone.put("_rg", rg);
+        zone.put("id", "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Network/dnsZones/" + zoneName);
+        zone.put("name", zoneName);
+        zone.put("type", "Microsoft.Network/dnsZones");
+        zone.put("location", bodyString(body, "location", "global"));
+        if (body.get("tags") instanceof Map<?, ?> tags && !tags.isEmpty()) {
+            zone.put("tags", tags);
+        } else if (existingZone != null && existingZone.containsKey("tags")) {
+            zone.put("tags", existingZone.get("tags"));
+        }
+        zone.put("etag", etag);
+        zone.put("properties", properties);
+
+        resources.put(key, zone);
+
+        if (existingZone == null) {
+            createDefaultRecordSets(sub, rg, zoneName);
+        }
+
+        return Response.status(existingZone == null ? 201 : 200).entity(stripInternal(zone)).build();
+    }
+
+    private void createDefaultRecordSets(String sub, String rg, String zoneName) {
+        String soaKey = sub + "/" + rg + "/net/dnsZones/" + zoneName + "/SOA/@";
+        Map<String, Object> soaProperties = new LinkedHashMap<>();
+        soaProperties.put("fqdn", zoneName + ".");
+        soaProperties.put("TTL", 3600);
+        soaProperties.put("SOARecord", Map.of(
+                "host", "ns1-01.azure-dns.com.",
+                "email", "azuredns-hostmaster.microsoft.com.",
+                "serialNumber", 1L,
+                "refreshTime", 3600L,
+                "retryTime", 300L,
+                "expireTime", 2419200L,
+                "minimumTTL", 300L
+        ));
+        Map<String, Object> soa = new LinkedHashMap<>();
+        soa.put("_sub", sub);
+        soa.put("_rg", rg);
+        soa.put("id", "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Network/dnsZones/" + zoneName + "/SOA/@");
+        soa.put("name", "@");
+        soa.put("type", "Microsoft.Network/dnsZones/SOA");
+        soa.put("etag", "\"" + java.util.UUID.randomUUID() + "\"");
+        soa.put("properties", soaProperties);
+        resources.put(soaKey, soa);
+
+        String nsKey = sub + "/" + rg + "/net/dnsZones/" + zoneName + "/NS/@";
+        Map<String, Object> nsProperties = new LinkedHashMap<>();
+        nsProperties.put("fqdn", zoneName + ".");
+        nsProperties.put("TTL", 172800);
+        nsProperties.put("NSRecords", List.of(
+                Map.of("nsdname", "ns1-01.azure-dns.com."),
+                Map.of("nsdname", "ns2-01.azure-dns.net."),
+                Map.of("nsdname", "ns3-01.azure-dns.org."),
+                Map.of("nsdname", "ns4-01.azure-dns.info.")
+        ));
+        Map<String, Object> ns = new LinkedHashMap<>();
+        ns.put("_sub", sub);
+        ns.put("_rg", rg);
+        ns.put("id", "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Network/dnsZones/" + zoneName + "/NS/@");
+        ns.put("name", "@");
+        ns.put("type", "Microsoft.Network/dnsZones/NS");
+        ns.put("etag", "\"" + java.util.UUID.randomUUID() + "\"");
+        ns.put("properties", nsProperties);
+        resources.put(nsKey, ns);
+    }
+
+    private Response deleteDnsZone(String sub, String rg, String zoneName) {
+        String key = sub + "/" + rg + "/net/dnsZones/" + zoneName;
+        Map<String, Object> zone = resources.remove(key);
+        if (zone == null) {
+            return notFound("dnsZones/" + zoneName);
+        }
+        String prefix = key + "/";
+        resources.keySet().removeIf(k -> k.startsWith(prefix));
+        return Response.ok().build();
+    }
+
+    private List<Map<String, Object>> listAllRecordSets(String sub, String rg, String zoneName) {
+        String prefix = sub + "/" + rg + "/net/dnsZones/" + zoneName + "/";
+        return resources.entrySet().stream()
+                .filter(e -> e.getKey().startsWith(prefix))
+                .map(Map.Entry::getValue)
+                .map(NetworkService::stripInternal)
+                .toList();
+    }
+
+    private List<Map<String, Object>> listRecordSetsByType(String sub, String rg, String zoneName, String recordType) {
+        String prefix = sub + "/" + rg + "/net/dnsZones/" + zoneName + "/" + recordType + "/";
+        return resources.entrySet().stream()
+                .filter(e -> e.getKey().startsWith(prefix))
+                .map(Map.Entry::getValue)
+                .map(NetworkService::stripInternal)
+                .toList();
+    }
+
+    private Response getRecordSet(String sub, String rg, String zoneName, String recordType, String relativeRecordSetName) {
+        String key = sub + "/" + rg + "/net/dnsZones/" + zoneName + "/" + recordType + "/" + relativeRecordSetName;
+        Map<String, Object> recordSet = resources.get(key);
+        if (recordSet == null) {
+            return notFound("dnsZones/" + zoneName + "/" + recordType + "/" + relativeRecordSetName);
+        }
+        return Response.ok(stripInternal(recordSet)).build();
+    }
+
+    private Response deleteRecordSet(String sub, String rg, String zoneName, String recordType, String relativeRecordSetName) {
+        if ("@".equals(relativeRecordSetName) && ("SOA".equals(recordType) || "NS".equals(recordType))) {
+            return Response.status(400).entity(Map.of("error", Map.of(
+                    "code", "BadRequest",
+                    "message", "Default SOA and NS record sets at the zone root cannot be deleted."
+            ))).build();
+        }
+
+        String key = sub + "/" + rg + "/net/dnsZones/" + zoneName + "/" + recordType + "/" + relativeRecordSetName;
+        Map<String, Object> recordSet = resources.remove(key);
+        if (recordSet == null) {
+            return notFound("dnsZones/" + zoneName + "/" + recordType + "/" + relativeRecordSetName);
+        }
+
+        decrementZoneRecordSetCount(sub, rg, zoneName);
+
+        return Response.ok().build();
+    }
+
+    private Response createOrUpdateRecordSet(AzureRequest request, String sub, String rg, String zoneName, String recordType, String relativeRecordSetName) {
+        String key = sub + "/" + rg + "/net/dnsZones/" + zoneName + "/" + recordType + "/" + relativeRecordSetName;
+
+        String zoneKey = sub + "/" + rg + "/net/dnsZones/" + zoneName;
+        Map<String, Object> parentZone = resources.get(zoneKey);
+        if (parentZone == null) {
+            return Response.status(404).entity(Map.of("error", Map.of(
+                    "code", "ParentResourceNotFound",
+                    "message", "DNS Zone " + zoneName + " was not found."
+            ))).build();
+        }
+
+        Map<String, Object> existingRecordSet = resources.get(key);
+
+        String ifMatch = request.headers().getHeaderString("If-Match");
+        String ifNoneMatch = request.headers().getHeaderString("If-None-Match");
+
+        if (ifMatch != null) {
+            if ("*".equals(ifMatch)) {
+                if (existingRecordSet == null) {
+                    return preconditionFailed();
+                }
+            } else {
+                if (existingRecordSet == null || !ifMatch.equals(existingRecordSet.get("etag"))) {
+                    return preconditionFailed();
+                }
+            }
+        }
+
+        if (ifNoneMatch != null) {
+            if ("*".equals(ifNoneMatch)) {
+                if (existingRecordSet != null) {
+                    return preconditionFailed();
+                }
+            } else {
+                if (existingRecordSet != null && ifNoneMatch.equals(existingRecordSet.get("etag"))) {
+                    return preconditionFailed();
+                }
+            }
+        }
+
+        Map<String, Object> body = parseBody(request);
+        Map<String, Object> bodyProps = body.containsKey("properties") ? cast(body.get("properties")) : body;
+
+        Object ttlVal = bodyProps.containsKey("TTL") ? bodyProps.get("TTL") : bodyProps.get("ttl");
+        int ttl = ttlVal instanceof Number n ? n.intValue() : 3600;
+
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("fqdn", "@".equals(relativeRecordSetName) ? zoneName + "." : relativeRecordSetName + "." + zoneName + ".");
+        properties.put("TTL", ttl);
+
+        if (bodyProps.containsKey("metadata")) {
+            properties.put("metadata", bodyProps.get("metadata"));
+        } else if (bodyProps.containsKey("Metadata")) {
+            properties.put("metadata", bodyProps.get("Metadata"));
+        }
+
+        copyRecordProperties(recordType, bodyProps, properties);
+
+        String newEtag = "\"" + java.util.UUID.randomUUID() + "\"";
+
+        Map<String, Object> recordSet = new LinkedHashMap<>();
+        recordSet.put("_sub", sub);
+        recordSet.put("_rg", rg);
+        recordSet.put("id", "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Network/dnsZones/" + zoneName + "/" + recordType + "/" + relativeRecordSetName);
+        recordSet.put("name", relativeRecordSetName);
+        recordSet.put("type", "Microsoft.Network/dnsZones/" + recordType);
+        recordSet.put("etag", newEtag);
+        recordSet.put("properties", properties);
+
+        resources.put(key, recordSet);
+
+        if (existingRecordSet == null) {
+            incrementZoneRecordSetCount(sub, rg, zoneName);
+        }
+
+        return Response.status(existingRecordSet == null ? 201 : 200).entity(stripInternal(recordSet)).build();
+    }
+
+    private static void copyRecordProperties(String recordType, Map<String, Object> bodyProps, Map<String, Object> properties) {
+        String uType = recordType.toUpperCase();
+        switch (uType) {
+            case "A"     -> copyProp(bodyProps, properties, "aRecords", "ARecords");
+            case "AAAA"  -> copyProp(bodyProps, properties, "aaaaRecords", "AAAARecords");
+            case "CNAME" -> copyProp(bodyProps, properties, "cnameRecord", "CNAMERecord");
+            case "MX"    -> copyProp(bodyProps, properties, "mxRecords", "MXRecords");
+            case "NS"    -> copyProp(bodyProps, properties, "nsRecords", "NSRecords");
+            case "SOA"   -> copyProp(bodyProps, properties, "soaRecord", "SOARecord");
+            case "SRV"   -> copyProp(bodyProps, properties, "srvRecords", "SRVRecords");
+            case "TXT"   -> copyProp(bodyProps, properties, "txtRecords", "TXTRecords");
+            case "CAA"   -> copyProp(bodyProps, properties, "caaRecords", "CAARecords");
+        }
+    }
+
+    private static void copyProp(Map<String, Object> src, Map<String, Object> dest, String key1, String key2) {
+        if (src.containsKey(key1)) {
+            dest.put(key1, src.get(key1));
+            dest.put(key2, src.get(key1));
+        } else if (src.containsKey(key2)) {
+            dest.put(key1, src.get(key2));
+            dest.put(key2, src.get(key2));
+        }
+    }
+
+    private void incrementZoneRecordSetCount(String sub, String rg, String zoneName) {
+        String zoneKey = sub + "/" + rg + "/net/dnsZones/" + zoneName;
+        Map<String, Object> zone = resources.get(zoneKey);
+        if (zone != null) {
+            Map<String, Object> props = new LinkedHashMap<>(cast(zone.get("properties")));
+            int count = ((Number) props.getOrDefault("numberOfRecordSets", 2)).intValue();
+            props.put("numberOfRecordSets", count + 1);
+            zone.put("properties", props);
+        }
+    }
+
+    private void decrementZoneRecordSetCount(String sub, String rg, String zoneName) {
+        String zoneKey = sub + "/" + rg + "/net/dnsZones/" + zoneName;
+        Map<String, Object> zone = resources.get(zoneKey);
+        if (zone != null) {
+            Map<String, Object> props = new LinkedHashMap<>(cast(zone.get("properties")));
+            int count = ((Number) props.getOrDefault("numberOfRecordSets", 2)).intValue();
+            props.put("numberOfRecordSets", Math.max(2, count - 1));
+            zone.put("properties", props);
+        }
+    }
+
+    private Response preconditionFailed() {
+        return Response.status(412).entity(Map.of("error", Map.of(
+                "code", "PreconditionFailed",
+                "message", "The precondition given in the Request-Headers failed for this resource."
         ))).build();
     }
 }

--- a/src/test/java/io/floci/az/services/network/NetworkHandlerTest.java
+++ b/src/test/java/io/floci/az/services/network/NetworkHandlerTest.java
@@ -113,4 +113,163 @@ class NetworkHandlerTest {
                 .body("properties.ipConfigurations[0].properties.primary", equalTo(true))
                 .body("properties.ipConfigurations[0].properties.provisioningState", equalTo("Succeeded"));
     }
+
+    @Test
+    void dnsZoneAndRecordSetsLifecycleAndConcurrency() {
+        String zoneBody = """
+                {
+                  "location": "global",
+                  "tags": {"project": "floci"},
+                  "properties": {
+                    "zoneType": "Public"
+                  }
+                }
+                """;
+
+        // 1. Create DNS Zone
+        given().contentType("application/json").body(zoneBody)
+                .when().put(BASE + "/dnsZones/example.com" + API)
+                .then().statusCode(201)
+                .body("name", equalTo("example.com"))
+                .body("type", equalTo("Microsoft.Network/dnsZones"))
+                .body("location", equalTo("global"))
+                .body("tags.project", equalTo("floci"))
+                .body("properties.zoneType", equalTo("Public"))
+                .body("properties.numberOfRecordSets", equalTo(2))
+                .body("properties.nameServers", hasSize(4));
+
+        // 2. Get default SOA and NS records
+        given().when().get(BASE + "/dnsZones/example.com/SOA/@" + API)
+                .then().statusCode(200)
+                .body("name", equalTo("@"))
+                .body("type", equalTo("Microsoft.Network/dnsZones/SOA"))
+                .body("properties.fqdn", equalTo("example.com."))
+                .body("properties.SOARecord.host", equalTo("ns1-01.azure-dns.com."));
+
+        given().when().get(BASE + "/dnsZones/example.com/NS/@" + API)
+                .then().statusCode(200)
+                .body("name", equalTo("@"))
+                .body("type", equalTo("Microsoft.Network/dnsZones/NS"))
+                .body("properties.fqdn", equalTo("example.com."))
+                .body("properties.NSRecords[0].nsdname", equalTo("ns1-01.azure-dns.com."));
+
+        // 3. Create A Record Set
+        String aRecordBody = """
+                {
+                  "properties": {
+                    "TTL": 600,
+                    "ARecords": [
+                      {"ipv4Address": "192.168.1.1"}
+                    ]
+                  }
+                }
+                """;
+
+        String etag = given().contentType("application/json").body(aRecordBody)
+                .when().put(BASE + "/dnsZones/example.com/A/www" + API)
+                .then().statusCode(201)
+                .body("name", equalTo("www"))
+                .body("type", equalTo("Microsoft.Network/dnsZones/A"))
+                .body("properties.fqdn", equalTo("www.example.com."))
+                .body("properties.TTL", equalTo(600))
+                .body("properties.ARecords[0].ipv4Address", equalTo("192.168.1.1"))
+                .extract().path("etag");
+
+        // 4. Verify parent zone record count incremented to 3
+        given().when().get(BASE + "/dnsZones/example.com" + API)
+                .then().statusCode(200)
+                .body("properties.numberOfRecordSets", equalTo(3));
+
+        // 5. Test concurrency checks
+        // PUT with wrong If-Match should fail
+        given().contentType("application/json").body(aRecordBody)
+                .header("If-Match", "\"wrong-etag\"")
+                .when().put(BASE + "/dnsZones/example.com/A/www" + API)
+                .then().statusCode(412);
+
+        // PUT with If-None-Match: * should fail
+        given().contentType("application/json").body(aRecordBody)
+                .header("If-None-Match", "*")
+                .when().put(BASE + "/dnsZones/example.com/A/www" + API)
+                .then().statusCode(412);
+
+        // PUT with correct If-Match should succeed
+        String newEtag = given().contentType("application/json")
+                .body("""
+                      {
+                        "properties": {
+                          "TTL": 300,
+                          "aRecords": [{"ipv4Address": "10.0.0.1"}]
+                        }
+                      }
+                      """)
+                .header("If-Match", etag)
+                .when().put(BASE + "/dnsZones/example.com/A/www" + API)
+                .then().statusCode(200)
+                .body("properties.TTL", equalTo(300))
+                .body("properties.ARecords[0].ipv4Address", equalTo("10.0.0.1"))
+                .extract().path("etag");
+
+        // 6. Create CNAME and TXT records
+        given().contentType("application/json")
+                .body("""
+                      {
+                        "properties": {
+                          "TTL": 3600,
+                          "cnameRecord": {"cname": "www.example.com"}
+                        }
+                      }
+                      """)
+                .when().put(BASE + "/dnsZones/example.com/CNAME/alias" + API)
+                .then().statusCode(201);
+
+        given().contentType("application/json")
+                .body("""
+                      {
+                        "properties": {
+                          "TTL": 3600,
+                          "txtRecords": [{"value": ["v=spf1 include:spf.protection.outlook.com -all"]}]
+                        }
+                      }
+                      """)
+                .when().put(BASE + "/dnsZones/example.com/TXT/@" + API)
+                .then().statusCode(201);
+
+        // 7. List all record sets
+        given().when().get(BASE + "/dnsZones/example.com/recordsets" + API)
+                .then().statusCode(200)
+                .body("value", hasSize(5)); // SOA@, NS@, A/www, CNAME/alias, TXT@
+
+        // 8. List record sets by type
+        given().when().get(BASE + "/dnsZones/example.com/A" + API)
+                .then().statusCode(200)
+                .body("value", hasSize(1))
+                .body("value[0].name", equalTo("www"));
+
+        // 9. Try to delete default root NS record (should fail)
+        given().when().delete(BASE + "/dnsZones/example.com/NS/@" + API)
+                .then().statusCode(400)
+                .body("error.code", equalTo("BadRequest"));
+
+        // 10. Delete custom A record
+        given().when().delete(BASE + "/dnsZones/example.com/A/www" + API)
+                .then().statusCode(200);
+
+        // Parent zone count decremented back to 4 (NS@, SOA@, CNAME/alias, TXT@)
+        given().when().get(BASE + "/dnsZones/example.com" + API)
+                .then().statusCode(200)
+                .body("properties.numberOfRecordSets", equalTo(4));
+
+        // 11. Delete DNS Zone
+        given().when().delete(BASE + "/dnsZones/example.com" + API)
+                .then().statusCode(200);
+
+        // Zone not found
+        given().when().get(BASE + "/dnsZones/example.com" + API)
+                .then().statusCode(404);
+
+        // Records also deleted
+        given().when().get(BASE + "/dnsZones/example.com/CNAME/alias" + API)
+                .then().statusCode(404);
+    }
 }


### PR DESCRIPTION

## Summary

Implements Azure DNS support in **floci-az**, enabling metadata-driven management of DNS Zones and Record Sets aligned with Azure ARM behavior (`Microsoft.Network/dnsZones`).

This includes full CRUD support for DNS zones and record sets, listing capabilities, concurrency control using ETags, cascading deletes, and default record set generation.

Closes #63

---

## Type of change

* [x] New feature (`feat:`)

---

## Azure Compatibility

This implementation follows Azure DNS REST API behavior as defined in:
[https://learn.microsoft.com/en-us/rest/api/dns/](https://learn.microsoft.com/en-us/rest/api/dns/)

Key compatibility points:

* Uses Azure ARM resource structure for DNS zones and record sets
* Supports standard Azure DNS record types (A, AAAA, CNAME, TXT, MX, NS, SOA, SRV, CAA)
* Implements ETag / If-Match concurrency semantics (returns 412 Precondition Failed on mismatch)
* Matches Azure-style cascading delete behavior for zones and child record sets
* FQDN formatting follows Azure convention (trailing dot handling)

No external SDK calls were used; implementation is fully metadata-driven as per project design.

---

## Checklist

* [x] `./mvnw test` passes locally
* [x] New integration test(s) added (NetworkHandlerTest coverage)
* [x] DNS Zone CRUD implemented
* [x] Record Set CRUD implemented (all supported types)
* [x] Listing by zone and type implemented
* [x] ETag / If-Match concurrency implemented
* [x] Cascading delete implemented
* [x] Default SOA/NS record generation implemented
* [x] Commit messages follow Conventional Commits

