### PR TITLE
chore(compat): pin @azure/app-configuration to 1.11.0 in node SDK suite

### DIFF
--- a/compatibility-tests/sdk-test-node/package.json
+++ b/compatibility-tests/sdk-test-node/package.json
@@ -5,8 +5,9 @@
   "scripts": {
     "test": "jest --testTimeout=30000 --reporters=default --reporters=jest-junit"
   },
+  "comment_app-configuration": "Pinned to exactly 1.11.0: 1.12.0's connection-string credential sets an invalid request header named 'Connection String' ('Header name must be a valid HTTP token'), breaking this suite. No lockfile is committed, so a caret range drifts to it on every build. Revisit when the SDK regression is fixed.",
   "dependencies": {
-    "@azure/app-configuration": "^1.11.0",
+    "@azure/app-configuration": "1.11.0",
     "@azure/cosmos": "^4.1.0",
     "@azure/data-tables": "^13.3.0",
     "@azure/keyvault-secrets": "^4.8.0",


### PR DESCRIPTION
## Summary

The `sdk-test-node` job started failing with no code change:

```
TypeError: Header name must be a valid HTTP token ["Connection String"]
```

Root cause: **`@azure/app-configuration` 1.12.0** — its connection-string credential sets an invalid request header literally named `Connection String`, which the HTTP layer rejects. The node suite intentionally does **not** commit a `package-lock.json` (it's gitignored), so the previous caret range `^1.11.0` drifted to the broken `1.12.0` on every fresh `npm install`. This affects `main` too on its next build (surfaced on #77).

Fix: pin `@azure/app-configuration` to exactly `1.11.0` (the last good release) until the SDK regression is fixed. No Dockerfile/lockfile change.

**Verified:** full node suite **72/72 green** against the emulator (App Config 5/5, vs 5 failing before).

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## Azure Compatibility

No protocol change. Pins the App Configuration Node SDK to the last release whose connection-string credential emits valid headers.

## Checklist

- [x] `./mvnw test` passes locally (unaffected — node-only change)
- [ ] New or updated integration test added (n/a — dependency pin)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)