### PR TITLE
fix: return blob prefixes for delimited lists

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/BlobCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/BlobCompatibilityTest.java
@@ -10,6 +10,7 @@ import com.azure.storage.blob.models.BlobRange;
 import com.azure.storage.blob.models.BlobRequestConditions;
 import com.azure.storage.blob.models.BlobStorageException;
 import com.azure.storage.blob.models.BlockListType;
+import com.azure.storage.blob.models.ListBlobsOptions;
 import com.azure.storage.blob.specialized.BlockBlobClient;
 import com.azure.core.util.Context;
 import org.junit.jupiter.api.*;
@@ -98,6 +99,25 @@ class BlobCompatibilityTest {
 
         long count = container.listBlobs().stream().count();
         assertEquals(5, count);
+
+        client.deleteBlobContainer(name);
+    }
+
+    @Test
+    @DisplayName("blob hierarchy listing: returns common prefixes")
+    void blobHierarchyListingReturnsPrefixes() {
+        String name = containerName();
+        BlobContainerClient container = client.createBlobContainer(name);
+
+        byte[] data = "data".getBytes(StandardCharsets.UTF_8);
+        container.getBlobClient("level0/file1.txt").upload(new java.io.ByteArrayInputStream(data), data.length, true);
+        container.getBlobClient("level0/file2.txt").upload(new java.io.ByteArrayInputStream(data), data.length, true);
+        container.getBlobClient("root.txt").upload(new java.io.ByteArrayInputStream(data), data.length, true);
+
+        List<BlobItem> items = container.listBlobsByHierarchy("/", new ListBlobsOptions(), null).stream().toList();
+        assertEquals(List.of("level0/", "root.txt"), items.stream().map(BlobItem::getName).sorted().toList());
+        assertTrue(items.stream().filter(BlobItem::isPrefix).map(BlobItem::getName).toList().contains("level0/"));
+        assertTrue(items.stream().filter(item -> !item.isPrefix()).map(BlobItem::getName).toList().contains("root.txt"));
 
         client.deleteBlobContainer(name);
     }

--- a/src/main/java/io/floci/az/services/blob/BlobModels.java
+++ b/src/main/java/io/floci/az/services/blob/BlobModels.java
@@ -1,5 +1,6 @@
 package io.floci.az.services.blob;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
@@ -41,12 +42,29 @@ public class BlobModels {
         @JacksonXmlProperty(localName = "ServiceEndpoint", isAttribute = true) String ServiceEndpoint,
         @JacksonXmlProperty(localName = "ContainerName", isAttribute = true) String ContainerName,
         @JacksonXmlProperty(localName = "Prefix") String Prefix,
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        @JacksonXmlProperty(localName = "Delimiter") String Delimiter,
         @JacksonXmlProperty(localName = "Marker") String Marker,
         @JacksonXmlProperty(localName = "MaxResults") Integer MaxResults,
-        @JacksonXmlElementWrapper(localName = "Blobs")
-        @JacksonXmlProperty(localName = "Blob")
-        List<BlobItem> Blobs,
+        @JacksonXmlProperty(localName = "Blobs") BlobItems Blobs,
         @JacksonXmlProperty(localName = "NextMarker") String NextMarker
+    ) {}
+
+    @RegisterForReflection
+    public record BlobItems(
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        @JacksonXmlElementWrapper(useWrapping = false)
+        @JacksonXmlProperty(localName = "BlobPrefix")
+        List<BlobPrefix> BlobPrefixes,
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        @JacksonXmlElementWrapper(useWrapping = false)
+        @JacksonXmlProperty(localName = "Blob")
+        List<BlobItem> Blobs
+    ) {}
+
+    @RegisterForReflection
+    public record BlobPrefix(
+        @JacksonXmlProperty(localName = "Name") String Name
     ) {}
 
     @RegisterForReflection

