### PR TITLE
fix: route dfs blob requests

### DIFF
--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -35,6 +35,10 @@
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>
+            <artifactId>azure-storage-file-datalake</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.azure</groupId>
             <artifactId>azure-storage-queue</artifactId>
         </dependency>
         <dependency>

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/DataLakeCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/DataLakeCompatibilityTest.java
@@ -1,0 +1,48 @@
+package io.floci.az.compat;
+
+import com.azure.storage.common.StorageSharedKeyCredential;
+import com.azure.storage.file.datalake.DataLakeFileClient;
+import com.azure.storage.file.datalake.DataLakeFileSystemClient;
+import com.azure.storage.file.datalake.DataLakeServiceClient;
+import com.azure.storage.file.datalake.DataLakeServiceClientBuilder;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("Data Lake Storage Compatibility")
+class DataLakeCompatibilityTest {
+
+    private DataLakeServiceClient client;
+
+    @BeforeAll
+    void setup() {
+        EmulatorConfig.assumeEmulatorRunning();
+        client = new DataLakeServiceClientBuilder()
+                .endpoint(EmulatorConfig.httpBase())
+                .credential(new StorageSharedKeyCredential(EmulatorConfig.ACCOUNT, EmulatorConfig.DEV_KEY))
+                .addPolicy((context, next) -> {
+                    context.getHttpRequest().setHeader("Host", EmulatorConfig.ACCOUNT + ".dfs.core.windows.net");
+                    return next.process();
+                })
+                .buildClient();
+    }
+
+    @Test
+    @DisplayName("file create: creates path through dfs endpoint")
+    void fileCreateUsesDfsEndpoint() {
+        String name = "test-" + UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+        DataLakeFileSystemClient fileSystem = client.createFileSystem(name);
+
+        DataLakeFileClient file = fileSystem.createFile("dir/file.txt");
+
+        assertTrue(file.exists());
+
+        client.deleteFileSystem(name);
+    }
+}

--- a/src/main/java/io/floci/az/core/AzureRoutingFilter.java
+++ b/src/main/java/io/floci/az/core/AzureRoutingFilter.java
@@ -159,6 +159,25 @@ public class AzureRoutingFilter {
             }
         }
 
+        if (hostOnly != null && hostOnly.endsWith(".dfs.core.windows.net")) {
+            String blobAccount = hostOnly.substring(0, hostOnly.length() - ".dfs.core.windows.net".length());
+            Map<String, String> blobQueryParams = new HashMap<>();
+            requestContext.getUriInfo().getQueryParameters().forEach((k, v) -> blobQueryParams.put(k, v.get(0)));
+            AzureRequest blobRequest = new AzureRequest(
+                requestContext.getMethod(), blobAccount, "blob",
+                path, headers, requestContext.getEntityStream(), blobQueryParams, null, secure);
+            AuthContext blobAuth = authPipeline.resolve(blobRequest);
+            blobRequest = new AzureRequest(
+                requestContext.getMethod(), blobAccount, "blob",
+                path, headers, requestContext.getEntityStream(), blobQueryParams, blobAuth, secure);
+            Optional<AzureServiceHandler> blobHandler = serviceRegistry.resolve("blob");
+            if (blobHandler.isPresent()) {
+                LOGGER.infof("Dispatching dfs.core.windows.net request to BlobServiceHandler: %s %s (account=%s)",
+                    requestContext.getMethod(), path, blobAccount);
+                return blobHandler.get().handle(blobRequest);
+            }
+        }
+
         // Queue Storage: {account}.queue.core.windows.net
         if (hostOnly != null && hostOnly.endsWith(".queue.core.windows.net")) {
             String queueAccount = hostOnly.substring(0, hostOnly.length() - ".queue.core.windows.net".length());

--- a/src/test/java/io/floci/az/services/BlobServiceTest.java
+++ b/src/test/java/io/floci/az/services/BlobServiceTest.java
@@ -61,6 +61,25 @@ public class BlobServiceTest {
     }
 
     @Test
+    void createDfsFile() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("x-ms-version", "2023-11-03")
+            .when().put("/{container}/dir/file.txt?resource=file", CONTAINER)
+            .then()
+            .statusCode(201)
+            .header("x-ms-request-server-encrypted", "true");
+
+        given()
+            .when().get("/{account}/{container}/dir/file.txt", ACCOUNT, CONTAINER)
+            .then()
+            .statusCode(200)
+            .body(equalTo(""));
+    }
+
+    @Test
     void setAndGetBlobMetadata() {
         given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
         given()


### PR DESCRIPTION
## Summary

Closes #87

Route `*.dfs.core.windows.net` storage requests with the account from the host so ADLS Path Create can create files in the requested filesystem.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

Verified `Path Create` for a file against Azure Blob Storage / Data Lake Storage Gen2 using `x-ms-version: 2023-11-03`. Azure returns `201 Created` with an empty body for `PUT /{filesystem}/dir/file.txt?resource=file`; Floci now routes the same DFS host form to the correct account and filesystem path.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
