### PR TITLE
fix: paginate blob listings

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/BlobCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/BlobCompatibilityTest.java
@@ -122,6 +122,32 @@ class BlobCompatibilityTest {
         client.deleteBlobContainer(name);
     }
 
+    @Test
+    @DisplayName("blob listing pagination: follows continuation token")
+    void blobListingPaginationFollowsContinuationToken() {
+        String name = containerName();
+        BlobContainerClient container = client.createBlobContainer(name);
+
+        for (int i = 0; i < 5; i++) {
+            byte[] data = ("content-" + i).getBytes(StandardCharsets.UTF_8);
+            container.getBlobClient("file-" + i + ".txt")
+                .upload(new java.io.ByteArrayInputStream(data), data.length, true);
+        }
+
+        var pages = container.listBlobs(new ListBlobsOptions().setMaxResultsPerPage(2), null)
+                .iterableByPage()
+                .iterator();
+        assertTrue(pages.hasNext());
+        List<String> firstPage = pages.next().getElements().stream().map(BlobItem::getName).toList();
+        assertTrue(pages.hasNext());
+        List<String> secondPage = pages.next().getElements().stream().map(BlobItem::getName).toList();
+
+        assertEquals(List.of("file-0.txt", "file-1.txt"), firstPage);
+        assertEquals(List.of("file-2.txt", "file-3.txt"), secondPage);
+
+        client.deleteBlobContainer(name);
+    }
+
     // --- Error cases ---
 
     @Test

--- a/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
+++ b/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
@@ -393,6 +393,8 @@ public class BlobServiceHandler implements AzureServiceHandler {
     private Response listBlobs(AzureRequest request, String containerName) {
         String prefix = request.queryParams().getOrDefault("prefix", "");
         String delimiter = request.queryParams().getOrDefault("delimiter", "");
+        String marker = request.queryParams().getOrDefault("marker", "");
+        int maxResults = parseMaxResults(request.queryParams().get("maxresults"));
         String keyPrefix = objKey(request.accountName(), containerName, prefix);
 
         List<BlobModels.BlobPrefix> blobPrefixes = new ArrayList<>();
@@ -419,13 +421,29 @@ public class BlobServiceHandler implements AzureServiceHandler {
                     so.metadata().getOrDefault("BlobType", "BlockBlob")
             ), includes(request.queryParams().get("include"), "metadata") ? userMetadata(so.metadata()) : null));
         });
+        blobs.sort(Comparator.comparing(BlobModels.BlobItem::Name));
 
+        int start = 0;
+        if (!marker.isEmpty()) {
+            while (start < blobs.size() && blobs.get(start).Name().compareTo(marker) < 0) {
+                start++;
+            }
+        }
+        int end = Math.min(start + maxResults, blobs.size());
+        String nextMarker = end < blobs.size() ? blobs.get(end).Name() : "";
         BlobModels.BlobListResponse response = new BlobModels.BlobListResponse(
                 "http://localhost:4577/" + request.accountName(),
-                containerName, prefix, delimiter, "", 1000, new BlobModels.BlobItems(blobPrefixes, blobs), ""
+                containerName, prefix, delimiter, marker, maxResults, new BlobModels.BlobItems(blobPrefixes, blobs.subList(start, end)), nextMarker
         );
 
         return Response.ok(XmlUtils.toXml(response)).type(MediaType.APPLICATION_XML).build();
+    }
+
+    private static int parseMaxResults(String value) {
+        if (value == null || value.isBlank()) {
+            return 1000;
+        }
+        return Integer.parseInt(value);
     }
 
     // ── Block Blob ────────────────────────────────────────────────────────────

--- a/src/test/java/io/floci/az/services/BlobServiceTest.java
+++ b/src/test/java/io/floci/az/services/BlobServiceTest.java
@@ -4,7 +4,11 @@ import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 @QuarkusTest
@@ -238,6 +242,46 @@ public class BlobServiceTest {
     }
 
     @Test
+    void listBlobsHonorsMaxResultsAndMarker() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        for (String name : new String[] {"a.txt", "b.txt", "c.txt"}) {
+            given()
+                .header("x-ms-blob-type", "BlockBlob")
+                .body(name)
+                .put("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, name);
+        }
+
+        String page1 = given()
+            .when().get("/{account}/{container}?restype=container&comp=list&maxresults=2", ACCOUNT, CONTAINER)
+            .then()
+            .statusCode(200)
+            .contentType(containsString("xml"))
+            .extract().asString();
+
+        assertThat(page1, containsString("<MaxResults>2</MaxResults>"));
+        assertThat(page1, containsString("<Blob><Name>a.txt</Name>"));
+        assertThat(page1, containsString("<Blob><Name>b.txt</Name>"));
+        assertThat(page1, not(containsString("<Blob><Name>c.txt</Name>")));
+
+        String marker = nextMarker(page1);
+        assertThat(marker, not(emptyString()));
+
+        String page2 = given()
+            .queryParam("marker", marker)
+            .when().get("/{account}/{container}?restype=container&comp=list&maxresults=2", ACCOUNT, CONTAINER)
+            .then()
+            .statusCode(200)
+            .contentType(containsString("xml"))
+            .extract().asString();
+
+        assertThat(page2, containsString("<Marker>" + marker + "</Marker>"));
+        assertThat(page2, not(containsString("<Blob><Name>a.txt</Name>")));
+        assertThat(page2, not(containsString("<Blob><Name>b.txt</Name>")));
+        assertThat(page2, containsString("<Blob><Name>c.txt</Name>"));
+        assertThat(nextMarker(page2), is(""));
+    }
+
+    @Test
     void rangeRequestReturnsPartialContent() {
         given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
         given()
@@ -298,5 +342,11 @@ public class BlobServiceTest {
             .when().get("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB)
             .then()
             .statusCode(416);
+    }
+
+    private static String nextMarker(String response) {
+        Matcher matcher = Pattern.compile("<NextMarker>(.*?)</NextMarker>").matcher(response);
+        assertThat(matcher.find(), is(true));
+        return matcher.group(1);
     }
 }


### PR DESCRIPTION
## Summary

Closes #85

Honor `maxresults` and `marker` when listing blobs so clients can page through large containers.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

Verified `List Blobs` with `maxresults=2` and a returned marker against Azure Blob Storage using `x-ms-version: 2023-11-03`. Azure returns two blobs and a non-empty `NextMarker` on the first page, then the remaining blob with an empty `NextMarker` on the second page; Floci now supports the same paging flow.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
