### PR TITLE
fix: reject expired blob sas

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/BlobCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/BlobCompatibilityTest.java
@@ -1,6 +1,7 @@
 package io.floci.az.compat;
 
 import com.azure.storage.blob.BlobClient;
+import com.azure.storage.blob.BlobClientBuilder;
 import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
@@ -135,6 +136,27 @@ class BlobCompatibilityTest {
             () -> blob.downloadContent());
         assertEquals(BlobErrorCode.BLOB_NOT_FOUND, ex.getErrorCode());
         assertEquals(404, ex.getStatusCode());
+
+        client.deleteBlobContainer(name);
+    }
+
+    @Test
+    @DisplayName("expired blob SAS: rejects request")
+    void expiredBlobSasRejectsRequest() {
+        String name = containerName();
+        BlobContainerClient container = client.createBlobContainer(name);
+        BlobClient blob = container.getBlobClient("sas.txt");
+
+        byte[] content = "sas".getBytes(StandardCharsets.UTF_8);
+        blob.upload(new java.io.ByteArrayInputStream(content), content.length, true);
+
+        BlobClient sasBlob = new BlobClientBuilder()
+                .endpoint(EmulatorConfig.httpBase() + "/" + EmulatorConfig.ACCOUNT + "/" + name
+                        + "/sas.txt?sv=2023-11-03&sr=b&sp=r&se=2020-01-01T00%3A00%3A00Z&sig=expired")
+                .buildClient();
+        BlobStorageException ex = assertThrows(BlobStorageException.class, sasBlob::downloadContent);
+        assertEquals(BlobErrorCode.AUTHENTICATION_FAILED, ex.getErrorCode());
+        assertEquals(403, ex.getStatusCode());
 
         client.deleteBlobContainer(name);
     }

--- a/src/main/java/io/floci/az/core/auth/SasTokenParser.java
+++ b/src/main/java/io/floci/az/core/auth/SasTokenParser.java
@@ -4,6 +4,12 @@ import io.floci.az.core.AuthContext;
 import io.floci.az.core.AuthType;
 import io.floci.az.core.AzureRequest;
 import jakarta.enterprise.context.ApplicationScoped;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.Optional;
 
 @ApplicationScoped
@@ -11,6 +17,18 @@ public class SasTokenParser implements AuthVerifier {
     @Override
     public Optional<AuthContext> verify(AzureRequest request) {
         if (request.queryParams().containsKey("sig") && request.queryParams().containsKey("sv")) {
+            String signedExpiry = request.queryParams().get("se");
+            if (signedExpiry != null) {
+                try {
+                    String decodedExpiry = URLDecoder.decode(signedExpiry, StandardCharsets.UTF_8);
+                    Instant expiry = OffsetDateTime.parse(decodedExpiry).toInstant();
+                    if (!expiry.isAfter(Instant.now())) {
+                        return Optional.of(new AuthContext(request.accountName(), AuthType.SAS, false));
+                    }
+                } catch (DateTimeParseException e) {
+                    return Optional.of(new AuthContext(request.accountName(), AuthType.SAS, false));
+                }
+            }
             // Accept any sig in dev mode
             return Optional.of(new AuthContext(request.accountName(), AuthType.SAS, true));
         }

--- a/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
+++ b/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
@@ -72,7 +72,12 @@ public class BlobServiceHandler implements AzureServiceHandler {
         LOGGER.infof("BlobService handling: %s %s", method, path);
 
         Response response;
-        if (path.isEmpty() || path.equals("/")) {
+        if (request.authContext() != null && !request.authContext().isValid()) {
+            response = new AzureErrorResponse("AuthenticationFailed",
+                    "Server failed to authenticate the request. Make sure the value of Authorization header "
+                            + "is formed correctly including the signature.")
+                    .toXmlResponse(Response.Status.FORBIDDEN.getStatusCode());
+        } else if (path.isEmpty() || path.equals("/")) {
             if ("GET".equalsIgnoreCase(method) && "list".equals(query.get("comp"))) {
                 response = listContainers(request);
             } else if ("service".equals(query.get("restype")) && "properties".equals(query.get("comp"))) {

--- a/src/test/java/io/floci/az/services/BlobServiceTest.java
+++ b/src/test/java/io/floci/az/services/BlobServiceTest.java
@@ -80,6 +80,23 @@ public class BlobServiceTest {
     }
 
     @Test
+    void expiredSasReturnsAuthenticationFailed() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        given()
+            .header("x-ms-blob-type", "BlockBlob")
+            .body(BLOB_CONTENT)
+            .put("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB);
+
+        given()
+            .when().get("/{account}/{container}/{blob}?se=2000-01-01T00%3A00Z&sp=r&sv=2026-04-06&sr=b&sig=ignored",
+                    ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(403)
+            .header("x-ms-error-code", "AuthenticationFailed")
+            .body(containsString("AuthenticationFailed"));
+    }
+
+    @Test
     void setAndGetBlobMetadata() {
         given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
         given()


### PR DESCRIPTION
## Summary

Closes #89

Reject blob SAS requests when the signed expiry time has passed instead of serving the blob.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

Verified `Get Blob` with an expired service SAS against Azure Blob Storage. Azure returns `403 AuthenticationFailed` when `se` is before the request time; Floci now returns the same error for expired blob SAS requests.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
