### PR TITLE
fix: return content range for invalid blob ranges

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/BlobCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/BlobCompatibilityTest.java
@@ -197,6 +197,24 @@ class BlobCompatibilityTest {
         client.deleteBlobContainer(name);
     }
 
+    @Test
+    @DisplayName("empty blob range download: invalid range includes content range")
+    void emptyBlobRangeDownloadReturnsContentRange() {
+        String name = containerName();
+        BlobContainerClient container = client.createBlobContainer(name);
+        BlobClient blob = container.getBlobClient("empty-range.txt");
+
+        blob.upload(new java.io.ByteArrayInputStream(new byte[0]), 0, true);
+
+        BlobStorageException ex = assertThrows(BlobStorageException.class,
+            () -> blob.downloadStreamWithResponse(new ByteArrayOutputStream(), new BlobRange(0, 1L), null, null, false, null, Context.NONE));
+        assertEquals(BlobErrorCode.INVALID_RANGE, ex.getErrorCode());
+        assertEquals(416, ex.getStatusCode());
+        assertEquals("bytes */0", ex.getResponse().getHeaders().getValue("Content-Range"));
+
+        client.deleteBlobContainer(name);
+    }
+
     // --- Block Blob ---
 
     @Test

--- a/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
+++ b/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
@@ -287,9 +287,11 @@ public class BlobServiceHandler implements AzureServiceHandler {
                 rangeEnd   = parts.length > 1 && !parts[1].isEmpty()
                         ? Long.parseLong(parts[1]) : totalSize - 1;
                 if (rangeStart < 0 || rangeStart >= totalSize) {
-                    return new AzureErrorResponse("InvalidRange",
+                    return Response.fromResponse(new AzureErrorResponse("InvalidRange",
                             "The range specified is invalid for the current size of the resource.")
-                            .toXmlResponse(416);
+                            .toXmlResponse(416))
+                            .header("Content-Range", "bytes */" + totalSize)
+                            .build();
                 }
                 rangeEnd   = Math.min(rangeEnd, totalSize - 1);
                 isRangeRequest = true;

--- a/src/test/java/io/floci/az/services/BlobServiceTest.java
+++ b/src/test/java/io/floci/az/services/BlobServiceTest.java
@@ -227,6 +227,23 @@ public class BlobServiceTest {
     }
 
     @Test
+    void emptyBlobInvalidRangeIncludesContentRange() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        given()
+            .header("x-ms-blob-type", "BlockBlob")
+            .body("")
+            .put("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB);
+
+        given()
+            .header("x-ms-range", "bytes=0-0")
+            .when().get("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(416)
+            .header("Content-Range", "bytes */0")
+            .header("x-ms-error-code", "InvalidRange");
+    }
+
+    @Test
     void malformedRangeReturns416() {
         given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
         given()


### PR DESCRIPTION
## Summary

Closes #81

Return the Azure `Content-Range` header for invalid ranged blob reads so clients can determine the blob length.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

Verified `GET Blob` with `x-ms-range: bytes=0-0` on a zero-byte block blob against Azure Blob Storage using `x-ms-version: 2023-11-03`. Azure returns `416 InvalidRange` with `Content-Range: bytes */0`; Floci now returns the same header.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
