### PR TITLE
fix(banner): list Monitor and Email in the startup banner

### DIFF
--- a/src/main/java/io/floci/az/core/BannerLogger.java
+++ b/src/main/java/io/floci/az/core/BannerLogger.java
@@ -130,6 +130,12 @@ public class BannerLogger {
         if (config.services().eventGrid().enabled()) {
             sb.append(serviceStatus("eventgrid", true, getStorageMode("eventgrid")));
         }
+        if (config.services().monitor().enabled()) {
+            sb.append(serviceStatus("monitor", true, getStorageMode("monitor")));
+        }
+        if (config.services().email().enabled()) {
+            sb.append(String.format("   %-9s [%s]  %s\n", "email", "enabled ", "ACS Email (captured in-memory; no delivery)"));
+        }
         LOGGER.info(sb.toString());
         LOGGER.info("=== Local Azure Emulator Ready ===");
     }


### PR DESCRIPTION
## Summary

The **Monitor** (`Microsoft.OperationalInsights` / `Microsoft.Insights`) and **Email** (`Microsoft.Communication`) service handlers are enabled by default, but `BannerLogger` never listed them in its "Enabled Services" output. Per the CLAUDE.md rule to keep `BannerLogger` in sync with user-visible services, this adds them.

## Changes

- `BannerLogger` now appends a `monitor` line (with storage mode) and an `email` line (in-memory capture, no delivery) when each service is enabled.

Compiles clean (`./mvnw compile`). Docs for these two services are in a separate PR (#91).