--- a/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
+++ b/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
@@ -390,24 +390,37 @@ public class BlobServiceHandler implements AzureServiceHandler {
 
     private Response listBlobs(AzureRequest request, String containerName) {
         String prefix = request.queryParams().getOrDefault("prefix", "");
+        String delimiter = request.queryParams().getOrDefault("delimiter", "");
         String keyPrefix = objKey(request.accountName(), containerName, prefix);
 
-        List<BlobModels.BlobItem> blobs = store.scan(k -> k.startsWith(keyPrefix)).stream()
-                .map(so -> {
-                    String name = so.metadata().getOrDefault("Name", so.key());
-                    return new BlobModels.BlobItem(name, new BlobModels.BlobProperties(
-                            RFC1123_DATE_TIME.format(so.lastModified()),
-                            so.etag(),
-                            (long) so.data().length,
-                            so.metadata().getOrDefault("Content-Type", "application/octet-stream"),
-                            so.metadata().getOrDefault("BlobType", "BlockBlob")
-                    ), includes(request.queryParams().get("include"), "metadata") ? userMetadata(so.metadata()) : null);
-                })
-                .collect(Collectors.toList());
+        List<BlobModels.BlobPrefix> blobPrefixes = new ArrayList<>();
+        List<BlobModels.BlobItem> blobs = new ArrayList<>();
+        Set<String> seenPrefixes = new HashSet<>();
+        store.scan(k -> k.startsWith(keyPrefix)).forEach(so -> {
+            String name = so.metadata().getOrDefault("Name", so.key());
+            if (!delimiter.isEmpty()) {
+                String remaining = name.substring(prefix.length());
+                int delimiterIndex = remaining.indexOf(delimiter);
+                if (delimiterIndex >= 0) {
+                    String blobPrefix = name.substring(0, prefix.length() + delimiterIndex + delimiter.length());
+                    if (seenPrefixes.add(blobPrefix)) {
+                        blobPrefixes.add(new BlobModels.BlobPrefix(blobPrefix));
+                    }
+                    return;
+                }
+            }
+            blobs.add(new BlobModels.BlobItem(name, new BlobModels.BlobProperties(
+                    RFC1123_DATE_TIME.format(so.lastModified()),
+                    so.etag(),
+                    (long) so.data().length,
+                    so.metadata().getOrDefault("Content-Type", "application/octet-stream"),
+                    so.metadata().getOrDefault("BlobType", "BlockBlob")
+            ), includes(request.queryParams().get("include"), "metadata") ? userMetadata(so.metadata()) : null));
+        });
 
         BlobModels.BlobListResponse response = new BlobModels.BlobListResponse(
                 "http://localhost:4577/" + request.accountName(),
-                containerName, prefix, "", 1000, blobs, ""
+                containerName, prefix, delimiter, "", 1000, new BlobModels.BlobItems(blobPrefixes, blobs), ""
         );
 
         return Response.ok(XmlUtils.toXml(response)).type(MediaType.APPLICATION_XML).build();

--- a/src/test/java/io/floci/az/services/BlobServiceTest.java
+++ b/src/test/java/io/floci/az/services/BlobServiceTest.java
@@ -196,6 +196,29 @@ public class BlobServiceTest {
     }
 
     @Test
+    void listBlobsWithDelimiterReturnsBlobPrefixes() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        given()
+            .header("x-ms-blob-type", "BlockBlob")
+            .body("nested")
+            .put("/{account}/{container}/level0/file.txt", ACCOUNT, CONTAINER);
+        given()
+            .header("x-ms-blob-type", "BlockBlob")
+            .body("top")
+            .put("/{account}/{container}/other.txt", ACCOUNT, CONTAINER);
+
+        given()
+            .when().get("/{account}/{container}?restype=container&comp=list&delimiter=/", ACCOUNT, CONTAINER)
+            .then()
+            .statusCode(200)
+            .contentType(containsString("xml"))
+            .body(containsString("<Delimiter>/</Delimiter>"))
+            .body(containsString("<BlobPrefix><Name>level0/</Name></BlobPrefix>"))
+            .body(containsString("<Blob><Name>other.txt</Name>"))
+            .body(not(containsString("<Blob><Name>level0/file.txt</Name>")));
+    }
+
+    @Test
     void rangeRequestReturnsPartialContent() {
         given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
         given()


### PR DESCRIPTION
## Summary

Closes #83

Return Azure `BlobPrefix` entries when listing blobs with a delimiter, so nested blob names are grouped under directory-like prefixes.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

Verified `List Blobs` with `delimiter=/` against Azure Blob Storage using `x-ms-version: 2023-11-03`. Azure returns `BlobPrefix` for nested names and `Blob` for top-level names; Floci now returns the same entry shape.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
