### PR TITLE
feat(vm): back virtual machines with real containers in non-mocked mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **vm:** Container-backed virtual machines (`floci-az.services.vm.mocked=false`). Each VM is backed by a long-lived Linux container (image resolved from `storageProfile.imageReference` via `VmImageResolver`, falling back to `ubuntu:22.04`) kept alive with `tail -f /dev/null`. Azure power actions map onto the container: `start` → docker start, `powerOff`/`deallocate` → docker stop (container retained), `restart`/`redeploy`/`reapply` → docker restart, delete → stop + remove. VMs provision asynchronously (`Creating` → `Succeeded` once the container is running, surfaced via a readiness poller) so SDK/Terraform LRO pollers complete. Docker failures degrade gracefully to mocked-style state and are never fatal. Mocked mode remains the default, so unit tests stay Docker-free.
+
 ## [0.6.0] - 2026-06-09
 
 ### Added

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/VmCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/VmCompatibilityTest.java
@@ -1,0 +1,329 @@
+package io.floci.az.compat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Compatibility test for Azure Virtual Machines (Microsoft.Compute/virtualMachines) and the
+ * Microsoft.Network dependency stubs (virtualNetworks / networkInterfaces) exposed by floci-az.
+ *
+ * <p>Mirrors {@link ApiManagementCompatibilityTest}: the established repo pattern for ARM
+ * management-plane services is to drive the real Azure REST wire protocol with a raw
+ * {@link HttpClient} rather than the heavyweight fluent {@code azure-resourcemanager-*} SDK
+ * (which would require subscription/provider-registration endpoints floci-az does not emulate).
+ *
+ * <p>Covers the full lifecycle the {@code azure-mgmt-compute} / {@code azure-resourcemanager-compute}
+ * SDKs and {@code azurerm_linux_virtual_machine} exercise: create (with vnet/subnet/nic
+ * dependencies) → get → {@code $expand=instanceView} → instanceView → power actions
+ * (powerOff / start / deallocate, asserting the {@code Azure-AsyncOperation} LRO header and the
+ * resulting PowerState) → list by resource group and by subscription → delete.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@DisplayName("Virtual Machines Compatibility")
+class VmCompatibilityTest {
+
+    private static final String BASE =
+            System.getenv().getOrDefault("FLOCI_AZ_ENDPOINT", "http://localhost:4577");
+    private static final String SUBSCRIPTION = "00000000-0000-0000-0000-000000000001";
+    private static final String RG = "vm-rg-" + UUID.randomUUID().toString().substring(0, 8);
+    private static final String VM = "vm-" + UUID.randomUUID().toString().substring(0, 8);
+    private static final String VNET = "vnet-" + UUID.randomUUID().toString().substring(0, 8);
+    private static final String NIC = VM + "-nic";
+
+    private static final String COMPUTE_API = "2024-11-01";
+    private static final String NETWORK_API = "2024-05-01";
+    private static final String RG_API = "2021-04-01";
+
+    private static final HttpClient http = HttpClient.newHttpClient();
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeAll
+    static void setup() {
+        EmulatorConfig.assumeEmulatorRunning();
+    }
+
+    @Test
+    @Order(1)
+    void createNetworkDependencies_returnSucceeded() throws Exception {
+        assertOk(put(resourceGroupUrl(), "{\"location\":\"eastus\"}"), "create resource group");
+
+        String vnetBody = """
+                {
+                  "location": "eastus",
+                  "properties": {
+                    "addressSpace": {"addressPrefixes": ["10.0.0.0/16"]},
+                    "subnets": [
+                      {"name": "default", "properties": {"addressPrefix": "10.0.0.0/24"}}
+                    ]
+                  }
+                }
+                """;
+        HttpResponse<String> vnetResp = put(vnetUrl(), vnetBody);
+        assertOk(vnetResp, "create virtual network");
+        assertEquals("Succeeded",
+                mapper.readTree(vnetResp.body()).get("properties").get("provisioningState").asText());
+
+        String nicBody = """
+                {
+                  "location": "eastus",
+                  "properties": {
+                    "ipConfigurations": [
+                      {"name": "ipconfig1", "properties": {"subnet": {"id": "%s/subnets/default"}}}
+                    ]
+                  }
+                }
+                """.formatted(vnetResourceId());
+        HttpResponse<String> nicResp = put(nicUrl(), nicBody);
+        assertOk(nicResp, "create network interface");
+        JsonNode nic = mapper.readTree(nicResp.body());
+        assertEquals("Succeeded", nic.get("properties").get("provisioningState").asText());
+        assertNotNull(nic.get("properties").get("ipConfigurations").get(0)
+                        .get("properties").get("privateIPAddress"),
+                "NIC stub should synthesize a privateIPAddress");
+    }
+
+    @Test
+    @Order(2)
+    void createVm_returnsSucceededWithEchoedProperties() throws Exception {
+        String body = """
+                {
+                  "location": "eastus",
+                  "tags": {"env": "compat"},
+                  "properties": {
+                    "hardwareProfile": {"vmSize": "Standard_D2s_v3"},
+                    "storageProfile": {
+                      "imageReference": {
+                        "publisher": "Canonical",
+                        "offer": "0001-com-ubuntu-server-jammy",
+                        "sku": "22_04-lts",
+                        "version": "latest"
+                      },
+                      "osDisk": {"createOption": "FromImage", "name": "%s-osdisk"}
+                    },
+                    "osProfile": {"adminUsername": "azureuser", "computerName": "%s"},
+                    "networkProfile": {
+                      "networkInterfaces": [{"id": "%s"}]
+                    }
+                  }
+                }
+                """.formatted(VM, VM, nicResourceId());
+
+        HttpResponse<String> resp = put(vmUrl(), body);
+        assertEquals(201, resp.statusCode(), "create VM: " + resp.body());
+
+        JsonNode json = mapper.readTree(resp.body());
+        assertEquals(VM, json.get("name").asText());
+        assertEquals("Microsoft.Compute/virtualMachines", json.get("type").asText());
+        assertEquals("eastus", json.get("location").asText());
+        assertEquals("compat", json.get("tags").get("env").asText());
+        JsonNode props = json.get("properties");
+        assertEquals("Succeeded", props.get("provisioningState").asText());
+        assertTrue(props.get("vmId").asText().length() > 0, "vmId should be synthesized");
+        assertEquals("Standard_D2s_v3", props.get("hardwareProfile").get("vmSize").asText());
+        assertEquals("azureuser", props.get("osProfile").get("adminUsername").asText());
+        assertEquals(nicResourceId(),
+                props.get("networkProfile").get("networkInterfaces").get(0).get("id").asText());
+    }
+
+    @Test
+    @Order(3)
+    void getVm_andExpandInstanceView_reportRunning() throws Exception {
+        HttpResponse<String> getResp = get(vmUrl());
+        assertEquals(200, getResp.statusCode(), getResp.body());
+        assertEquals(VM, mapper.readTree(getResp.body()).get("name").asText());
+
+        HttpResponse<String> expandResp = get(vmUrl() + "&$expand=instanceView");
+        assertEquals(200, expandResp.statusCode(), expandResp.body());
+        JsonNode statuses = mapper.readTree(expandResp.body())
+                .get("properties").get("instanceView").get("statuses");
+        assertHasStatusCode(statuses, "PowerState/running");
+    }
+
+    @Test
+    @Order(4)
+    void instanceView_reportsProvisioningAndPowerState() throws Exception {
+        HttpResponse<String> resp = get(vmUrl("/instanceView"));
+        assertEquals(200, resp.statusCode(), resp.body());
+        JsonNode statuses = mapper.readTree(resp.body()).get("statuses");
+        assertHasStatusCode(statuses, "ProvisioningState/succeeded");
+        assertHasStatusCode(statuses, "PowerState/running");
+    }
+
+    @Test
+    @Order(5)
+    void powerActions_emitAsyncHeaderAndChangePowerState() throws Exception {
+        HttpResponse<String> off = post(vmUrl("/powerOff"));
+        assertEquals(202, off.statusCode(), off.body());
+        assertTrue(off.headers().firstValue("Azure-AsyncOperation").orElse("").contains("/operations/"),
+                "powerOff must return an Azure-AsyncOperation header for SDK LRO polling");
+        assertTrue(off.headers().firstValue("Location").isPresent(),
+                "powerOff must return a Location header (final-state-via: location)");
+        assertPowerState("PowerState/stopped");
+
+        assertEquals(202, post(vmUrl("/start")).statusCode());
+        assertPowerState("PowerState/running");
+
+        assertEquals(202, post(vmUrl("/deallocate")).statusCode());
+        assertPowerState("PowerState/deallocated");
+
+        assertEquals(202, post(vmUrl("/restart")).statusCode());
+        assertPowerState("PowerState/running");
+    }
+
+    @Test
+    @Order(6)
+    void asyncOperationStatus_returnsSucceeded() throws Exception {
+        HttpResponse<String> action = post(vmUrl("/start"));
+        String asyncUrl = action.headers().firstValue("Azure-AsyncOperation").orElseThrow();
+        HttpResponse<String> statusResp = get(asyncUrl);
+        assertEquals(200, statusResp.statusCode(), statusResp.body());
+        assertEquals("Succeeded", mapper.readTree(statusResp.body()).get("status").asText());
+    }
+
+    @Test
+    @Order(7)
+    void listVms_bySubscriptionAndResourceGroup() throws Exception {
+        HttpResponse<String> rgList = get(vmCollectionInRgUrl());
+        assertEquals(200, rgList.statusCode(), rgList.body());
+        assertContainsName(mapper.readTree(rgList.body()).get("value"), VM);
+
+        HttpResponse<String> subList = get(vmCollectionInSubUrl());
+        assertEquals(200, subList.statusCode(), subList.body());
+        assertContainsName(mapper.readTree(subList.body()).get("value"), VM);
+    }
+
+    @Test
+    @Order(8)
+    void deleteVm_thenGetReturns404() throws Exception {
+        assertOk(delete(vmUrl()), "delete VM");
+        assertEquals(404, get(vmUrl()).statusCode());
+        // Delete is idempotent.
+        assertOk(delete(vmUrl()), "delete VM (idempotent)");
+    }
+
+    // ── URL builders ────────────────────────────────────────────────────────────
+
+    private static String resourceGroupUrl() {
+        return BASE + "/subscriptions/" + SUBSCRIPTION + "/resourceGroups/" + RG
+                + "?api-version=" + RG_API;
+    }
+
+    private static String computeProviderUrl() {
+        return BASE + "/subscriptions/" + SUBSCRIPTION + "/resourceGroups/" + RG
+                + "/providers/Microsoft.Compute";
+    }
+
+    private static String vmUrl() {
+        return computeProviderUrl() + "/virtualMachines/" + VM + "?api-version=" + COMPUTE_API;
+    }
+
+    private static String vmUrl(String childPath) {
+        return computeProviderUrl() + "/virtualMachines/" + VM + childPath
+                + "?api-version=" + COMPUTE_API;
+    }
+
+    private static String vmCollectionInRgUrl() {
+        return computeProviderUrl() + "/virtualMachines?api-version=" + COMPUTE_API;
+    }
+
+    private static String vmCollectionInSubUrl() {
+        return BASE + "/subscriptions/" + SUBSCRIPTION
+                + "/providers/Microsoft.Compute/virtualMachines?api-version=" + COMPUTE_API;
+    }
+
+    private static String vnetResourceId() {
+        return "/subscriptions/" + SUBSCRIPTION + "/resourceGroups/" + RG
+                + "/providers/Microsoft.Network/virtualNetworks/" + VNET;
+    }
+
+    private static String vnetUrl() {
+        return BASE + vnetResourceId() + "?api-version=" + NETWORK_API;
+    }
+
+    private static String nicResourceId() {
+        return "/subscriptions/" + SUBSCRIPTION + "/resourceGroups/" + RG
+                + "/providers/Microsoft.Network/networkInterfaces/" + NIC;
+    }
+
+    private static String nicUrl() {
+        return BASE + nicResourceId() + "?api-version=" + NETWORK_API;
+    }
+
+    // ── HTTP helpers ────────────────────────────────────────────────────────────
+
+    private static HttpResponse<String> get(String url) throws Exception {
+        return http.send(HttpRequest.newBuilder(URI.create(url)).GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    private static HttpResponse<String> put(String url, String json) throws Exception {
+        return http.send(HttpRequest.newBuilder(URI.create(url))
+                        .PUT(HttpRequest.BodyPublishers.ofString(json))
+                        .header("Content-Type", "application/json")
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    private static HttpResponse<String> post(String url) throws Exception {
+        return http.send(HttpRequest.newBuilder(URI.create(url))
+                        .POST(HttpRequest.BodyPublishers.noBody())
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    private static HttpResponse<String> delete(String url) throws Exception {
+        return http.send(HttpRequest.newBuilder(URI.create(url)).DELETE().build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    // ── Assertions ──────────────────────────────────────────────────────────────
+
+    private static void assertPowerState(String code) throws Exception {
+        HttpResponse<String> resp = get(vmUrl("/instanceView"));
+        assertEquals(200, resp.statusCode(), resp.body());
+        assertHasStatusCode(mapper.readTree(resp.body()).get("statuses"), code);
+    }
+
+    private static void assertHasStatusCode(JsonNode statuses, String code) {
+        assertNotNull(statuses, "statuses array missing");
+        assertTrue(statuses.isArray(), "Expected statuses array but got " + statuses);
+        for (JsonNode s : statuses) {
+            if (code.equals(s.get("code").asText())) {
+                return;
+            }
+        }
+        throw new AssertionError("Expected statuses to contain code " + code + ": " + statuses);
+    }
+
+    private static void assertContainsName(JsonNode array, String name) {
+        assertNotNull(array);
+        assertTrue(array.isArray(), "Expected array but got " + array);
+        for (JsonNode item : array) {
+            if (name.equals(item.get("name").asText())) {
+                return;
+            }
+        }
+        throw new AssertionError("Expected list to contain name " + name + ": " + array);
+    }
+
+    private static void assertOk(HttpResponse<String> resp, String operation) {
+        assertTrue(resp.statusCode() >= 200 && resp.statusCode() < 300,
+                operation + " failed: " + resp.statusCode() + " " + resp.body());
+    }
+}

--- a/compatibility-tests/sdk-test-python/tests/test_vm.py
+++ b/compatibility-tests/sdk-test-python/tests/test_vm.py
@@ -1,0 +1,222 @@
+"""Azure Virtual Machines compatibility test.
+
+Drives the ``Microsoft.Compute/virtualMachines`` ARM surface and its
+``Microsoft.Network`` dependency stubs (virtual network / network interface)
+through the real Azure REST wire protocol.
+
+Mirrors ``test_acr.py``: the established pattern for ARM management-plane
+services in this suite is raw ``requests`` against the REST paths rather than the
+fluent ``azure-mgmt-compute`` SDK (which expects subscription / provider-registration
+endpoints floci-az does not emulate). Covers the lifecycle the
+``azure-mgmt-compute`` SDK and ``azurerm_linux_virtual_machine`` exercise:
+create (vnet/subnet/nic → VM) → get → ``$expand=instanceView`` → instanceView →
+power actions (powerOff / start / deallocate / restart, asserting the
+``Azure-AsyncOperation`` + ``Location`` LRO headers and the resulting PowerState) →
+list by resource group and by subscription → delete.
+"""
+import os
+
+import pytest
+import requests
+
+EMULATOR_BASE = os.environ.get("FLOCI_AZ_ENDPOINT", "http://localhost:4577")
+SUB = os.environ.get("FLOCI_AZ_SUBSCRIPTION", "00000000-0000-0000-0000-000000000001")
+RG = "sdk-test-rg-vm"
+VM = "sdktestvm"
+VNET = "sdktestvnet"
+NIC = f"{VM}-nic"
+
+COMPUTE_API = "2024-11-01"
+NETWORK_API = "2024-05-01"
+RG_API = "2021-04-01"
+
+HEADERS = {"Authorization": "Bearer fake", "Content-Type": "application/json"}
+
+RG_BASE = f"{EMULATOR_BASE}/subscriptions/{SUB}/resourceGroups/{RG}"
+COMPUTE_BASE = f"{RG_BASE}/providers/Microsoft.Compute"
+VM_URL = f"{COMPUTE_BASE}/virtualMachines/{VM}"
+VNET_ID = f"/subscriptions/{SUB}/resourceGroups/{RG}/providers/Microsoft.Network/virtualNetworks/{VNET}"
+NIC_ID = f"/subscriptions/{SUB}/resourceGroups/{RG}/providers/Microsoft.Network/networkInterfaces/{NIC}"
+
+
+def _statuses_codes(statuses):
+    return [s.get("code") for s in statuses]
+
+
+@pytest.fixture(scope="module")
+def provisioned_vm():
+    requests.put(
+        f"{RG_BASE}?api-version={RG_API}",
+        json={"location": "eastus"},
+        headers=HEADERS,
+        timeout=10,
+    )
+
+    vnet_body = {
+        "location": "eastus",
+        "properties": {
+            "addressSpace": {"addressPrefixes": ["10.0.0.0/16"]},
+            "subnets": [
+                {"name": "default", "properties": {"addressPrefix": "10.0.0.0/24"}}
+            ],
+        },
+    }
+    vnet = requests.put(
+        f"{EMULATOR_BASE}{VNET_ID}?api-version={NETWORK_API}",
+        json=vnet_body,
+        headers=HEADERS,
+        timeout=10,
+    )
+    assert vnet.status_code in (200, 201), vnet.text
+    assert vnet.json()["properties"]["provisioningState"] == "Succeeded"
+
+    nic_body = {
+        "location": "eastus",
+        "properties": {
+            "ipConfigurations": [
+                {
+                    "name": "ipconfig1",
+                    "properties": {"subnet": {"id": f"{VNET_ID}/subnets/default"}},
+                }
+            ]
+        },
+    }
+    nic = requests.put(
+        f"{EMULATOR_BASE}{NIC_ID}?api-version={NETWORK_API}",
+        json=nic_body,
+        headers=HEADERS,
+        timeout=10,
+    )
+    assert nic.status_code in (200, 201), nic.text
+    nic_props = nic.json()["properties"]
+    assert nic_props["provisioningState"] == "Succeeded"
+    assert nic_props["ipConfigurations"][0]["properties"].get("privateIPAddress")
+
+    vm_body = {
+        "location": "eastus",
+        "tags": {"env": "compat"},
+        "properties": {
+            "hardwareProfile": {"vmSize": "Standard_D2s_v3"},
+            "storageProfile": {
+                "imageReference": {
+                    "publisher": "Canonical",
+                    "offer": "0001-com-ubuntu-server-jammy",
+                    "sku": "22_04-lts",
+                    "version": "latest",
+                },
+                "osDisk": {"createOption": "FromImage", "name": f"{VM}-osdisk"},
+            },
+            "osProfile": {"adminUsername": "azureuser", "computerName": VM},
+            "networkProfile": {"networkInterfaces": [{"id": NIC_ID}]},
+        },
+    }
+    put = requests.put(
+        f"{VM_URL}?api-version={COMPUTE_API}", json=vm_body, headers=HEADERS, timeout=10
+    )
+    assert put.status_code == 201, put.text
+    yield put.json()
+
+    requests.delete(f"{VM_URL}?api-version={COMPUTE_API}", headers=HEADERS, timeout=10)
+
+
+def _power_action(action):
+    resp = requests.post(
+        f"{VM_URL}/{action}?api-version={COMPUTE_API}", headers=HEADERS, timeout=10
+    )
+    assert resp.status_code == 202, resp.text
+    return resp
+
+
+def _instance_view():
+    resp = requests.get(
+        f"{VM_URL}/instanceView?api-version={COMPUTE_API}", headers=HEADERS, timeout=10
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def test_create_returns_succeeded_with_echoed_properties(provisioned_vm):
+    assert provisioned_vm["name"] == VM
+    assert provisioned_vm["type"] == "Microsoft.Compute/virtualMachines"
+    assert provisioned_vm["location"] == "eastus"
+    assert provisioned_vm["tags"]["env"] == "compat"
+    props = provisioned_vm["properties"]
+    assert props["provisioningState"] == "Succeeded"
+    assert props.get("vmId")
+    assert props["hardwareProfile"]["vmSize"] == "Standard_D2s_v3"
+    assert props["osProfile"]["adminUsername"] == "azureuser"
+    assert props["networkProfile"]["networkInterfaces"][0]["id"] == NIC_ID
+
+
+def test_get_and_expand_instance_view(provisioned_vm):
+    got = requests.get(f"{VM_URL}?api-version={COMPUTE_API}", headers=HEADERS, timeout=10)
+    assert got.status_code == 200, got.text
+    assert got.json()["name"] == VM
+
+    expand = requests.get(
+        f"{VM_URL}?api-version={COMPUTE_API}&$expand=instanceView",
+        headers=HEADERS,
+        timeout=10,
+    )
+    assert expand.status_code == 200, expand.text
+    statuses = expand.json()["properties"]["instanceView"]["statuses"]
+    assert "PowerState/running" in _statuses_codes(statuses)
+
+
+def test_instance_view_reports_provisioning_and_power_state(provisioned_vm):
+    codes = _statuses_codes(_instance_view()["statuses"])
+    assert "ProvisioningState/succeeded" in codes
+    assert "PowerState/running" in codes
+
+
+def test_power_actions_emit_async_header_and_change_state(provisioned_vm):
+    off = _power_action("powerOff")
+    assert "/operations/" in off.headers.get("Azure-AsyncOperation", "")
+    assert off.headers.get("Location"), "powerOff must return a Location header"
+    assert "PowerState/stopped" in _statuses_codes(_instance_view()["statuses"])
+
+    _power_action("start")
+    assert "PowerState/running" in _statuses_codes(_instance_view()["statuses"])
+
+    _power_action("deallocate")
+    assert "PowerState/deallocated" in _statuses_codes(_instance_view()["statuses"])
+
+    _power_action("restart")
+    assert "PowerState/running" in _statuses_codes(_instance_view()["statuses"])
+
+
+def test_async_operation_status_returns_succeeded(provisioned_vm):
+    action = _power_action("start")
+    async_url = action.headers["Azure-AsyncOperation"]
+    status = requests.get(async_url, headers=HEADERS, timeout=10)
+    assert status.status_code == 200, status.text
+    assert status.json()["status"] == "Succeeded"
+
+
+def test_list_by_resource_group_and_subscription(provisioned_vm):
+    rg_list = requests.get(
+        f"{COMPUTE_BASE}/virtualMachines?api-version={COMPUTE_API}",
+        headers=HEADERS,
+        timeout=10,
+    )
+    assert rg_list.status_code == 200, rg_list.text
+    assert VM in [v["name"] for v in rg_list.json()["value"]]
+
+    sub_list = requests.get(
+        f"{EMULATOR_BASE}/subscriptions/{SUB}/providers/Microsoft.Compute/virtualMachines"
+        f"?api-version={COMPUTE_API}",
+        headers=HEADERS,
+        timeout=10,
+    )
+    assert sub_list.status_code == 200, sub_list.text
+    assert VM in [v["name"] for v in sub_list.json()["value"]]
+
+
+def test_delete_then_get_returns_404(provisioned_vm):
+    delete = requests.delete(f"{VM_URL}?api-version={COMPUTE_API}", headers=HEADERS, timeout=10)
+    assert delete.status_code in (200, 202, 204), delete.text
+    got = requests.get(f"{VM_URL}?api-version={COMPUTE_API}", headers=HEADERS, timeout=10)
+    assert got.status_code == 404, got.text
+    # Delete is idempotent.
+    again = requests.delete(f"{VM_URL}?api-version={COMPUTE_API}", headers=HEADERS, timeout=10)
+    assert again.status_code in (200, 202, 204), again.text

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   floci-az:
     build:
       context: .
-      dockerfile: docker/Dockerfile
+      dockerfile: docker/Dockerfile.native
     ports:
       - "4577:4577"
     volumes:

--- a/docs/services/vm.md
+++ b/docs/services/vm.md
@@ -2,9 +2,14 @@
 
 Compatible with the `azure-mgmt-compute` SDK, the `az vm` CLI, Terraform's `azurerm_linux_virtual_machine`, and any ARM-speaking client.
 
-> **No Docker required** (mocked mode, the default). VMs are emulated as pure ARM control-plane
-> resources: they provision instantly and report power state. Real Docker-backed VMs are planned
-> (set `FLOCI_AZ_SERVICES_VM_MOCKED=false` once available).
+> **Mocked mode (default): no Docker required.** VMs are emulated as pure ARM control-plane
+> resources: they provision instantly and report power state.
+>
+> **Container-backed mode:** set `FLOCI_AZ_SERVICES_VM_MOCKED=false` to back each VM with a real
+> Linux container. The image is resolved from `storageProfile.imageReference` (falling back to
+> `ubuntu:22.04`), and power actions map onto Docker: `start` → start, `powerOff`/`deallocate` →
+> stop, `restart` → restart, delete → remove. VMs provision asynchronously (`Creating` →
+> `Succeeded` once the container is running).
 
 ---
 
@@ -100,7 +105,7 @@ floci-az:
   services:
     vm:
       enabled: true
-      mocked: true              # true = no Docker, pure ARM state. false = container-backed (planned)
+      mocked: true              # true = no Docker, pure ARM state. false = container-backed
       default-image: "ubuntu:22.04"
 ```
 
@@ -115,7 +120,8 @@ floci-az:
 ## Notes & limitations
 
 - Mocked mode does not run a real OS — there is no SSH, no guest agent, and `runCommand` is not executed.
-- Network resources are ARM control-plane emulation only. NIC private IPs and public IPs are
-  synthesized by the Network emulator, not allocated from a real address pool.
-- Real container-backed VMs (image resolution via `imageReference`, `docker start/stop/restart`)
-  are planned for a follow-up.
+- Container-backed mode (`mocked=false`) runs a stock base image kept alive with `tail -f /dev/null`;
+  it is a real Linux container, not a true VM/hypervisor — there is no separate kernel, no cloud-init,
+  and `osProfile.customData` / SSH key injection are not applied.
+- Network dependency shells echo submitted properties with `provisioningState = "Succeeded"`;
+  NIC private IPs and public IPs are synthesized, not allocated from a real address pool.

--- a/src/main/java/io/floci/az/core/docker/ContainerLifecycleManager.java
+++ b/src/main/java/io/floci/az/core/docker/ContainerLifecycleManager.java
@@ -181,6 +181,42 @@ public class ContainerLifecycleManager {
         }
     }
 
+    /** Starts a previously-created (stopped) container in place, without removing it. */
+    public void start(String containerId) {
+        try {
+            dockerClient.startContainerCmd(containerId).exec();
+            LOG.infov("Started container {0}", containerId);
+        } catch (NotFoundException e) {
+            LOG.warnv("Container {0} not found; cannot start", containerId);
+        } catch (Exception e) {
+            LOG.warnv("Error starting container {0}: {1}", containerId, e.getMessage());
+        }
+    }
+
+    /** Stops a running container without removing it, so it can be started again later. */
+    public void stop(String containerId, int timeoutSeconds) {
+        try {
+            dockerClient.stopContainerCmd(containerId).withTimeout(timeoutSeconds).exec();
+            LOG.infov("Stopped container {0}", containerId);
+        } catch (NotFoundException e) {
+            LOG.debugv("Container {0} not found (already stopped/removed)", containerId);
+        } catch (Exception e) {
+            LOG.warnv("Error stopping container {0}: {1}", containerId, e.getMessage());
+        }
+    }
+
+    /** Restarts a container in place (stop + start), keeping it for further use. */
+    public void restart(String containerId, int timeoutSeconds) {
+        try {
+            dockerClient.restartContainerCmd(containerId).withTimeout(timeoutSeconds).exec();
+            LOG.infov("Restarted container {0}", containerId);
+        } catch (NotFoundException e) {
+            LOG.warnv("Container {0} not found; cannot restart", containerId);
+        } catch (Exception e) {
+            LOG.warnv("Error restarting container {0}: {1}", containerId, e.getMessage());
+        }
+    }
+
     public boolean isContainerRunning(String containerId) {
         try {
             InspectContainerResponse inspect = dockerClient.inspectContainerCmd(containerId).exec();

--- a/src/main/java/io/floci/az/services/vm/VmContainerManager.java
+++ b/src/main/java/io/floci/az/services/vm/VmContainerManager.java
@@ -1,0 +1,158 @@
+package io.floci.az.services.vm;
+
+import io.floci.az.config.EmulatorConfig;
+import io.floci.az.core.docker.ContainerBuilder;
+import io.floci.az.core.docker.ContainerLifecycleManager;
+import io.floci.az.core.docker.ContainerLifecycleManager.ContainerInfo;
+import io.floci.az.core.docker.ContainerSpec;
+import io.floci.az.services.vm.VmModels.VirtualMachine;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Manages the Docker lifecycle of containers backing virtual machines in non-mocked mode
+ * ({@code floci-az.services.vm.mocked=false}).
+ *
+ * <p>Each VM is backed by one long-lived Linux container kept alive with
+ * {@code tail -f /dev/null} (mirroring the AWS sibling's EC2 backing). Azure power actions map
+ * onto Docker operations:</p>
+ * <ul>
+ *   <li>{@code start} → docker start</li>
+ *   <li>{@code powerOff} / {@code deallocate} → docker stop (container retained)</li>
+ *   <li>{@code restart} / {@code redeploy} / {@code reapply} → docker restart</li>
+ *   <li>delete → docker stop + remove</li>
+ * </ul>
+ *
+ * <p>Per the floci-az sidecar rules this never calls {@code dockerClient} directly — it goes
+ * through {@link ContainerBuilder} and {@link ContainerLifecycleManager} — and all Docker
+ * failures are non-fatal so the service degrades gracefully when Docker is unavailable.</p>
+ */
+@ApplicationScoped
+public class VmContainerManager {
+
+    private static final Logger LOG = Logger.getLogger(VmContainerManager.class);
+
+    /** Keep-alive command so a stock base image stays running as an emulated VM. */
+    private static final List<String> KEEP_ALIVE = List.of("tail", "-f", "/dev/null");
+    private static final int STOP_TIMEOUT_SECONDS = 10;
+
+    private final ContainerBuilder containerBuilder;
+    private final ContainerLifecycleManager lifecycleManager;
+    private final VmImageResolver imageResolver;
+    private final EmulatorConfig config;
+
+    @Inject
+    public VmContainerManager(ContainerBuilder containerBuilder,
+                              ContainerLifecycleManager lifecycleManager,
+                              VmImageResolver imageResolver,
+                              EmulatorConfig config) {
+        this.containerBuilder = containerBuilder;
+        this.lifecycleManager = lifecycleManager;
+        this.imageResolver = imageResolver;
+        this.config = config;
+    }
+
+    /**
+     * Launches a keep-alive container backing the VM and records its id on {@code vm}.
+     * The VM stays in {@code provisioningState=Creating} until the readiness poller observes the
+     * container running.
+     */
+    public void startVm(VirtualMachine vm) {
+        String image = resolveImage(vm);
+        String containerName = containerName(vm);
+
+        LOG.infov("Starting container for VM {0} using image {1}", vm.getName(), image);
+
+        lifecycleManager.removeIfExists(containerName);
+
+        ContainerSpec spec = containerBuilder.newContainer(image)
+                .withName(containerName)
+                .withCmd(KEEP_ALIVE)
+                .withDockerNetwork(config.services().dockerNetwork())
+                .withLogRotation()
+                .build();
+
+        ContainerInfo info = lifecycleManager.createAndStart(spec);
+        vm.setContainerId(info.containerId());
+
+        LOG.infov("Container {0} started for VM {1}", info.containerId(), vm.getName());
+    }
+
+    /** True once the backing container is up — the readiness signal for a plain VM. */
+    public boolean isRunning(VirtualMachine vm) {
+        return vm.getContainerId() != null
+                && lifecycleManager.isContainerRunning(vm.getContainerId());
+    }
+
+    /** Power-on: start the (stopped) backing container. */
+    public void startContainer(VirtualMachine vm) {
+        if (vm.getContainerId() != null) {
+            lifecycleManager.start(vm.getContainerId());
+        }
+    }
+
+    /** Power-off / deallocate: stop the backing container but keep it for a later start. */
+    public void stopContainer(VirtualMachine vm) {
+        if (vm.getContainerId() != null) {
+            lifecycleManager.stop(vm.getContainerId(), STOP_TIMEOUT_SECONDS);
+        }
+    }
+
+    /** Restart: bounce the backing container in place. */
+    public void restartContainer(VirtualMachine vm) {
+        if (vm.getContainerId() != null) {
+            lifecycleManager.restart(vm.getContainerId(), STOP_TIMEOUT_SECONDS);
+        }
+    }
+
+    /** Delete: stop and remove the backing container. */
+    public void removeVm(VirtualMachine vm) {
+        if (vm.getContainerId() != null) {
+            lifecycleManager.stopAndRemove(vm.getContainerId(), null);
+        } else {
+            lifecycleManager.removeIfExists(containerName(vm));
+        }
+    }
+
+    private String resolveImage(VirtualMachine vm) {
+        Map<String, Object> imageReference = imageReference(vm);
+        if (imageReference != null) {
+            return imageResolver.resolve(imageReference);
+        }
+        return config.services().vm().defaultImage();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> imageReference(VirtualMachine vm) {
+        if (vm.getProperties() == null) {
+            return null;
+        }
+        Object storageProfile = vm.getProperties().get("storageProfile");
+        if (storageProfile instanceof Map<?, ?> sp) {
+            Object imageRef = ((Map<String, Object>) sp).get("imageReference");
+            if (imageRef instanceof Map<?, ?> ir) {
+                return (Map<String, Object>) ir;
+            }
+        }
+        return null;
+    }
+
+    static String containerName(VirtualMachine vm) {
+        String id = vm.getVmId() != null
+                ? vm.getVmId().replace("-", "")
+                : sanitize(vm.getName());
+        if (id.length() > 12) {
+            id = id.substring(0, 12);
+        }
+        return "floci-az-vm-" + id;
+    }
+
+    private static String sanitize(String name) {
+        return name == null ? "unknown" : name.toLowerCase(Locale.ROOT).replaceAll("[^a-z0-9]", "");
+    }
+}

--- a/src/main/java/io/floci/az/services/vm/VmHandler.java
+++ b/src/main/java/io/floci/az/services/vm/VmHandler.java
@@ -12,6 +12,8 @@ import io.floci.az.core.storage.StorageBackend;
 import io.floci.az.core.storage.StorageFactory;
 import io.floci.az.services.vm.VmModels.PowerState;
 import io.floci.az.services.vm.VmModels.VirtualMachine;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
@@ -26,6 +28,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 /**
  * HTTP handler for Azure Virtual Machines (Microsoft.Compute/virtualMachines) management-plane
@@ -62,12 +67,42 @@ public class VmHandler implements AzureServiceHandler {
     private static final String API_VERSION = "2024-11-01";
 
     private final EmulatorConfig config;
+    private final VmContainerManager containerManager;
     private final StorageBackend<String, StoredObject> storage;
+    private final ScheduledExecutorService poller = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread t = new Thread(r, "vm-readiness-poller");
+        t.setDaemon(true);
+        return t;
+    });
 
     @Inject
-    public VmHandler(EmulatorConfig config, StorageFactory storageFactory) {
+    public VmHandler(EmulatorConfig config,
+                     VmContainerManager containerManager,
+                     StorageFactory storageFactory) {
         this.config = config;
+        this.containerManager = containerManager;
         this.storage = storageFactory.create("vm");
+    }
+
+    @PostConstruct
+    public void init() {
+        if (!config.services().vm().mocked()) {
+            startReadinessPoller();
+        }
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        poller.shutdownNow();
+        if (!config.services().vm().mocked()) {
+            scanAll().forEach(vm -> {
+                try {
+                    containerManager.removeVm(vm);
+                } catch (Exception e) {
+                    LOG.warnv("Error removing container for VM {0}: {1}", vm.getName(), e.getMessage());
+                }
+            });
+        }
     }
 
     @Override
@@ -154,11 +189,27 @@ public class VmHandler implements AzureServiceHandler {
             vm.setTags(tags.isEmpty() ? null : tags);
             vm.setProperties(properties);
 
-            // Mocked mode: VM is provisioned and powered on immediately. Non-mocked Docker
-            // backing is wired in phase 2 (would set "Creating" + launch a container here).
-            vm.setProvisioningState("Succeeded");
-            if (isNew || vm.getPowerState() == null) {
-                vm.setPowerState(PowerState.RUNNING.code());
+            if (config.services().vm().mocked()) {
+                // Mocked mode: VM is provisioned and powered on immediately (no Docker).
+                vm.setProvisioningState("Succeeded");
+                if (isNew || vm.getPowerState() == null) {
+                    vm.setPowerState(PowerState.RUNNING.code());
+                }
+            } else if (isNew) {
+                // Real mode: launch a backing container; the readiness poller flips the VM to
+                // Succeeded once it is running. Docker failures degrade to mocked-style state.
+                vm.setProvisioningState("Creating");
+                vm.setPowerState(PowerState.STARTING.code());
+                try {
+                    containerManager.startVm(vm);
+                } catch (Exception e) {
+                    LOG.errorf(e, "Failed to start container for VM %s; degrading to mocked state", vmName);
+                    vm.setProvisioningState("Succeeded");
+                    vm.setPowerState(PowerState.RUNNING.code());
+                }
+            } else {
+                // Real mode update: keep the existing container and power state.
+                vm.setProvisioningState("Succeeded");
             }
 
             putVm(key, vm);
@@ -198,7 +249,17 @@ public class VmHandler implements AzureServiceHandler {
     }
 
     private Response handleDelete(String sub, String rg, String vmName) {
-        storage.delete(storageKey(sub, rg, vmName));
+        String key = storageKey(sub, rg, vmName);
+        if (!config.services().vm().mocked()) {
+            getVm(key).ifPresent(vm -> {
+                try {
+                    containerManager.removeVm(vm);
+                } catch (Exception e) {
+                    LOG.warnv("Error removing container for VM {0}: {1}", vmName, e.getMessage());
+                }
+            });
+        }
+        storage.delete(key);
         // Delete synchronously with 204 No Content. The azurerm provider's virtualmachines
         // DeleteThenPoll treats a 202/200 as a long-running operation and polls the collection
         // forever against the emulator; a terminal 204 signals the delete is complete so
@@ -244,6 +305,21 @@ public class VmHandler implements AzureServiceHandler {
             case "deallocate" -> PowerState.DEALLOCATED;
             default           -> PowerState.RUNNING;  // start, restart, redeploy, reapply
         };
+
+        if (!config.services().vm().mocked()) {
+            // Map the Azure power action onto the backing container. Failures are non-fatal:
+            // the recorded power state still transitions so the control plane stays consistent.
+            try {
+                switch (action) {
+                    case "powerOff", "deallocate"        -> containerManager.stopContainer(vm);
+                    case "restart", "redeploy", "reapply" -> containerManager.restartContainer(vm);
+                    default                               -> containerManager.startContainer(vm);
+                }
+            } catch (Exception e) {
+                LOG.warnv("Power action {0} on VM {1} failed: {2}", action, vmName, e.getMessage());
+            }
+        }
+
         vm.setPowerState(target.code());
         vm.setProvisioningState("Succeeded");
         putVm(key, vm);
@@ -320,6 +396,25 @@ public class VmHandler implements AzureServiceHandler {
                 .header("Azure-AsyncOperation", url)
                 .header("Location", url)
                 .build();
+    }
+
+    // ── Readiness poller (non-mocked mode) ───────────────────────────────────────
+
+    private void startReadinessPoller() {
+        poller.scheduleAtFixedRate(() -> {
+            try {
+                scanAll().forEach(vm -> {
+                    if ("Creating".equals(vm.getProvisioningState()) && containerManager.isRunning(vm)) {
+                        vm.setProvisioningState("Succeeded");
+                        vm.setPowerState(PowerState.RUNNING.code());
+                        putVm(vm.storageKey(), vm);
+                        LOG.infov("VM {0} container is running; provisioningState=Succeeded", vm.getName());
+                    }
+                });
+            } catch (Exception e) {
+                LOG.error("Error in VM readiness poller", e);
+            }
+        }, 2, 3, TimeUnit.SECONDS);
     }
 
     // ── Storage helpers ────────────────────────────────────────────────────────

--- a/src/test/java/io/floci/az/services/vm/VmDockerTest.java
+++ b/src/test/java/io/floci/az/services/vm/VmDockerTest.java
@@ -1,0 +1,154 @@
+package io.floci.az.services.vm;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.*;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * VM handler tests with {@code mocked=false} — starts a real Docker container backing the VM.
+ *
+ * <p>Skipped automatically when Docker is unavailable. The backing image (ubuntu:22.04) may need
+ * to be pulled on first run, so provisioning is polled with a generous timeout.
+ *
+ * <p>Tests are ordered and share state: the VM is created in test 1, reaches Succeeded in test 2,
+ * its power state is driven through the container in tests 3-4, and it is deleted in test 5.
+ * {@code @BeforeAll} only does a filesystem check so it is safe before Quarkus is ready;
+ * the HTTP reset is done inside the first {@code @Test}.
+ */
+@QuarkusTest
+@TestProfile(VmDockerTest.RealModeProfile.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@DisplayName("VmHandler — real Docker-backed mode (Docker required)")
+class VmDockerTest {
+
+    public static class RealModeProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("floci-az.services.vm.mocked", "false");
+        }
+    }
+
+    private static final String SUB  = "test-sub-vm-docker";
+    private static final String RG   = "test-rg-vm-docker";
+    private static final String NAME = "docker-test-vm";
+    private static final String API  = "?api-version=2024-11-01";
+    private static final String BASE =
+            "/subscriptions/" + SUB + "/resourceGroups/" + RG + "/providers/Microsoft.Compute";
+    private static final String VM_PATH = BASE + "/virtualMachines/" + NAME;
+
+    private static final String CREATE_BODY = """
+            {
+              "location": "eastus",
+              "properties": {
+                "hardwareProfile": {"vmSize": "Standard_D2s_v3"},
+                "storageProfile": {
+                  "imageReference": {
+                    "publisher": "Canonical",
+                    "offer": "0001-com-ubuntu-server-jammy",
+                    "sku": "22_04-lts",
+                    "version": "latest"
+                  }
+                },
+                "osProfile": {"adminUsername": "azureuser", "computerName": "dockervm"}
+              }
+            }
+            """;
+
+    /** Pure filesystem check — safe to run before Quarkus is fully ready. */
+    @BeforeAll
+    void checkDockerAvailable() {
+        boolean dockerAvailable = Files.exists(Paths.get("/var/run/docker.sock"))
+                || System.getenv("DOCKER_HOST") != null;
+        assumeTrue(dockerAvailable, "Docker socket not available — skipping real VM tests");
+    }
+
+    @AfterAll
+    void cleanup() {
+        try {
+            given().delete(VM_PATH + API);
+        } catch (Exception ignored) {}
+    }
+
+    @Test
+    @Order(1)
+    @DisplayName("PUT VM returns 201 with provisioningState Creating/Succeeded")
+    void createVmReturns201() {
+        given().post("/_admin/reset").then().statusCode(204);
+
+        given().contentType("application/json").body(CREATE_BODY)
+                .when().put(VM_PATH + API)
+                .then().statusCode(201)
+                .body("name", equalTo(NAME))
+                .body("properties.provisioningState", oneOf("Creating", "Succeeded", "Failed"));
+    }
+
+    @Test
+    @Order(2)
+    @DisplayName("VM reaches provisioningState=Succeeded once the container is running")
+    void vmReachesSucceeded() throws InterruptedException {
+        long deadline = System.currentTimeMillis() + 120_000;
+        String state = "Creating";
+
+        while (!"Succeeded".equals(state) && !"Failed".equals(state)
+                && System.currentTimeMillis() < deadline) {
+            Thread.sleep(3_000);
+            Response r = given().when().get(VM_PATH + API);
+            if (r.statusCode() == 200) {
+                state = r.path("properties.provisioningState");
+            }
+        }
+
+        assumeTrue(!"Failed".equals(state), "VM container failed to start — Docker may be misconfigured");
+        assertEquals("Succeeded", state, "VM did not reach Succeeded within 120 s; last state=" + state);
+
+        given().when().get(VM_PATH + "/instanceView" + API)
+                .then().statusCode(200)
+                .body("statuses.code", hasItems("ProvisioningState/succeeded", "PowerState/running"));
+    }
+
+    @Test
+    @Order(3)
+    @DisplayName("powerOff stops the container -> PowerState/stopped; start -> running")
+    void powerOffThenStart() {
+        given().when().post(VM_PATH + "/powerOff" + API).then().statusCode(202);
+        given().when().get(VM_PATH + "/instanceView" + API)
+                .then().body("statuses.code", hasItem("PowerState/stopped"));
+
+        given().when().post(VM_PATH + "/start" + API).then().statusCode(202);
+        given().when().get(VM_PATH + "/instanceView" + API)
+                .then().body("statuses.code", hasItem("PowerState/running"));
+    }
+
+    @Test
+    @Order(4)
+    @DisplayName("deallocate -> deallocated; restart -> running")
+    void deallocateThenRestart() {
+        given().when().post(VM_PATH + "/deallocate" + API).then().statusCode(202);
+        given().when().get(VM_PATH + "/instanceView" + API)
+                .then().body("statuses.code", hasItem("PowerState/deallocated"));
+
+        given().when().post(VM_PATH + "/restart" + API).then().statusCode(202);
+        given().when().get(VM_PATH + "/instanceView" + API)
+                .then().body("statuses.code", hasItem("PowerState/running"));
+    }
+
+    @Test
+    @Order(5)
+    @DisplayName("DELETE removes the VM and its container; subsequent GET returns 404")
+    void deleteVm() {
+        given().when().delete(VM_PATH + API).then().statusCode(204);
+        given().when().get(VM_PATH + API).then().statusCode(404);
+    }
+}


### PR DESCRIPTION
## Summary
Adds container-backed virtual machines when `floci-az.services.vm.mocked=false`. Each VM maps to a long-lived Linux container (image resolved from `storageProfile.imageReference` via VmImageResolver, falling back to `ubuntu:22.04`, kept alive with `tail -f /dev/null`). Azure power actions map onto the container: `start` → docker start; `powerOff`/`deallocate` → docker stop (container retained); `restart`/`redeploy`/`reapply` → docker restart; delete → stop + remove. VMs provision asynchronously (`Creating` → `Succeeded` once the container is running, via a readiness poller) so SDK/Terraform LRO pollers complete. Docker failures degrade gracefully to mocked-style state and are never fatal; mocked mode stays the default so unit tests remain Docker-free.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

Microsoft.Compute/virtualMachines, API version 2024-11-01. Verified against the Python SDK VM suite and Terraform/OpenTofu LRO pollers.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added (VmCompatibilityTest.java, VmDockerTest.java, sdk-test-python/tests/test_vm.py)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)