### PR TITLE
fix: make PostgreSQL data plane reachable on a shared Docker network (+ compat test)

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,7 +624,7 @@ The [`compatibility-tests`](./compatibility-tests/) directory validates Floci AZ
 | Module              | Language / Tool | Coverage                                                                                                                       | Tests |
 |---------------------|-----------------|--------------------------------------------------------------------------------------------------------------------------------|------:|
 | `sdk-test-python`   | Python 3        | Blob, Queue, Table, Cosmos, App Configuration, Key Vault, ACR, Redis                                                            |   124 |
-| `sdk-test-java`     | Java 21         | Storage, Cosmos (+ Mongo/PostgreSQL/Cassandra/Gremlin/Table/NoSQL engines), App Config, Key Vault, Event Hubs, Service Bus, Functions, API Management, SQL | 242 |
+| `sdk-test-java`     | Java 21         | Storage, Cosmos (+ Mongo/PostgreSQL/Cassandra/Gremlin/Table/NoSQL engines), App Config, Key Vault, Event Hubs, Service Bus, Functions, API Management, SQL, PostgreSQL (Flexible Server) | 252 |
 | `sdk-test-node`     | Node.js         | App Configuration, Blob, Cosmos, Event Hubs, Key Vault, Queue, Table                                                            |    72 |
 | `compat-terraform`  | Terraform       | `azurerm` provider apply/destroy (resource group, storage, key vault, VNet, VM, Redis, ACR)                                     |    12 |
 | `compat-opentofu`   | OpenTofu        | Same `azurerm` suite via `tofu`, plus PostgreSQL Flexible Server (server + database)                                            |    14 |

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/PostgresCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/PostgresCompatibilityTest.java
@@ -95,6 +95,10 @@ class PostgresCompatibilityTest {
         assertNotNull(defaultJdbcUrl, "jdbcUrl missing from /connect response");
         // Derive the app-database URL from the default (.../postgres?...  ->  .../compat_db?...).
         appJdbcUrl = defaultJdbcUrl.replace("/postgres?", "/" + DB + "?");
+        // Fail loudly if the replace did not match (e.g. the connection-string format changed),
+        // rather than silently running the DDL/DML test against the default `postgres` database.
+        assertNotEquals(defaultJdbcUrl, appJdbcUrl,
+            "app JDBC URL derivation failed — '/postgres?' pattern not found in: " + defaultJdbcUrl);
     }
 
     @AfterAll

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/PostgresCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/PostgresCompatibilityTest.java
@@ -1,0 +1,357 @@
+package io.floci.az.compat;
+
+import org.junit.jupiter.api.*;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.sql.*;
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Integration tests for the Azure Database for PostgreSQL (Flexible Server) emulation layer.
+ *
+ * <p>Requires:
+ * <ul>
+ *   <li>floci-az emulator running (default: http://localhost:4577)</li>
+ *   <li>Docker available so floci-az can start PostgreSQL containers</li>
+ * </ul>
+ *
+ * <p>Unlike Azure SQL there is no EULA — the {@code postgres} image is PostgreSQL-licensed.
+ *
+ * <p>Run selectively (Docker needed):
+ * <pre>
+ *   mvn test -Dtest=PostgresCompatibilityTest -pl compatibility-tests/sdk-test-java
+ * </pre>
+ */
+@DisplayName("PostgreSQL Flexible Server compatibility")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class PostgresCompatibilityTest {
+
+    // ── Config ────────────────────────────────────────────────────────────────
+
+    private static final String BASE =
+        System.getenv().getOrDefault("FLOCI_AZ_ENDPOINT", "http://localhost:4577");
+
+    private static final String SUB    = "compat-sub-001";
+    private static final String RG     = "compat-rg";
+    private static final String SERVER = "compat-pg-server";
+    private static final String DB     = "compat_db";
+    private static final String LOGIN  = "psqladmin";
+    private static final String PWD    = "FlociAz_Strong123!";
+
+    private static final String ARM_BASE =
+        BASE + "/subscriptions/" + SUB + "/resourceGroups/" + RG + "/providers/Microsoft.DBforPostgreSQL";
+    private static final String API = "?api-version=2024-08-01";
+
+    // ── Shared state populated by @BeforeAll ──────────────────────────────────
+
+    /** JDBC URL for the server's default {@code postgres} database. */
+    private static String defaultJdbcUrl;
+    /** JDBC URL for {@value #DB}, derived from the default URL. */
+    private static volatile String appJdbcUrl;
+
+    private static HttpClient http;
+
+    // ── Lifecycle ─────────────────────────────────────────────────────────────
+
+    @BeforeAll
+    @Timeout(value = 10, unit = java.util.concurrent.TimeUnit.MINUTES)
+    static void createServer() throws Exception {
+        EmulatorConfig.assumeEmulatorRunning();
+
+        http = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(5))
+            .build();
+
+        send("POST", BASE + "/_admin/reset", null);
+
+        String serverBody = String.format(
+            "{\"location\":\"eastus\","
+            + "\"sku\":{\"name\":\"Standard_B1ms\",\"tier\":\"Burstable\"},"
+            + "\"properties\":{"
+            + "\"administratorLogin\":\"%s\","
+            + "\"administratorLoginPassword\":\"%s\","
+            + "\"version\":\"16\","
+            + "\"storage\":{\"storageSizeGB\":32}}}",
+            LOGIN, PWD);
+
+        // Allow up to 5 minutes: first-time image pull (postgres:17-alpine) + container start.
+        HttpResponse<String> resp = send("PUT",
+            ARM_BASE + "/flexibleServers/" + SERVER + API, serverBody, Duration.ofMinutes(5));
+
+        assertTrue(resp.statusCode() == 200 || resp.statusCode() == 201,
+            "PUT server failed (" + resp.statusCode() + "): " + resp.body());
+
+        HttpResponse<String> connectResp = send("GET",
+            BASE + "/devstoreaccount1-postgres/flexibleServers/" + SERVER + "/connect", null);
+        assertEquals(200, connectResp.statusCode(), "/connect failed: " + connectResp.body());
+
+        defaultJdbcUrl = extractField(connectResp.body(), "jdbcUrl");
+        assertNotNull(defaultJdbcUrl, "jdbcUrl missing from /connect response");
+        // Derive the app-database URL from the default (.../postgres?...  ->  .../compat_db?...).
+        appJdbcUrl = defaultJdbcUrl.replace("/postgres?", "/" + DB + "?");
+    }
+
+    @AfterAll
+    static void deleteServer() throws Exception {
+        if (http == null) return;
+        try {
+            send("DELETE", ARM_BASE + "/flexibleServers/" + SERVER + API, null);
+        } catch (Exception ignored) {
+            // best-effort cleanup
+        }
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    @Test
+    @Order(10)
+    @DisplayName("GET server returns 200 with expected properties")
+    void getServer() throws Exception {
+        HttpResponse<String> resp = send("GET",
+            ARM_BASE + "/flexibleServers/" + SERVER + API, null);
+        assertEquals(200, resp.statusCode());
+
+        String body = resp.body();
+        assertTrue(body.contains("\"name\":\"" + SERVER + "\""), "server name in response");
+        assertTrue(body.contains("\"administratorLogin\":\"" + LOGIN + "\""), "login in response");
+        assertTrue(body.contains("\"provisioningState\":\"Succeeded\""), "provisioningState=Succeeded");
+        assertTrue(body.contains("fullyQualifiedDomainName"), "fqdn present");
+    }
+
+    @Test
+    @Order(15)
+    @DisplayName("list servers returns server in value array")
+    void listServers() throws Exception {
+        HttpResponse<String> resp = send("GET", ARM_BASE + "/flexibleServers" + API, null);
+        assertEquals(200, resp.statusCode());
+        assertTrue(resp.body().contains(SERVER), "server name in list response");
+    }
+
+    @Test
+    @Order(20)
+    @DisplayName("JDBC connect to the default postgres database succeeds")
+    void jdbcConnectDefault() throws Exception {
+        try (Connection conn = DriverManager.getConnection(defaultJdbcUrl)) {
+            assertFalse(conn.isClosed(), "connection should be open");
+            try (Statement st = conn.createStatement();
+                 ResultSet rs = st.executeQuery("SELECT version()")) {
+                assertTrue(rs.next(), "version() should return a row");
+                String version = rs.getString(1);
+                assertNotNull(version);
+                assertTrue(version.contains("PostgreSQL"), "version() should mention PostgreSQL: " + version);
+            }
+        }
+    }
+
+    @Test
+    @Order(30)
+    @DisplayName("PUT database registers it and returns 200/201")
+    void createDatabase() throws Exception {
+        String dbBody = "{\"properties\":{\"charset\":\"UTF8\",\"collation\":\"en_US.utf8\"}}";
+
+        HttpResponse<String> resp = send("PUT",
+            ARM_BASE + "/flexibleServers/" + SERVER + "/databases/" + DB + API,
+            dbBody, Duration.ofSeconds(60));
+        assertTrue(resp.statusCode() == 200 || resp.statusCode() == 201,
+            "PUT database failed (" + resp.statusCode() + "): " + resp.body());
+        assertTrue(resp.body().contains("\"name\":\"" + DB + "\""), "db name in response");
+    }
+
+    @Test
+    @Order(40)
+    @DisplayName("JDBC: CREATE DATABASE then run DDL/DML against it")
+    void jdbcDdlAndDml() throws Exception {
+        assumeTrue(appJdbcUrl != null, "server setup did not complete — skipping");
+
+        // The emulator registers the database in state but does NOT execute CREATE DATABASE
+        // inside the container — that is the application's responsibility (Flyway, Liquibase,
+        // migrations, etc.). We create it here to simulate what a migration tool would do.
+        // CREATE DATABASE cannot run while connected to the target db, so use the default one.
+        try (Connection admin = DriverManager.getConnection(defaultJdbcUrl)) {
+            admin.setAutoCommit(true);
+            boolean exists;
+            try (Statement st = admin.createStatement();
+                 ResultSet rs = st.executeQuery("SELECT 1 FROM pg_database WHERE datname = '" + DB + "'")) {
+                exists = rs.next();
+            }
+            if (!exists) {
+                try (Statement st = admin.createStatement()) {
+                    st.execute("CREATE DATABASE " + DB);
+                }
+            }
+        }
+
+        try (Connection conn = DriverManager.getConnection(appJdbcUrl)) {
+            try (Statement st = conn.createStatement()) {
+                st.executeUpdate(
+                    "CREATE TABLE compat_test ("
+                    + "  id   INT PRIMARY KEY,"
+                    + "  name VARCHAR(100) NOT NULL,"
+                    + "  val  DOUBLE PRECISION"
+                    + ")");
+            }
+
+            try (PreparedStatement ps = conn.prepareStatement(
+                    "INSERT INTO compat_test (id, name, val) VALUES (?,?,?)")) {
+                ps.setInt(1, 1); ps.setString(2, "alpha"); ps.setDouble(3, 1.1); ps.addBatch();
+                ps.setInt(1, 2); ps.setString(2, "beta");  ps.setDouble(3, 2.2); ps.addBatch();
+                ps.setInt(1, 3); ps.setString(2, "gamma"); ps.setDouble(3, 3.3); ps.addBatch();
+                ps.executeBatch();
+            }
+
+            try (Statement st = conn.createStatement();
+                 ResultSet rs = st.executeQuery("SELECT id, name, val FROM compat_test ORDER BY id")) {
+                assertTrue(rs.next()); assertEquals(1, rs.getInt("id")); assertEquals("alpha", rs.getString("name"));
+                assertTrue(rs.next()); assertEquals(2, rs.getInt("id")); assertEquals("beta",  rs.getString("name"));
+                assertTrue(rs.next()); assertEquals(3, rs.getInt("id")); assertEquals("gamma", rs.getString("name"));
+                assertFalse(rs.next(), "should be exactly 3 rows");
+            }
+
+            try (PreparedStatement ps = conn.prepareStatement(
+                    "UPDATE compat_test SET val = ? WHERE id = ?")) {
+                ps.setDouble(1, 99.9); ps.setInt(2, 2);
+                assertEquals(1, ps.executeUpdate());
+            }
+
+            try (Statement st = conn.createStatement();
+                 ResultSet rs = st.executeQuery("SELECT val FROM compat_test WHERE id = 2")) {
+                assertTrue(rs.next());
+                assertEquals(99.9, rs.getDouble("val"), 0.001);
+            }
+
+            try (Statement st = conn.createStatement()) {
+                st.executeUpdate("DROP TABLE compat_test");
+            }
+        }
+    }
+
+    @Test
+    @Order(50)
+    @DisplayName("checkNameAvailability — used server name is unavailable")
+    void checkNameUnavailable() throws Exception {
+        String body = "{\"name\":\"" + SERVER + "\",\"type\":\"Microsoft.DBforPostgreSQL/flexibleServers\"}";
+        HttpResponse<String> resp = send("POST",
+            BASE + "/subscriptions/" + SUB
+            + "/providers/Microsoft.DBforPostgreSQL/locations/eastus/checkNameAvailability" + API,
+            body);
+        assertEquals(200, resp.statusCode());
+        assertTrue(resp.body().contains("\"nameAvailable\":false"),
+            "name should be unavailable: " + resp.body());
+    }
+
+    @Test
+    @Order(55)
+    @DisplayName("Firewall rule CRUD on a real server")
+    void firewallRuleCrud() throws Exception {
+        String ruleName = "AllowLocal";
+        String ruleBody = "{\"properties\":{\"startIpAddress\":\"0.0.0.0\",\"endIpAddress\":\"255.255.255.255\"}}";
+        String ruleUrl = ARM_BASE + "/flexibleServers/" + SERVER + "/firewallRules/" + ruleName + API;
+
+        HttpResponse<String> putResp = send("PUT", ruleUrl, ruleBody);
+        assertTrue(putResp.statusCode() == 200 || putResp.statusCode() == 201,
+            "PUT firewall rule: " + putResp.body());
+
+        HttpResponse<String> getResp = send("GET", ruleUrl, null);
+        assertEquals(200, getResp.statusCode());
+        assertTrue(getResp.body().contains("\"0.0.0.0\""), "startIpAddress in GET response");
+
+        HttpResponse<String> listResp = send("GET",
+            ARM_BASE + "/flexibleServers/" + SERVER + "/firewallRules" + API, null);
+        assertEquals(200, listResp.statusCode());
+        assertTrue(listResp.body().contains(ruleName), "rule name in list");
+
+        HttpResponse<String> delResp = send("DELETE", ruleUrl, null);
+        assertEquals(204, delResp.statusCode());
+
+        HttpResponse<String> getAfter = send("GET", ruleUrl, null);
+        assertEquals(404, getAfter.statusCode());
+    }
+
+    @Test
+    @Order(60)
+    @DisplayName("Configuration put/get round-trips a server parameter")
+    void configurationRoundTrip() throws Exception {
+        String cfgUrl = ARM_BASE + "/flexibleServers/" + SERVER + "/configurations/max_connections" + API;
+
+        HttpResponse<String> putResp = send("PUT", cfgUrl,
+            "{\"properties\":{\"value\":\"200\",\"source\":\"user-override\"}}");
+        assertEquals(200, putResp.statusCode(), "PUT configuration: " + putResp.body());
+
+        HttpResponse<String> getResp = send("GET", cfgUrl, null);
+        assertEquals(200, getResp.statusCode());
+        assertTrue(getResp.body().contains("\"value\":\"200\""), "configuration value persisted");
+    }
+
+    @Test
+    @Order(70)
+    @DisplayName("DELETE app database removes it from server")
+    void deleteDatabase() throws Exception {
+        HttpResponse<String> resp = send("DELETE",
+            ARM_BASE + "/flexibleServers/" + SERVER + "/databases/" + DB + API, null);
+        assertEquals(204, resp.statusCode(), "DELETE database: " + resp.body());
+
+        HttpResponse<String> getResp = send("GET",
+            ARM_BASE + "/flexibleServers/" + SERVER + "/databases/" + DB + API, null);
+        assertEquals(404, getResp.statusCode());
+    }
+
+    @Test
+    @Order(80)
+    @DisplayName("_admin/reset wipes all PostgreSQL state and frees the server name")
+    void adminResetClearsState() throws Exception {
+        HttpResponse<String> before = send("GET", ARM_BASE + "/flexibleServers/" + SERVER + API, null);
+        assertEquals(200, before.statusCode(), "Server should exist before reset: " + before.body());
+
+        HttpResponse<String> resetResp = send("POST", BASE + "/_admin/reset", null);
+        assertEquals(204, resetResp.statusCode(), "/_admin/reset should return 204: " + resetResp.body());
+
+        HttpResponse<String> afterServer = send("GET", ARM_BASE + "/flexibleServers/" + SERVER + API, null);
+        assertEquals(404, afterServer.statusCode(), "Server should be gone after reset: " + afterServer.body());
+
+        String checkBody = "{\"name\":\"" + SERVER + "\",\"type\":\"Microsoft.DBforPostgreSQL/flexibleServers\"}";
+        HttpResponse<String> checkResp = send("POST",
+            BASE + "/subscriptions/" + SUB
+            + "/providers/Microsoft.DBforPostgreSQL/locations/eastus/checkNameAvailability" + API,
+            checkBody);
+        assertEquals(200, checkResp.statusCode());
+        assertTrue(checkResp.body().contains("\"nameAvailable\":true"),
+            "Name should be available again after reset: " + checkResp.body());
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static HttpResponse<String> send(String method, String url, String jsonBody) throws Exception {
+        return send(method, url, jsonBody, Duration.ofSeconds(10));
+    }
+
+    private static HttpResponse<String> send(String method, String url, String jsonBody,
+                                             Duration timeout) throws Exception {
+        HttpRequest.Builder builder = HttpRequest.newBuilder()
+            .uri(URI.create(url))
+            .timeout(timeout);
+
+        if (jsonBody != null) {
+            builder.header("Content-Type", "application/json")
+                   .method(method, HttpRequest.BodyPublishers.ofString(jsonBody));
+        } else {
+            builder.method(method, HttpRequest.BodyPublishers.noBody());
+        }
+        return http.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+    }
+
+    private static String extractField(String json, String field) {
+        String needle = "\"" + field + "\":\"";
+        int start = json.indexOf(needle);
+        if (start < 0) return null;
+        start += needle.length();
+        int end = json.indexOf("\"", start);
+        if (end < 0) return null;
+        return json.substring(start, end).replace("\\/", "/");
+    }
+}

--- a/src/main/java/io/floci/az/services/postgres/PostgresHandler.java
+++ b/src/main/java/io/floci/az/services/postgres/PostgresHandler.java
@@ -180,7 +180,7 @@ public class PostgresHandler implements AzureServiceHandler {
                 PostgresState.ServerEntry entry = new PostgresState.ServerEntry(
                     serverName, sub, rg, location, version, login, password,
                     skuName, skuTier, storageGB,
-                    null, 0, tags,
+                    null, 0, "localhost", tags,
                     new ConcurrentHashMap<>(), new ConcurrentHashMap<>(), new ConcurrentHashMap<>(),
                     Instant.now());
                 state.putServer(entry);
@@ -225,7 +225,7 @@ public class PostgresHandler implements AzureServiceHandler {
                 existing.location(), version, existing.administratorLogin(),
                 password.isBlank() ? existing.administratorLoginPassword() : password,
                 skuName, skuTier, storageGB,
-                existing.containerId(), existing.hostPort(), mergedTags,
+                existing.containerId(), existing.hostPort(), existing.host(), mergedTags,
                 existing.databases(), existing.firewallRules(), existing.configurations(),
                 existing.createdAt());
             state.putServer(updated);

--- a/src/main/java/io/floci/az/services/postgres/PostgresHandler.java
+++ b/src/main/java/io/floci/az/services/postgres/PostgresHandler.java
@@ -447,7 +447,9 @@ public class PostgresHandler implements AzureServiceHandler {
         props.put("provisioningState", ready ? "Succeeded" : "Creating");
         props.put("storage", Map.of("storageSizeGB", s.storageSizeGB()));
         props.put("network", Map.of("publicNetworkAccess", "Enabled"));
-        // floci-az convenience — not in the real spec
+        // floci-az convenience — not in the real spec. This is the reachable port (the published
+        // host port for host networking, or the in-network container port when floci-az runs in a
+        // container). Prefer the /connect endpoint, which returns the matching reachable host.
         if (s.hostPort() > 0) props.put("localPort", s.hostPort());
 
         Map<String, Object> resp = new LinkedHashMap<>();

--- a/src/main/java/io/floci/az/services/postgres/PostgresServerManager.java
+++ b/src/main/java/io/floci/az/services/postgres/PostgresServerManager.java
@@ -2,6 +2,7 @@ package io.floci.az.services.postgres;
 
 import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.docker.ContainerBuilder;
+import io.floci.az.core.docker.ContainerDetector;
 import io.floci.az.core.docker.ContainerLifecycleManager;
 import io.floci.az.core.docker.ContainerSpec;
 import jakarta.annotation.PreDestroy;
@@ -40,6 +41,7 @@ public class PostgresServerManager {
     @Inject EmulatorConfig config;
     @Inject ContainerLifecycleManager containerManager;
     @Inject ContainerBuilder containerBuilder;
+    @Inject ContainerDetector containerDetector;
 
     /** containerId → container name, for cleanup on shutdown. */
     private final ConcurrentHashMap<String, String> managedContainers = new ConcurrentHashMap<>();
@@ -63,7 +65,8 @@ public class PostgresServerManager {
 
         ContainerSpec spec = containerBuilder.newContainer(image)
             .withName(containerName)
-            .withDynamicPort(PG_CONTAINER_PORT)   // OS picks host port
+            .withDynamicPort(PG_CONTAINER_PORT)   // OS picks host port (used for host networking)
+            .withDockerNetwork(config.services().dockerNetwork())  // join the shared network when running in Docker
             .withEnv("POSTGRES_USER", entry.administratorLogin())
             .withEnv("POSTGRES_PASSWORD", entry.administratorLoginPassword())
             .withEnv("POSTGRES_DB", "postgres")
@@ -78,14 +81,28 @@ public class PostgresServerManager {
             .orElseThrow(() -> new RuntimeException(
                 "Could not resolve host port for PostgreSQL container " + containerName));
 
+        // Pick the address an application can actually reach (mirrors RedisCacheManager):
+        // when floci-az runs inside a container, clients on the shared Docker network reach the
+        // sidecar by its container name on the container port; otherwise via localhost:hostPort.
+        String reachableHost;
+        int reachablePort;
+        if (containerDetector.isRunningInContainer()) {
+            reachableHost = containerName;
+            reachablePort = PG_CONTAINER_PORT;
+        } else {
+            reachableHost = "localhost";
+            reachablePort = hostPort;
+        }
+
         managedContainers.put(containerId, containerName);
-        LOG.infof("PostgreSQL container started: server=%s containerId=%s port=%d",
-            entry.serverName(), containerId, hostPort);
+        LOG.infof("PostgreSQL container started: server=%s containerId=%s endpoint=%s:%d",
+            entry.serverName(), containerId, reachableHost, reachablePort);
 
-        waitForReady(hostPort, pgConfig.startupTimeoutSeconds());
-        LOG.infof("PostgreSQL server ready: server=%s port=%d", entry.serverName(), hostPort);
+        waitForReady(reachableHost, reachablePort, pgConfig.startupTimeoutSeconds());
+        LOG.infof("PostgreSQL server ready: server=%s endpoint=%s:%d",
+            entry.serverName(), reachableHost, reachablePort);
 
-        return entry.withContainer(containerId, hostPort);
+        return entry.withContainer(containerId, reachablePort, reachableHost);
     }
 
     /**
@@ -109,14 +126,14 @@ public class PostgresServerManager {
      * first-boot init phase; a short post-TCP sleep covers that window without requiring
      * a JDBC/libpq driver on the main runtime classpath. Clients use their own retry logic.
      */
-    private void waitForReady(int port, int timeoutSeconds) {
-        LOG.infof("Waiting for PostgreSQL to be ready on port %d (timeout=%ds)…", port, timeoutSeconds);
+    private void waitForReady(String host, int port, int timeoutSeconds) {
+        LOG.infof("Waiting for PostgreSQL to be ready on %s:%d (timeout=%ds)…", host, port, timeoutSeconds);
         long deadline = System.currentTimeMillis() + (long) timeoutSeconds * 1000;
 
         // Phase 1 — wait for the port to accept TCP connections
         while (System.currentTimeMillis() < deadline) {
-            try (Socket s = new Socket("localhost", port)) {
-                LOG.infof("PostgreSQL TCP port %d is open — waiting for engine init…", port);
+            try (Socket s = new Socket(host, port)) {
+                LOG.infof("PostgreSQL TCP %s:%d is open — waiting for engine init…", host, port);
                 break;
             } catch (Exception e) {
                 sleep(1000);
@@ -129,7 +146,7 @@ public class PostgresServerManager {
             sleep(postTcpMs);
         }
 
-        LOG.infof("PostgreSQL ready: port=%d", port);
+        LOG.infof("PostgreSQL ready: %s:%d", host, port);
     }
 
     private static void sleep(long ms) {

--- a/src/main/java/io/floci/az/services/postgres/PostgresState.java
+++ b/src/main/java/io/floci/az/services/postgres/PostgresState.java
@@ -217,7 +217,7 @@ public class PostgresState {
                         e.serverName(), e.subscriptionId(), e.resourceGroupName(),
                         e.location(), e.version(), e.administratorLogin(), e.administratorLoginPassword(),
                         e.skuName(), e.skuTier(), e.storageSizeGB(),
-                        null, 0,   // containerId / hostPort are always reset on load
+                        null, 0, "localhost",   // containerId / hostPort / host are always reset on load
                         new ConcurrentHashMap<>(e.tags() != null ? e.tags() : Map.of()),
                         new ConcurrentHashMap<>(e.databases() != null ? e.databases() : Map.of()),
                         new ConcurrentHashMap<>(e.firewallRules() != null ? e.firewallRules() : Map.of()),
@@ -263,6 +263,7 @@ public class PostgresState {
             int storageSizeGB,
             String containerId,                   // null until container starts; not persisted
             int hostPort,                         // 0 until container starts; not persisted
+            String host,                          // reachable host: "localhost" or the container name on a shared Docker network; not persisted
             Map<String, String> tags,
             Map<String, DatabaseEntry> databases,
             Map<String, FirewallRule> firewallRules,
@@ -275,20 +276,22 @@ public class PostgresState {
                 subscriptionId, resourceGroupName, serverName);
         }
 
-        public ServerEntry withContainer(String id, int port) {
+        public ServerEntry withContainer(String id, int port, String reachableHost) {
             return new ServerEntry(serverName, subscriptionId, resourceGroupName,
                 location, version, administratorLogin, administratorLoginPassword,
                 skuName, skuTier, storageSizeGB,
-                id, port, tags, databases, firewallRules, configurations, createdAt);
+                id, port, reachableHost, tags, databases, firewallRules, configurations, createdAt);
         }
 
         /**
-         * The FQDN as Azure would expose it would be {@code {name}.postgres.database.azure.com},
-         * which does not resolve locally. floci-az returns {@code localhost}; the live host port
-         * is exposed separately (see the convenience {@code /connect} endpoint).
+         * The host an application uses to reach the data plane. Azure would expose
+         * {@code {name}.postgres.database.azure.com}, which does not resolve locally; floci-az
+         * returns the actually-reachable host instead — {@code localhost} for host networking,
+         * or the container name when floci-az runs inside Docker on a shared network. The live
+         * port is exposed separately (see the convenience {@code /connect} endpoint).
          */
         public String fullyQualifiedDomainName() {
-            return "localhost";
+            return host != null && !host.isBlank() ? host : "localhost";
         }
     }
 

--- a/src/test/java/io/floci/az/services/postgres/PostgresStateTest.java
+++ b/src/test/java/io/floci/az/services/postgres/PostgresStateTest.java
@@ -39,7 +39,7 @@ class PostgresStateTest {
             name, sub, rg, "eastus", "16",
             "psqladmin", "StrongPass1!",
             "Standard_B1ms", "Burstable", 32,
-            "container-abc", 54320,
+            "container-abc", 54320, "localhost",
             Map.of(), new ConcurrentHashMap<>(), new ConcurrentHashMap<>(), new ConcurrentHashMap<>(),
             Instant.now());
     }
@@ -186,16 +186,19 @@ class PostgresStateTest {
     @DisplayName("ServerEntry.withContainer updates containerId and port immutably")
     void withContainer() {
         PostgresState.ServerEntry original = server("srv");
-        PostgresState.ServerEntry updated  = original.withContainer("new-container", 54444);
+        PostgresState.ServerEntry updated  = original.withContainer("new-container", 54444, "floci-az-pg-srv");
         assertEquals("new-container", updated.containerId());
         assertEquals(54444, updated.hostPort());
+        assertEquals("floci-az-pg-srv", updated.host());
         assertEquals("container-abc", original.containerId(), "original is immutable");
     }
 
     @Test
-    @DisplayName("fullyQualifiedDomainName is localhost in dev mode")
+    @DisplayName("fullyQualifiedDomainName reflects the reachable host")
     void fqdn() {
         assertEquals("localhost", server("srv").fullyQualifiedDomainName());
+        assertEquals("floci-az-pg-srv",
+            server("srv").withContainer("c", 5432, "floci-az-pg-srv").fullyQualifiedDomainName());
     }
 
     // ── Persistence cycle ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Adds the first **data-plane** compatibility test for the PostgreSQL Flexible Server service
(#80) — and fixes the real bug it surfaced.

`PostgresCompatibilityTest` (in `sdk-test-java`) creates a flexible server via ARM, fetches the
connection string from `/connect`, then connects over JDBC (`org.postgresql`) and exercises the
live data plane: `CREATE DATABASE`, `CREATE TABLE`, batch `INSERT`, `SELECT`, `UPDATE`, `DROP`,
plus `checkNameAvailability`, firewall-rule CRUD, configuration round-trip, and admin-reset.

## The bug it caught

Running in the native compat matrix, the JDBC steps failed with
`Connection to localhost:5432 refused`. Root cause: when floci-az runs **inside a container**
(docker-compose / CI), the postgres sidecar is reachable by other containers via its **name on
the shared Docker network**, not `localhost:<published-port>`. The PostgreSQL service hardcoded
`localhost`, so applications in any networked deployment could not reach the database, and the
readiness probe silently timed out against an unreachable `localhost`. (Azure SQL has the same
limitation, but its compat test is EULA-skipped so it never ran.)

## The fix

Mirror `RedisCacheManager`: attach the container to the configured Docker network, and use
`ContainerDetector` to report the **container name + container port** as the reachable endpoint
when running in a container (otherwise `localhost` + the published port). `/connect`,
`fullyQualifiedDomainName`, and the readiness probe all now use the reachable host.
`ServerEntry` gains a non-persisted `host` field.

## Tests

- New `PostgresCompatibilityTest` (gated on a reachable emulator; runs in the native matrix).
- Existing Postgres unit/handler/state tests updated for the `host` field; full suite green (235).

Net effect: container-backed PostgreSQL now works in docker-compose/CI deployments, not just
with host networking — verified end-to-end by the new test.