### PR TITLE
fix: make Azure SQL data plane reachable on a shared Docker network

### DIFF
--- a/src/main/java/io/floci/az/services/sql/SqlHandler.java
+++ b/src/main/java/io/floci/az/services/sql/SqlHandler.java
@@ -183,7 +183,7 @@ public class SqlHandler implements AzureServiceHandler {
                 var firewallRules = new java.util.concurrent.ConcurrentHashMap<String, SqlState.SqlFirewallRule>();
                 entry = new SqlState.SqlServerEntry(
                     serverName, sub, rg, location, login, password,
-                    null, 0, tags, databases, firewallRules, Instant.now());
+                    null, 0, "localhost", tags, databases, firewallRules, Instant.now());
                 state.putServer(entry);
 
                 if (config.services().sql().mocked()) {
@@ -226,7 +226,7 @@ public class SqlHandler implements AzureServiceHandler {
                 state.putServer(new SqlState.SqlServerEntry(
                     serverName, sub, rg, location, login,
                     password.isBlank() ? entry.administratorLoginPassword() : password,
-                    entry.containerId(), entry.hostPort(), tags,
+                    entry.containerId(), entry.hostPort(), entry.host(), tags,
                     entry.databases(), entry.firewallRules(), entry.createdAt()));
                 entry = state.getServer(serverName).get();
             }

--- a/src/main/java/io/floci/az/services/sql/SqlHandler.java
+++ b/src/main/java/io/floci/az/services/sql/SqlHandler.java
@@ -438,7 +438,9 @@ public class SqlHandler implements AzureServiceHandler {
         props.put("fullyQualifiedDomainName", s.fullyQualifiedDomainName());
         props.put("minimalTlsVersion", "None");
         props.put("publicNetworkAccess", "Enabled");
-        // floci-az convenience — not in the real spec
+        // floci-az convenience — not in the real spec. This is the reachable port (the published
+        // host port for host networking, or the in-network container port when floci-az runs in a
+        // container). Prefer the /connect endpoint, which returns the matching reachable host.
         if (s.hostPort() > 0) props.put("localPort", s.hostPort());
 
         Map<String, Object> resp = new LinkedHashMap<>();

--- a/src/main/java/io/floci/az/services/sql/SqlServerManager.java
+++ b/src/main/java/io/floci/az/services/sql/SqlServerManager.java
@@ -2,6 +2,7 @@ package io.floci.az.services.sql;
 
 import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.docker.ContainerBuilder;
+import io.floci.az.core.docker.ContainerDetector;
 import io.floci.az.core.docker.ContainerLifecycleManager;
 import io.floci.az.core.docker.ContainerSpec;
 import jakarta.annotation.PreDestroy;
@@ -37,6 +38,7 @@ public class SqlServerManager {
     @Inject EmulatorConfig config;
     @Inject ContainerLifecycleManager containerManager;
     @Inject ContainerBuilder containerBuilder;
+    @Inject ContainerDetector containerDetector;
 
     /** containerId → container name, for cleanup on shutdown. */
     private final ConcurrentHashMap<String, String> managedContainers = new ConcurrentHashMap<>();
@@ -64,7 +66,8 @@ public class SqlServerManager {
 
         ContainerSpec spec = containerBuilder.newContainer(image)
             .withName(containerName)
-            .withDynamicPort(SQL_CONTAINER_PORT)   // OS picks host port
+            .withDynamicPort(SQL_CONTAINER_PORT)   // OS picks host port (used for host networking)
+            .withDockerNetwork(config.services().dockerNetwork())  // join the shared network when running in Docker
             .withEnv("ACCEPT_EULA", "Y")
             .withEnv("MSSQL_SA_PASSWORD", password)
             .withEnv("SA_PASSWORD", password)       // azure-sql-edge uses SA_PASSWORD
@@ -79,14 +82,27 @@ public class SqlServerManager {
             .orElseThrow(() -> new RuntimeException(
                 "Could not resolve host port for SQL Server container " + containerName));
 
+        // Pick the address an application can actually reach (mirrors RedisCacheManager):
+        // when floci-az runs inside a container, clients on the shared Docker network reach the
+        // sidecar by its container name on the container port; otherwise via localhost:hostPort.
+        String reachableHost;
+        int reachablePort;
+        if (containerDetector.isRunningInContainer()) {
+            reachableHost = containerName;
+            reachablePort = SQL_CONTAINER_PORT;
+        } else {
+            reachableHost = "localhost";
+            reachablePort = hostPort;
+        }
+
         managedContainers.put(containerId, containerName);
-        LOG.infof("SQL Server container started: server=%s containerId=%s port=%d",
-            entry.serverName(), containerId, hostPort);
+        LOG.infof("SQL Server container started: server=%s containerId=%s endpoint=%s:%d",
+            entry.serverName(), containerId, reachableHost, reachablePort);
 
-        waitForReady(hostPort, sqlConfig.startupTimeoutSeconds());
-        LOG.infof("SQL Server ready: server=%s port=%d", entry.serverName(), hostPort);
+        waitForReady(reachableHost, reachablePort, sqlConfig.startupTimeoutSeconds());
+        LOG.infof("SQL Server ready: server=%s endpoint=%s:%d", entry.serverName(), reachableHost, reachablePort);
 
-        return entry.withContainer(containerId, hostPort);
+        return entry.withContainer(containerId, reachablePort, reachableHost);
     }
 
     /**
@@ -121,14 +137,14 @@ public class SqlServerManager {
      * clients.  A brief post-TCP sleep covers the remaining boot window without
      * requiring a JDBC driver on the main runtime classpath.
      */
-    private void waitForReady(int port, int timeoutSeconds) {
-        LOG.infof("Waiting for SQL Server to be ready on port %d (timeout=%ds)…", port, timeoutSeconds);
+    private void waitForReady(String host, int port, int timeoutSeconds) {
+        LOG.infof("Waiting for SQL Server to be ready on %s:%d (timeout=%ds)…", host, port, timeoutSeconds);
         long deadline = System.currentTimeMillis() + (long) timeoutSeconds * 1000;
 
         // Phase 1 — wait for the port to accept TCP connections
         while (System.currentTimeMillis() < deadline) {
-            try (Socket s = new Socket("localhost", port)) {
-                LOG.infof("SQL Server TCP port %d is open — waiting for engine init…", port);
+            try (Socket s = new Socket(host, port)) {
+                LOG.infof("SQL Server TCP %s:%d is open — waiting for engine init…", host, port);
                 break;
             } catch (Exception e) {
                 sleep(1000);
@@ -143,7 +159,7 @@ public class SqlServerManager {
             sleep(postTcpMs);
         }
 
-        LOG.infof("SQL Server ready: port=%d", port);
+        LOG.infof("SQL Server ready: %s:%d", host, port);
     }
 
     private static void sleep(long ms) {

--- a/src/main/java/io/floci/az/services/sql/SqlState.java
+++ b/src/main/java/io/floci/az/services/sql/SqlState.java
@@ -208,7 +208,7 @@ public class SqlState {
                     SqlServerEntry restored = new SqlServerEntry(
                         e.serverName(), e.subscriptionId(), e.resourceGroupName(),
                         e.location(), e.administratorLogin(), e.administratorLoginPassword(),
-                        null, 0,   // containerId / hostPort are always reset on load
+                        null, 0, "localhost",   // containerId / hostPort / host are always reset on load
                         new ConcurrentHashMap<>(e.tags() != null ? e.tags() : Map.of()),
                         new ConcurrentHashMap<>(e.databases() != null ? e.databases() : Map.of()),
                         new ConcurrentHashMap<>(e.firewallRules() != null ? e.firewallRules() : Map.of()),
@@ -249,6 +249,7 @@ public class SqlState {
             String administratorLoginPassword,   // stored, never returned in GET responses
             String containerId,                   // null until container starts; not persisted
             int hostPort,                         // 0 until container starts; not persisted
+            String host,                          // reachable host: "localhost" or the container name on a shared Docker network; not persisted
             Map<String, String> tags,
             Map<String, SqlDatabaseEntry> databases,
             Map<String, SqlFirewallRule> firewallRules,
@@ -260,15 +261,20 @@ public class SqlState {
                 subscriptionId, resourceGroupName, serverName);
         }
 
-        public SqlServerEntry withContainer(String id, int port) {
+        public SqlServerEntry withContainer(String id, int port, String reachableHost) {
             return new SqlServerEntry(serverName, subscriptionId, resourceGroupName,
                 location, administratorLogin, administratorLoginPassword,
-                id, port, tags, databases, firewallRules, createdAt);
+                id, port, reachableHost, tags, databases, firewallRules, createdAt);
         }
 
-        /** Returns the FQDN as Azure would expose it. In local dev this is always localhost. */
+        /**
+         * The host an application uses to reach the data plane. Azure would expose
+         * {@code {name}.database.windows.net}; floci-az returns the actually-reachable host —
+         * {@code localhost} for host networking, or the container name when floci-az runs
+         * inside Docker on a shared network.
+         */
         public String fullyQualifiedDomainName() {
-            return "localhost";
+            return host != null && !host.isBlank() ? host : "localhost";
         }
     }
 

--- a/src/test/java/io/floci/az/services/sql/SqlStateTest.java
+++ b/src/test/java/io/floci/az/services/sql/SqlStateTest.java
@@ -34,7 +34,7 @@ class SqlStateTest {
         return new SqlState.SqlServerEntry(
             name, "sub-001", "rg-test", "eastus",
             "sa", "StrongPass1!",
-            "container-abc", 14330,
+            "container-abc", 14330, "localhost",
             Map.of(), new ConcurrentHashMap<>(), new ConcurrentHashMap<>(), Instant.now());
     }
 
@@ -86,7 +86,7 @@ class SqlStateTest {
         state.putServer(server("b"));
         state.putServer(new SqlState.SqlServerEntry(
             "c", "sub-other", "rg-test", "eastus",
-            "sa", "pass", null, 0, Map.of(),
+            "sa", "pass", null, 0, "localhost", Map.of(),
             new ConcurrentHashMap<>(), new ConcurrentHashMap<>(), Instant.now()));
 
         List<SqlState.SqlServerEntry> result = state.listServersBySubscription("sub-001");
@@ -101,7 +101,7 @@ class SqlStateTest {
         state.putServer(server("x"));
         state.putServer(new SqlState.SqlServerEntry(
             "y", "sub-001", "rg-other", "westus",
-            "sa", "pass", null, 0, Map.of(),
+            "sa", "pass", null, 0, "localhost", Map.of(),
             new ConcurrentHashMap<>(), new ConcurrentHashMap<>(), Instant.now()));
 
         List<SqlState.SqlServerEntry> result =
@@ -213,9 +213,11 @@ class SqlStateTest {
     @DisplayName("SqlServerEntry.withContainer updates containerId and port")
     void withContainer() {
         SqlState.SqlServerEntry original = server("srv");
-        SqlState.SqlServerEntry updated  = original.withContainer("new-container", 14444);
+        SqlState.SqlServerEntry updated  = original.withContainer("new-container", 14444, "floci-az-sql-srv");
         assertEquals("new-container", updated.containerId());
         assertEquals(14444, updated.hostPort());
+        assertEquals("floci-az-sql-srv", updated.host());
+        assertEquals("floci-az-sql-srv", updated.fullyQualifiedDomainName());
         // original is immutable
         assertEquals("container-abc", original.containerId());
     }

--- a/src/test/java/io/floci/az/services/sql/SqlStateTest.java
+++ b/src/test/java/io/floci/az/services/sql/SqlStateTest.java
@@ -240,8 +240,10 @@ class SqlStateTest {
         InMemoryStorage<String, StoredObject> sharedBackend = new InMemoryStorage<>();
         SqlState original = new SqlState(sharedBackend);
 
-        // Populate: server with containerId/hostPort set (as if a container is running)
-        original.putServer(server("persist-srv"));   // containerId="container-abc", hostPort=14330
+        // Populate: server with containerId/hostPort/host set (as if a container is running on a
+        // shared Docker network, so host is the container name rather than localhost).
+        original.putServer(server("persist-srv")
+            .withContainer("container-abc", 14330, "floci-az-sql-persist-srv"));
         original.putDatabase("persist-srv",
             SqlState.SqlDatabaseEntry.create("mydb", "persist-srv",
                 "SQL_Latin1_General_CP1_CI_AS", null, null));
@@ -264,6 +266,8 @@ class SqlStateTest {
             "containerId must be null after reload — container is gone");
         assertEquals(0, entry.get().hostPort(),
             "hostPort must be 0 after reload — container is gone");
+        assertEquals("localhost", entry.get().host(),
+            "host must reset to localhost after reload — the container's network name is gone");
 
         // ── Child resources are fully restored ────────────────────────────────
         assertTrue(reloaded.databaseExists("persist-srv", "mydb"), "database restored");


### PR DESCRIPTION
## Summary

Makes the Azure SQL data plane reachable when floci-az runs inside a container
(docker-compose / CI), resolving the same issue fixed for PostgreSQL Flexible Server in #97.

The `azure-sql-edge` sidecar is reachable by other containers via its name on the shared Docker
network, not `localhost:<published-port>`. `SqlConnectionInfo` / `fullyQualifiedDomainName`
hardcoded `localhost`, so applications in a networked deployment could not connect to the
database, and the readiness probe timed out against an unreachable `localhost`.

## Change

Following the existing `RedisCacheManager` pattern: attach the container to the configured
Docker network, and report the container name + container port as the reachable endpoint when
running inside a container (`ContainerDetector`), otherwise `localhost` + the published port.
`/connect`, `fullyQualifiedDomainName`, and the readiness probe use the reachable host.
`SqlServerEntry` gains a non-persisted `host` field.

## Testing

Full test suite passes; `SqlState` tests updated for the new field. The identical PostgreSQL
change in #97 is covered end to end by the native compatibility matrix.