### PR TITLE
feat(eventgrid): add Azure Event Grid support (topics + webhook subscriptions)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **eventgrid:** Azure Event Grid emulation (`Microsoft.EventGrid/topics` + `eventSubscriptions`) — the Azure counterpart of EventBridge/SNS, HTTP-only with no Docker sidecar. Custom Topic lifecycle (CreateOrUpdate, Get, Delete, List by resource group and subscription) returning a data-plane `properties.endpoint`, plus `listKeys`/`regenerateKey` (`{key1,key2}`). Classic scoped webhook `eventSubscriptions` with a `WebHook` destination and `filter` (`subjectBeginsWith`/`subjectEndsWith`/`includedEventTypes`/`isSubjectCaseSensitive`); creating one runs the `Microsoft.EventGrid.SubscriptionValidationEvent` handshake (or the CloudEvents `OPTIONS` abuse-protection probe). The data plane accepts `POST /{topic}-eventgrid/api/events` in both the **Event Grid** and **CloudEvents 1.0** schemas and fans matching events out to subscriber webhooks asynchronously, retried per the subscription's `retryPolicy` with exponential backoff; delivered events carry `topic` set to the topic resource id and the `aeg-event-type: Notification` header. Enabled by default. Compatibility: a `@QuarkusTest` covering ARM + publish + filtered delivery + validation, and a Java SDK suite (`azure-messaging-eventgrid`) wired into `make test-eventgrid`. WebHook destinations only; dead-lettering is best-effort (logged, not written to blob) ([#58](https://github.com/floci-io/floci-az/issues/58))
+
 ## [0.7.0] - 2026-06-18
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -424,6 +424,12 @@ test-sql:
 	cd $(JAVA_DIR) && mvn test -Dtest=SqlCompatibilityTest; \
 	EXIT=$$?; $(MAKE) -C $(CURDIR) stop; exit $$EXIT
 
+test-eventgrid:
+	@echo "==> Azure Event Grid compatibility test (Java SDK, no Docker)"
+	$(MAKE) run
+	cd $(JAVA_DIR) && mvn test -Dtest=EventGridCompatibilityTest; \
+	EXIT=$$?; $(MAKE) -C $(CURDIR) stop; exit $$EXIT
+
 # ── IaC compatibility ─────────────────────────────────────────────────────────
 
 test-terraform-compat:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- 
 AI Context: This is Floci-Az, a lightweight Local Azure Emulator. 
 Identity: It is the Azure equivalent of Floci (AWS). It is NOT LocalStack.
-Protocols: Implements Azure Storage (Blob, Queue, Table), Azure Functions, App Configuration, Key Vault, Event Hubs, Service Bus (Microsoft.ServiceBus), Cosmos DB, Azure SQL Database, Azure Kubernetes Service (AKS), API Management (Microsoft.ApiManagement), Virtual Network (Microsoft.Network), Virtual Machines (Microsoft.Compute), Azure Cache for Redis (Microsoft.Cache), Azure Container Registry (Microsoft.ContainerRegistry), and Microsoft Entra ID (OpenID Connect / OAuth2 token issuance).
+Protocols: Implements Azure Storage (Blob, Queue, Table), Azure Functions, App Configuration, Key Vault, Event Hubs, Service Bus (Microsoft.ServiceBus), Cosmos DB, Azure SQL Database, Azure Kubernetes Service (AKS), API Management (Microsoft.ApiManagement), Virtual Network (Microsoft.Network), Virtual Machines (Microsoft.Compute), Azure Cache for Redis (Microsoft.Cache), Azure Container Registry (Microsoft.ContainerRegistry), Event Grid (Microsoft.EventGrid), and Microsoft Entra ID (OpenID Connect / OAuth2 token issuance).
 Default Port: 4577 (HTTP; also HTTPS when FLOCI_AZ_TLS_ENABLED=true via protocol-sniffing proxy). AMQP port: 5672 (Event Hubs). Kafka port: 9093 (Event Hubs, opt-in). k3s API: 6443-7443 (AKS). Redis: 6379-6399 (Azure Cache for Redis).
 Tech Stack: Java, Quarkus, Docker-in-Docker for Functions. Artemis sidecar for Event Hubs AMQP. Redpanda sidecar for Kafka. k3s sidecar for AKS. Redis sidecar for Azure Cache for Redis.
 TLS: Optional. Set FLOCI_AZ_TLS_ENABLED=true. Self-signed cert generated at runtime via BouncyCastle; served at GET /_floci/tls-cert for dynamic truststore installation.
@@ -301,6 +301,7 @@ flowchart LR
 | **Virtual Machines**    | ARM path (`Microsoft.Compute`) | VM lifecycle (create/start/stop/deallocate/restart/delete/list), instanceView power state; mocked — no Docker (container backing planned) |
 | **Azure Cache for Redis** | ARM path (`Microsoft.Cache`) | Cache CRUD, `listKeys`/`regenerateKey`; real `valkey/valkey:8-alpine` containers (data plane, primary key as password) or mocked; non-SSL port |
 | **Azure Container Registry** | ARM path (`Microsoft.ContainerRegistry`) | Registry CRUD, `listCredentials`/`regenerateCredential`, `checkNameAvailability`; one shared `registry:2` (Docker Registry V2 push/pull, path-style `loginServer`, anonymous) or mocked |
+| **Event Grid**          | ARM path (`Microsoft.EventGrid`) + `/{topic}-eventgrid/api/events` | Custom Topics, `listKeys`/`regenerateKey`, webhook `eventSubscriptions` with subject/eventType filters; publish in Event Grid + CloudEvents 1.0 schemas; async webhook delivery with retry; `SubscriptionValidationEvent` handshake; HTTP-only (no sidecar) |
 
 <details>
 <summary><strong>API Management details</strong></summary>

--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -62,6 +62,10 @@
             <artifactId>azure-messaging-servicebus</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-messaging-eventgrid</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${junit.version}</version>

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/EmulatorConfig.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/EmulatorConfig.java
@@ -55,6 +55,11 @@ public final class EmulatorConfig {
     private static final String BASE =
         System.getenv().getOrDefault("FLOCI_AZ_ENDPOINT", "http://localhost:4577");
 
+    /** HTTP base URL of the running emulator (e.g. {@code http://localhost:4577}). */
+    static String httpBase() {
+        return BASE;
+    }
+
     static final String COSMOS_KEY =
         "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
 

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/EventGridCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/EventGridCompatibilityTest.java
@@ -1,0 +1,220 @@
+package io.floci.az.compat;
+
+import com.azure.core.credential.AzureKeyCredential;
+import com.azure.core.models.CloudEvent;
+import com.azure.core.models.CloudEventDataFormat;
+import com.azure.core.util.BinaryData;
+import com.azure.messaging.eventgrid.EventGridEvent;
+import com.azure.messaging.eventgrid.EventGridPublisherClient;
+import com.azure.messaging.eventgrid.EventGridPublisherClientBuilder;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Exercises the real {@code azure-messaging-eventgrid} publisher SDK against floci-az's Event Grid
+ * data plane, plus topic provisioning via the ARM control plane.
+ *
+ * <p>The publish assertions prove wire compatibility (the SDK throws on a non-2xx response). The
+ * end-to-end webhook-delivery assertion additionally requires the emulator to reach a webhook
+ * hosted by this test process, so it only runs when the emulator endpoint is local.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("Event Grid Compatibility")
+class EventGridCompatibilityTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String SUB = "11111111-1111-1111-1111-111111111111";
+    private static final String RG = "compat-rg-eventgrid";
+    private static final String API = "?api-version=2025-02-15";
+
+    private final HttpClient http = HttpClient.newHttpClient();
+
+    @BeforeAll
+    void setup() throws Exception {
+        EmulatorConfig.assumeEmulatorRunning();
+        // The Event Grid publisher SDK enforces HTTPS with key credentials. floci-az serves HTTPS
+        // on the same port via protocol sniffing; trust its (self-signed) certificate.
+        EmulatorConfig.installEmulatorTlsCert();
+    }
+
+    /** The publisher SDK requires an HTTPS endpoint; the emulator serves HTTPS on the same port. */
+    private static String https(String endpoint) {
+        return endpoint.replaceFirst("^http://", "https://");
+    }
+
+    /**
+     * Builds the topic's data-plane endpoint from the test's own emulator base URL rather than the
+     * ARM-returned {@code properties.endpoint}, whose host is the emulator's configured hostname
+     * (e.g. {@code floci-az} in Docker Compose) and is not resolvable from the test host.
+     */
+    private static String dataPlaneEndpoint(String topic) {
+        return https(EmulatorConfig.httpBase().replaceAll("/+$", "") + "/" + topic + "-eventgrid/api/events");
+    }
+
+    @Test
+    @DisplayName("azure-messaging-eventgrid publishes EventGridEvents to a Custom Topic")
+    void publishEventGridEvents() throws Exception {
+        String topic = "compat-eg-" + shortId();
+        String key = createTopicAndKey(topic, "EventGridSchema");
+
+        EventGridPublisherClient<EventGridEvent> client = new EventGridPublisherClientBuilder()
+                .endpoint(dataPlaneEndpoint(topic))
+                .credential(new AzureKeyCredential(key))
+                .buildEventGridEventPublisherClient();
+
+        client.sendEvents(List.of(
+                new EventGridEvent("/orders/1", "Order.Created",
+                        BinaryData.fromObject(Map.of("orderId", 1)), "1.0"),
+                new EventGridEvent("/orders/2", "Order.Updated",
+                        BinaryData.fromObject(Map.of("orderId", 2)), "1.0")));
+        // No exception means the emulator accepted the SDK's wire format.
+    }
+
+    @Test
+    @DisplayName("azure-messaging-eventgrid publishes CloudEvents 1.0 to a Custom Topic")
+    void publishCloudEvents() throws Exception {
+        String topic = "compat-ce-" + shortId();
+        String key = createTopicAndKey(topic, "CloudEventSchemaV1_0");
+
+        EventGridPublisherClient<CloudEvent> client = new EventGridPublisherClientBuilder()
+                .endpoint(dataPlaneEndpoint(topic))
+                .credential(new AzureKeyCredential(key))
+                .buildCloudEventPublisherClient();
+
+        client.sendEvent(new CloudEvent("/orders", "Order.Created",
+                BinaryData.fromObject(Map.of("orderId", 7)), CloudEventDataFormat.JSON, "application/json"));
+    }
+
+    @Test
+    @DisplayName("published event is delivered to a subscriber webhook")
+    void endToEndWebhookDelivery() throws Exception {
+        List<JsonNode> validations = new CopyOnWriteArrayList<>();
+        List<JsonNode> notifications = new CopyOnWriteArrayList<>();
+        HttpServer webhook = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        webhook.createContext("/hook", exchange -> {
+            JsonNode root = MAPPER.readTree(exchange.getRequestBody().readAllBytes());
+            JsonNode first = root.isArray() && root.size() > 0 ? root.get(0) : root;
+            String code = first.path("data").path("validationCode").asText(null);
+            if (code != null) {
+                validations.add(first);
+                byte[] resp = ("{\"validationResponse\":\"" + code + "\"}").getBytes(StandardCharsets.UTF_8);
+                exchange.sendResponseHeaders(200, resp.length);
+                exchange.getResponseBody().write(resp);
+            } else {
+                root.forEach(notifications::add);
+                exchange.sendResponseHeaders(200, -1);
+            }
+            exchange.close();
+        });
+        webhook.start();
+        try {
+            String topic = "compat-e2e-" + shortId();
+            createTopic(topic, "EventGridSchema");
+            String key = topicKey(topic);
+            String webhookUrl = "http://127.0.0.1:" + webhook.getAddress().getPort() + "/hook";
+            createSubscription(topic, "sub-e2e", webhookUrl);
+
+            // The emulator must reach this test's webhook to validate it. When the emulator runs in a
+            // container (e.g. compat-docker), it cannot reach the host's 127.0.0.1 — skip rather than
+            // fail. The in-process EventGridHandlerTest covers delivery deterministically.
+            for (int i = 0; i < 20 && validations.isEmpty(); i++) {
+                Thread.sleep(100);
+            }
+            Assumptions.assumeFalse(validations.isEmpty(),
+                    "emulator cannot reach this test's webhook (likely containerized); delivery covered in-process");
+
+            EventGridPublisherClient<EventGridEvent> client = new EventGridPublisherClientBuilder()
+                    .endpoint(dataPlaneEndpoint(topic))
+                    .credential(new AzureKeyCredential(key))
+                    .buildEventGridEventPublisherClient();
+            client.sendEvent(new EventGridEvent("/orders/42", "Order.Created",
+                    BinaryData.fromObject(Map.of("orderId", 42)), "1.0"));
+
+            for (int i = 0; i < 50 && notifications.isEmpty(); i++) {
+                Thread.sleep(100);
+            }
+            assertTrue(!notifications.isEmpty(), "expected the event to be delivered to the webhook");
+            assertEquals("Order.Created", notifications.get(0).path("eventType").asText());
+        } finally {
+            webhook.stop(0);
+        }
+    }
+
+    // ── ARM provisioning helpers (raw HTTP) ──────────────────────────────────────
+
+    private String createTopic(String topic, String inputSchema) throws Exception {
+        String url = EmulatorConfig.httpBase()
+                + "/subscriptions/" + SUB + "/resourceGroups/" + RG
+                + "/providers/Microsoft.EventGrid/topics/" + topic + API;
+        String body = "{\"location\":\"eastus\",\"properties\":{\"inputSchema\":\"" + inputSchema + "\"}}";
+        HttpResponse<String> resp = http.send(HttpRequest.newBuilder(URI.create(url))
+                .header("Content-Type", "application/json")
+                .PUT(HttpRequest.BodyPublishers.ofString(body)).build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, resp.statusCode(), "create topic: " + resp.body());
+        String endpoint = MAPPER.readTree(resp.body()).path("properties").path("endpoint").asText(null);
+        assertNotNull(endpoint, "topic must expose a data-plane endpoint");
+        return endpoint;
+    }
+
+    private String createTopicAndKey(String topic, String inputSchema) throws Exception {
+        createTopic(topic, inputSchema);
+        return topicKey(topic);
+    }
+
+    private String topicKey(String topic) throws Exception {
+        String url = EmulatorConfig.httpBase()
+                + "/subscriptions/" + SUB + "/resourceGroups/" + RG
+                + "/providers/Microsoft.EventGrid/topics/" + topic + "/listKeys" + API;
+        HttpResponse<String> resp = http.send(HttpRequest.newBuilder(URI.create(url))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.noBody()).build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, resp.statusCode(), "listKeys: " + resp.body());
+        return MAPPER.readTree(resp.body()).path("key1").asText();
+    }
+
+    private void createSubscription(String topic, String name, String webhookUrl) throws Exception {
+        String scope = "/subscriptions/" + SUB + "/resourceGroups/" + RG
+                + "/providers/Microsoft.EventGrid/topics/" + topic;
+        String url = EmulatorConfig.httpBase() + scope
+                + "/providers/Microsoft.EventGrid/eventSubscriptions/" + name + API;
+        String body = "{\"properties\":{\"destination\":{\"endpointType\":\"WebHook\","
+                + "\"properties\":{\"endpointUrl\":\"" + webhookUrl + "\"}}}}";
+        HttpResponse<String> resp = http.send(HttpRequest.newBuilder(URI.create(url))
+                .header("Content-Type", "application/json")
+                .PUT(HttpRequest.BodyPublishers.ofString(body)).build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, resp.statusCode(), "create subscription: " + resp.body());
+    }
+
+    private static String shortId() {
+        return UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+    }
+
+    @AfterAll
+    void done() {
+    }
+}

--- a/docs/services/event-grid.md
+++ b/docs/services/event-grid.md
@@ -1,0 +1,145 @@
+# Event Grid
+
+Compatible with the `azure-messaging-eventgrid` publisher SDK, the
+`azure-resourcemanager-eventgrid` / ARM management plane, and any HTTP client. Event Grid is the
+Azure counterpart of an event router (publish/subscribe with webhook fan-out) — a **Custom Topic**
+receives events and pushes them to subscriber **webhook** endpoints.
+
+> **HTTP-only — no Docker.** Topics, subscriptions, publishing, and delivery are all in-process.
+> There is no sidecar.
+
+---
+
+## Features
+
+- **Custom Topics** — CreateOrUpdate, Get, Delete, List (by resource group and by subscription),
+  with `properties.endpoint` and `inputSchema` (`EventGridSchema` default, or `CloudEventSchemaV1_0`)
+- **Access keys** — `listKeys` returns `{key1, key2}`; `regenerateKey` rotates one of them
+- **Event subscriptions** — classic scoped `eventSubscriptions` with a **WebHook** destination,
+  `filter` (`subjectBeginsWith`, `subjectEndsWith`, `includedEventTypes`, `isSubjectCaseSensitive`),
+  and `retryPolicy`
+- **Publish** — `POST /api/events` accepts a JSON array of events in the **Event Grid** or
+  **CloudEvents 1.0** schema
+- **Delivery** — events are fanned out asynchronously to matching subscribers, retried per the
+  subscription's `retryPolicy` with exponential backoff
+- **Validation handshake** — creating a webhook subscription triggers a
+  `Microsoft.EventGrid.SubscriptionValidationEvent` (or, for CloudEvents, the `OPTIONS`
+  abuse-protection probe)
+
+---
+
+## Endpoints
+
+Management operations use ARM paths; publishing uses the topic's data-plane endpoint.
+
+```
+PUT    /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.EventGrid/topics/{name}
+GET    /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.EventGrid/topics/{name}
+DELETE /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.EventGrid/topics/{name}
+POST   .../topics/{name}/listKeys
+POST   .../topics/{name}/regenerateKey         # body: {"keyName":"key1"|"key2"}
+GET    /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.EventGrid/topics
+GET    /subscriptions/{sub}/providers/Microsoft.EventGrid/topics
+
+PUT    {topicId}/providers/Microsoft.EventGrid/eventSubscriptions/{name}
+GET    {topicId}/providers/Microsoft.EventGrid/eventSubscriptions/{name}
+DELETE {topicId}/providers/Microsoft.EventGrid/eventSubscriptions/{name}
+GET    {topicId}/providers/Microsoft.EventGrid/eventSubscriptions
+
+POST   /{name}-eventgrid/api/events            # data-plane publish (topic endpoint)
+```
+
+---
+
+## Quickstart
+
+### 1 — Create a topic
+
+```bash
+curl -s -X PUT \
+  "http://localhost:4577/subscriptions/my-sub/resourceGroups/my-rg/providers/Microsoft.EventGrid/topics/my-topic?api-version=2025-02-15" \
+  -H "Content-Type: application/json" \
+  -d '{"location":"eastus","properties":{"inputSchema":"EventGridSchema"}}'
+```
+
+The response carries the data-plane endpoint:
+
+```json
+{
+  "name": "my-topic",
+  "type": "Microsoft.EventGrid/topics",
+  "properties": {
+    "provisioningState": "Succeeded",
+    "endpoint": "http://localhost:4577/my-topic-eventgrid/api/events",
+    "inputSchema": "EventGridSchema"
+  }
+}
+```
+
+Fetch the keys with `POST .../topics/my-topic/listKeys` → `{"key1":"…","key2":"…"}`.
+
+### 2 — Subscribe a webhook
+
+```bash
+curl -s -X PUT \
+  "http://localhost:4577/subscriptions/my-sub/resourceGroups/my-rg/providers/Microsoft.EventGrid/topics/my-topic/providers/Microsoft.EventGrid/eventSubscriptions/my-sub-1?api-version=2025-02-15" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "properties": {
+      "destination": {"endpointType": "WebHook", "properties": {"endpointUrl": "https://my-app.example/hook"}},
+      "filter": {"subjectBeginsWith": "/orders"}
+    }
+  }'
+```
+
+The emulator immediately runs the validation handshake against the webhook (a
+`SubscriptionValidationEvent`; the subscriber must echo `{"validationResponse": "<code>"}`).
+
+### 3 — Publish events
+
+```python
+from azure.core.credentials import AzureKeyCredential
+from azure.eventgrid import EventGridPublisherClient, EventGridEvent
+
+client = EventGridPublisherClient(
+    "http://localhost:4577/my-topic-eventgrid/api/events", AzureKeyCredential("<key1>"))
+client.send([EventGridEvent(
+    subject="/orders/123", event_type="Order.Created",
+    data={"orderId": 123}, data_version="1.0")])
+```
+
+Events whose `subject` matches the subscription filter are POSTed (as a JSON array) to the webhook,
+with `topic` set to the topic's full resource id and an `aeg-event-type: Notification` header.
+
+---
+
+## Configuration
+
+```yaml
+floci-az:
+  services:
+    event-grid:
+      enabled: true
+      default-region: eastus          # region label baked into the topic endpoint host text
+      max-delivery-attempts: 30        # default when a subscription omits its own retryPolicy
+```
+
+| Env var | Default | Description |
+|---|---|---|
+| `FLOCI_AZ_SERVICES_EVENT_GRID_ENABLED` | `true` | Enable/disable the service |
+| `FLOCI_AZ_SERVICES_EVENT_GRID_DEFAULT_REGION` | `eastus` | Region label for the topic endpoint |
+| `FLOCI_AZ_SERVICES_EVENT_GRID_MAX_DELIVERY_ATTEMPTS` | `30` | Default delivery attempts |
+
+---
+
+## Notes & limitations
+
+- **WebHook destinations only.** Service Bus, Event Hub, Storage Queue, and Azure Function
+  destinations, plus Domains, Partner/System Topics, and the Event Grid Namespace (MQTT/pull)
+  surface are out of scope.
+- **Dead-lettering is best-effort.** When delivery exhausts `retryPolicy.maxDeliveryAttempts`, the
+  event is logged and dropped; it is not written to a `deadLetterDestination` blob container.
+- **Auth is permissive.** The `aeg-sas-key` header is accepted but not validated against the topic
+  keys (dev mode), matching the rest of the emulator.
+- **`CustomEventSchema`** is accepted but treated as the Event Grid schema.
+- **Advanced filters** (`advancedFilters`, array filtering) are accepted but not evaluated.

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -22,6 +22,7 @@ Floci-AZ provides emulation for several core Azure services.
 | **Azure Cache for Redis** | ARM path (`Microsoft.Cache`) | ✅ Cache CRUD, listKeys/regenerateKey; real Redis containers (data plane) or mocked |
 | **Azure Container Registry** | ARM path (`Microsoft.ContainerRegistry`) | ✅ Registry CRUD, admin credentials, checkNameAvailability; one shared `registry:2` (Docker Registry V2 push/pull) or mocked |
 | **Microsoft Entra ID** | `/{tenant}/oauth2/...` + `/.well-known/openid-configuration` | ✅ OpenID Connect provider — RS256-signed tokens, JWKS, discovery; client-credentials + ROPC grants (app registration, Graph, interactive flows planned) |
+| **Event Grid** | ARM path (`Microsoft.EventGrid`) + `/{topic}-eventgrid/api/events` | ✅ Custom Topics, access keys, webhook event subscriptions with filters, publish (Event Grid + CloudEvents 1.0), async delivery with retry, subscription validation handshake |
 
 ## Unified Endpoint
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,5 +85,6 @@ nav:
     - Virtual Machines: services/vm.md
     - Azure Cache for Redis: services/redis.md
     - Azure Container Registry: services/acr.md
+    - Event Grid: services/event-grid.md
   - Contributing: contributing.md
   - Changelog: changelog.md

--- a/src/main/java/io/floci/az/config/EmulatorConfig.java
+++ b/src/main/java/io/floci/az/config/EmulatorConfig.java
@@ -131,6 +131,7 @@ public interface EmulatorConfig {
         EntraConfig            entra();
         ArmConfig              arm();
         NetworkConfig          network();
+        EventGridConfig        eventGrid();
 
 
         /** Shared Docker network for sidecar containers (Artemis, Redpanda, etc.). */
@@ -138,6 +139,23 @@ public interface EmulatorConfig {
 
         // Added Email service configuration
         EmailServiceConfig email();
+    }
+
+    /**
+     * Microsoft.EventGrid — Custom Topics and webhook event subscriptions. HTTP-only:
+     * events published to a topic endpoint are fanned out to subscriber webhooks.
+     */
+    interface EventGridConfig {
+        @WithDefault("true")
+        boolean enabled();
+
+        /** Region label baked into the topic data-plane endpoint host returned by ARM. */
+        @WithDefault("eastus")
+        String defaultRegion();
+
+        /** Default maximum delivery attempts when a subscription omits its own retry policy. */
+        @WithDefault("30")
+        int maxDeliveryAttempts();
     }
 
     interface MonitorConfig {

--- a/src/main/java/io/floci/az/core/AdminController.java
+++ b/src/main/java/io/floci/az/core/AdminController.java
@@ -5,6 +5,7 @@ import io.floci.az.services.acr.AcrHandler;
 import io.floci.az.services.aks.AksHandler;
 import io.floci.az.services.blob.BlobServiceHandler;
 import io.floci.az.services.cosmos.CosmosHandler;
+import io.floci.az.services.eventgrid.EventGridHandler;
 import io.floci.az.services.eventhub.EventHubHandler;
 import io.floci.az.services.functions.FunctionsServiceHandler;
 import io.floci.az.services.keyvault.KeyVaultHandler;
@@ -42,6 +43,7 @@ public class AdminController {
     @Inject VmHandler               vmHandler;
     @Inject RedisHandler            redisHandler;
     @Inject MonitorHandler          monitorHandler;
+    @Inject EventGridHandler        eventGridHandler;
 
     @GET
     @Path("/accounts")
@@ -78,6 +80,7 @@ public class AdminController {
         vmHandler.clearAll();
         redisHandler.clearAll();
         monitorHandler.clearAll();
+        eventGridHandler.clearAll();
 
         // Docker-backed services — stop containers first, then clear state
         sqlHandler.clearAll();

--- a/src/main/java/io/floci/az/core/AzureRoutingFilter.java
+++ b/src/main/java/io/floci/az/core/AzureRoutingFilter.java
@@ -15,6 +15,7 @@ import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 import org.jboss.resteasy.reactive.server.ServerRequestFilter;
 
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -292,19 +293,9 @@ public class AzureRoutingFilter {
         //   subscriptions/{sub}/[resourceGroups/{rg}/]providers/Microsoft.ContainerService/...
         // ---------------------------------------------------------------
         if (path.startsWith("subscriptions/") && path.contains("/providers/Microsoft.ContainerService/")) {
-            Map<String, String> aksQueryParams = new HashMap<>();
-            requestContext.getUriInfo().getQueryParameters().forEach((k, v) -> aksQueryParams.put(k, v.get(0)));
-            AzureRequest aksRequest = new AzureRequest(
-                requestContext.getMethod(), "aks", "aks", path, headers,
-                requestContext.getEntityStream(), aksQueryParams, null, secure);
-            AuthContext aksAuth = authPipeline.resolve(aksRequest);
-            aksRequest = new AzureRequest(
-                requestContext.getMethod(), "aks", "aks", path, headers,
-                requestContext.getEntityStream(), aksQueryParams, aksAuth, secure);
-            Optional<AzureServiceHandler> aksHandler = serviceRegistry.resolve("aks");
-            if (aksHandler.isPresent()) {
-                LOGGER.infof("Dispatching ARM AKS request to AksHandler: %s %s", requestContext.getMethod(), path);
-                return aksHandler.get().handle(aksRequest);
+            Response response = dispatchManagementPlane(requestContext, "aks", path, headers, secure);
+            if (response != null) {
+                return response;
             }
         }
 
@@ -314,19 +305,9 @@ public class AzureRoutingFilter {
         //   subscriptions/{sub}/providers/Microsoft.ContainerRegistry/checkNameAvailability
         // ---------------------------------------------------------------
         if (path.startsWith("subscriptions/") && path.contains("/providers/Microsoft.ContainerRegistry/")) {
-            Map<String, String> acrQueryParams = new HashMap<>();
-            requestContext.getUriInfo().getQueryParameters().forEach((k, v) -> acrQueryParams.put(k, v.get(0)));
-            AzureRequest acrRequest = new AzureRequest(
-                requestContext.getMethod(), "acr", "acr", path, headers,
-                requestContext.getEntityStream(), acrQueryParams, null, secure);
-            AuthContext acrAuth = authPipeline.resolve(acrRequest);
-            acrRequest = new AzureRequest(
-                requestContext.getMethod(), "acr", "acr", path, headers,
-                requestContext.getEntityStream(), acrQueryParams, acrAuth, secure);
-            Optional<AzureServiceHandler> acrHandler = serviceRegistry.resolve("acr");
-            if (acrHandler.isPresent()) {
-                LOGGER.infof("Dispatching ARM ACR request to AcrHandler: %s %s", requestContext.getMethod(), path);
-                return acrHandler.get().handle(acrRequest);
+            Response response = dispatchManagementPlane(requestContext, "acr", path, headers, secure);
+            if (response != null) {
+                return response;
             }
         }
 
@@ -338,19 +319,9 @@ public class AzureRoutingFilter {
         // here we just detect the ARM prefix and dispatch the full path.
         // ---------------------------------------------------------------
         if (path.startsWith("subscriptions/") && path.contains("/providers/Microsoft.Sql/")) {
-            Map<String, String> sqlQueryParams = new HashMap<>();
-            requestContext.getUriInfo().getQueryParameters().forEach((k, v) -> sqlQueryParams.put(k, v.get(0)));
-            AzureRequest sqlRequest = new AzureRequest(
-                requestContext.getMethod(), "sql", "sql", path, headers,
-                requestContext.getEntityStream(), sqlQueryParams, null, secure);
-            AuthContext sqlAuth = authPipeline.resolve(sqlRequest);
-            sqlRequest = new AzureRequest(
-                requestContext.getMethod(), "sql", "sql", path, headers,
-                requestContext.getEntityStream(), sqlQueryParams, sqlAuth, secure);
-            Optional<AzureServiceHandler> sqlHandler = serviceRegistry.resolve("sql");
-            if (sqlHandler.isPresent()) {
-                LOGGER.infof("Dispatching ARM SQL request to SqlHandler: %s %s", requestContext.getMethod(), path);
-                return sqlHandler.get().handle(sqlRequest);
+            Response response = dispatchManagementPlane(requestContext, "sql", path, headers, secure);
+            if (response != null) {
+                return response;
             }
         }
 
@@ -360,19 +331,9 @@ public class AzureRoutingFilter {
         //   subscriptions/{sub}/providers/Microsoft.Compute/locations/{loc}/operations/{opId}
         // ---------------------------------------------------------------
         if (path.startsWith("subscriptions/") && path.contains("/providers/Microsoft.Compute/")) {
-            Map<String, String> vmQueryParams = new HashMap<>();
-            requestContext.getUriInfo().getQueryParameters().forEach((k, v) -> vmQueryParams.put(k, v.get(0)));
-            AzureRequest vmRequest = new AzureRequest(
-                requestContext.getMethod(), "vm", "vm", path, headers,
-                requestContext.getEntityStream(), vmQueryParams, null, secure);
-            AuthContext vmAuth = authPipeline.resolve(vmRequest);
-            vmRequest = new AzureRequest(
-                requestContext.getMethod(), "vm", "vm", path, headers,
-                requestContext.getEntityStream(), vmQueryParams, vmAuth, secure);
-            Optional<AzureServiceHandler> vmHandler = serviceRegistry.resolve("vm");
-            if (vmHandler.isPresent()) {
-                LOGGER.infof("Dispatching ARM VM request to VmHandler: %s %s", requestContext.getMethod(), path);
-                return vmHandler.get().handle(vmRequest);
+            Response response = dispatchManagementPlane(requestContext, "vm", path, headers, secure);
+            if (response != null) {
+                return response;
             }
         }
 
@@ -381,19 +342,9 @@ public class AzureRoutingFilter {
         //   subscriptions/{sub}/[resourceGroups/{rg}/]providers/Microsoft.Cache/redis/...
         // ---------------------------------------------------------------
         if (path.startsWith("subscriptions/") && path.contains("/providers/Microsoft.Cache/")) {
-            Map<String, String> redisQueryParams = new HashMap<>();
-            requestContext.getUriInfo().getQueryParameters().forEach((k, v) -> redisQueryParams.put(k, v.get(0)));
-            AzureRequest redisRequest = new AzureRequest(
-                requestContext.getMethod(), "redis", "redis", path, headers,
-                requestContext.getEntityStream(), redisQueryParams, null, secure);
-            AuthContext redisAuth = authPipeline.resolve(redisRequest);
-            redisRequest = new AzureRequest(
-                requestContext.getMethod(), "redis", "redis", path, headers,
-                requestContext.getEntityStream(), redisQueryParams, redisAuth, secure);
-            Optional<AzureServiceHandler> redisHandler = serviceRegistry.resolve("redis");
-            if (redisHandler.isPresent()) {
-                LOGGER.infof("Dispatching ARM Redis request to RedisHandler: %s %s", requestContext.getMethod(), path);
-                return redisHandler.get().handle(redisRequest);
+            Response response = dispatchManagementPlane(requestContext, "redis", path, headers, secure);
+            if (response != null) {
+                return response;
             }
         }
 
@@ -402,19 +353,21 @@ public class AzureRoutingFilter {
         //   subscriptions/{sub}/[resourceGroups/{rg}/]providers/Microsoft.Communication/...
         // ---------------------------------------------------------------
         if (path.startsWith("subscriptions/") && path.contains("/providers/Microsoft.Communication/")) {
-            Map<String, String> emailQueryParams = new HashMap<>();
-            requestContext.getUriInfo().getQueryParameters().forEach((k, v) -> emailQueryParams.put(k, v.get(0)));
-            AzureRequest emailRequest = new AzureRequest(
-                requestContext.getMethod(), "email", "email", path, headers,
-                requestContext.getEntityStream(), emailQueryParams, null, secure);
-            AuthContext emailAuth = authPipeline.resolve(emailRequest);
-            emailRequest = new AzureRequest(
-                requestContext.getMethod(), "email", "email", path, headers,
-                requestContext.getEntityStream(), emailQueryParams, emailAuth, secure);
-            Optional<AzureServiceHandler> emailHandler = serviceRegistry.resolve("email");
-            if (emailHandler.isPresent()) {
-                LOGGER.infof("Dispatching ARM Communication request to EmailHandler: %s %s", requestContext.getMethod(), path);
-                return emailHandler.get().handle(emailRequest);
+            Response response = dispatchManagementPlane(requestContext, "email", path, headers, secure);
+            if (response != null) {
+                return response;
+            }
+        }
+
+        // ---------------------------------------------------------------
+        // Azure Event Grid — ARM management-plane paths:
+        //   subscriptions/{sub}/[resourceGroups/{rg}/]providers/Microsoft.EventGrid/topics/...
+        //   {topicScope}/providers/Microsoft.EventGrid/eventSubscriptions/{name}
+        // ---------------------------------------------------------------
+        if (path.startsWith("subscriptions/") && path.contains("/providers/Microsoft.EventGrid/")) {
+            Response response = dispatchManagementPlane(requestContext, "eventgrid", path, headers, secure);
+            if (response != null) {
+                return response;
             }
         }
 
@@ -523,6 +476,9 @@ public class AzureRoutingFilter {
         } else if (accountName.endsWith("-keyvault")) {
             serviceType = "keyvault";
             accountName = accountName.substring(0, accountName.length() - 9);
+        } else if (accountName.endsWith("-eventgrid")) {
+            serviceType = "eventgrid";
+            accountName = accountName.substring(0, accountName.length() - 10);
         } else if (accountName.endsWith("-eventhub")) {
             serviceType = "eventhub";
             accountName = accountName.substring(0, accountName.length() - 9);
@@ -592,6 +548,35 @@ public class AzureRoutingFilter {
         LOGGER.warnf("No handler found for serviceType: %s", serviceType);
         return new AzureErrorResponse("ServiceNotImplemented", "The specified service is not implemented.")
                 .toXmlResponse(Response.Status.NOT_IMPLEMENTED.getStatusCode());
+    }
+
+    /**
+     * Builds an {@link AzureRequest} for a path-routed management-plane call (account name and
+     * service type are both {@code serviceType}), resolves auth, and dispatches it to the matching
+     * handler. Returns {@code null} when no handler is registered or the service is disabled, so the
+     * caller can fall through to the next route.
+     */
+    private Response dispatchManagementPlane(ContainerRequestContext requestContext, String serviceType,
+                                             String path, HttpHeaders headers, boolean secure) {
+        Map<String, String> queryParams = new HashMap<>();
+        requestContext.getUriInfo().getQueryParameters().forEach((k, v) -> queryParams.put(k, v.get(0)));
+        InputStream entityStream = requestContext.getEntityStream();
+
+        AzureRequest request = new AzureRequest(
+            requestContext.getMethod(), serviceType, serviceType, path, headers,
+            entityStream, queryParams, null, secure);
+        AuthContext auth = authPipeline.resolve(request);
+        request = new AzureRequest(
+            requestContext.getMethod(), serviceType, serviceType, path, headers,
+            entityStream, queryParams, auth, secure);
+
+        Optional<AzureServiceHandler> handler = serviceRegistry.resolve(serviceType);
+        if (handler.isPresent()) {
+            LOGGER.infof("Dispatching ARM %s request to %s: %s %s", serviceType,
+                handler.get().getClass().getSimpleName(), requestContext.getMethod(), path);
+            return handler.get().handle(request);
+        }
+        return null;
     }
 
     private String resolveServiceType(ContainerRequestContext requestContext, String resourcePath) {

--- a/src/main/java/io/floci/az/core/AzureServiceRegistry.java
+++ b/src/main/java/io/floci/az/core/AzureServiceRegistry.java
@@ -49,6 +49,7 @@ public class AzureServiceRegistry {
             case "monitor"    -> config.services().monitor().enabled();
             case "entra"      -> config.services().entra().enabled();
             case "arm"        -> config.services().arm().enabled();
+            case "eventgrid"  -> config.services().eventGrid().enabled();
             case "cosmos-engine" -> config.services().cosmos().enabled();
             case "cosmos-mongo", "cosmos-table", "cosmos-cassandra",
                  "cosmos-gremlin", "cosmos-postgresql", "cosmos-nosql" ->

--- a/src/main/java/io/floci/az/core/BannerLogger.java
+++ b/src/main/java/io/floci/az/core/BannerLogger.java
@@ -127,6 +127,9 @@ public class BannerLogger {
         sb.append(String.format("   %-9s [%s]  %s\n", "network",
                 config.services().network().enabled() ? "enabled " : "disabled",
                 "Microsoft.Network (vnet, subnet, nic, public-ip, nsg, dns)"));
+        if (config.services().eventGrid().enabled()) {
+            sb.append(serviceStatus("eventgrid", true, getStorageMode("eventgrid")));
+        }
         LOGGER.info(sb.toString());
         LOGGER.info("=== Local Azure Emulator Ready ===");
     }

--- a/src/main/java/io/floci/az/services/eventgrid/EventGridDelivery.java
+++ b/src/main/java/io/floci/az/services/eventgrid/EventGridDelivery.java
@@ -1,0 +1,187 @@
+package io.floci.az.services.eventgrid;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.floci.az.services.eventgrid.EventGridModels.EventSubscription;
+import io.floci.az.services.eventgrid.EventGridModels.RetryPolicy;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import org.jboss.logging.Logger;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Delivers Event Grid notifications to subscriber webhooks.
+ *
+ * <p>Delivery is asynchronous and retried per the subscription's {@link RetryPolicy} with
+ * exponential backoff. The subscription validation handshake (run synchronously when a webhook
+ * subscription is created) and the CloudEvents abuse-protection probe live here too, since they
+ * share the same outbound HTTP machinery.
+ */
+@ApplicationScoped
+public class EventGridDelivery {
+
+    private static final Logger LOG = Logger.getLogger(EventGridDelivery.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static final long BACKOFF_BASE_MS = 200;
+    private static final long BACKOFF_CAP_MS = 30_000;
+    private static final Duration HTTP_TIMEOUT = Duration.ofSeconds(10);
+
+    private HttpClient httpClient;
+    private ScheduledExecutorService scheduler;
+
+    @PostConstruct
+    void init() {
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(5))
+                .build();
+        this.scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread t = new Thread(r, "eventgrid-delivery");
+            t.setDaemon(true);
+            return t;
+        });
+    }
+
+    @PreDestroy
+    void shutdown() {
+        if (scheduler != null) {
+            scheduler.shutdownNow();
+        }
+    }
+
+    /**
+     * Schedules delivery of a single already-rendered event to a subscription's webhook, retrying
+     * on failure. {@code body} is a JSON array containing the one event (Event Grid always POSTs
+     * an array).
+     */
+    public void deliver(EventSubscription sub, byte[] body, String contentType) {
+        attempt(sub, body, contentType, 1);
+    }
+
+    private void attempt(EventSubscription sub, byte[] body, String contentType, int attempt) {
+        scheduler.execute(() -> {
+            int maxAttempts = Math.max(1, sub.retryPolicy().maxDeliveryAttempts());
+            try {
+                HttpRequest req = HttpRequest.newBuilder(URI.create(sub.endpointUrl()))
+                        .timeout(HTTP_TIMEOUT)
+                        .header("Content-Type", contentType)
+                        .header("aeg-event-type", "Notification")
+                        .header("aeg-subscription-name", sub.name())
+                        .POST(HttpRequest.BodyPublishers.ofByteArray(body))
+                        .build();
+                HttpResponse<Void> resp = httpClient.send(req, HttpResponse.BodyHandlers.discarding());
+                if (resp.statusCode() >= 200 && resp.statusCode() < 300) {
+                    LOG.debugv("Delivered event to {0} (attempt {1}, status {2})",
+                            sub.endpointUrl(), attempt, resp.statusCode());
+                    return;
+                }
+                LOG.debugv("Delivery to {0} got status {1} (attempt {2}/{3})",
+                        sub.endpointUrl(), resp.statusCode(), attempt, maxAttempts);
+            } catch (Exception e) {
+                LOG.debugv("Delivery to {0} failed (attempt {1}/{2}): {3}",
+                        sub.endpointUrl(), attempt, maxAttempts, e.getMessage());
+            }
+            reschedule(sub, body, contentType, attempt, maxAttempts);
+        });
+    }
+
+    private void reschedule(EventSubscription sub, byte[] body, String contentType,
+                            int attempt, int maxAttempts) {
+        if (attempt >= maxAttempts) {
+            LOG.warnv("Event Grid delivery to {0} (subscription {1}) exhausted {2} attempts; dead-lettering (dropped)",
+                    sub.endpointUrl(), sub.name(), maxAttempts);
+            return;
+        }
+        long delay = Math.min(BACKOFF_BASE_MS * (1L << Math.min(attempt - 1, 20)), BACKOFF_CAP_MS);
+        scheduler.schedule(() -> attempt(sub, body, contentType, attempt + 1),
+                delay, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Runs the subscription validation handshake for a webhook destination. Tolerant by design:
+     * any failure is logged and reported as not-validated, but the caller still provisions the
+     * subscription so local development is not blocked by an unreachable endpoint.
+     *
+     * @return {@code true} when the subscriber proved ownership (echoed the validation code, passed
+     *         the CloudEvents abuse-protection probe, or returned 2xx).
+     */
+    public boolean validate(EventSubscription sub, String topicResourceId) {
+        if (EventGridModels.SCHEMA_CLOUD_EVENT.equalsIgnoreCase(sub.eventDeliverySchema())) {
+            return validateCloudEvents(sub);
+        }
+        return validateEventGrid(sub, topicResourceId);
+    }
+
+    private boolean validateEventGrid(EventSubscription sub, String topicResourceId) {
+        String code = UUID.randomUUID().toString();
+        String validationUrl = sub.endpointUrl() + (sub.endpointUrl().contains("?") ? "&" : "?")
+                + "id=" + code;
+        Map<String, Object> event = Map.of(
+                "id", UUID.randomUUID().toString(),
+                "topic", topicResourceId,
+                "subject", "",
+                "eventType", "Microsoft.EventGrid.SubscriptionValidationEvent",
+                "eventTime", java.time.OffsetDateTime.now(java.time.ZoneOffset.UTC).toString(),
+                "metadataVersion", "1",
+                "dataVersion", "1",
+                "data", Map.of("validationCode", code, "validationUrl", validationUrl));
+        try {
+            byte[] body = MAPPER.writeValueAsBytes(List.of(event));
+            HttpRequest req = HttpRequest.newBuilder(URI.create(sub.endpointUrl()))
+                    .timeout(HTTP_TIMEOUT)
+                    .header("Content-Type", "application/json")
+                    .header("aeg-event-type", "SubscriptionValidation")
+                    .POST(HttpRequest.BodyPublishers.ofByteArray(body))
+                    .build();
+            HttpResponse<String> resp = httpClient.send(req, HttpResponse.BodyHandlers.ofString());
+            if (resp.statusCode() < 200 || resp.statusCode() >= 300) {
+                return false;
+            }
+            String echoed = extractValidationResponse(resp.body());
+            return code.equals(echoed) || echoed == null;
+        } catch (Exception e) {
+            LOG.warnv("Subscription validation POST to {0} failed: {1}", sub.endpointUrl(), e.getMessage());
+            return false;
+        }
+    }
+
+    private String extractValidationResponse(String body) {
+        if (body == null || body.isBlank()) {
+            return null;
+        }
+        try {
+            var node = MAPPER.readTree(body).path("validationResponse");
+            return node.isTextual() ? node.asText() : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private boolean validateCloudEvents(EventSubscription sub) {
+        try {
+            HttpRequest req = HttpRequest.newBuilder(URI.create(sub.endpointUrl()))
+                    .timeout(HTTP_TIMEOUT)
+                    .header("WebHook-Request-Origin", "eventgrid.azure.net")
+                    .method("OPTIONS", HttpRequest.BodyPublishers.noBody())
+                    .build();
+            HttpResponse<Void> resp = httpClient.send(req, HttpResponse.BodyHandlers.discarding());
+            boolean allowed = resp.headers().firstValue("WebHook-Allowed-Origin").isPresent();
+            return allowed && resp.statusCode() >= 200 && resp.statusCode() < 300;
+        } catch (Exception e) {
+            LOG.warnv("CloudEvents abuse-protection probe to {0} failed: {1}", sub.endpointUrl(), e.getMessage());
+            return false;
+        }
+    }
+}

--- a/src/main/java/io/floci/az/services/eventgrid/EventGridHandler.java
+++ b/src/main/java/io/floci/az/services/eventgrid/EventGridHandler.java
@@ -1,0 +1,72 @@
+package io.floci.az.services.eventgrid;
+
+import io.floci.az.core.AzureRequest;
+import io.floci.az.core.AzureServiceHandler;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+
+/**
+ * Azure Event Grid handler. Serves both planes for {@code serviceType="eventgrid"}:
+ * <ul>
+ *   <li>Control plane — ARM paths containing {@code /providers/Microsoft.EventGrid/}
+ *       (topics + classic scoped eventSubscriptions) → {@link EventGridService}.</li>
+ *   <li>Data plane — {@code POST /api/events} reached via the {@code {topic}-eventgrid}
+ *       account suffix → {@link EventGridPublisher}.</li>
+ * </ul>
+ */
+@ApplicationScoped
+public class EventGridHandler implements AzureServiceHandler {
+
+    private static final Logger LOG = Logger.getLogger(EventGridHandler.class);
+    private static final String ARM_MARKER = "/providers/Microsoft.EventGrid/";
+
+    private final EventGridService service;
+    private final EventGridPublisher publisher;
+
+    @Inject
+    public EventGridHandler(EventGridService service, EventGridPublisher publisher) {
+        this.service = service;
+        this.publisher = publisher;
+    }
+
+    @Override
+    public String getServiceType() {
+        return "eventgrid";
+    }
+
+    @Override
+    public boolean canHandle(AzureRequest request) {
+        return "eventgrid".equals(request.serviceType());
+    }
+
+    @Override
+    public Response handle(AzureRequest req) {
+        String method = req.method().toUpperCase();
+
+        // Control plane: the routing filter forwards the full ARM path as resourcePath.
+        if (req.resourcePath().contains(ARM_MARKER)) {
+            return service.handleArm(req, req.resourcePath(), method);
+        }
+
+        // Data plane: {topic}-eventgrid/api/events
+        String path = stripQuery(req.resourcePath());
+        if (path.equals("api/events") && "POST".equals(method)) {
+            return publisher.publish(req, req.accountName());
+        }
+
+        LOG.debugf("EventGrid: unhandled %s /%s", method, path);
+        return Response.status(404).entity("{\"error\":{\"code\":\"NotFound\",\"message\":\"Unsupported Event Grid path: "
+                + path + "\"}}").type("application/json").build();
+    }
+
+    public void clearAll() {
+        service.clearAll();
+    }
+
+    private static String stripQuery(String path) {
+        int q = path.indexOf('?');
+        return q >= 0 ? path.substring(0, q) : path;
+    }
+}

--- a/src/main/java/io/floci/az/services/eventgrid/EventGridModels.java
+++ b/src/main/java/io/floci/az/services/eventgrid/EventGridModels.java
@@ -1,0 +1,71 @@
+package io.floci.az.services.eventgrid;
+
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.List;
+
+/**
+ * Domain objects for Azure Event Grid Custom Topics and webhook event subscriptions.
+ *
+ * <p>These records are the persisted source of truth; the ARM resource JSON returned to clients
+ * is projected from them in {@link EventGridService}. The nested records are registered for
+ * reflection so Jackson can (de)serialize them in the GraalVM native image.
+ */
+@RegisterForReflection(targets = {
+        EventGridModels.Topic.class,
+        EventGridModels.EventSubscription.class,
+        EventGridModels.Filter.class,
+        EventGridModels.RetryPolicy.class})
+public final class EventGridModels {
+
+    private EventGridModels() {
+    }
+
+    /** Input event schema a topic accepts and that delivery defaults to. */
+    public static final String SCHEMA_EVENT_GRID = "EventGridSchema";
+    public static final String SCHEMA_CLOUD_EVENT = "CloudEventSchemaV1_0";
+    public static final String SCHEMA_CUSTOM = "CustomEventSchema";
+
+    public record Topic(
+            String subscriptionId,
+            String resourceGroup,
+            String name,
+            String location,
+            String inputSchema,
+            String key1,
+            String key2) {
+
+        public String resourceId() {
+            return "/subscriptions/" + subscriptionId + "/resourceGroups/" + resourceGroup
+                    + "/providers/Microsoft.EventGrid/topics/" + name;
+        }
+    }
+
+    public record EventSubscription(
+            String name,
+            String topicResourceId,
+            String endpointUrl,
+            String eventDeliverySchema,
+            Filter filter,
+            RetryPolicy retryPolicy,
+            String deadLetterEndpointUrl) {
+
+        public String resourceId() {
+            return topicResourceId + "/providers/Microsoft.EventGrid/eventSubscriptions/" + name;
+        }
+    }
+
+    public record Filter(
+            String subjectBeginsWith,
+            String subjectEndsWith,
+            List<String> includedEventTypes,
+            boolean isSubjectCaseSensitive) {
+
+        public static Filter empty() {
+            return new Filter(null, null, List.of(), false);
+        }
+    }
+
+    public record RetryPolicy(int maxDeliveryAttempts, int eventTimeToLiveInMinutes) {
+    }
+}

--- a/src/main/java/io/floci/az/services/eventgrid/EventGridPublisher.java
+++ b/src/main/java/io/floci/az/services/eventgrid/EventGridPublisher.java
@@ -1,0 +1,190 @@
+package io.floci.az.services.eventgrid;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.floci.az.core.AzureRequest;
+import io.floci.az.services.eventgrid.EventGridModels.EventSubscription;
+import io.floci.az.services.eventgrid.EventGridModels.Filter;
+import io.floci.az.services.eventgrid.EventGridModels.Topic;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Data-plane publish endpoint ({@code POST /api/events}). Parses incoming events (Event Grid or
+ * CloudEvents 1.0 schema), matches them against each subscription's filter, renders them into the
+ * subscription's delivery schema, and hands them to {@link EventGridDelivery} for async fan-out.
+ */
+@ApplicationScoped
+public class EventGridPublisher {
+
+    private static final Logger LOG = Logger.getLogger(EventGridPublisher.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final EventGridService service;
+    private final EventGridDelivery delivery;
+
+    @Inject
+    public EventGridPublisher(EventGridService service, EventGridDelivery delivery) {
+        this.service = service;
+        this.delivery = delivery;
+    }
+
+    /** Internal canonical view of an incoming event, schema-agnostic. */
+    private record CanonEvent(String id, String subject, String eventType,
+                              String eventTime, JsonNode data, String dataVersion) {
+    }
+
+    public Response publish(AzureRequest req, String topicName) {
+        Optional<Topic> topic = service.findTopicByName(topicName);
+        if (topic.isEmpty()) {
+            return error(404, "ResourceNotFound", "Topic '" + topicName + "' was not found.");
+        }
+
+        List<JsonNode> events;
+        try {
+            JsonNode root = MAPPER.readTree(req.bodyStream());
+            if (root == null || root.isNull()) {
+                return error(400, "BadRequest", "Request body is empty.");
+            }
+            events = root.isArray() ? toList(root) : List.of(root);
+        } catch (Exception e) {
+            return error(400, "BadRequest", "Could not parse request body: " + e.getMessage());
+        }
+
+        Topic t = topic.get();
+        String topicResourceId = t.resourceId();
+        List<EventSubscription> subs = service.subscriptionsForTopic(topicResourceId);
+
+        for (JsonNode raw : events) {
+            CanonEvent event = canonicalize(raw, t.inputSchema());
+            for (EventSubscription sub : subs) {
+                if (!matches(sub.filter(), event.subject(), event.eventType())) {
+                    continue;
+                }
+                dispatch(sub, event, topicResourceId);
+            }
+        }
+        LOG.debugv("Published {0} event(s) to topic {1} ({2} subscription(s))",
+                events.size(), topicName, subs.size());
+        return Response.ok().build();
+    }
+
+    private void dispatch(EventSubscription sub, CanonEvent event, String topicResourceId) {
+        boolean cloudEvents = EventGridModels.SCHEMA_CLOUD_EVENT.equalsIgnoreCase(sub.eventDeliverySchema());
+        Map<String, Object> rendered = cloudEvents
+                ? renderCloudEvent(event, topicResourceId)
+                : renderEventGridEvent(event, topicResourceId);
+        String contentType = cloudEvents ? "application/cloudevents-batch+json" : "application/json";
+        try {
+            byte[] body = MAPPER.writeValueAsBytes(List.of(rendered));
+            delivery.deliver(sub, body, contentType);
+        } catch (Exception e) {
+            LOG.warnv("Failed to render event for subscription {0}: {1}", sub.name(), e.getMessage());
+        }
+    }
+
+    private CanonEvent canonicalize(JsonNode e, String inputSchema) {
+        if (EventGridModels.SCHEMA_CLOUD_EVENT.equalsIgnoreCase(inputSchema)) {
+            return new CanonEvent(
+                    text(e, "id"), text(e, "subject"), text(e, "type"),
+                    text(e, "time"), e.get("data"), "1");
+        }
+        // EventGridSchema and CustomEventSchema (treated as Event Grid).
+        return new CanonEvent(
+                text(e, "id"), text(e, "subject"), text(e, "eventType"),
+                text(e, "eventTime"), e.get("data"), textOr(e, "dataVersion", "1"));
+    }
+
+    private Map<String, Object> renderEventGridEvent(CanonEvent e, String topicResourceId) {
+        Map<String, Object> out = new LinkedHashMap<>();
+        out.put("id", e.id());
+        out.put("topic", topicResourceId);
+        out.put("subject", e.subject() == null ? "" : e.subject());
+        out.put("eventType", e.eventType());
+        out.put("eventTime", e.eventTime());
+        out.put("data", asObject(e.data()));
+        out.put("dataVersion", e.dataVersion());
+        out.put("metadataVersion", "1");
+        return out;
+    }
+
+    private Map<String, Object> renderCloudEvent(CanonEvent e, String topicResourceId) {
+        Map<String, Object> out = new LinkedHashMap<>();
+        out.put("id", e.id());
+        out.put("source", topicResourceId);
+        out.put("type", e.eventType());
+        if (e.subject() != null) {
+            out.put("subject", e.subject());
+        }
+        out.put("time", e.eventTime());
+        out.put("specversion", "1.0");
+        out.put("data", asObject(e.data()));
+        return out;
+    }
+
+    private boolean matches(Filter f, String subject, String eventType) {
+        if (!f.includedEventTypes().isEmpty()) {
+            boolean typeMatch = eventType != null && f.includedEventTypes().stream()
+                    .anyMatch(t -> t.equalsIgnoreCase(eventType));
+            if (!typeMatch) {
+                return false;
+            }
+        }
+        String subj = subject == null ? "" : subject;
+        if (f.subjectBeginsWith() != null && !f.subjectBeginsWith().isEmpty()
+                && !startsWith(subj, f.subjectBeginsWith(), f.isSubjectCaseSensitive())) {
+            return false;
+        }
+        if (f.subjectEndsWith() != null && !f.subjectEndsWith().isEmpty()
+                && !endsWith(subj, f.subjectEndsWith(), f.isSubjectCaseSensitive())) {
+            return false;
+        }
+        return true;
+    }
+
+    private static boolean startsWith(String subject, String prefix, boolean caseSensitive) {
+        return caseSensitive ? subject.startsWith(prefix)
+                : subject.toLowerCase(Locale.ROOT).startsWith(prefix.toLowerCase(Locale.ROOT));
+    }
+
+    private static boolean endsWith(String subject, String suffix, boolean caseSensitive) {
+        return caseSensitive ? subject.endsWith(suffix)
+                : subject.toLowerCase(Locale.ROOT).endsWith(suffix.toLowerCase(Locale.ROOT));
+    }
+
+    private Object asObject(JsonNode data) {
+        if (data == null || data.isNull() || data.isMissingNode()) {
+            return null;
+        }
+        return MAPPER.convertValue(data, Object.class);
+    }
+
+    private static List<JsonNode> toList(JsonNode array) {
+        java.util.List<JsonNode> list = new java.util.ArrayList<>();
+        array.forEach(list::add);
+        return list;
+    }
+
+    private static String text(JsonNode node, String field) {
+        JsonNode v = node.get(field);
+        return v != null && v.isValueNode() ? v.asText() : null;
+    }
+
+    private static String textOr(JsonNode node, String field, String fallback) {
+        String v = text(node, field);
+        return v != null ? v : fallback;
+    }
+
+    private static Response error(int status, String code, String message) {
+        return Response.status(status).entity(Map.of("error", Map.of(
+                "code", code, "message", message))).build();
+    }
+}

--- a/src/main/java/io/floci/az/services/eventgrid/EventGridService.java
+++ b/src/main/java/io/floci/az/services/eventgrid/EventGridService.java
@@ -1,0 +1,469 @@
+package io.floci.az.services.eventgrid;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.floci.az.config.EmulatorConfig;
+import io.floci.az.core.AzureRequest;
+import io.floci.az.core.StoredObject;
+import io.floci.az.core.storage.StorageBackend;
+import io.floci.az.core.storage.StorageFactory;
+import io.floci.az.services.eventgrid.EventGridModels.EventSubscription;
+import io.floci.az.services.eventgrid.EventGridModels.Filter;
+import io.floci.az.services.eventgrid.EventGridModels.RetryPolicy;
+import io.floci.az.services.eventgrid.EventGridModels.Topic;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+
+import java.io.IOException;
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * ARM (management-plane) handler for {@code Microsoft.EventGrid/topics} and the classic scoped
+ * {@code eventSubscriptions}. State is persisted via {@link StorageBackend}; the ARM resource JSON
+ * returned to clients is projected from the stored {@link EventGridModels} records.
+ */
+@ApplicationScoped
+public class EventGridService {
+
+    private static final Logger LOG = Logger.getLogger(EventGridService.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    private static final String TOPIC_PREFIX = "eg/topics/";
+    private static final String SUB_PREFIX = "eg/subs/";
+    private static final String ES_MARKER = "/providers/Microsoft.EventGrid/eventSubscriptions";
+    private static final String EG_MARKER = "/providers/Microsoft.EventGrid/";
+
+    private final StorageBackend<String, StoredObject> store;
+    private final EmulatorConfig config;
+    private final EventGridDelivery delivery;
+
+    @Inject
+    public EventGridService(StorageFactory factory, EmulatorConfig config, EventGridDelivery delivery) {
+        this.store = factory.create("eventgrid");
+        this.config = config;
+        this.delivery = delivery;
+    }
+
+    // ── ARM dispatch ──────────────────────────────────────────────────────────
+
+    public Response handleArm(AzureRequest req, String path, String method) {
+        int esIdx = path.indexOf(ES_MARKER);
+        if (esIdx >= 0) {
+            String scope = normalizeId(path.substring(0, esIdx));
+            String rest = stripQuery(path.substring(esIdx + ES_MARKER.length()));
+            return handleEventSubscriptions(req, method, scope, rest);
+        }
+
+        int idx = path.indexOf(EG_MARKER);
+        if (idx < 0) {
+            return notFound(path);
+        }
+        String[] seg = split(stripQuery(path.substring(idx + EG_MARKER.length())));
+        if (seg.length == 0 || !"topics".equals(seg[0])) {
+            return notFound(path);
+        }
+
+        String sub = extractSegment(path, "subscriptions");
+        String rg = extractSegment(path, "resourceGroups");
+
+        if (seg.length == 1) {
+            if (!"GET".equals(method)) {
+                return Response.status(405).build();
+            }
+            return rg == null ? Response.ok(Map.of("value", listTopicsBySubscription(sub))).build()
+                    : Response.ok(Map.of("value", listTopicsByResourceGroup(sub, rg))).build();
+        }
+
+        String topicName = seg[1];
+        if (seg.length == 2) {
+            return switch (method) {
+                case "PUT" -> createOrUpdateTopic(req, sub, rg, topicName);
+                case "GET" -> getTopic(sub, rg, topicName);
+                case "DELETE" -> deleteTopic(sub, rg, topicName);
+                default -> Response.status(405).build();
+            };
+        }
+        if (seg.length == 3 && "POST".equals(method)) {
+            return switch (seg[2]) {
+                case "listKeys" -> listKeys(sub, rg, topicName);
+                case "regenerateKey" -> regenerateKey(req, sub, rg, topicName);
+                default -> notFound(path);
+            };
+        }
+        return notFound(path);
+    }
+
+    // ── Topics ─────────────────────────────────────────────────────────────────
+
+    private Response createOrUpdateTopic(AzureRequest req, String sub, String rg, String name) {
+        Map<String, Object> body = parseBody(req);
+        Map<String, Object> properties = cast(body.get("properties"));
+        String inputSchema = stringOr(properties.get("inputSchema"), EventGridModels.SCHEMA_EVENT_GRID);
+        String location = stringOr(body.get("location"), config.services().eventGrid().defaultRegion());
+
+        Topic existing = readTopic(sub, rg, name).orElse(null);
+        String key1 = existing != null ? existing.key1() : generateKey();
+        String key2 = existing != null ? existing.key2() : generateKey();
+
+        Topic topic = new Topic(sub, rg, name, location, inputSchema, key1, key2);
+        writeTopic(topic);
+        LOG.infov("ARM: created Event Grid topic {0} (schema={1})", name, inputSchema);
+        return Response.ok(topicJson(topic)).build();
+    }
+
+    private Response getTopic(String sub, String rg, String name) {
+        return readTopic(sub, rg, name)
+                .<Response>map(t -> Response.ok(topicJson(t)).build())
+                .orElseGet(() -> notFound("topics/" + name));
+    }
+
+    private Response deleteTopic(String sub, String rg, String name) {
+        Optional<Topic> topic = readTopic(sub, rg, name);
+        store.delete(topicKey(sub, rg, name));
+        topic.ifPresent(t -> {
+            String prefix = SUB_PREFIX + t.resourceId().toLowerCase() + "/";
+            store.keys().stream().filter(k -> k.startsWith(prefix)).toList()
+                    .forEach(store::delete);
+        });
+        return Response.ok().build();
+    }
+
+    private Response listKeys(String sub, String rg, String name) {
+        return readTopic(sub, rg, name)
+                .<Response>map(t -> Response.ok(Map.of("key1", t.key1(), "key2", t.key2())).build())
+                .orElseGet(() -> notFound("topics/" + name));
+    }
+
+    private Response regenerateKey(AzureRequest req, String sub, String rg, String name) {
+        Optional<Topic> existing = readTopic(sub, rg, name);
+        if (existing.isEmpty()) {
+            return notFound("topics/" + name);
+        }
+        Topic t = existing.get();
+        String keyName = stringOr(parseBody(req).get("keyName"), "key1");
+        Topic updated = "key2".equalsIgnoreCase(keyName)
+                ? new Topic(sub, rg, name, t.location(), t.inputSchema(), t.key1(), generateKey())
+                : new Topic(sub, rg, name, t.location(), t.inputSchema(), generateKey(), t.key2());
+        writeTopic(updated);
+        return Response.ok(Map.of("key1", updated.key1(), "key2", updated.key2())).build();
+    }
+
+    // ── Event subscriptions ─────────────────────────────────────────────────────
+
+    private Response handleEventSubscriptions(AzureRequest req, String method, String topicResourceId, String rest) {
+        if (rest.isBlank() || "/".equals(rest)) {
+            if (!"GET".equals(method)) {
+                return Response.status(405).build();
+            }
+            List<Map<String, Object>> items = subscriptionsForTopic(topicResourceId).stream()
+                    .map(this::subscriptionJson).toList();
+            return Response.ok(Map.of("value", items)).build();
+        }
+        String[] seg = split(rest);
+        String name = seg[0];
+        if (seg.length == 2 && "getFullUrl".equals(seg[1]) && "POST".equals(method)) {
+            return readSubscription(topicResourceId, name)
+                    .<Response>map(s -> Response.ok(Map.of("endpointUrl", s.endpointUrl())).build())
+                    .orElseGet(() -> notFound("eventSubscriptions/" + name));
+        }
+        return switch (method) {
+            case "PUT" -> createOrUpdateSubscription(req, topicResourceId, name);
+            case "GET" -> readSubscription(topicResourceId, name)
+                    .<Response>map(s -> Response.ok(subscriptionJson(s)).build())
+                    .orElseGet(() -> notFound("eventSubscriptions/" + name));
+            case "DELETE" -> {
+                store.delete(subKey(topicResourceId, name));
+                yield Response.ok().build();
+            }
+            default -> Response.status(405).build();
+        };
+    }
+
+    private Response createOrUpdateSubscription(AzureRequest req, String topicResourceId, String name) {
+        Map<String, Object> body = parseBody(req);
+        Map<String, Object> properties = cast(body.get("properties"));
+
+        Map<String, Object> destination = cast(properties.get("destination"));
+        Map<String, Object> destProps = cast(destination.get("properties"));
+        String endpointUrl = stringOr(destProps.get("endpointUrl"), null);
+        if (endpointUrl == null) {
+            return badRequest("Event subscription '" + name + "' requires destination.properties.endpointUrl");
+        }
+
+        String schema = stringOr(properties.get("eventDeliverySchema"), EventGridModels.SCHEMA_EVENT_GRID);
+        Filter filter = parseFilter(cast(properties.get("filter")));
+        RetryPolicy retry = parseRetryPolicy(cast(properties.get("retryPolicy")));
+        String deadLetter = parseDeadLetter(cast(properties.get("deadLetterDestination")));
+
+        EventSubscription es = new EventSubscription(name, topicResourceId, endpointUrl,
+                schema, filter, retry, deadLetter);
+        writeSubscription(es);
+
+        boolean validated = delivery.validate(es, topicResourceId);
+        LOG.infov("ARM: created Event Grid subscription {0} → {1} (validated={2})",
+                name, endpointUrl, validated);
+        return Response.ok(subscriptionJson(es)).build();
+    }
+
+    private Filter parseFilter(Map<String, Object> raw) {
+        if (raw.isEmpty()) {
+            return Filter.empty();
+        }
+        return new Filter(
+                stringOr(raw.get("subjectBeginsWith"), null),
+                stringOr(raw.get("subjectEndsWith"), null),
+                stringList(raw.get("includedEventTypes")),
+                Boolean.parseBoolean(String.valueOf(raw.getOrDefault("isSubjectCaseSensitive", false))));
+    }
+
+    private RetryPolicy parseRetryPolicy(Map<String, Object> raw) {
+        int maxAttempts = intOr(raw.get("maxDeliveryAttempts"), config.services().eventGrid().maxDeliveryAttempts());
+        int ttl = intOr(raw.get("eventTimeToLiveInMinutes"), 1440);
+        return new RetryPolicy(maxAttempts, ttl);
+    }
+
+    private String parseDeadLetter(Map<String, Object> raw) {
+        Map<String, Object> props = cast(raw.get("properties"));
+        return stringOr(props.get("endpointUrl"), null);
+    }
+
+    // ── Lookups used by the data plane ──────────────────────────────────────────
+
+    public Optional<Topic> findTopicByName(String name) {
+        return store.scan(k -> k.startsWith(TOPIC_PREFIX)).stream()
+                .map(this::toTopicFrom)
+                .filter(t -> t != null && t.name().equals(name))
+                .findFirst();
+    }
+
+    public List<EventSubscription> subscriptionsForTopic(String topicResourceId) {
+        String prefix = SUB_PREFIX + topicResourceId.toLowerCase() + "/";
+        return store.scan(k -> k.startsWith(prefix)).stream()
+                .map(this::toSubscriptionFrom)
+                .filter(s -> s != null)
+                .toList();
+    }
+
+    public void clearAll() {
+        store.clear();
+    }
+
+    // ── JSON projection ─────────────────────────────────────────────────────────
+
+    private Map<String, Object> topicJson(Topic t) {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("provisioningState", "Succeeded");
+        properties.put("endpoint", topicEndpoint(t.name()));
+        properties.put("inputSchema", t.inputSchema());
+        properties.put("publicNetworkAccess", "Enabled");
+
+        Map<String, Object> resource = new LinkedHashMap<>();
+        resource.put("id", t.resourceId());
+        resource.put("name", t.name());
+        resource.put("type", "Microsoft.EventGrid/topics");
+        resource.put("location", t.location());
+        resource.put("properties", properties);
+        return resource;
+    }
+
+    private Map<String, Object> subscriptionJson(EventSubscription s) {
+        Map<String, Object> destProps = new LinkedHashMap<>();
+        destProps.put("endpointUrl", s.endpointUrl());
+        Map<String, Object> destination = new LinkedHashMap<>();
+        destination.put("endpointType", "WebHook");
+        destination.put("properties", destProps);
+
+        Map<String, Object> filter = new LinkedHashMap<>();
+        filter.put("subjectBeginsWith", s.filter().subjectBeginsWith());
+        filter.put("subjectEndsWith", s.filter().subjectEndsWith());
+        filter.put("includedEventTypes",
+                s.filter().includedEventTypes().isEmpty() ? null : s.filter().includedEventTypes());
+        filter.put("isSubjectCaseSensitive", s.filter().isSubjectCaseSensitive());
+
+        Map<String, Object> retry = new LinkedHashMap<>();
+        retry.put("maxDeliveryAttempts", s.retryPolicy().maxDeliveryAttempts());
+        retry.put("eventTimeToLiveInMinutes", s.retryPolicy().eventTimeToLiveInMinutes());
+
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("provisioningState", "Succeeded");
+        properties.put("topic", s.topicResourceId());
+        properties.put("destination", destination);
+        properties.put("filter", filter);
+        properties.put("retryPolicy", retry);
+        properties.put("eventDeliverySchema", s.eventDeliverySchema());
+        properties.put("labels", List.of());
+
+        Map<String, Object> resource = new LinkedHashMap<>();
+        resource.put("id", s.resourceId());
+        resource.put("name", s.name());
+        resource.put("type", "Microsoft.EventGrid/eventSubscriptions");
+        resource.put("properties", properties);
+        return resource;
+    }
+
+    private String topicEndpoint(String name) {
+        return config.effectiveBaseUrl().replaceAll("/+$", "") + "/" + name + "-eventgrid/api/events";
+    }
+
+    private List<Map<String, Object>> listTopicsByResourceGroup(String sub, String rg) {
+        return store.scan(k -> k.startsWith(topicRgPrefix(sub, rg))).stream()
+                .map(this::toTopicFrom).filter(t -> t != null)
+                .map(this::topicJson).toList();
+    }
+
+    private List<Map<String, Object>> listTopicsBySubscription(String sub) {
+        return store.scan(k -> k.startsWith(TOPIC_PREFIX + sub + "/")).stream()
+                .map(this::toTopicFrom).filter(t -> t != null)
+                .map(this::topicJson).toList();
+    }
+
+    // ── Persistence helpers ──────────────────────────────────────────────────────
+
+    private Optional<Topic> readTopic(String sub, String rg, String name) {
+        return store.get(topicKey(sub, rg, name)).map(this::toTopicFrom);
+    }
+
+    private void writeTopic(Topic t) {
+        store.put(topicKey(t.subscriptionId(), t.resourceGroup(), t.name()), serialize(t));
+    }
+
+    private Optional<EventSubscription> readSubscription(String topicResourceId, String name) {
+        return store.get(subKey(topicResourceId, name)).map(this::toSubscriptionFrom);
+    }
+
+    private void writeSubscription(EventSubscription s) {
+        store.put(subKey(s.topicResourceId(), s.name()), serialize(s));
+    }
+
+    private Topic toTopicFrom(StoredObject obj) {
+        return deserialize(obj, Topic.class);
+    }
+
+    private EventSubscription toSubscriptionFrom(StoredObject obj) {
+        return deserialize(obj, EventSubscription.class);
+    }
+
+    private <T> StoredObject serialize(T value) {
+        try {
+            return new StoredObject("eg", MAPPER.writeValueAsBytes(value), Map.of(), Instant.now(), "eg");
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to serialize Event Grid model", e);
+        }
+    }
+
+    private <T> T deserialize(StoredObject obj, Class<T> type) {
+        try {
+            return MAPPER.readValue(obj.data(), type);
+        } catch (Exception e) {
+            LOG.warnv("Failed to deserialize Event Grid {0}: {1}", type.getSimpleName(), e.getMessage());
+            return null;
+        }
+    }
+
+    private static String topicKey(String sub, String rg, String name) {
+        return topicRgPrefix(sub, rg) + name;
+    }
+
+    private static String topicRgPrefix(String sub, String rg) {
+        return TOPIC_PREFIX + sub + "/" + rg + "/";
+    }
+
+    private static String subKey(String topicResourceId, String name) {
+        return SUB_PREFIX + topicResourceId.toLowerCase() + "/" + name;
+    }
+
+    // ── Generic parsing helpers ──────────────────────────────────────────────────
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> parseBody(AzureRequest req) {
+        try {
+            if (req.bodyStream() == null || req.bodyStream().available() == 0) {
+                return Map.of();
+            }
+            return MAPPER.readValue(req.bodyStream(), Map.class);
+        } catch (IOException e) {
+            return Map.of();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> cast(Object value) {
+        return value instanceof Map<?, ?> m ? (Map<String, Object>) m : Map.of();
+    }
+
+    private static String stringOr(Object value, String fallback) {
+        return value instanceof String s && !s.isBlank() ? s : fallback;
+    }
+
+    private static int intOr(Object value, int fallback) {
+        if (value instanceof Number n) {
+            return n.intValue();
+        }
+        if (value instanceof String s && !s.isBlank()) {
+            try {
+                return Integer.parseInt(s.trim());
+            } catch (NumberFormatException ignored) {
+                return fallback;
+            }
+        }
+        return fallback;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> stringList(Object value) {
+        if (value instanceof List<?> list) {
+            return list.stream().filter(String.class::isInstance).map(String.class::cast).toList();
+        }
+        return List.of();
+    }
+
+    private static String generateKey() {
+        byte[] bytes = new byte[32];
+        RANDOM.nextBytes(bytes);
+        return Base64.getEncoder().encodeToString(bytes);
+    }
+
+    private static String normalizeId(String id) {
+        return id.startsWith("/") ? id : "/" + id;
+    }
+
+    private static String stripQuery(String path) {
+        int q = path.indexOf('?');
+        return q >= 0 ? path.substring(0, q) : path;
+    }
+
+    private static String[] split(String tail) {
+        String clean = tail.replaceAll("^/+", "").replaceAll("/+$", "");
+        return clean.isBlank() ? new String[0] : clean.split("/", -1);
+    }
+
+    private static String extractSegment(String path, String marker) {
+        String[] parts = path.split("/");
+        for (int i = 0; i < parts.length - 1; i++) {
+            if (marker.equalsIgnoreCase(parts[i])) {
+                return parts[i + 1];
+            }
+        }
+        return null;
+    }
+
+    private static Response notFound(String resource) {
+        return Response.status(404).entity(Map.of("error", Map.of(
+                "code", "ResourceNotFound",
+                "message", "Resource not found: " + resource))).build();
+    }
+
+    private static Response badRequest(String message) {
+        return Response.status(400).entity(Map.of("error", Map.of(
+                "code", "InvalidRequest",
+                "message", message))).build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,7 +23,8 @@ quarkus:
       --initialize-at-run-time=io.floci.az.services.acr.AcrHandler,
       --initialize-at-run-time=io.floci.az.services.redis.RedisHandler,
       --initialize-at-run-time=io.floci.az.services.entra.TokenIssuer,
-      --initialize-at-run-time=io.floci.az.services.entra.SigningKeyProvider
+      --initialize-at-run-time=io.floci.az.services.entra.SigningKeyProvider,
+      --initialize-at-run-time=io.floci.az.services.eventgrid.EventGridService
 
 floci-az:
   port: 4577
@@ -185,6 +186,10 @@ floci-az:
       enabled: true       # central management plane (/providers, /subscriptions, resource groups). Disabling turns OFF all ARM-based services.
     network:
       enabled: true       # Microsoft.Network — VNet, subnets, NIC, public IP, NSG, and DNS zones
+    event-grid:
+      enabled: true       # Microsoft.EventGrid — Custom Topics + webhook event subscriptions (HTTP pub/push)
+      default-region: eastus
+      max-delivery-attempts: 30
 
   auth:
     # dev: accept any credentials without signature validation

--- a/src/test/java/io/floci/az/services/eventgrid/EventGridHandlerTest.java
+++ b/src/test/java/io/floci/az/services/eventgrid/EventGridHandlerTest.java
@@ -1,0 +1,193 @@
+package io.floci.az.services.eventgrid;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpServer;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Quarkus-level tests for {@link EventGridHandler}.
+ *
+ * <p>Covers the ARM control plane (topic CRUD + listKeys), the subscription validation handshake,
+ * and end-to-end publish → webhook delivery with subject filtering. A small in-process
+ * {@link HttpServer} stands in for the subscriber webhook so deliveries can be asserted without a
+ * new dependency.
+ */
+@QuarkusTest
+@DisplayName("EventGridHandler — ARM, publish, and webhook delivery")
+class EventGridHandlerTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static final String SUB = "test-sub-eventgrid";
+    private static final String RG = "test-rg-eventgrid";
+    private static final String TOPIC = "orders-topic";
+    private static final String API = "?api-version=2025-02-15";
+    private static final String TOPIC_SCOPE =
+            "/subscriptions/" + SUB + "/resourceGroups/" + RG + "/providers/Microsoft.EventGrid/topics/" + TOPIC;
+    private static final String TOPIC_BASE =
+            "/subscriptions/" + SUB + "/resourceGroups/" + RG + "/providers/Microsoft.EventGrid/topics/" + TOPIC;
+
+    private HttpServer webhook;
+    private final List<JsonNode> validations = new CopyOnWriteArrayList<>();
+    private final List<JsonNode> notifications = new CopyOnWriteArrayList<>();
+
+    @BeforeEach
+    void setUp() throws IOException {
+        given().post("/_admin/reset").then().statusCode(204);
+        validations.clear();
+        notifications.clear();
+
+        webhook = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        webhook.createContext("/hook", exchange -> {
+            byte[] body = exchange.getRequestBody().readAllBytes();
+            JsonNode root = MAPPER.readTree(body);
+            JsonNode first = root.isArray() && root.size() > 0 ? root.get(0) : root;
+            String validationCode = first.path("data").path("validationCode").asText(null);
+            if (validationCode != null) {
+                validations.add(first);
+                byte[] resp = ("{\"validationResponse\":\"" + validationCode + "\"}").getBytes(StandardCharsets.UTF_8);
+                exchange.getResponseHeaders().add("Content-Type", "application/json");
+                exchange.sendResponseHeaders(200, resp.length);
+                exchange.getResponseBody().write(resp);
+            } else {
+                root.forEach(notifications::add);
+                exchange.sendResponseHeaders(200, -1);
+            }
+            exchange.close();
+        });
+        webhook.start();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (webhook != null) {
+            webhook.stop(0);
+        }
+    }
+
+    private String webhookUrl() {
+        return "http://127.0.0.1:" + webhook.getAddress().getPort() + "/hook";
+    }
+
+    private void createTopic() {
+        given()
+            .contentType("application/json")
+            .body("{\"location\":\"eastus\",\"properties\":{}}")
+            .when().put(TOPIC_BASE + API)
+            .then().statusCode(200)
+            .body("name", equalTo(TOPIC))
+            .body("type", equalTo("Microsoft.EventGrid/topics"))
+            .body("properties.provisioningState", equalTo("Succeeded"))
+            .body("properties.endpoint", notNullValue());
+    }
+
+    private void createSubscription(String subscriptionName, String subjectBeginsWith) {
+        String filter = subjectBeginsWith == null ? "{}"
+                : "{\"subjectBeginsWith\":\"" + subjectBeginsWith + "\"}";
+        String body = "{\"properties\":{"
+                + "\"destination\":{\"endpointType\":\"WebHook\",\"properties\":{\"endpointUrl\":\""
+                + webhookUrl() + "\"}},"
+                + "\"filter\":" + filter + "}}";
+        given()
+            .contentType("application/json")
+            .body(body)
+            .when().put(TOPIC_SCOPE + "/providers/Microsoft.EventGrid/eventSubscriptions/" + subscriptionName + API)
+            .then().statusCode(200)
+            .body("name", equalTo(subscriptionName))
+            .body("type", equalTo("Microsoft.EventGrid/eventSubscriptions"))
+            .body("properties.destination.properties.endpointUrl", equalTo(webhookUrl()));
+    }
+
+    @Test
+    @DisplayName("topic listKeys returns key1 and key2")
+    void listKeysReturnsBothKeys() {
+        createTopic();
+        given()
+            .when().post(TOPIC_BASE + "/listKeys" + API)
+            .then().statusCode(200)
+            .body("key1", notNullValue())
+            .body("key2", notNullValue());
+    }
+
+    @Test
+    @DisplayName("creating a webhook subscription runs the validation handshake")
+    void subscriptionCreationValidatesWebhook() {
+        createTopic();
+        createSubscription("sub-validate", null);
+
+        assertEquals(1, validations.size(), "subscriber should receive exactly one validation event");
+        assertEquals("Microsoft.EventGrid.SubscriptionValidationEvent",
+                validations.get(0).path("eventType").asText());
+    }
+
+    @Test
+    @DisplayName("published event is delivered to a matching subscription with topic set to the resource id")
+    void publishDeliversToMatchingSubscription() throws InterruptedException {
+        createTopic();
+        createSubscription("sub-all", "/orders");
+
+        String events = "[{"
+                + "\"id\":\"evt-1\","
+                + "\"subject\":\"/orders/123\","
+                + "\"eventType\":\"Order.Created\","
+                + "\"eventTime\":\"2026-06-20T00:00:00Z\","
+                + "\"dataVersion\":\"1.0\","
+                + "\"data\":{\"orderId\":123}"
+                + "}]";
+        given()
+            .contentType("application/json").body(events)
+            .when().post("/" + TOPIC + "-eventgrid/api/events")
+            .then().statusCode(200);
+
+        JsonNode delivered = awaitNotification();
+        assertEquals("Order.Created", delivered.path("eventType").asText());
+        assertEquals("/orders/123", delivered.path("subject").asText());
+        assertEquals(TOPIC_SCOPE, delivered.path("topic").asText(),
+                "delivered event topic must be the topic's full resource id");
+        assertEquals("1", delivered.path("metadataVersion").asText());
+    }
+
+    @Test
+    @DisplayName("subjectBeginsWith filter excludes non-matching events")
+    void filterExcludesNonMatchingEvents() throws InterruptedException {
+        createTopic();
+        createSubscription("sub-filtered", "/orders");
+
+        String events = "[{"
+                + "\"id\":\"evt-2\",\"subject\":\"/shipments/9\",\"eventType\":\"Shipment.Created\","
+                + "\"eventTime\":\"2026-06-20T00:00:00Z\",\"dataVersion\":\"1.0\",\"data\":{}}]";
+        given()
+            .contentType("application/json").body(events)
+            .when().post("/" + TOPIC + "-eventgrid/api/events")
+            .then().statusCode(200);
+
+        // Give the async delivery scheduler a chance to (not) deliver.
+        Thread.sleep(1000);
+        assertTrue(notifications.isEmpty(), "event under /shipments should not match subjectBeginsWith=/orders");
+    }
+
+    private JsonNode awaitNotification() throws InterruptedException {
+        for (int i = 0; i < 50 && notifications.isEmpty(); i++) {
+            Thread.sleep(100);
+        }
+        assertTrue(!notifications.isEmpty(), "expected a delivered notification within the timeout");
+        return notifications.get(0);
+    }
+}


### PR DESCRIPTION
## Summary

Implements **Azure Event Grid** (`Microsoft.EventGrid/topics` + `eventSubscriptions`) — the Azure counterpart of EventBridge/SNS. HTTP-only, no Docker sidecar. Closes #58.

- Custom Topic CRUD + `listKeys`/`regenerateKey`, returning a data-plane `properties.endpoint`
- Classic scoped webhook `eventSubscriptions` with `subjectBeginsWith`/`subjectEndsWith`/`includedEventTypes` filters + `SubscriptionValidationEvent` handshake (and CloudEvents `OPTIONS` abuse-protection)
- Publish (`POST /api/events`) in **Event Grid** and **CloudEvents 1.0** schemas
- Async webhook delivery with `retryPolicy` backoff; best-effort dead-letter (logged)
- Refactors the 7 duplicated ARM-provider dispatch blocks in `AzureRoutingFilter` into one `dispatchManagementPlane()` helper

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

Wire shapes taken from `azure-rest-api-specs` (`eventgrid` resource-manager `2025-02-15` + data-plane `2018-01-01`). Verified end-to-end with the **`azure-messaging-eventgrid` 4.25.0** publisher SDK (EventGridEvent + CloudEvent clients) against the native Docker image.

## Checklist

- [x] `./mvnw test` passes locally (only `AksDockerTest` fails — pre-existing, needs a privileged k3s container)
- [x] New or updated integration test added (`EventGridHandlerTest` + `EventGridCompatibilityTest`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)