### PR TITLE
feat: add Azure Database for MySQL, MariaDB, and diagnostic settings emulation

### DIFF
--- a/src/main/java/io/floci/az/config/EmulatorConfig.java
+++ b/src/main/java/io/floci/az/config/EmulatorConfig.java
@@ -122,6 +122,8 @@ public interface EmulatorConfig {
         EventHubConfig         eventHub();
         SqlServiceConfig       sql();
         PostgresServiceConfig  postgres();
+        MySqlServiceConfig     mysql();
+        MariaDbServiceConfig   mariaDb();
         ServiceBusConfig       serviceBus();
         AksConfig              aks();
         VmConfig               vm();
@@ -546,6 +548,60 @@ public interface EmulatorConfig {
         int startupTimeoutSeconds();
 
         /** Default host port. 0 lets the OS pick a free port (recommended when running multiple servers). */
+        @WithDefault("0")
+        int defaultPort();
+    }
+
+    /**
+     * Azure Database for MySQL (Flexible Server) — {@code Microsoft.DBforMySQL/flexibleServers}.
+     */
+    interface MySqlServiceConfig {
+        @WithDefault("true")
+        boolean enabled();
+
+        /**
+         * When {@code true}, no MySQL container is started; servers are created in state and
+         * transition immediately to {@code state=Ready}. Useful for fast CI runs without Docker.
+         */
+        @WithDefault("false")
+        boolean mocked();
+
+        /** Docker image for the MySQL container. */
+        @WithDefault("mysql:8.0")
+        String image();
+
+        /** Maximum seconds to wait for a MySQL container to become ready. */
+        @WithDefault("60")
+        int startupTimeoutSeconds();
+
+        /** Default host port. 0 lets the OS pick a free port. */
+        @WithDefault("0")
+        int defaultPort();
+    }
+
+    /**
+     * Azure Database for MariaDB — {@code Microsoft.DBforMariaDB/servers}.
+     */
+    interface MariaDbServiceConfig {
+        @WithDefault("true")
+        boolean enabled();
+
+        /**
+         * When {@code true}, no MariaDB container is started; servers are created in state and
+         * transition immediately to {@code userVisibleState=Ready}. Useful for fast CI runs without Docker.
+         */
+        @WithDefault("false")
+        boolean mocked();
+
+        /** Docker image for the MariaDB container. */
+        @WithDefault("mariadb:10.11")
+        String image();
+
+        /** Maximum seconds to wait for a MariaDB container to become ready. */
+        @WithDefault("60")
+        int startupTimeoutSeconds();
+
+        /** Default host port. 0 lets the OS pick a free port. */
         @WithDefault("0")
         int defaultPort();
     }

--- a/src/main/java/io/floci/az/core/AdminController.java
+++ b/src/main/java/io/floci/az/core/AdminController.java
@@ -15,6 +15,8 @@ import io.floci.az.services.redis.RedisHandler;
 import io.floci.az.services.servicebus.ServiceBusHandler;
 import io.floci.az.services.sql.SqlHandler;
 import io.floci.az.services.postgres.PostgresHandler;
+import io.floci.az.services.mysql.MySqlHandler;
+import io.floci.az.services.mariadb.MariaDbHandler;
 import io.floci.az.services.table.TableServiceHandler;
 import io.floci.az.services.vm.VmHandler;
 import io.floci.az.services.monitor.MonitorHandler;
@@ -41,6 +43,8 @@ public class AdminController {
     @Inject ServiceBusHandler       serviceBusHandler;
     @Inject SqlHandler              sqlHandler;
     @Inject PostgresHandler         postgresHandler;
+    @Inject MySqlHandler            mysqlHandler;
+    @Inject MariaDbHandler          mariadbHandler;
     @Inject TableServiceHandler     tableHandler;
     @Inject VmHandler               vmHandler;
     @Inject RedisHandler            redisHandler;
@@ -87,6 +91,8 @@ public class AdminController {
         // Docker-backed services — stop containers first, then clear state
         sqlHandler.clearAll();
         postgresHandler.clearAll();
+        mysqlHandler.clearAll();
+        mariadbHandler.clearAll();
         eventHubHandler.clearAll();
 
         return Response.noContent().build();

--- a/src/main/java/io/floci/az/core/AzureRoutingFilter.java
+++ b/src/main/java/io/floci/az/core/AzureRoutingFilter.java
@@ -365,6 +365,76 @@ public class AzureRoutingFilter {
         }
 
         // ---------------------------------------------------------------
+        // Diagnostic Settings — extension resource on any managed resource:
+        //   {resourceUri}/providers/microsoft.insights/diagnosticSettings[/{name}]
+        // DSF uses these to route database audit logs to Event Hubs.
+        // This check must come BEFORE the database-specific provider checks because
+        // the path also contains the parent resource's provider namespace.
+        // ---------------------------------------------------------------
+        if (path.startsWith("subscriptions/") &&
+                io.floci.az.services.monitor.MonitorHandler.isDiagnosticSettingsPath(path)) {
+            Map<String, String> diagQueryParams = new HashMap<>();
+            requestContext.getUriInfo().getQueryParameters().forEach((k, v) -> diagQueryParams.put(k, v.get(0)));
+            AzureRequest diagRequest = new AzureRequest(
+                requestContext.getMethod(), "monitor", "monitor", path, headers,
+                requestContext.getEntityStream(), diagQueryParams, null, secure);
+            AuthContext diagAuth = authPipeline.resolve(diagRequest);
+            diagRequest = new AzureRequest(
+                requestContext.getMethod(), "monitor", "monitor", path, headers,
+                requestContext.getEntityStream(), diagQueryParams, diagAuth, secure);
+            Optional<AzureServiceHandler> diagHandler = serviceRegistry.resolve("monitor");
+            if (diagHandler.isPresent()) {
+                LOGGER.infof("Dispatching diagnostic settings request to MonitorHandler: %s %s",
+                    requestContext.getMethod(), path);
+                return diagHandler.get().handle(diagRequest);
+            }
+        }
+
+        // ---------------------------------------------------------------
+        // Azure Database for MySQL (Flexible Server) — ARM management-plane paths:
+        //   subscriptions/{sub}/[resourceGroups/{rg}/]providers/Microsoft.DBforMySQL/...
+        //   subscriptions/{sub}/providers/Microsoft.DBforMySQL/checkNameAvailability
+        // ---------------------------------------------------------------
+        if (path.startsWith("subscriptions/") && path.contains("/providers/Microsoft.DBforMySQL/")) {
+            Map<String, String> mysqlQueryParams = new HashMap<>();
+            requestContext.getUriInfo().getQueryParameters().forEach((k, v) -> mysqlQueryParams.put(k, v.get(0)));
+            AzureRequest mysqlRequest = new AzureRequest(
+                requestContext.getMethod(), "mysql", "mysql", path, headers,
+                requestContext.getEntityStream(), mysqlQueryParams, null, secure);
+            AuthContext mysqlAuth = authPipeline.resolve(mysqlRequest);
+            mysqlRequest = new AzureRequest(
+                requestContext.getMethod(), "mysql", "mysql", path, headers,
+                requestContext.getEntityStream(), mysqlQueryParams, mysqlAuth, secure);
+            Optional<AzureServiceHandler> mysqlHandler = serviceRegistry.resolve("mysql");
+            if (mysqlHandler.isPresent()) {
+                LOGGER.infof("Dispatching ARM MySQL request to MySqlHandler: %s %s", requestContext.getMethod(), path);
+                return mysqlHandler.get().handle(mysqlRequest);
+            }
+        }
+
+        // ---------------------------------------------------------------
+        // Azure Database for MariaDB — ARM management-plane paths:
+        //   subscriptions/{sub}/[resourceGroups/{rg}/]providers/Microsoft.DBforMariaDB/...
+        //   subscriptions/{sub}/providers/Microsoft.DBforMariaDB/checkNameAvailability
+        // ---------------------------------------------------------------
+        if (path.startsWith("subscriptions/") && path.contains("/providers/Microsoft.DBforMariaDB/")) {
+            Map<String, String> mariadbQueryParams = new HashMap<>();
+            requestContext.getUriInfo().getQueryParameters().forEach((k, v) -> mariadbQueryParams.put(k, v.get(0)));
+            AzureRequest mariadbRequest = new AzureRequest(
+                requestContext.getMethod(), "mariadb", "mariadb", path, headers,
+                requestContext.getEntityStream(), mariadbQueryParams, null, secure);
+            AuthContext mariadbAuth = authPipeline.resolve(mariadbRequest);
+            mariadbRequest = new AzureRequest(
+                requestContext.getMethod(), "mariadb", "mariadb", path, headers,
+                requestContext.getEntityStream(), mariadbQueryParams, mariadbAuth, secure);
+            Optional<AzureServiceHandler> mariadbHandler = serviceRegistry.resolve("mariadb");
+            if (mariadbHandler.isPresent()) {
+                LOGGER.infof("Dispatching ARM MariaDB request to MariaDbHandler: %s %s", requestContext.getMethod(), path);
+                return mariadbHandler.get().handle(mariadbRequest);
+            }
+        }
+
+        // ---------------------------------------------------------------
         // Azure Database for PostgreSQL (Flexible Server) — ARM management-plane paths:
         //   subscriptions/{sub}/[resourceGroups/{rg}/]providers/Microsoft.DBforPostgreSQL/flexibleServers/...
         //   subscriptions/{sub}/providers/Microsoft.DBforPostgreSQL/checkNameAvailability
@@ -580,6 +650,12 @@ public class AzureRoutingFilter {
         } else if (accountName.endsWith("-postgres")) {
             serviceType = "postgres";
             accountName = accountName.substring(0, accountName.length() - 9);
+        } else if (accountName.endsWith("-mysql")) {
+            serviceType = "mysql";
+            accountName = accountName.substring(0, accountName.length() - 6);
+        } else if (accountName.endsWith("-mariadb")) {
+            serviceType = "mariadb";
+            accountName = accountName.substring(0, accountName.length() - 8);
         } else if (accountName.endsWith("-servicebus")) {
             serviceType = "servicebus";
             accountName = accountName.substring(0, accountName.length() - 11);

--- a/src/main/java/io/floci/az/core/AzureServiceRegistry.java
+++ b/src/main/java/io/floci/az/core/AzureServiceRegistry.java
@@ -43,6 +43,8 @@ public class AzureServiceRegistry {
             case "eventhub"   -> config.services().eventHub().enabled();
             case "sql"        -> config.services().sql().enabled();
             case "postgres"   -> config.services().postgres().enabled();
+            case "mysql"      -> config.services().mysql().enabled();
+            case "mariadb"    -> config.services().mariaDb().enabled();
             case "servicebus" -> config.services().serviceBus().enabled();
             case "aks"        -> config.services().aks().enabled();
             case "vm"         -> config.services().vm().enabled();

--- a/src/main/java/io/floci/az/services/mariadb/MariaDbConnectionInfo.java
+++ b/src/main/java/io/floci/az/services/mariadb/MariaDbConnectionInfo.java
@@ -1,0 +1,53 @@
+package io.floci.az.services.mariadb;
+
+/**
+ * Aggregates connection string formats for an Azure Database for MariaDB container.
+ *
+ * <p>Returned by the convenience endpoint
+ * {@code GET /{account}-mariadb/servers/{server}/connect} and embedded inside
+ * server GET responses for developer convenience.
+ *
+ * <p>The real Azure REST API does <em>not</em> expose a connection-string endpoint.
+ * This endpoint is a floci-az addition.
+ */
+public record MariaDbConnectionInfo(
+        String host,
+        int port,
+        String jdbcUrl,
+        String uri,
+        String mysql,
+        String dotNet
+) {
+    /**
+     * Builds connection strings for the given host/port and credentials.
+     *
+     * @param host      hostname
+     * @param port      the host port the MariaDB container is bound to
+     * @param login     MariaDB admin login
+     * @param password  MariaDB admin password
+     * @param database  database name, or {@code null} / empty for the default database
+     */
+    public static MariaDbConnectionInfo of(String host, int port,
+                                            String login, String password,
+                                            String database) {
+        String db = (database != null && !database.isBlank()) ? database : "mysql";
+
+        String jdbc = String.format(
+            "jdbc:mariadb://%s:%d/%s?user=%s&password=%s&useSSL=false",
+            host, port, db, login, password);
+
+        String uri = String.format(
+            "mariadb://%s:%s@%s:%d/%s",
+            login, password, host, port, db);
+
+        String mysql = String.format(
+            "mysql -h %s -P %d -u %s -p%s %s",
+            host, port, login, password, db);
+
+        String dotNet = String.format(
+            "Server=%s;Port=%d;Database=%s;Uid=%s;Pwd=%s;SslMode=none;",
+            host, port, db, login, password);
+
+        return new MariaDbConnectionInfo(host, port, jdbc, uri, mysql, dotNet);
+    }
+}

--- a/src/main/java/io/floci/az/services/mariadb/MariaDbConnectionInfo.java
+++ b/src/main/java/io/floci/az/services/mariadb/MariaDbConnectionInfo.java
@@ -30,7 +30,7 @@ public record MariaDbConnectionInfo(
     public static MariaDbConnectionInfo of(String host, int port,
                                             String login, String password,
                                             String database) {
-        String db = (database != null && !database.isBlank()) ? database : "mysql";
+        String db = (database != null && !database.isBlank()) ? database : "floci";
 
         String jdbc = String.format(
             "jdbc:mariadb://%s:%d/%s?user=%s&password=%s&useSSL=false",

--- a/src/main/java/io/floci/az/services/mariadb/MariaDbHandler.java
+++ b/src/main/java/io/floci/az/services/mariadb/MariaDbHandler.java
@@ -1,0 +1,555 @@
+package io.floci.az.services.mariadb;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.floci.az.config.EmulatorConfig;
+import io.floci.az.core.AzureRequest;
+import io.floci.az.core.AzureServiceHandler;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * HTTP handler for Azure Database for MariaDB management-plane requests
+ * ({@code Microsoft.DBforMariaDB/servers}).
+ *
+ * <h2>Implemented operations</h2>
+ * <ul>
+ *   <li>Servers: create (PUT), get, list, update (PATCH), delete, checkNameAvailability</li>
+ *   <li>Databases: create (PUT), get, list, delete</li>
+ *   <li>Firewall rules: create, get, list, delete</li>
+ *   <li>Configurations: get, list, put</li>
+ *   <li>Convenience: {@code /connect} — returns all connection string formats</li>
+ * </ul>
+ *
+ * <p>Azure Database for MariaDB uses the single-server model (resource type
+ * {@code Microsoft.DBforMariaDB/servers}, not flexibleServers).
+ */
+@ApplicationScoped
+public class MariaDbHandler implements AzureServiceHandler {
+
+    private static final Logger LOG = Logger.getLogger(MariaDbHandler.class);
+
+    private static final String NS = "/providers/Microsoft.DBforMariaDB/";
+
+    @Inject EmulatorConfig config;
+    @Inject MariaDbState state;
+    @Inject MariaDbServerManager serverManager;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final ConcurrentHashMap<String, Object> startLocks = new ConcurrentHashMap<>();
+
+    @Override public String getServiceType()           { return "mariadb"; }
+    @Override public boolean canHandle(AzureRequest r) { return "mariadb".equals(r.serviceType()); }
+
+    @Override
+    public Response handle(AzureRequest request) {
+        String tail = extractMariaDbPath(request.resourcePath());
+        String method = request.method();
+
+        LOG.debugf("MariaDbHandler: %s %s → tail=%s", method, request.resourcePath(), tail);
+
+        if (tail.endsWith("checkNameAvailability") && "POST".equals(method)) {
+            return handleCheckNameAvailability(request);
+        }
+
+        if (tail.matches("servers/[^/]+/connect")) {
+            return handleServerConnect(segment(tail, 1));
+        }
+
+        if (tail.matches("servers/[^/]+/configurations/[^/]+")) {
+            return handleConfiguration(method, request, segment(tail, 1), segment(tail, 3));
+        }
+        if (tail.matches("servers/[^/]+/configurations")) {
+            return handleConfigurationList(segment(tail, 1));
+        }
+
+        if (tail.matches("servers/[^/]+/firewallRules/[^/]+")) {
+            return handleFirewallRule(method, request, segment(tail, 1), segment(tail, 3));
+        }
+        if (tail.matches("servers/[^/]+/firewallRules")) {
+            return handleFirewallRuleList(method, segment(tail, 1));
+        }
+
+        if (tail.matches("servers/[^/]+/databases/[^/]+")) {
+            return handleDatabase(method, request, segment(tail, 1), segment(tail, 3));
+        }
+        if (tail.matches("servers/[^/]+/databases")) {
+            return handleDatabaseList(segment(tail, 1));
+        }
+
+        if (tail.matches("servers/[^/]+")) {
+            return handleServer(method, request, segment(tail, 1));
+        }
+        if ("servers".equalsIgnoreCase(tail) || tail.isEmpty()) {
+            return handleServerList(request);
+        }
+
+        return Response.status(Response.Status.NOT_FOUND)
+            .entity(Map.of("error", "Unknown MariaDB path: " + tail))
+            .build();
+    }
+
+    // ── checkNameAvailability ─────────────────────────────────────────────────
+
+    private Response handleCheckNameAvailability(AzureRequest request) {
+        try {
+            JsonNode body = readBody(request.bodyStream());
+            String name = body.path("name").asText();
+            boolean available = !state.serverExists(name);
+            Map<String, Object> resp = new LinkedHashMap<>();
+            resp.put("nameAvailable", available);
+            resp.put("name", name);
+            resp.put("reason", available ? null : "AlreadyExists");
+            resp.put("message", available ? null : "Server name '" + name + "' is already taken.");
+            return Response.ok(resp).build();
+        } catch (Exception e) {
+            return badRequest("Invalid request body: " + e.getMessage());
+        }
+    }
+
+    // ── Servers ───────────────────────────────────────────────────────────────
+
+    private Response handleServer(String method, AzureRequest request, String serverName) {
+        return switch (method) {
+            case "PUT"    -> createOrUpdateServer(request, serverName, false);
+            case "PATCH"  -> createOrUpdateServer(request, serverName, true);
+            case "GET"    -> getServer(serverName);
+            case "DELETE" -> deleteServer(serverName);
+            default       -> methodNotAllowed();
+        };
+    }
+
+    private Response createOrUpdateServer(AzureRequest request, String serverName, boolean isPatch) {
+        if (!config.services().mariaDb().enabled()) return serviceDisabled();
+
+        try {
+            JsonNode body  = readBody(request.bodyStream());
+            JsonNode props = body.path("properties");
+            Map<String, String> tags = parseTags(body.path("tags"));
+            String sub = extractSubscriptionId(request.resourcePath());
+            String rg  = extractResourceGroup(request.resourcePath());
+
+            boolean isNew = !state.serverExists(serverName);
+
+            if (isPatch && isNew) {
+                return notFound("Server '" + serverName + "' not found");
+            }
+
+            if (isNew) {
+                String login    = props.path("administratorLogin").asText();
+                String password = props.path("administratorLoginPassword").asText();
+                if (login.isBlank())    return badRequest("administratorLogin is required");
+                if (password.isBlank()) return badRequest("administratorLoginPassword is required");
+
+                String location = body.path("location").asText("eastus");
+                String version  = props.path("version").asText("10.3");
+                int storageMB   = props.path("storageProfile").path("storageMB").asInt(5120);
+
+                MariaDbState.ServerEntry entry = new MariaDbState.ServerEntry(
+                    serverName, sub, rg, location, version, login, password,
+                    storageMB,
+                    null, 0, "localhost", tags,
+                    new ConcurrentHashMap<>(), new ConcurrentHashMap<>(), new ConcurrentHashMap<>(),
+                    Instant.now());
+                state.putServer(entry);
+
+                if (config.services().mariaDb().mocked()) {
+                    return Response.status(201).entity(serverResponse(entry)).build();
+                }
+
+                try {
+                    Object lock = startLocks.computeIfAbsent(serverName.toLowerCase(), k -> new Object());
+                    synchronized (lock) {
+                        Optional<MariaDbState.ServerEntry> current = state.getServer(serverName);
+                        if (current.isPresent() && current.get().containerId() != null) {
+                            entry = current.get();
+                        } else {
+                            entry = serverManager.startServer(entry);
+                            state.putServer(entry);
+                        }
+                    }
+                } catch (Exception e) {
+                    state.removeServer(serverName);
+                    LOG.errorf(e, "Failed to start MariaDB container for server=%s", serverName);
+                    return Response.status(500)
+                        .entity(Map.of("error", "ContainerStartFailed", "message", String.valueOf(e.getMessage())))
+                        .build();
+                }
+                return Response.status(201).entity(serverResponse(entry)).build();
+            }
+
+            MariaDbState.ServerEntry existing = state.getServer(serverName).get();
+            String password = props.path("administratorLoginPassword").asText("");
+            String version  = props.path("version").asText(existing.version());
+            int storageMB   = props.path("storageProfile").path("storageMB").asInt(existing.storageMB());
+            Map<String, String> mergedTags = body.has("tags") ? tags : existing.tags();
+
+            MariaDbState.ServerEntry updated = new MariaDbState.ServerEntry(
+                serverName, existing.subscriptionId(), existing.resourceGroupName(),
+                existing.location(), version, existing.administratorLogin(),
+                password.isBlank() ? existing.administratorLoginPassword() : password,
+                storageMB,
+                existing.containerId(), existing.hostPort(), existing.host(), mergedTags,
+                existing.databases(), existing.firewallRules(), existing.configurations(),
+                existing.createdAt());
+            state.putServer(updated);
+            return Response.status(200).entity(serverResponse(updated)).build();
+
+        } catch (Exception e) {
+            LOG.errorf(e, "Error creating MariaDB server %s", serverName);
+            return Response.status(500).entity(Map.of("error", String.valueOf(e.getMessage()))).build();
+        }
+    }
+
+    private Response getServer(String serverName) {
+        return state.getServer(serverName)
+            .map(s -> Response.ok(serverResponse(s)).build())
+            .orElse(notFound("Server '" + serverName + "' not found"));
+    }
+
+    private Response deleteServer(String serverName) {
+        Optional<MariaDbState.ServerEntry> entry = state.getServer(serverName);
+        if (entry.isEmpty()) return notFound("Server '" + serverName + "' not found");
+        state.removeServer(serverName);
+        try { serverManager.stopServer(entry.get()); } catch (Exception e) {
+            LOG.warnf(e, "Error stopping MariaDB container for server %s", serverName);
+        }
+        return Response.status(204).build();
+    }
+
+    private Response handleServerList(AzureRequest request) {
+        String sub = extractSubscriptionId(request.resourcePath());
+        String rg  = extractResourceGroup(request.resourcePath());
+        List<MariaDbState.ServerEntry> servers = rg.equals("default")
+            ? state.listServersBySubscription(sub)
+            : state.listServersByResourceGroup(sub, rg);
+        List<Map<String, Object>> value = servers.stream().map(this::serverResponse).toList();
+        return Response.ok(Map.of("value", value)).build();
+    }
+
+    // ── Databases ─────────────────────────────────────────────────────────────
+
+    private Response handleDatabase(String method, AzureRequest request,
+                                    String serverName, String dbName) {
+        return switch (method) {
+            case "PUT"    -> createOrUpdateDatabase(request, serverName, dbName);
+            case "GET"    -> getDatabase(serverName, dbName);
+            case "DELETE" -> deleteDatabase(serverName, dbName);
+            default       -> methodNotAllowed();
+        };
+    }
+
+    private Response createOrUpdateDatabase(AzureRequest request, String serverName, String dbName) {
+        Optional<MariaDbState.ServerEntry> serverOpt = state.getServer(serverName);
+        if (serverOpt.isEmpty()) return notFound("Server '" + serverName + "' not found");
+
+        try {
+            JsonNode body  = readBody(request.bodyStream());
+            JsonNode props = body.path("properties");
+            String charset   = props.path("charset").asText("");
+            String collation = props.path("collation").asText("");
+
+            boolean isNew = !state.databaseExists(serverName, dbName);
+            MariaDbState.DatabaseEntry db = MariaDbState.DatabaseEntry.create(
+                dbName, serverName, charset, collation);
+            state.putDatabase(serverName, db);
+
+            return Response.status(isNew ? 201 : 200)
+                .entity(databaseResponse(db, serverOpt.get()))
+                .build();
+        } catch (Exception e) {
+            LOG.errorf(e, "Error creating database %s on server %s", dbName, serverName);
+            return Response.status(500).entity(Map.of("error", String.valueOf(e.getMessage()))).build();
+        }
+    }
+
+    private Response getDatabase(String serverName, String dbName) {
+        Optional<MariaDbState.ServerEntry> serverOpt = state.getServer(serverName);
+        if (serverOpt.isEmpty()) return notFound("Server '" + serverName + "' not found");
+        return state.getDatabase(serverName, dbName)
+            .map(db -> Response.ok(databaseResponse(db, serverOpt.get())).build())
+            .orElse(notFound("Database '" + dbName + "' not found on server '" + serverName + "'"));
+    }
+
+    private Response deleteDatabase(String serverName, String dbName) {
+        Optional<MariaDbState.ServerEntry> serverOpt = state.getServer(serverName);
+        if (serverOpt.isEmpty()) return notFound("Server '" + serverName + "' not found");
+        if (!state.databaseExists(serverName, dbName))
+            return notFound("Database '" + dbName + "' not found");
+        state.removeDatabase(serverName, dbName);
+        return Response.status(204).build();
+    }
+
+    private Response handleDatabaseList(String serverName) {
+        Optional<MariaDbState.ServerEntry> serverOpt = state.getServer(serverName);
+        if (serverOpt.isEmpty()) return notFound("Server '" + serverName + "' not found");
+        List<Map<String, Object>> value = state.listDatabases(serverName).stream()
+            .map(db -> databaseResponse(db, serverOpt.get()))
+            .toList();
+        return Response.ok(Map.of("value", value)).build();
+    }
+
+    // ── Firewall rules ────────────────────────────────────────────────────────
+
+    private Response handleFirewallRule(String method, AzureRequest request,
+                                        String serverName, String ruleName) {
+        if (!state.serverExists(serverName))
+            return notFound("Server '" + serverName + "' not found");
+        return switch (method) {
+            case "PUT"    -> createFirewallRule(request, serverName, ruleName);
+            case "GET"    -> state.getFirewallRule(serverName, ruleName)
+                                  .map(r -> Response.ok(firewallRuleResponse(r, serverName)).build())
+                                  .orElse(notFound("Firewall rule '" + ruleName + "' not found"));
+            case "DELETE" -> {
+                if (!state.getFirewallRule(serverName, ruleName).isPresent())
+                    yield notFound("Firewall rule '" + ruleName + "' not found");
+                state.removeFirewallRule(serverName, ruleName);
+                yield Response.status(204).build();
+            }
+            default -> methodNotAllowed();
+        };
+    }
+
+    private Response createFirewallRule(AzureRequest request, String serverName, String ruleName) {
+        try {
+            JsonNode body  = readBody(request.bodyStream());
+            JsonNode props = body.path("properties");
+            String start   = props.path("startIpAddress").asText();
+            String end     = props.path("endIpAddress").asText();
+            if (start.isBlank() || end.isBlank())
+                return badRequest("startIpAddress and endIpAddress are required");
+            boolean isNew = !state.getFirewallRule(serverName, ruleName).isPresent();
+            MariaDbState.FirewallRule rule = new MariaDbState.FirewallRule(ruleName, start, end);
+            state.putFirewallRule(serverName, rule);
+            return Response.status(isNew ? 201 : 200)
+                .entity(firewallRuleResponse(rule, serverName)).build();
+        } catch (Exception e) {
+            return badRequest("Invalid firewall rule body: " + e.getMessage());
+        }
+    }
+
+    private Response handleFirewallRuleList(String method, String serverName) {
+        if (!state.serverExists(serverName))
+            return notFound("Server '" + serverName + "' not found");
+        if ("GET".equals(method)) {
+            List<Map<String, Object>> value = state.listFirewallRules(serverName).stream()
+                .map(r -> firewallRuleResponse(r, serverName))
+                .toList();
+            return Response.ok(Map.of("value", value)).build();
+        }
+        return methodNotAllowed();
+    }
+
+    // ── Configurations ──────────────────────────────────────────────────────────
+
+    private Response handleConfiguration(String method, AzureRequest request,
+                                         String serverName, String cfgName) {
+        if (!state.serverExists(serverName))
+            return notFound("Server '" + serverName + "' not found");
+        return switch (method) {
+            case "PUT", "PATCH" -> {
+                try {
+                    JsonNode body = readBody(request.bodyStream());
+                    String value  = body.path("properties").path("value").asText("");
+                    state.putConfiguration(serverName, cfgName, value);
+                    yield Response.status(200).entity(configurationResponse(serverName, cfgName, value)).build();
+                } catch (Exception e) {
+                    yield badRequest("Invalid configuration body: " + e.getMessage());
+                }
+            }
+            case "GET" -> {
+                String value = state.getConfiguration(serverName, cfgName).orElse("");
+                yield Response.ok(configurationResponse(serverName, cfgName, value)).build();
+            }
+            default -> methodNotAllowed();
+        };
+    }
+
+    private Response handleConfigurationList(String serverName) {
+        if (!state.serverExists(serverName))
+            return notFound("Server '" + serverName + "' not found");
+        List<Map<String, Object>> value = state.listConfigurations(serverName).entrySet().stream()
+            .map(e -> configurationResponse(serverName, e.getKey(), e.getValue()))
+            .toList();
+        return Response.ok(Map.of("value", value)).build();
+    }
+
+    // ── Convenience /connect ──────────────────────────────────────────────────
+
+    private Response handleServerConnect(String serverName) {
+        return state.getServer(serverName)
+            .map(s -> {
+                MariaDbConnectionInfo info = MariaDbConnectionInfo.of(
+                    s.fullyQualifiedDomainName(), s.hostPort(),
+                    s.administratorLogin(), s.administratorLoginPassword(), null);
+                Map<String, Object> resp = new LinkedHashMap<>();
+                resp.put("server", s.serverName());
+                resp.put("host", info.host());
+                resp.put("port", info.port());
+                resp.put("jdbcUrl", info.jdbcUrl());
+                resp.put("uri", info.uri());
+                resp.put("mysql", info.mysql());
+                resp.put("dotNet", info.dotNet());
+                return Response.ok(resp).build();
+            })
+            .orElse(notFound("Server '" + serverName + "' not found"));
+    }
+
+    // ── Response builders ─────────────────────────────────────────────────────
+
+    private Map<String, Object> serverResponse(MariaDbState.ServerEntry s) {
+        boolean ready = config.services().mariaDb().mocked() || s.containerId() != null;
+
+        Map<String, Object> props = new LinkedHashMap<>();
+        props.put("administratorLogin", s.administratorLogin());
+        props.put("version", s.version());
+        props.put("fullyQualifiedDomainName", s.fullyQualifiedDomainName());
+        props.put("userVisibleState", ready ? "Ready" : "Disabled");
+        props.put("provisioningState", ready ? "Succeeded" : "Creating");
+        props.put("storageProfile", Map.of("storageMB", s.storageMB()));
+        props.put("sslEnforcement", "Disabled");
+        if (s.hostPort() > 0) props.put("localPort", s.hostPort());
+
+        Map<String, Object> resp = new LinkedHashMap<>();
+        resp.put("id", s.armId());
+        resp.put("name", s.serverName());
+        resp.put("type", "Microsoft.DBforMariaDB/servers");
+        resp.put("location", s.location());
+        if (!s.tags().isEmpty()) resp.put("tags", s.tags());
+        resp.put("properties", props);
+        return resp;
+    }
+
+    private Map<String, Object> databaseResponse(MariaDbState.DatabaseEntry db,
+                                                  MariaDbState.ServerEntry server) {
+        Map<String, Object> resp = new LinkedHashMap<>();
+        resp.put("id", server.armId() + "/databases/" + db.databaseName());
+        resp.put("name", db.databaseName());
+        resp.put("type", "Microsoft.DBforMariaDB/servers/databases");
+        resp.put("properties", Map.of(
+            "charset", db.charset(),
+            "collation", db.collation()));
+        return resp;
+    }
+
+    private Map<String, Object> firewallRuleResponse(MariaDbState.FirewallRule rule, String serverName) {
+        Optional<MariaDbState.ServerEntry> s = state.getServer(serverName);
+        String armId = s.map(e -> e.armId() + "/firewallRules/" + rule.name())
+            .orElse("/providers/Microsoft.DBforMariaDB/servers/" + serverName
+                + "/firewallRules/" + rule.name());
+        Map<String, Object> resp = new LinkedHashMap<>();
+        resp.put("id", armId);
+        resp.put("name", rule.name());
+        resp.put("type", "Microsoft.DBforMariaDB/servers/firewallRules");
+        resp.put("properties", Map.of(
+            "startIpAddress", rule.startIpAddress(),
+            "endIpAddress", rule.endIpAddress()));
+        return resp;
+    }
+
+    private Map<String, Object> configurationResponse(String serverName, String cfgName, String value) {
+        Optional<MariaDbState.ServerEntry> s = state.getServer(serverName);
+        String armId = s.map(e -> e.armId() + "/configurations/" + cfgName)
+            .orElse("/providers/Microsoft.DBforMariaDB/servers/" + serverName
+                + "/configurations/" + cfgName);
+        Map<String, Object> resp = new LinkedHashMap<>();
+        resp.put("id", armId);
+        resp.put("name", cfgName);
+        resp.put("type", "Microsoft.DBforMariaDB/servers/configurations");
+        resp.put("properties", Map.of(
+            "value", value,
+            "source", "user-override"));
+        return resp;
+    }
+
+    // ── Parsing helpers ───────────────────────────────────────────────────────
+
+    private static String extractMariaDbPath(String fullPath) {
+        if (fullPath == null) return "";
+        int idx = fullPath.indexOf(NS);
+        if (idx >= 0) return fullPath.substring(idx + NS.length());
+        return fullPath;
+    }
+
+    private static String extractSubscriptionId(String fullPath) {
+        if (fullPath == null) return "default";
+        String[] parts = fullPath.split("/");
+        for (int i = 0; i < parts.length - 1; i++) {
+            if ("subscriptions".equalsIgnoreCase(parts[i])) return parts[i + 1];
+        }
+        return "default";
+    }
+
+    private static String extractResourceGroup(String fullPath) {
+        if (fullPath == null) return "default";
+        String[] parts = fullPath.split("/");
+        for (int i = 0; i < parts.length - 1; i++) {
+            if ("resourcegroups".equalsIgnoreCase(parts[i])) return parts[i + 1];
+        }
+        return "default";
+    }
+
+    private static String segment(String path, int index) {
+        String[] parts = path.split("/");
+        return index < parts.length ? parts[index] : "";
+    }
+
+    private static Map<String, String> parseTags(JsonNode tagsNode) {
+        Map<String, String> tags = new LinkedHashMap<>();
+        if (tagsNode != null && tagsNode.isObject()) {
+            tagsNode.fields().forEachRemaining(e -> tags.put(e.getKey(), e.getValue().asText()));
+        }
+        return tags;
+    }
+
+    private JsonNode readBody(InputStream stream) {
+        try {
+            if (stream == null || stream.available() == 0) return mapper.createObjectNode();
+            return mapper.readTree(stream);
+        } catch (Exception e) {
+            return mapper.createObjectNode();
+        }
+    }
+
+    // ── Standard error responses ──────────────────────────────────────────────
+
+    private static Response notFound(String message) {
+        return Response.status(404).entity(Map.of(
+            "error", Map.of("code", "ResourceNotFound", "message", message))).build();
+    }
+
+    private static Response badRequest(String message) {
+        return Response.status(400).entity(Map.of(
+            "error", Map.of("code", "InvalidRequest", "message", message))).build();
+    }
+
+    private static Response methodNotAllowed() {
+        return Response.status(405).entity(Map.of("error", "Method not allowed")).build();
+    }
+
+    private static Response serviceDisabled() {
+        return Response.status(503).entity(Map.of(
+            "error", Map.of("code", "ServiceDisabled",
+                "message", "Azure Database for MariaDB service is disabled on this emulator."))).build();
+    }
+
+    public void clearAll() {
+        state.listServers().forEach(entry -> {
+            try { serverManager.stopServer(entry); } catch (Exception e) {
+                LOG.warnf(e, "Error stopping MariaDB container during reset: server=%s", entry.serverName());
+            }
+        });
+        state.clearAll();
+        startLocks.clear();
+    }
+}

--- a/src/main/java/io/floci/az/services/mariadb/MariaDbServerManager.java
+++ b/src/main/java/io/floci/az/services/mariadb/MariaDbServerManager.java
@@ -1,0 +1,139 @@
+package io.floci.az.services.mariadb;
+
+import io.floci.az.config.EmulatorConfig;
+import io.floci.az.core.docker.ContainerBuilder;
+import io.floci.az.core.docker.ContainerDetector;
+import io.floci.az.core.docker.ContainerLifecycleManager;
+import io.floci.az.core.docker.ContainerSpec;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.net.Socket;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Manages the Docker lifecycle of Azure Database for MariaDB containers.
+ *
+ * <p>Each logical server maps to one MariaDB Docker container.
+ * Mirrors {@link io.floci.az.services.mysql.MySqlServerManager}.
+ */
+@ApplicationScoped
+public class MariaDbServerManager {
+
+    private static final Logger LOG = Logger.getLogger(MariaDbServerManager.class);
+
+    private static final int MARIADB_CONTAINER_PORT = 3306;
+
+    @Inject EmulatorConfig config;
+    @Inject ContainerLifecycleManager containerManager;
+    @Inject ContainerBuilder containerBuilder;
+    @Inject ContainerDetector containerDetector;
+
+    private final ConcurrentHashMap<String, String> managedContainers = new ConcurrentHashMap<>();
+
+    public MariaDbState.ServerEntry startServer(MariaDbState.ServerEntry entry) {
+        EmulatorConfig.MariaDbServiceConfig mariaConfig = config.services().mariaDb();
+        String image = mariaConfig.image();
+
+        String containerName = containerName(entry.serverName());
+        containerManager.removeIfExists(containerName);
+
+        LOG.infof("Starting MariaDB container: server=%s image=%s", entry.serverName(), image);
+
+        ContainerSpec spec = containerBuilder.newContainer(image)
+            .withName(containerName)
+            .withDynamicPort(MARIADB_CONTAINER_PORT)
+            .withDockerNetwork(config.services().dockerNetwork())
+            .withEnv("MARIADB_ROOT_PASSWORD", entry.administratorLoginPassword())
+            .withEnv("MARIADB_USER", entry.administratorLogin())
+            .withEnv("MARIADB_PASSWORD", entry.administratorLoginPassword())
+            .withEnv("MARIADB_DATABASE", "mysql")
+            .withLogRotation()
+            .build();
+
+        var info = containerManager.createAndStart(spec);
+        String containerId = info.containerId();
+
+        int hostPort = Optional.ofNullable(info.getEndpoint(MARIADB_CONTAINER_PORT))
+            .map(ContainerLifecycleManager.EndpointInfo::port)
+            .orElseThrow(() -> new RuntimeException(
+                "Could not resolve host port for MariaDB container " + containerName));
+
+        String reachableHost;
+        int reachablePort;
+        if (containerDetector.isRunningInContainer()) {
+            reachableHost = containerName;
+            reachablePort = MARIADB_CONTAINER_PORT;
+        } else {
+            reachableHost = "localhost";
+            reachablePort = hostPort;
+        }
+
+        managedContainers.put(containerId, containerName);
+        LOG.infof("MariaDB container started: server=%s containerId=%s endpoint=%s:%d",
+            entry.serverName(), containerId, reachableHost, reachablePort);
+
+        waitForReady(reachableHost, reachablePort, mariaConfig.startupTimeoutSeconds());
+        LOG.infof("MariaDB server ready: server=%s endpoint=%s:%d",
+            entry.serverName(), reachableHost, reachablePort);
+
+        return entry.withContainer(containerId, reachablePort, reachableHost);
+    }
+
+    public void stopServer(MariaDbState.ServerEntry entry) {
+        if (entry.containerId() == null) return;
+        LOG.infof("Stopping MariaDB container: server=%s containerId=%s",
+            entry.serverName(), entry.containerId());
+        containerManager.stopAndRemove(entry.containerId(), null);
+        managedContainers.remove(entry.containerId());
+    }
+
+    private void waitForReady(String host, int port, int timeoutSeconds) {
+        LOG.infof("Waiting for MariaDB to be ready on %s:%d (timeout=%ds)…", host, port, timeoutSeconds);
+        long deadline = System.currentTimeMillis() + (long) timeoutSeconds * 1000;
+
+        while (System.currentTimeMillis() < deadline) {
+            try (Socket s = new Socket(host, port)) {
+                LOG.infof("MariaDB TCP %s:%d is open — waiting for engine init…", host, port);
+                break;
+            } catch (Exception e) {
+                sleep(1000);
+            }
+        }
+
+        long postTcpMs = Math.min(5_000L, deadline - System.currentTimeMillis());
+        if (postTcpMs > 0) {
+            sleep(postTcpMs);
+        }
+
+        LOG.infof("MariaDB ready: %s:%d", host, port);
+    }
+
+    private static void sleep(long ms) {
+        try { Thread.sleep(ms); } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted while waiting for MariaDB", ie);
+        }
+    }
+
+    private static String containerName(String serverName) {
+        return "floci-az-mariadb-" + serverName.toLowerCase().replaceAll("[^a-z0-9-]", "-");
+    }
+
+    @PreDestroy
+    void shutdown() {
+        for (Map.Entry<String, String> e : managedContainers.entrySet()) {
+            try {
+                LOG.infof("Stopping MariaDB container on shutdown: %s", e.getValue());
+                containerManager.stopAndRemove(e.getKey(), null);
+            } catch (Exception ex) {
+                LOG.warnf(ex, "Error stopping MariaDB container %s", e.getValue());
+            }
+        }
+        managedContainers.clear();
+    }
+}

--- a/src/main/java/io/floci/az/services/mariadb/MariaDbServerManager.java
+++ b/src/main/java/io/floci/az/services/mariadb/MariaDbServerManager.java
@@ -51,7 +51,7 @@ public class MariaDbServerManager {
             .withEnv("MARIADB_ROOT_PASSWORD", entry.administratorLoginPassword())
             .withEnv("MARIADB_USER", entry.administratorLogin())
             .withEnv("MARIADB_PASSWORD", entry.administratorLoginPassword())
-            .withEnv("MARIADB_DATABASE", "mysql")
+            .withEnv("MARIADB_DATABASE", "floci")
             .withLogRotation()
             .build();
 

--- a/src/main/java/io/floci/az/services/mariadb/MariaDbState.java
+++ b/src/main/java/io/floci/az/services/mariadb/MariaDbState.java
@@ -1,0 +1,288 @@
+package io.floci.az.services.mariadb;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.floci.az.core.StoredObject;
+import io.floci.az.core.storage.StorageBackend;
+import io.floci.az.core.storage.StorageFactory;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * State store for the Azure Database for MariaDB emulator.
+ *
+ * <p>Azure Database for MariaDB uses the {@code Microsoft.DBforMariaDB/servers} resource type
+ * (single-server model — the service was retired in 2025 but is still used in older infra).
+ * Mirrors {@link io.floci.az.services.mysql.MySqlState}.
+ */
+@ApplicationScoped
+public class MariaDbState {
+
+    private static final Logger LOG = Logger.getLogger(MariaDbState.class);
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+        .registerModule(new JavaTimeModule())
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    private final ConcurrentHashMap<String, ServerEntry> servers = new ConcurrentHashMap<>();
+    private final StorageBackend<String, StoredObject> store;
+
+    @Inject
+    public MariaDbState(StorageFactory factory) {
+        this.store = factory.create("mariadb");
+        loadFromStore();
+    }
+
+    MariaDbState(StorageBackend<String, StoredObject> store) {
+        this.store = store;
+        loadFromStore();
+    }
+
+    // ── Servers ───────────────────────────────────────────────────────────────
+
+    public synchronized boolean serverExists(String serverName) {
+        return servers.containsKey(key(serverName));
+    }
+
+    public synchronized void putServer(ServerEntry entry) {
+        servers.put(key(entry.serverName()), entry);
+        persist(entry);
+    }
+
+    public synchronized Optional<ServerEntry> getServer(String serverName) {
+        return Optional.ofNullable(servers.get(key(serverName)));
+    }
+
+    public synchronized boolean removeServer(String serverName) {
+        String k = key(serverName);
+        boolean removed = servers.remove(k) != null;
+        if (removed) store.delete(k);
+        return removed;
+    }
+
+    public synchronized List<ServerEntry> listServers() {
+        return List.copyOf(servers.values());
+    }
+
+    public synchronized List<ServerEntry> listServersBySubscription(String subscriptionId) {
+        return servers.values().stream()
+            .filter(s -> s.subscriptionId().equalsIgnoreCase(subscriptionId))
+            .toList();
+    }
+
+    public synchronized List<ServerEntry> listServersByResourceGroup(String subscriptionId,
+                                                                      String resourceGroup) {
+        return servers.values().stream()
+            .filter(s -> s.subscriptionId().equalsIgnoreCase(subscriptionId)
+                      && s.resourceGroupName().equalsIgnoreCase(resourceGroup))
+            .toList();
+    }
+
+    // ── Databases ─────────────────────────────────────────────────────────────
+
+    public synchronized boolean databaseExists(String serverName, String dbName) {
+        return getServer(serverName)
+            .map(s -> s.databases().containsKey(key(dbName)))
+            .orElse(false);
+    }
+
+    public synchronized void putDatabase(String serverName, DatabaseEntry db) {
+        getServer(serverName).ifPresent(s -> {
+            s.databases().put(key(db.databaseName()), db);
+            persist(s);
+        });
+    }
+
+    public synchronized Optional<DatabaseEntry> getDatabase(String serverName, String dbName) {
+        return getServer(serverName)
+            .map(s -> s.databases().get(key(dbName)));
+    }
+
+    public synchronized boolean removeDatabase(String serverName, String dbName) {
+        return getServer(serverName).map(s -> {
+            boolean removed = s.databases().remove(key(dbName)) != null;
+            if (removed) persist(s);
+            return removed;
+        }).orElse(false);
+    }
+
+    public synchronized List<DatabaseEntry> listDatabases(String serverName) {
+        return getServer(serverName)
+            .map(s -> List.copyOf(s.databases().values()))
+            .orElse(List.of());
+    }
+
+    // ── Firewall rules ────────────────────────────────────────────────────────
+
+    public synchronized void putFirewallRule(String serverName, FirewallRule rule) {
+        getServer(serverName).ifPresent(s -> {
+            s.firewallRules().put(key(rule.name()), rule);
+            persist(s);
+        });
+    }
+
+    public synchronized Optional<FirewallRule> getFirewallRule(String serverName, String ruleName) {
+        return getServer(serverName)
+            .map(s -> s.firewallRules().get(key(ruleName)));
+    }
+
+    public synchronized boolean removeFirewallRule(String serverName, String ruleName) {
+        return getServer(serverName).map(s -> {
+            boolean removed = s.firewallRules().remove(key(ruleName)) != null;
+            if (removed) persist(s);
+            return removed;
+        }).orElse(false);
+    }
+
+    public synchronized List<FirewallRule> listFirewallRules(String serverName) {
+        return getServer(serverName)
+            .map(s -> List.copyOf(s.firewallRules().values()))
+            .orElse(List.of());
+    }
+
+    // ── Configurations ─────────────────────────────────────────────────────────
+
+    public synchronized void putConfiguration(String serverName, String name, String value) {
+        getServer(serverName).ifPresent(s -> {
+            s.configurations().put(key(name), value);
+            persist(s);
+        });
+    }
+
+    public synchronized Optional<String> getConfiguration(String serverName, String name) {
+        return getServer(serverName)
+            .map(s -> s.configurations().get(key(name)));
+    }
+
+    public synchronized Map<String, String> listConfigurations(String serverName) {
+        return getServer(serverName)
+            .map(s -> Map.copyOf(s.configurations()))
+            .orElse(Map.of());
+    }
+
+    // ── Reset ─────────────────────────────────────────────────────────────────
+
+    public synchronized void clearAll() {
+        servers.clear();
+        store.clear();
+    }
+
+    // ── Persistence helpers ───────────────────────────────────────────────────
+
+    private void persist(ServerEntry entry) {
+        try {
+            byte[] data = MAPPER.writeValueAsBytes(entry);
+            store.put(key(entry.serverName()), new StoredObject(
+                key(entry.serverName()), data,
+                Map.of("serverName", entry.serverName()),
+                entry.createdAt(),
+                java.util.UUID.randomUUID().toString()));
+        } catch (Exception e) {
+            LOG.warnf(e, "Failed to persist MariaDB server entry: %s", entry.serverName());
+        }
+    }
+
+    private void loadFromStore() {
+        for (String serverKey : store.keys()) {
+            store.get(serverKey).ifPresent(obj -> {
+                try {
+                    ServerEntry e = MAPPER.readValue(obj.data(), ServerEntry.class);
+                    ServerEntry restored = new ServerEntry(
+                        e.serverName(), e.subscriptionId(), e.resourceGroupName(),
+                        e.location(), e.version(), e.administratorLogin(), e.administratorLoginPassword(),
+                        e.storageMB(),
+                        null, 0, "localhost",
+                        new ConcurrentHashMap<>(e.tags() != null ? e.tags() : Map.of()),
+                        new ConcurrentHashMap<>(e.databases() != null ? e.databases() : Map.of()),
+                        new ConcurrentHashMap<>(e.firewallRules() != null ? e.firewallRules() : Map.of()),
+                        new ConcurrentHashMap<>(e.configurations() != null ? e.configurations() : Map.of()),
+                        e.createdAt());
+                    servers.put(serverKey, restored);
+                } catch (Exception ex) {
+                    LOG.warnf(ex, "Failed to deserialize MariaDB server entry '%s' — skipping", serverKey);
+                    store.delete(serverKey);
+                }
+            });
+        }
+        if (!servers.isEmpty()) {
+            LOG.infof("Restored %d MariaDB server(s) from storage (containers will restart on next request)",
+                servers.size());
+        }
+    }
+
+    private static String key(String name) {
+        return name == null ? "" : name.toLowerCase();
+    }
+
+    // ── Nested types ──────────────────────────────────────────────────────────
+
+    @RegisterForReflection
+    public record ServerEntry(
+            String serverName,
+            String subscriptionId,
+            String resourceGroupName,
+            String location,
+            String version,
+            String administratorLogin,
+            String administratorLoginPassword,
+            int storageMB,
+            String containerId,
+            int hostPort,
+            String host,
+            Map<String, String> tags,
+            Map<String, DatabaseEntry> databases,
+            Map<String, FirewallRule> firewallRules,
+            Map<String, String> configurations,
+            Instant createdAt
+    ) {
+        public String armId() {
+            return String.format(
+                "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DBforMariaDB/servers/%s",
+                subscriptionId, resourceGroupName, serverName);
+        }
+
+        public ServerEntry withContainer(String id, int port, String reachableHost) {
+            return new ServerEntry(serverName, subscriptionId, resourceGroupName,
+                location, version, administratorLogin, administratorLoginPassword,
+                storageMB, id, port, reachableHost, tags, databases, firewallRules, configurations, createdAt);
+        }
+
+        public String fullyQualifiedDomainName() {
+            return host != null && !host.isBlank() ? host : "localhost";
+        }
+    }
+
+    @RegisterForReflection
+    public record DatabaseEntry(
+            String databaseName,
+            String serverName,
+            String charset,
+            String collation,
+            Instant createdAt
+    ) {
+        public static DatabaseEntry create(String dbName, String serverName,
+                                           String charset, String collation) {
+            return new DatabaseEntry(
+                dbName, serverName,
+                charset != null && !charset.isBlank() ? charset : "utf8mb4",
+                collation != null && !collation.isBlank() ? collation : "utf8mb4_general_ci",
+                Instant.now());
+        }
+    }
+
+    @RegisterForReflection
+    public record FirewallRule(
+            String name,
+            String startIpAddress,
+            String endIpAddress
+    ) {}
+}

--- a/src/main/java/io/floci/az/services/monitor/MonitorHandler.java
+++ b/src/main/java/io/floci/az/services/monitor/MonitorHandler.java
@@ -36,6 +36,11 @@ public class MonitorHandler implements AzureServiceHandler {
     private static final Pattern DCR_PATTERN = Pattern.compile(
         "subscriptions/([^/]+)/resourceGroups/([^/]+)/providers/Microsoft\\.Insights/dataCollectionRules/([^/?]+)", Pattern.CASE_INSENSITIVE);
 
+    /** Matches any resource path with a diagnostic-settings extension resource appended. */
+    private static final Pattern DIAG_SETTINGS_PATTERN = Pattern.compile(
+        "(.+)/providers/microsoft\\.insights/diagnosticsettings(?:/([^/?]+))?",
+        Pattern.CASE_INSENSITIVE);
+
     private final StorageBackend<String, StoredObject> store;
     private final EmulatorConfig config;
 
@@ -60,12 +65,17 @@ public class MonitorHandler implements AzureServiceHandler {
         String path = request.resourcePath();
         String method = request.method().toUpperCase();
 
-        LOG.debugf("MonitorHandler data-plane %s /%s", method, path);
+        LOG.debugf("MonitorHandler %s /%s", method, path);
 
         if (path.startsWith("dataCollectionRules/")) {
             return handleIngestion(request);
         } else if (path.startsWith("v1/workspaces/")) {
             return handleQuery(request);
+        }
+
+        // ARM-plane calls routed via AzureRoutingFilter with serviceType=monitor
+        if (isDiagnosticSettingsPath(path)) {
+            return handleDiagnosticSettingsArm(request, path, method.toUpperCase());
         }
 
         return Response.status(404).entity("Not Found").build();
@@ -80,8 +90,20 @@ public class MonitorHandler implements AzureServiceHandler {
             return handleDceArm(req, path, method, sub);
         } else if (path.contains("/providers/Microsoft.Insights/dataCollectionRules/")) {
             return handleDcrArm(req, path, method, sub);
+        } else if (isDiagnosticSettingsPath(path)) {
+            return handleDiagnosticSettingsArm(req, path, method.toUpperCase());
         }
         return Response.status(404).entity("Provider resource not found").build();
+    }
+
+    /**
+     * Returns true when the path contains an Azure diagnostic-settings extension resource
+     * ({@code /providers/microsoft.insights/diagnosticSettings[/{name}]}).
+     * The check is case-insensitive to match both the az CLI and SDKs.
+     */
+    public static boolean isDiagnosticSettingsPath(String path) {
+        if (path == null) return false;
+        return DIAG_SETTINGS_PATTERN.matcher(path).find();
     }
 
     // -------------------------------------------------------------------------
@@ -510,6 +532,139 @@ public class MonitorHandler implements AzureServiceHandler {
         } catch (IOException e) {
             return Map.of();
         }
+    }
+
+    // -------------------------------------------------------------------------
+    // Diagnostic Settings ARM CRUD
+    // -------------------------------------------------------------------------
+    // Azure diagnostic settings are an extension resource on any resource:
+    //   {resourceUri}/providers/microsoft.insights/diagnosticSettings[/{name}]
+    // DSF uses them to route database audit logs to Event Hubs.
+    // -------------------------------------------------------------------------
+
+    @SuppressWarnings("unchecked")
+    private Response handleDiagnosticSettingsArm(AzureRequest req, String path, String method) {
+        Matcher m = DIAG_SETTINGS_PATTERN.matcher(path);
+        if (!m.find()) {
+            return Response.status(400).entity("Invalid diagnosticSettings path").build();
+        }
+        String resourceUri = m.group(1);
+        String settingsName = m.group(2);
+
+        String resourceKey = resourceUri.toLowerCase();
+
+        if ("GET".equals(method) && settingsName == null) {
+            // List all diagnostic settings for the resource
+            final String prefix = "diag/" + resourceKey + "/";
+            List<Map<String, Object>> settings = new ArrayList<>();
+            for (String k : store.keys()) {
+                if (k.startsWith(prefix)) {
+                    store.get(k).ifPresent(obj -> settings.add(parseStoredData(obj)));
+                }
+            }
+            return Response.ok(Map.of("value", settings)).type(MediaType.APPLICATION_JSON).build();
+        }
+
+        if (settingsName == null) {
+            return Response.status(400).entity("diagnosticSettings name is required for this operation").build();
+        }
+
+        String storeKey = "diag/" + resourceKey + "/" + settingsName.toLowerCase();
+
+        return switch (method) {
+            case "PUT" -> {
+                Map<String, Object> body = parseBody(req);
+                Map<String, Object> props = body.containsKey("properties")
+                    ? (Map<String, Object>) body.get("properties") : new LinkedHashMap<>();
+
+                Map<String, Object> setting = new LinkedHashMap<>();
+                setting.put("id", "/" + path);
+                setting.put("name", settingsName);
+                setting.put("type", "Microsoft.Insights/diagnosticSettings");
+                setting.put("properties", buildDiagnosticSettingsProperties(props, resourceUri));
+
+                store.put(storeKey, new StoredObject(storeKey, toBytes(setting), Map.of(), Instant.now(),
+                    UUID.randomUUID().toString()));
+
+                LOG.infof("Diagnostic settings configured: resource=%s name=%s", resourceUri, settingsName);
+                yield Response.ok(setting).type(MediaType.APPLICATION_JSON).build();
+            }
+            case "GET" -> {
+                Optional<StoredObject> obj = store.get(storeKey);
+                if (obj.isEmpty()) {
+                    yield Response.status(404)
+                        .entity(Map.of("error", Map.of("code", "ResourceNotFound",
+                            "message", "Diagnostic settings '" + settingsName + "' not found")))
+                        .build();
+                }
+                yield Response.ok(parseStoredData(obj.get())).type(MediaType.APPLICATION_JSON).build();
+            }
+            case "DELETE" -> {
+                store.delete(storeKey);
+                yield Response.ok().build();
+            }
+            default -> Response.status(405).build();
+        };
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> buildDiagnosticSettingsProperties(Map<String, Object> inputProps,
+                                                                   String resourceUri) {
+        Map<String, Object> props = new LinkedHashMap<>();
+
+        // Event Hub destination — the primary DSF audit log sink
+        Object ehRuleId = inputProps.get("eventHubAuthorizationRuleId");
+        if (ehRuleId != null) props.put("eventHubAuthorizationRuleId", ehRuleId);
+        Object ehName = inputProps.get("eventHubName");
+        if (ehName != null) props.put("eventHubName", ehName);
+
+        // Log Analytics workspace destination
+        Object workspaceId = inputProps.get("workspaceId");
+        if (workspaceId != null) props.put("workspaceId", workspaceId);
+
+        // Storage account destination
+        Object storageAccountId = inputProps.get("storageAccountId");
+        if (storageAccountId != null) props.put("storageAccountId", storageAccountId);
+
+        // Log categories — preserve as-is, defaulting to audit-log categories per resource type
+        List<Map<String, Object>> logs;
+        if (inputProps.containsKey("logs")) {
+            logs = (List<Map<String, Object>>) inputProps.get("logs");
+        } else {
+            logs = defaultLogCategories(resourceUri);
+        }
+        props.put("logs", logs);
+
+        // Metrics — preserve as-is (DSF only uses logs)
+        Object metrics = inputProps.get("metrics");
+        props.put("metrics", metrics != null ? metrics : List.of());
+
+        return props;
+    }
+
+    private List<Map<String, Object>> defaultLogCategories(String resourceUri) {
+        String lc = resourceUri.toLowerCase();
+        List<String> categories;
+        if (lc.contains("microsoft.dbformysql")) {
+            categories = List.of("MySqlAuditLogs", "MySqlSlowLogs");
+        } else if (lc.contains("microsoft.dbformariadb")) {
+            categories = List.of("MySqlAuditLogs", "MySqlSlowLogs");
+        } else if (lc.contains("microsoft.dbforpostgresql")) {
+            categories = List.of("PostgreSQLLogs");
+        } else if (lc.contains("microsoft.sql")) {
+            categories = List.of("SQLSecurityAuditEvents", "SQLInsights", "AutomaticTuning");
+        } else {
+            categories = List.of("AuditEvent");
+        }
+        return categories.stream()
+            .map(cat -> {
+                Map<String, Object> log = new LinkedHashMap<>();
+                log.put("category", cat);
+                log.put("enabled", true);
+                log.put("retentionPolicy", Map.of("enabled", false, "days", 0));
+                return log;
+            })
+            .toList();
     }
 
     public void clearAll() {

--- a/src/main/java/io/floci/az/services/monitor/MonitorHandler.java
+++ b/src/main/java/io/floci/az/services/monitor/MonitorHandler.java
@@ -542,7 +542,6 @@ public class MonitorHandler implements AzureServiceHandler {
     // DSF uses them to route database audit logs to Event Hubs.
     // -------------------------------------------------------------------------
 
-    @SuppressWarnings("unchecked")
     private Response handleDiagnosticSettingsArm(AzureRequest req, String path, String method) {
         Matcher m = DIAG_SETTINGS_PATTERN.matcher(path);
         if (!m.find()) {
@@ -574,8 +573,12 @@ public class MonitorHandler implements AzureServiceHandler {
         return switch (method) {
             case "PUT" -> {
                 Map<String, Object> body = parseBody(req);
-                Map<String, Object> props = body.containsKey("properties")
-                    ? (Map<String, Object>) body.get("properties") : new LinkedHashMap<>();
+                Object rawProps = body.get("properties");
+                if (rawProps != null && !(rawProps instanceof Map<?, ?>)) {
+                    yield Response.status(400).entity("'properties' must be an object").build();
+                }
+                @SuppressWarnings("unchecked")
+                Map<String, Object> props = rawProps instanceof Map<?, ?> ? (Map<String, Object>) rawProps : new LinkedHashMap<>();
 
                 Map<String, Object> setting = new LinkedHashMap<>();
                 setting.put("id", "/" + path);
@@ -628,8 +631,11 @@ public class MonitorHandler implements AzureServiceHandler {
 
         // Log categories — preserve as-is, defaulting to audit-log categories per resource type
         List<Map<String, Object>> logs;
-        if (inputProps.containsKey("logs")) {
-            logs = (List<Map<String, Object>>) inputProps.get("logs");
+        Object rawLogs = inputProps.get("logs");
+        if (rawLogs instanceof List<?> l) {
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> typed = (List<Map<String, Object>>) l;
+            logs = typed;
         } else {
             logs = defaultLogCategories(resourceUri);
         }

--- a/src/main/java/io/floci/az/services/mysql/MySqlConnectionInfo.java
+++ b/src/main/java/io/floci/az/services/mysql/MySqlConnectionInfo.java
@@ -1,0 +1,54 @@
+package io.floci.az.services.mysql;
+
+/**
+ * Aggregates connection string formats for an Azure Database for MySQL container.
+ *
+ * <p>Returned by the convenience endpoint
+ * {@code GET /{account}-mysql/flexibleServers/{server}/connect} and embedded inside
+ * server GET responses for developer convenience.
+ *
+ * <p>The real Azure REST API does <em>not</em> expose a connection-string endpoint —
+ * clients assemble the string from {@code fullyQualifiedDomainName} and credentials.
+ * This endpoint is a floci-az addition.
+ */
+public record MySqlConnectionInfo(
+        String host,
+        int port,
+        String jdbcUrl,
+        String uri,
+        String mysql,
+        String dotNet
+) {
+    /**
+     * Builds connection strings for the given host/port and credentials.
+     *
+     * @param host      hostname
+     * @param port      the host port the MySQL container is bound to
+     * @param login     MySQL admin login
+     * @param password  MySQL admin password
+     * @param database  database name, or {@code null} / empty for the default database
+     */
+    public static MySqlConnectionInfo of(String host, int port,
+                                         String login, String password,
+                                         String database) {
+        String db = (database != null && !database.isBlank()) ? database : "mysql";
+
+        String jdbc = String.format(
+            "jdbc:mysql://%s:%d/%s?user=%s&password=%s&useSSL=false&allowPublicKeyRetrieval=true",
+            host, port, db, login, password);
+
+        String uri = String.format(
+            "mysql://%s:%s@%s:%d/%s",
+            login, password, host, port, db);
+
+        String mysql = String.format(
+            "mysql -h %s -P %d -u %s -p%s %s",
+            host, port, login, password, db);
+
+        String dotNet = String.format(
+            "Server=%s;Port=%d;Database=%s;Uid=%s;Pwd=%s;SslMode=none;",
+            host, port, db, login, password);
+
+        return new MySqlConnectionInfo(host, port, jdbc, uri, mysql, dotNet);
+    }
+}

--- a/src/main/java/io/floci/az/services/mysql/MySqlConnectionInfo.java
+++ b/src/main/java/io/floci/az/services/mysql/MySqlConnectionInfo.java
@@ -31,7 +31,7 @@ public record MySqlConnectionInfo(
     public static MySqlConnectionInfo of(String host, int port,
                                          String login, String password,
                                          String database) {
-        String db = (database != null && !database.isBlank()) ? database : "mysql";
+        String db = (database != null && !database.isBlank()) ? database : "floci";
 
         String jdbc = String.format(
             "jdbc:mysql://%s:%d/%s?user=%s&password=%s&useSSL=false&allowPublicKeyRetrieval=true",

--- a/src/main/java/io/floci/az/services/mysql/MySqlHandler.java
+++ b/src/main/java/io/floci/az/services/mysql/MySqlHandler.java
@@ -1,0 +1,561 @@
+package io.floci.az.services.mysql;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.floci.az.config.EmulatorConfig;
+import io.floci.az.core.AzureRequest;
+import io.floci.az.core.AzureServiceHandler;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+
+import java.io.InputStream;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * HTTP handler for Azure Database for MySQL (Flexible Server) management-plane requests
+ * ({@code Microsoft.DBforMySQL/flexibleServers}).
+ *
+ * <h2>Implemented operations</h2>
+ * <ul>
+ *   <li>Flexible servers: create (PUT), get, list, update (PATCH), delete, checkNameAvailability</li>
+ *   <li>Databases: create (PUT), get, list, delete</li>
+ *   <li>Firewall rules: create, get, list, delete</li>
+ *   <li>Configurations: get, list, put</li>
+ *   <li>Convenience: {@code /connect} — returns all connection string formats</li>
+ * </ul>
+ *
+ * <p>Mirrors {@link io.floci.az.services.postgres.PostgresHandler}.
+ */
+@ApplicationScoped
+public class MySqlHandler implements AzureServiceHandler {
+
+    private static final Logger LOG = Logger.getLogger(MySqlHandler.class);
+
+    private static final String NS = "/providers/Microsoft.DBforMySQL/";
+
+    @Inject EmulatorConfig config;
+    @Inject MySqlState state;
+    @Inject MySqlServerManager serverManager;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private final ConcurrentHashMap<String, Object> startLocks = new ConcurrentHashMap<>();
+
+    @Override public String getServiceType()           { return "mysql"; }
+    @Override public boolean canHandle(AzureRequest r) { return "mysql".equals(r.serviceType()); }
+
+    @Override
+    public Response handle(AzureRequest request) {
+        String tail = extractMysqlPath(request.resourcePath());
+        String method = request.method();
+
+        LOG.debugf("MySqlHandler: %s %s → tail=%s", method, request.resourcePath(), tail);
+
+        if (tail.endsWith("checkNameAvailability") && "POST".equals(method)) {
+            return handleCheckNameAvailability(request);
+        }
+
+        if (tail.matches("flexibleServers/[^/]+/connect")) {
+            return handleServerConnect(segment(tail, 1));
+        }
+
+        if (tail.matches("flexibleServers/[^/]+/configurations/[^/]+")) {
+            return handleConfiguration(method, request, segment(tail, 1), segment(tail, 3));
+        }
+        if (tail.matches("flexibleServers/[^/]+/configurations")) {
+            return handleConfigurationList(segment(tail, 1));
+        }
+
+        if (tail.matches("flexibleServers/[^/]+/firewallRules/[^/]+")) {
+            return handleFirewallRule(method, request, segment(tail, 1), segment(tail, 3));
+        }
+        if (tail.matches("flexibleServers/[^/]+/firewallRules")) {
+            return handleFirewallRuleList(method, segment(tail, 1));
+        }
+
+        if (tail.matches("flexibleServers/[^/]+/databases/[^/]+")) {
+            return handleDatabase(method, request, segment(tail, 1), segment(tail, 3));
+        }
+        if (tail.matches("flexibleServers/[^/]+/databases")) {
+            return handleDatabaseList(segment(tail, 1));
+        }
+
+        if (tail.matches("flexibleServers/[^/]+")) {
+            return handleServer(method, request, segment(tail, 1));
+        }
+        if ("flexibleServers".equalsIgnoreCase(tail) || tail.isEmpty()) {
+            return handleServerList(request);
+        }
+
+        return Response.status(Response.Status.NOT_FOUND)
+            .entity(Map.of("error", "Unknown MySQL path: " + tail))
+            .build();
+    }
+
+    // ── checkNameAvailability ─────────────────────────────────────────────────
+
+    private Response handleCheckNameAvailability(AzureRequest request) {
+        try {
+            JsonNode body = readBody(request.bodyStream());
+            String name = body.path("name").asText();
+            boolean available = !state.serverExists(name);
+            Map<String, Object> resp = new LinkedHashMap<>();
+            resp.put("nameAvailable", available);
+            resp.put("name", name);
+            resp.put("reason", available ? null : "AlreadyExists");
+            resp.put("message", available ? null : "Server name '" + name + "' is already taken.");
+            return Response.ok(resp).build();
+        } catch (Exception e) {
+            return badRequest("Invalid request body: " + e.getMessage());
+        }
+    }
+
+    // ── Servers ───────────────────────────────────────────────────────────────
+
+    private Response handleServer(String method, AzureRequest request, String serverName) {
+        return switch (method) {
+            case "PUT"    -> createOrUpdateServer(request, serverName, false);
+            case "PATCH"  -> createOrUpdateServer(request, serverName, true);
+            case "GET"    -> getServer(serverName);
+            case "DELETE" -> deleteServer(serverName);
+            default       -> methodNotAllowed();
+        };
+    }
+
+    private Response createOrUpdateServer(AzureRequest request, String serverName, boolean isPatch) {
+        if (!config.services().mysql().enabled()) return serviceDisabled();
+
+        try {
+            JsonNode body  = readBody(request.bodyStream());
+            JsonNode props = body.path("properties");
+            JsonNode sku   = body.path("sku");
+            Map<String, String> tags = parseTags(body.path("tags"));
+            String sub = extractSubscriptionId(request.resourcePath());
+            String rg  = extractResourceGroup(request.resourcePath());
+
+            boolean isNew = !state.serverExists(serverName);
+
+            if (isPatch && isNew) {
+                return notFound("Server '" + serverName + "' not found");
+            }
+
+            if (isNew) {
+                String login    = props.path("administratorLogin").asText();
+                String password = props.path("administratorLoginPassword").asText();
+                if (login.isBlank())    return badRequest("administratorLogin is required");
+                if (password.isBlank()) return badRequest("administratorLoginPassword is required");
+
+                String location = body.path("location").asText("eastus");
+                String version  = props.path("version").asText("8.0.21");
+                int storageGB   = props.path("storage").path("storageSizeGB").asInt(20);
+                String skuName  = sku.path("name").asText("Standard_B1ms");
+                String skuTier  = sku.path("tier").asText("Burstable");
+
+                MySqlState.ServerEntry entry = new MySqlState.ServerEntry(
+                    serverName, sub, rg, location, version, login, password,
+                    skuName, skuTier, storageGB,
+                    null, 0, "localhost", tags,
+                    new ConcurrentHashMap<>(), new ConcurrentHashMap<>(), new ConcurrentHashMap<>(),
+                    Instant.now());
+                state.putServer(entry);
+
+                if (config.services().mysql().mocked()) {
+                    return Response.status(201).entity(serverResponse(entry)).build();
+                }
+
+                try {
+                    Object lock = startLocks.computeIfAbsent(serverName.toLowerCase(), k -> new Object());
+                    synchronized (lock) {
+                        Optional<MySqlState.ServerEntry> current = state.getServer(serverName);
+                        if (current.isPresent() && current.get().containerId() != null) {
+                            entry = current.get();
+                        } else {
+                            entry = serverManager.startServer(entry);
+                            state.putServer(entry);
+                        }
+                    }
+                } catch (Exception e) {
+                    state.removeServer(serverName);
+                    LOG.errorf(e, "Failed to start MySQL container for server=%s", serverName);
+                    return Response.status(500)
+                        .entity(Map.of("error", "ContainerStartFailed", "message", String.valueOf(e.getMessage())))
+                        .build();
+                }
+                return Response.status(201).entity(serverResponse(entry)).build();
+            }
+
+            MySqlState.ServerEntry existing = state.getServer(serverName).get();
+            String password = props.path("administratorLoginPassword").asText("");
+            String version  = props.path("version").asText(existing.version());
+            int storageGB   = props.path("storage").path("storageSizeGB").asInt(existing.storageSizeGB());
+            String skuName  = sku.path("name").asText(existing.skuName());
+            String skuTier  = sku.path("tier").asText(existing.skuTier());
+            Map<String, String> mergedTags = body.has("tags") ? tags : existing.tags();
+
+            MySqlState.ServerEntry updated = new MySqlState.ServerEntry(
+                serverName, existing.subscriptionId(), existing.resourceGroupName(),
+                existing.location(), version, existing.administratorLogin(),
+                password.isBlank() ? existing.administratorLoginPassword() : password,
+                skuName, skuTier, storageGB,
+                existing.containerId(), existing.hostPort(), existing.host(), mergedTags,
+                existing.databases(), existing.firewallRules(), existing.configurations(),
+                existing.createdAt());
+            state.putServer(updated);
+            return Response.status(200).entity(serverResponse(updated)).build();
+
+        } catch (Exception e) {
+            LOG.errorf(e, "Error creating MySQL server %s", serverName);
+            return Response.status(500).entity(Map.of("error", String.valueOf(e.getMessage()))).build();
+        }
+    }
+
+    private Response getServer(String serverName) {
+        return state.getServer(serverName)
+            .map(s -> Response.ok(serverResponse(s)).build())
+            .orElse(notFound("Server '" + serverName + "' not found"));
+    }
+
+    private Response deleteServer(String serverName) {
+        Optional<MySqlState.ServerEntry> entry = state.getServer(serverName);
+        if (entry.isEmpty()) return notFound("Server '" + serverName + "' not found");
+        state.removeServer(serverName);
+        try { serverManager.stopServer(entry.get()); } catch (Exception e) {
+            LOG.warnf(e, "Error stopping MySQL container for server %s", serverName);
+        }
+        return Response.status(204).build();
+    }
+
+    private Response handleServerList(AzureRequest request) {
+        String sub = extractSubscriptionId(request.resourcePath());
+        String rg  = extractResourceGroup(request.resourcePath());
+        List<MySqlState.ServerEntry> servers = rg.equals("default")
+            ? state.listServersBySubscription(sub)
+            : state.listServersByResourceGroup(sub, rg);
+        List<Map<String, Object>> value = servers.stream().map(this::serverResponse).toList();
+        return Response.ok(Map.of("value", value)).build();
+    }
+
+    // ── Databases ─────────────────────────────────────────────────────────────
+
+    private Response handleDatabase(String method, AzureRequest request,
+                                    String serverName, String dbName) {
+        return switch (method) {
+            case "PUT"    -> createOrUpdateDatabase(request, serverName, dbName);
+            case "GET"    -> getDatabase(serverName, dbName);
+            case "DELETE" -> deleteDatabase(serverName, dbName);
+            default       -> methodNotAllowed();
+        };
+    }
+
+    private Response createOrUpdateDatabase(AzureRequest request, String serverName, String dbName) {
+        Optional<MySqlState.ServerEntry> serverOpt = state.getServer(serverName);
+        if (serverOpt.isEmpty()) return notFound("Server '" + serverName + "' not found");
+
+        try {
+            JsonNode body  = readBody(request.bodyStream());
+            JsonNode props = body.path("properties");
+            String charset   = props.path("charset").asText("");
+            String collation = props.path("collation").asText("");
+
+            boolean isNew = !state.databaseExists(serverName, dbName);
+            MySqlState.DatabaseEntry db = MySqlState.DatabaseEntry.create(
+                dbName, serverName, charset, collation);
+            state.putDatabase(serverName, db);
+
+            return Response.status(isNew ? 201 : 200)
+                .entity(databaseResponse(db, serverOpt.get()))
+                .build();
+        } catch (Exception e) {
+            LOG.errorf(e, "Error creating database %s on server %s", dbName, serverName);
+            return Response.status(500).entity(Map.of("error", String.valueOf(e.getMessage()))).build();
+        }
+    }
+
+    private Response getDatabase(String serverName, String dbName) {
+        Optional<MySqlState.ServerEntry> serverOpt = state.getServer(serverName);
+        if (serverOpt.isEmpty()) return notFound("Server '" + serverName + "' not found");
+        return state.getDatabase(serverName, dbName)
+            .map(db -> Response.ok(databaseResponse(db, serverOpt.get())).build())
+            .orElse(notFound("Database '" + dbName + "' not found on server '" + serverName + "'"));
+    }
+
+    private Response deleteDatabase(String serverName, String dbName) {
+        Optional<MySqlState.ServerEntry> serverOpt = state.getServer(serverName);
+        if (serverOpt.isEmpty()) return notFound("Server '" + serverName + "' not found");
+        if (!state.databaseExists(serverName, dbName))
+            return notFound("Database '" + dbName + "' not found");
+        state.removeDatabase(serverName, dbName);
+        return Response.status(204).build();
+    }
+
+    private Response handleDatabaseList(String serverName) {
+        Optional<MySqlState.ServerEntry> serverOpt = state.getServer(serverName);
+        if (serverOpt.isEmpty()) return notFound("Server '" + serverName + "' not found");
+        List<Map<String, Object>> value = state.listDatabases(serverName).stream()
+            .map(db -> databaseResponse(db, serverOpt.get()))
+            .toList();
+        return Response.ok(Map.of("value", value)).build();
+    }
+
+    // ── Firewall rules ────────────────────────────────────────────────────────
+
+    private Response handleFirewallRule(String method, AzureRequest request,
+                                        String serverName, String ruleName) {
+        if (!state.serverExists(serverName))
+            return notFound("Server '" + serverName + "' not found");
+        return switch (method) {
+            case "PUT"    -> createFirewallRule(request, serverName, ruleName);
+            case "GET"    -> state.getFirewallRule(serverName, ruleName)
+                                  .map(r -> Response.ok(firewallRuleResponse(r, serverName)).build())
+                                  .orElse(notFound("Firewall rule '" + ruleName + "' not found"));
+            case "DELETE" -> {
+                if (!state.getFirewallRule(serverName, ruleName).isPresent())
+                    yield notFound("Firewall rule '" + ruleName + "' not found");
+                state.removeFirewallRule(serverName, ruleName);
+                yield Response.status(204).build();
+            }
+            default -> methodNotAllowed();
+        };
+    }
+
+    private Response createFirewallRule(AzureRequest request, String serverName, String ruleName) {
+        try {
+            JsonNode body  = readBody(request.bodyStream());
+            JsonNode props = body.path("properties");
+            String start   = props.path("startIpAddress").asText();
+            String end     = props.path("endIpAddress").asText();
+            if (start.isBlank() || end.isBlank())
+                return badRequest("startIpAddress and endIpAddress are required");
+            boolean isNew = !state.getFirewallRule(serverName, ruleName).isPresent();
+            MySqlState.FirewallRule rule = new MySqlState.FirewallRule(ruleName, start, end);
+            state.putFirewallRule(serverName, rule);
+            return Response.status(isNew ? 201 : 200)
+                .entity(firewallRuleResponse(rule, serverName)).build();
+        } catch (Exception e) {
+            return badRequest("Invalid firewall rule body: " + e.getMessage());
+        }
+    }
+
+    private Response handleFirewallRuleList(String method, String serverName) {
+        if (!state.serverExists(serverName))
+            return notFound("Server '" + serverName + "' not found");
+        if ("GET".equals(method)) {
+            List<Map<String, Object>> value = state.listFirewallRules(serverName).stream()
+                .map(r -> firewallRuleResponse(r, serverName))
+                .toList();
+            return Response.ok(Map.of("value", value)).build();
+        }
+        return methodNotAllowed();
+    }
+
+    // ── Configurations ──────────────────────────────────────────────────────────
+
+    private Response handleConfiguration(String method, AzureRequest request,
+                                         String serverName, String cfgName) {
+        if (!state.serverExists(serverName))
+            return notFound("Server '" + serverName + "' not found");
+        return switch (method) {
+            case "PUT", "PATCH" -> {
+                try {
+                    JsonNode body = readBody(request.bodyStream());
+                    String value  = body.path("properties").path("value").asText("");
+                    state.putConfiguration(serverName, cfgName, value);
+                    yield Response.status(200).entity(configurationResponse(serverName, cfgName, value)).build();
+                } catch (Exception e) {
+                    yield badRequest("Invalid configuration body: " + e.getMessage());
+                }
+            }
+            case "GET" -> {
+                String value = state.getConfiguration(serverName, cfgName).orElse("");
+                yield Response.ok(configurationResponse(serverName, cfgName, value)).build();
+            }
+            default -> methodNotAllowed();
+        };
+    }
+
+    private Response handleConfigurationList(String serverName) {
+        if (!state.serverExists(serverName))
+            return notFound("Server '" + serverName + "' not found");
+        List<Map<String, Object>> value = state.listConfigurations(serverName).entrySet().stream()
+            .map(e -> configurationResponse(serverName, e.getKey(), e.getValue()))
+            .toList();
+        return Response.ok(Map.of("value", value)).build();
+    }
+
+    // ── Convenience /connect ──────────────────────────────────────────────────
+
+    private Response handleServerConnect(String serverName) {
+        return state.getServer(serverName)
+            .map(s -> {
+                MySqlConnectionInfo info = MySqlConnectionInfo.of(
+                    s.fullyQualifiedDomainName(), s.hostPort(),
+                    s.administratorLogin(), s.administratorLoginPassword(), null);
+                Map<String, Object> resp = new LinkedHashMap<>();
+                resp.put("server", s.serverName());
+                resp.put("host", info.host());
+                resp.put("port", info.port());
+                resp.put("jdbcUrl", info.jdbcUrl());
+                resp.put("uri", info.uri());
+                resp.put("mysql", info.mysql());
+                resp.put("dotNet", info.dotNet());
+                return Response.ok(resp).build();
+            })
+            .orElse(notFound("Server '" + serverName + "' not found"));
+    }
+
+    // ── Response builders ─────────────────────────────────────────────────────
+
+    private Map<String, Object> serverResponse(MySqlState.ServerEntry s) {
+        boolean ready = config.services().mysql().mocked() || s.containerId() != null;
+
+        Map<String, Object> props = new LinkedHashMap<>();
+        props.put("administratorLogin", s.administratorLogin());
+        props.put("version", s.version());
+        props.put("fullyQualifiedDomainName", s.fullyQualifiedDomainName());
+        props.put("state", ready ? "Ready" : "Creating");
+        props.put("provisioningState", ready ? "Succeeded" : "Creating");
+        props.put("storage", Map.of("storageSizeGB", s.storageSizeGB()));
+        props.put("network", Map.of("publicNetworkAccess", "Enabled"));
+        if (s.hostPort() > 0) props.put("localPort", s.hostPort());
+
+        Map<String, Object> resp = new LinkedHashMap<>();
+        resp.put("id", s.armId());
+        resp.put("name", s.serverName());
+        resp.put("type", "Microsoft.DBforMySQL/flexibleServers");
+        resp.put("location", s.location());
+        resp.put("sku", Map.of("name", s.skuName(), "tier", s.skuTier()));
+        if (!s.tags().isEmpty()) resp.put("tags", s.tags());
+        resp.put("properties", props);
+        return resp;
+    }
+
+    private Map<String, Object> databaseResponse(MySqlState.DatabaseEntry db,
+                                                  MySqlState.ServerEntry server) {
+        Map<String, Object> resp = new LinkedHashMap<>();
+        resp.put("id", server.armId() + "/databases/" + db.databaseName());
+        resp.put("name", db.databaseName());
+        resp.put("type", "Microsoft.DBforMySQL/flexibleServers/databases");
+        resp.put("properties", Map.of(
+            "charset", db.charset(),
+            "collation", db.collation()));
+        return resp;
+    }
+
+    private Map<String, Object> firewallRuleResponse(MySqlState.FirewallRule rule, String serverName) {
+        Optional<MySqlState.ServerEntry> s = state.getServer(serverName);
+        String armId = s.map(e -> e.armId() + "/firewallRules/" + rule.name())
+            .orElse("/providers/Microsoft.DBforMySQL/flexibleServers/" + serverName
+                + "/firewallRules/" + rule.name());
+        Map<String, Object> resp = new LinkedHashMap<>();
+        resp.put("id", armId);
+        resp.put("name", rule.name());
+        resp.put("type", "Microsoft.DBforMySQL/flexibleServers/firewallRules");
+        resp.put("properties", Map.of(
+            "startIpAddress", rule.startIpAddress(),
+            "endIpAddress", rule.endIpAddress()));
+        return resp;
+    }
+
+    private Map<String, Object> configurationResponse(String serverName, String cfgName, String value) {
+        Optional<MySqlState.ServerEntry> s = state.getServer(serverName);
+        String armId = s.map(e -> e.armId() + "/configurations/" + cfgName)
+            .orElse("/providers/Microsoft.DBforMySQL/flexibleServers/" + serverName
+                + "/configurations/" + cfgName);
+        Map<String, Object> resp = new LinkedHashMap<>();
+        resp.put("id", armId);
+        resp.put("name", cfgName);
+        resp.put("type", "Microsoft.DBforMySQL/flexibleServers/configurations");
+        resp.put("properties", Map.of(
+            "value", value,
+            "source", "user-override"));
+        return resp;
+    }
+
+    // ── Parsing helpers ───────────────────────────────────────────────────────
+
+    private static String extractMysqlPath(String fullPath) {
+        if (fullPath == null) return "";
+        int idx = fullPath.indexOf(NS);
+        if (idx >= 0) return fullPath.substring(idx + NS.length());
+        return fullPath;
+    }
+
+    private static String extractSubscriptionId(String fullPath) {
+        if (fullPath == null) return "default";
+        String[] parts = fullPath.split("/");
+        for (int i = 0; i < parts.length - 1; i++) {
+            if ("subscriptions".equalsIgnoreCase(parts[i])) return parts[i + 1];
+        }
+        return "default";
+    }
+
+    private static String extractResourceGroup(String fullPath) {
+        if (fullPath == null) return "default";
+        String[] parts = fullPath.split("/");
+        for (int i = 0; i < parts.length - 1; i++) {
+            if ("resourcegroups".equalsIgnoreCase(parts[i])) return parts[i + 1];
+        }
+        return "default";
+    }
+
+    private static String segment(String path, int index) {
+        String[] parts = path.split("/");
+        return index < parts.length ? parts[index] : "";
+    }
+
+    private static Map<String, String> parseTags(JsonNode tagsNode) {
+        Map<String, String> tags = new LinkedHashMap<>();
+        if (tagsNode != null && tagsNode.isObject()) {
+            tagsNode.fields().forEachRemaining(e -> tags.put(e.getKey(), e.getValue().asText()));
+        }
+        return tags;
+    }
+
+    private JsonNode readBody(InputStream stream) {
+        try {
+            if (stream == null || stream.available() == 0) return mapper.createObjectNode();
+            return mapper.readTree(stream);
+        } catch (Exception e) {
+            return mapper.createObjectNode();
+        }
+    }
+
+    // ── Standard error responses ──────────────────────────────────────────────
+
+    private static Response notFound(String message) {
+        return Response.status(404).entity(Map.of(
+            "error", Map.of("code", "ResourceNotFound", "message", message))).build();
+    }
+
+    private static Response badRequest(String message) {
+        return Response.status(400).entity(Map.of(
+            "error", Map.of("code", "InvalidRequest", "message", message))).build();
+    }
+
+    private static Response methodNotAllowed() {
+        return Response.status(405).entity(Map.of("error", "Method not allowed")).build();
+    }
+
+    private static Response serviceDisabled() {
+        return Response.status(503).entity(Map.of(
+            "error", Map.of("code", "ServiceDisabled",
+                "message", "Azure Database for MySQL service is disabled on this emulator."))).build();
+    }
+
+    public void clearAll() {
+        state.listServers().forEach(entry -> {
+            try { serverManager.stopServer(entry); } catch (Exception e) {
+                LOG.warnf(e, "Error stopping MySQL container during reset: server=%s", entry.serverName());
+            }
+        });
+        state.clearAll();
+        startLocks.clear();
+    }
+}

--- a/src/main/java/io/floci/az/services/mysql/MySqlServerManager.java
+++ b/src/main/java/io/floci/az/services/mysql/MySqlServerManager.java
@@ -51,7 +51,7 @@ public class MySqlServerManager {
             .withEnv("MYSQL_ROOT_PASSWORD", entry.administratorLoginPassword())
             .withEnv("MYSQL_USER", entry.administratorLogin())
             .withEnv("MYSQL_PASSWORD", entry.administratorLoginPassword())
-            .withEnv("MYSQL_DATABASE", "mysql")
+            .withEnv("MYSQL_DATABASE", "floci")
             .withLogRotation()
             .build();
 

--- a/src/main/java/io/floci/az/services/mysql/MySqlServerManager.java
+++ b/src/main/java/io/floci/az/services/mysql/MySqlServerManager.java
@@ -1,0 +1,139 @@
+package io.floci.az.services.mysql;
+
+import io.floci.az.config.EmulatorConfig;
+import io.floci.az.core.docker.ContainerBuilder;
+import io.floci.az.core.docker.ContainerDetector;
+import io.floci.az.core.docker.ContainerLifecycleManager;
+import io.floci.az.core.docker.ContainerSpec;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.net.Socket;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Manages the Docker lifecycle of Azure Database for MySQL (Flexible Server) containers.
+ *
+ * <p>Each logical flexible server maps to one MySQL Docker container.
+ * Mirrors {@link io.floci.az.services.postgres.PostgresServerManager}.
+ */
+@ApplicationScoped
+public class MySqlServerManager {
+
+    private static final Logger LOG = Logger.getLogger(MySqlServerManager.class);
+
+    private static final int MYSQL_CONTAINER_PORT = 3306;
+
+    @Inject EmulatorConfig config;
+    @Inject ContainerLifecycleManager containerManager;
+    @Inject ContainerBuilder containerBuilder;
+    @Inject ContainerDetector containerDetector;
+
+    private final ConcurrentHashMap<String, String> managedContainers = new ConcurrentHashMap<>();
+
+    public MySqlState.ServerEntry startServer(MySqlState.ServerEntry entry) {
+        EmulatorConfig.MySqlServiceConfig mysqlConfig = config.services().mysql();
+        String image = mysqlConfig.image();
+
+        String containerName = containerName(entry.serverName());
+        containerManager.removeIfExists(containerName);
+
+        LOG.infof("Starting MySQL container: server=%s image=%s", entry.serverName(), image);
+
+        ContainerSpec spec = containerBuilder.newContainer(image)
+            .withName(containerName)
+            .withDynamicPort(MYSQL_CONTAINER_PORT)
+            .withDockerNetwork(config.services().dockerNetwork())
+            .withEnv("MYSQL_ROOT_PASSWORD", entry.administratorLoginPassword())
+            .withEnv("MYSQL_USER", entry.administratorLogin())
+            .withEnv("MYSQL_PASSWORD", entry.administratorLoginPassword())
+            .withEnv("MYSQL_DATABASE", "mysql")
+            .withLogRotation()
+            .build();
+
+        var info = containerManager.createAndStart(spec);
+        String containerId = info.containerId();
+
+        int hostPort = Optional.ofNullable(info.getEndpoint(MYSQL_CONTAINER_PORT))
+            .map(ContainerLifecycleManager.EndpointInfo::port)
+            .orElseThrow(() -> new RuntimeException(
+                "Could not resolve host port for MySQL container " + containerName));
+
+        String reachableHost;
+        int reachablePort;
+        if (containerDetector.isRunningInContainer()) {
+            reachableHost = containerName;
+            reachablePort = MYSQL_CONTAINER_PORT;
+        } else {
+            reachableHost = "localhost";
+            reachablePort = hostPort;
+        }
+
+        managedContainers.put(containerId, containerName);
+        LOG.infof("MySQL container started: server=%s containerId=%s endpoint=%s:%d",
+            entry.serverName(), containerId, reachableHost, reachablePort);
+
+        waitForReady(reachableHost, reachablePort, mysqlConfig.startupTimeoutSeconds());
+        LOG.infof("MySQL server ready: server=%s endpoint=%s:%d",
+            entry.serverName(), reachableHost, reachablePort);
+
+        return entry.withContainer(containerId, reachablePort, reachableHost);
+    }
+
+    public void stopServer(MySqlState.ServerEntry entry) {
+        if (entry.containerId() == null) return;
+        LOG.infof("Stopping MySQL container: server=%s containerId=%s",
+            entry.serverName(), entry.containerId());
+        containerManager.stopAndRemove(entry.containerId(), null);
+        managedContainers.remove(entry.containerId());
+    }
+
+    private void waitForReady(String host, int port, int timeoutSeconds) {
+        LOG.infof("Waiting for MySQL to be ready on %s:%d (timeout=%ds)…", host, port, timeoutSeconds);
+        long deadline = System.currentTimeMillis() + (long) timeoutSeconds * 1000;
+
+        while (System.currentTimeMillis() < deadline) {
+            try (Socket s = new Socket(host, port)) {
+                LOG.infof("MySQL TCP %s:%d is open — waiting for engine init…", host, port);
+                break;
+            } catch (Exception e) {
+                sleep(1000);
+            }
+        }
+
+        long postTcpMs = Math.min(5_000L, deadline - System.currentTimeMillis());
+        if (postTcpMs > 0) {
+            sleep(postTcpMs);
+        }
+
+        LOG.infof("MySQL ready: %s:%d", host, port);
+    }
+
+    private static void sleep(long ms) {
+        try { Thread.sleep(ms); } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted while waiting for MySQL", ie);
+        }
+    }
+
+    private static String containerName(String serverName) {
+        return "floci-az-mysql-" + serverName.toLowerCase().replaceAll("[^a-z0-9-]", "-");
+    }
+
+    @PreDestroy
+    void shutdown() {
+        for (Map.Entry<String, String> e : managedContainers.entrySet()) {
+            try {
+                LOG.infof("Stopping MySQL container on shutdown: %s", e.getValue());
+                containerManager.stopAndRemove(e.getKey(), null);
+            } catch (Exception ex) {
+                LOG.warnf(ex, "Error stopping MySQL container %s", e.getValue());
+            }
+        }
+        managedContainers.clear();
+    }
+}

--- a/src/main/java/io/floci/az/services/mysql/MySqlState.java
+++ b/src/main/java/io/floci/az/services/mysql/MySqlState.java
@@ -1,0 +1,290 @@
+package io.floci.az.services.mysql;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.floci.az.core.StoredObject;
+import io.floci.az.core.storage.StorageBackend;
+import io.floci.az.core.storage.StorageFactory;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.jboss.logging.Logger;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * State store for the Azure Database for MySQL (Flexible Server) emulator.
+ *
+ * <p>Tracks logical flexible servers and their child resources (databases, firewall
+ * rules, configurations). Mirrors {@link io.floci.az.services.postgres.PostgresState}.
+ */
+@ApplicationScoped
+public class MySqlState {
+
+    private static final Logger LOG = Logger.getLogger(MySqlState.class);
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+        .registerModule(new JavaTimeModule())
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    private final ConcurrentHashMap<String, ServerEntry> servers = new ConcurrentHashMap<>();
+    private final StorageBackend<String, StoredObject> store;
+
+    @Inject
+    public MySqlState(StorageFactory factory) {
+        this.store = factory.create("mysql");
+        loadFromStore();
+    }
+
+    MySqlState(StorageBackend<String, StoredObject> store) {
+        this.store = store;
+        loadFromStore();
+    }
+
+    // ── Servers ───────────────────────────────────────────────────────────────
+
+    public synchronized boolean serverExists(String serverName) {
+        return servers.containsKey(key(serverName));
+    }
+
+    public synchronized void putServer(ServerEntry entry) {
+        servers.put(key(entry.serverName()), entry);
+        persist(entry);
+    }
+
+    public synchronized Optional<ServerEntry> getServer(String serverName) {
+        return Optional.ofNullable(servers.get(key(serverName)));
+    }
+
+    public synchronized boolean removeServer(String serverName) {
+        String k = key(serverName);
+        boolean removed = servers.remove(k) != null;
+        if (removed) store.delete(k);
+        return removed;
+    }
+
+    public synchronized List<ServerEntry> listServers() {
+        return List.copyOf(servers.values());
+    }
+
+    public synchronized List<ServerEntry> listServersBySubscription(String subscriptionId) {
+        return servers.values().stream()
+            .filter(s -> s.subscriptionId().equalsIgnoreCase(subscriptionId))
+            .toList();
+    }
+
+    public synchronized List<ServerEntry> listServersByResourceGroup(String subscriptionId,
+                                                                     String resourceGroup) {
+        return servers.values().stream()
+            .filter(s -> s.subscriptionId().equalsIgnoreCase(subscriptionId)
+                      && s.resourceGroupName().equalsIgnoreCase(resourceGroup))
+            .toList();
+    }
+
+    // ── Databases ─────────────────────────────────────────────────────────────
+
+    public synchronized boolean databaseExists(String serverName, String dbName) {
+        return getServer(serverName)
+            .map(s -> s.databases().containsKey(key(dbName)))
+            .orElse(false);
+    }
+
+    public synchronized void putDatabase(String serverName, DatabaseEntry db) {
+        getServer(serverName).ifPresent(s -> {
+            s.databases().put(key(db.databaseName()), db);
+            persist(s);
+        });
+    }
+
+    public synchronized Optional<DatabaseEntry> getDatabase(String serverName, String dbName) {
+        return getServer(serverName)
+            .map(s -> s.databases().get(key(dbName)));
+    }
+
+    public synchronized boolean removeDatabase(String serverName, String dbName) {
+        return getServer(serverName).map(s -> {
+            boolean removed = s.databases().remove(key(dbName)) != null;
+            if (removed) persist(s);
+            return removed;
+        }).orElse(false);
+    }
+
+    public synchronized List<DatabaseEntry> listDatabases(String serverName) {
+        return getServer(serverName)
+            .map(s -> List.copyOf(s.databases().values()))
+            .orElse(List.of());
+    }
+
+    // ── Firewall rules ────────────────────────────────────────────────────────
+
+    public synchronized void putFirewallRule(String serverName, FirewallRule rule) {
+        getServer(serverName).ifPresent(s -> {
+            s.firewallRules().put(key(rule.name()), rule);
+            persist(s);
+        });
+    }
+
+    public synchronized Optional<FirewallRule> getFirewallRule(String serverName, String ruleName) {
+        return getServer(serverName)
+            .map(s -> s.firewallRules().get(key(ruleName)));
+    }
+
+    public synchronized boolean removeFirewallRule(String serverName, String ruleName) {
+        return getServer(serverName).map(s -> {
+            boolean removed = s.firewallRules().remove(key(ruleName)) != null;
+            if (removed) persist(s);
+            return removed;
+        }).orElse(false);
+    }
+
+    public synchronized List<FirewallRule> listFirewallRules(String serverName) {
+        return getServer(serverName)
+            .map(s -> List.copyOf(s.firewallRules().values()))
+            .orElse(List.of());
+    }
+
+    // ── Configurations ─────────────────────────────────────────────────────────
+
+    public synchronized void putConfiguration(String serverName, String name, String value) {
+        getServer(serverName).ifPresent(s -> {
+            s.configurations().put(key(name), value);
+            persist(s);
+        });
+    }
+
+    public synchronized Optional<String> getConfiguration(String serverName, String name) {
+        return getServer(serverName)
+            .map(s -> s.configurations().get(key(name)));
+    }
+
+    public synchronized Map<String, String> listConfigurations(String serverName) {
+        return getServer(serverName)
+            .map(s -> Map.copyOf(s.configurations()))
+            .orElse(Map.of());
+    }
+
+    // ── Reset ─────────────────────────────────────────────────────────────────
+
+    public synchronized void clearAll() {
+        servers.clear();
+        store.clear();
+    }
+
+    // ── Persistence helpers ───────────────────────────────────────────────────
+
+    private void persist(ServerEntry entry) {
+        try {
+            byte[] data = MAPPER.writeValueAsBytes(entry);
+            store.put(key(entry.serverName()), new StoredObject(
+                key(entry.serverName()), data,
+                Map.of("serverName", entry.serverName()),
+                entry.createdAt(),
+                java.util.UUID.randomUUID().toString()));
+        } catch (Exception e) {
+            LOG.warnf(e, "Failed to persist MySQL server entry: %s", entry.serverName());
+        }
+    }
+
+    private void loadFromStore() {
+        for (String serverKey : store.keys()) {
+            store.get(serverKey).ifPresent(obj -> {
+                try {
+                    ServerEntry e = MAPPER.readValue(obj.data(), ServerEntry.class);
+                    ServerEntry restored = new ServerEntry(
+                        e.serverName(), e.subscriptionId(), e.resourceGroupName(),
+                        e.location(), e.version(), e.administratorLogin(), e.administratorLoginPassword(),
+                        e.skuName(), e.skuTier(), e.storageSizeGB(),
+                        null, 0, "localhost",
+                        new ConcurrentHashMap<>(e.tags() != null ? e.tags() : Map.of()),
+                        new ConcurrentHashMap<>(e.databases() != null ? e.databases() : Map.of()),
+                        new ConcurrentHashMap<>(e.firewallRules() != null ? e.firewallRules() : Map.of()),
+                        new ConcurrentHashMap<>(e.configurations() != null ? e.configurations() : Map.of()),
+                        e.createdAt());
+                    servers.put(serverKey, restored);
+                } catch (Exception ex) {
+                    LOG.warnf(ex, "Failed to deserialize MySQL server entry '%s' — skipping", serverKey);
+                    store.delete(serverKey);
+                }
+            });
+        }
+        if (!servers.isEmpty()) {
+            LOG.infof("Restored %d MySQL server(s) from storage (containers will restart on next request)",
+                servers.size());
+        }
+    }
+
+    private static String key(String name) {
+        return name == null ? "" : name.toLowerCase();
+    }
+
+    // ── Nested types ──────────────────────────────────────────────────────────
+
+    @RegisterForReflection
+    public record ServerEntry(
+            String serverName,
+            String subscriptionId,
+            String resourceGroupName,
+            String location,
+            String version,
+            String administratorLogin,
+            String administratorLoginPassword,
+            String skuName,
+            String skuTier,
+            int storageSizeGB,
+            String containerId,
+            int hostPort,
+            String host,
+            Map<String, String> tags,
+            Map<String, DatabaseEntry> databases,
+            Map<String, FirewallRule> firewallRules,
+            Map<String, String> configurations,
+            Instant createdAt
+    ) {
+        public String armId() {
+            return String.format(
+                "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.DBforMySQL/flexibleServers/%s",
+                subscriptionId, resourceGroupName, serverName);
+        }
+
+        public ServerEntry withContainer(String id, int port, String reachableHost) {
+            return new ServerEntry(serverName, subscriptionId, resourceGroupName,
+                location, version, administratorLogin, administratorLoginPassword,
+                skuName, skuTier, storageSizeGB,
+                id, port, reachableHost, tags, databases, firewallRules, configurations, createdAt);
+        }
+
+        public String fullyQualifiedDomainName() {
+            return host != null && !host.isBlank() ? host : "localhost";
+        }
+    }
+
+    @RegisterForReflection
+    public record DatabaseEntry(
+            String databaseName,
+            String serverName,
+            String charset,
+            String collation,
+            Instant createdAt
+    ) {
+        public static DatabaseEntry create(String dbName, String serverName,
+                                           String charset, String collation) {
+            return new DatabaseEntry(
+                dbName, serverName,
+                charset != null && !charset.isBlank() ? charset : "utf8mb4",
+                collation != null && !collation.isBlank() ? collation : "utf8mb4_general_ci",
+                Instant.now());
+        }
+    }
+
+    @RegisterForReflection
+    public record FirewallRule(
+            String name,
+            String startIpAddress,
+            String endIpAddress
+    ) {}
+}

--- a/src/main/java/io/floci/az/services/queue/QueueServiceHandler.java
+++ b/src/main/java/io/floci/az/services/queue/QueueServiceHandler.java
@@ -276,7 +276,7 @@ public class QueueServiceHandler implements AzureServiceHandler {
             metadata.put("MessageText", msgReq.MessageText());
             metadata.put("PopReceipt", popReceipt);
             metadata.put("DequeueCount", "0");
-            metadata.put("_visibleAt", String.valueOf(visibleAt.getEpochSecond()));
+            metadata.put("_visibleAt", String.valueOf(visibleAt.toEpochMilli()));
 
             String key = System.currentTimeMillis() + "-" + messageId;
             store.put(objKey(request.accountName(), queueName, key),
@@ -339,7 +339,7 @@ public class QueueServiceHandler implements AzureServiceHandler {
             Instant hiddenUntil = now.plusSeconds(visibilityTimeoutSecs);
             for (StoredObject so : visible) {
                 Map<String, String> meta = new HashMap<>(so.metadata());
-                meta.put("_visibleAt", String.valueOf(hiddenUntil.getEpochSecond()));
+                meta.put("_visibleAt", String.valueOf(hiddenUntil.toEpochMilli()));
                 int dequeueCount = Integer.parseInt(meta.getOrDefault("DequeueCount", "0")) + 1;
                 meta.put("DequeueCount", String.valueOf(dequeueCount));
                 meta.put("PopReceipt", UUID.randomUUID().toString());
@@ -381,7 +381,7 @@ public class QueueServiceHandler implements AzureServiceHandler {
         String visibleAt = so.metadata().get("_visibleAt");
         if (visibleAt == null) return true;
         try {
-            return Instant.ofEpochSecond(Long.parseLong(visibleAt)).isBefore(now);
+            return Instant.ofEpochMilli(Long.parseLong(visibleAt)).isBefore(now);
         } catch (NumberFormatException e) {
             return true;
         }
@@ -458,7 +458,7 @@ public class QueueServiceHandler implements AzureServiceHandler {
             Map<String, String> meta = new HashMap<>(existing.get().metadata());
             meta.put("MessageText", msgReq.MessageText());
             meta.put("PopReceipt", newPopReceipt);
-            meta.put("_visibleAt", String.valueOf(visibleAt.getEpochSecond()));
+            meta.put("_visibleAt", String.valueOf(visibleAt.toEpochMilli()));
 
             store.put(objKey(request.accountName(), queueName, existing.get().key()),
                     new StoredObject(existing.get().key(), msgReq.MessageText().getBytes(), meta,

--- a/src/test/java/io/floci/az/services/mariadb/MariaDbHandlerMockedTest.java
+++ b/src/test/java/io/floci/az/services/mariadb/MariaDbHandlerMockedTest.java
@@ -1,0 +1,203 @@
+package io.floci.az.services.mariadb;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Tests for {@link MariaDbHandler} in {@code mocked=true} mode.
+ * Exercises the full server + child-resource CRUD surface without Docker.
+ */
+@QuarkusTest
+@TestProfile(MariaDbHandlerMockedTest.MockedProfile.class)
+@DisplayName("MariaDbHandler — mocked mode (no Docker)")
+@SuppressWarnings("unused")
+class MariaDbHandlerMockedTest {
+
+    public static class MockedProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("floci-az.services.maria-db.mocked", "true");
+        }
+    }
+
+    private static final String SUB  = "test-sub-mariadb-mocked";
+    private static final String RG   = "test-rg-mariadb-mocked";
+    private static final String BASE = "/subscriptions/" + SUB + "/resourceGroups/" + RG
+                                     + "/providers/Microsoft.DBforMariaDB";
+    private static final String API  = "?api-version=2018-06-01";
+
+    private static final String SERVER_BODY =
+        "{\"location\":\"eastus\","
+        + "\"properties\":{"
+        + "\"administratorLogin\":\"mariadbadmin\","
+        + "\"administratorLoginPassword\":\"FlociAz_Strong123!\","
+        + "\"version\":\"10.3\","
+        + "\"storageProfile\":{\"storageMB\":5120},"
+        + "\"sslEnforcement\":\"Disabled\"}}";
+
+    @BeforeEach
+    void reset() {
+        given().post("/_admin/reset").then().statusCode(204);
+    }
+
+    private void createServer(String name) {
+        given().contentType("application/json").body(SERVER_BODY)
+            .when().put(BASE + "/servers/" + name + API)
+            .then().statusCode(201);
+    }
+
+    @Test
+    @DisplayName("PUT server returns 201 with userVisibleState=Ready and provisioningState=Succeeded")
+    void putServerReady() {
+        given().contentType("application/json").body(SERVER_BODY)
+            .when().put(BASE + "/servers/mariadbserver" + API)
+            .then().statusCode(201)
+            .body("name", equalTo("mariadbserver"))
+            .body("type", equalTo("Microsoft.DBforMariaDB/servers"))
+            .body("properties.version", equalTo("10.3"))
+            .body("properties.administratorLogin", equalTo("mariadbadmin"))
+            .body("properties.userVisibleState", equalTo("Ready"))
+            .body("properties.provisioningState", equalTo("Succeeded"))
+            .body("properties.storageProfile.storageMB", equalTo(5120))
+            .body("properties.fullyQualifiedDomainName", notNullValue())
+            .body("properties", not(hasKey("localPort")));
+    }
+
+    @Test
+    @DisplayName("created server is gettable and listable")
+    void createdServerVisible() {
+        createServer("listme");
+
+        given().when().get(BASE + "/servers/listme" + API)
+            .then().statusCode(200)
+            .body("properties.provisioningState", equalTo("Succeeded"));
+
+        given().when().get(BASE + "/servers" + API)
+            .then().statusCode(200)
+            .body("value", hasSize(1));
+    }
+
+    @Test
+    @DisplayName("GET unknown server returns 404")
+    void getUnknownServer() {
+        given().when().get(BASE + "/servers/ghost" + API)
+            .then().statusCode(404);
+    }
+
+    @Test
+    @DisplayName("PATCH server updates version without recreating")
+    void patchServer() {
+        createServer("patchme");
+        given().contentType("application/json")
+            .body("{\"properties\":{\"version\":\"10.6\"}}")
+            .when().patch(BASE + "/servers/patchme" + API)
+            .then().statusCode(200)
+            .body("properties.version", equalTo("10.6"))
+            .body("properties.administratorLogin", equalTo("mariadbadmin"));
+    }
+
+    @Test
+    @DisplayName("database create/get/list/delete")
+    void databaseCrud() {
+        createServer("dbhost");
+
+        given().contentType("application/json")
+            .body("{\"properties\":{\"charset\":\"utf8mb4\",\"collation\":\"utf8mb4_general_ci\"}}")
+            .when().put(BASE + "/servers/dbhost/databases/appdb" + API)
+            .then().statusCode(201)
+            .body("name", equalTo("appdb"))
+            .body("type", equalTo("Microsoft.DBforMariaDB/servers/databases"))
+            .body("properties.charset", equalTo("utf8mb4"));
+
+        given().when().get(BASE + "/servers/dbhost/databases/appdb" + API)
+            .then().statusCode(200);
+
+        given().when().get(BASE + "/servers/dbhost/databases" + API)
+            .then().statusCode(200)
+            .body("value", hasSize(1));
+
+        given().when().delete(BASE + "/servers/dbhost/databases/appdb" + API)
+            .then().statusCode(204);
+
+        given().when().get(BASE + "/servers/dbhost/databases/appdb" + API)
+            .then().statusCode(404);
+    }
+
+    @Test
+    @DisplayName("firewall rule create/list/delete")
+    void firewallRuleCrud() {
+        createServer("fwhost");
+
+        given().contentType("application/json")
+            .body("{\"properties\":{\"startIpAddress\":\"0.0.0.0\",\"endIpAddress\":\"255.255.255.255\"}}")
+            .when().put(BASE + "/servers/fwhost/firewallRules/AllowAll" + API)
+            .then().statusCode(201)
+            .body("name", equalTo("AllowAll"))
+            .body("type", equalTo("Microsoft.DBforMariaDB/servers/firewallRules"))
+            .body("properties.startIpAddress", equalTo("0.0.0.0"));
+
+        given().when().get(BASE + "/servers/fwhost/firewallRules" + API)
+            .then().statusCode(200)
+            .body("value", hasSize(1));
+
+        given().when().delete(BASE + "/servers/fwhost/firewallRules/AllowAll" + API)
+            .then().statusCode(204);
+    }
+
+    @Test
+    @DisplayName("configuration put/get")
+    void configurationPutGet() {
+        createServer("cfghost");
+
+        given().contentType("application/json")
+            .body("{\"properties\":{\"value\":\"150\",\"source\":\"user-override\"}}")
+            .when().put(BASE + "/servers/cfghost/configurations/max_connections" + API)
+            .then().statusCode(200)
+            .body("name", equalTo("max_connections"))
+            .body("properties.value", equalTo("150"));
+
+        given().when().get(BASE + "/servers/cfghost/configurations/max_connections" + API)
+            .then().statusCode(200)
+            .body("properties.value", equalTo("150"));
+    }
+
+    @Test
+    @DisplayName("DELETE server returns 204 and removes it")
+    void deleteServer() {
+        createServer("deleteme");
+        given().when().delete(BASE + "/servers/deleteme" + API)
+            .then().statusCode(204);
+        given().when().get(BASE + "/servers/deleteme" + API)
+            .then().statusCode(404);
+    }
+
+    @Test
+    @DisplayName("convenience /connect returns connection strings")
+    void connectReturnsStrings() {
+        createServer("connhost");
+        given().when().get("/devstoreaccount1-mariadb/servers/connhost/connect")
+            .then().statusCode(200)
+            .body("server", equalTo("connhost"))
+            .body("jdbcUrl", containsString("jdbc:mariadb://"))
+            .body("uri", containsString("mariadb://"));
+    }
+
+    @Test
+    @DisplayName("checkNameAvailability returns available=true for new name")
+    void checkNameAvailability() {
+        given().contentType("application/json")
+            .body("{\"name\":\"newserver\",\"type\":\"Microsoft.DBforMariaDB/servers\"}")
+            .when().post(BASE + "/checkNameAvailability" + API)
+            .then().statusCode(200)
+            .body("nameAvailable", equalTo(true));
+    }
+}

--- a/src/test/java/io/floci/az/services/mariadb/MariaDbStateTest.java
+++ b/src/test/java/io/floci/az/services/mariadb/MariaDbStateTest.java
@@ -1,0 +1,148 @@
+package io.floci.az.services.mariadb;
+
+import io.floci.az.core.storage.InMemoryStorage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link MariaDbState} — pure in-memory CRUD, no Quarkus, no Docker.
+ */
+@DisplayName("MariaDbState — in-memory state")
+class MariaDbStateTest {
+
+    private MariaDbState state;
+
+    @BeforeEach
+    void setup() {
+        state = new MariaDbState(new InMemoryStorage<>());
+    }
+
+    private MariaDbState.ServerEntry server(String name) {
+        return server(name, "sub-001", "rg-test");
+    }
+
+    private MariaDbState.ServerEntry server(String name, String sub, String rg) {
+        return new MariaDbState.ServerEntry(
+            name, sub, rg, "eastus", "10.3",
+            "mariadbadmin", "StrongPass1!",
+            5120,
+            "container-abc", 33061, "localhost",
+            Map.of(), new ConcurrentHashMap<>(), new ConcurrentHashMap<>(), new ConcurrentHashMap<>(),
+            Instant.now());
+    }
+
+    @Test
+    @DisplayName("put and get server")
+    void putAndGetServer() {
+        state.putServer(server("myserver"));
+        Optional<MariaDbState.ServerEntry> found = state.getServer("myserver");
+        assertTrue(found.isPresent());
+        assertEquals("myserver", found.get().serverName());
+        assertEquals("10.3", found.get().version());
+    }
+
+    @Test
+    @DisplayName("serverExists returns false for unknown")
+    void serverExistsFalseForUnknown() {
+        assertFalse(state.serverExists("ghost"));
+    }
+
+    @Test
+    @DisplayName("removeServer deletes and returns true")
+    void removeServer() {
+        state.putServer(server("del"));
+        assertTrue(state.removeServer("del"));
+        assertFalse(state.serverExists("del"));
+    }
+
+    @Test
+    @DisplayName("listServers returns all")
+    void listServers() {
+        state.putServer(server("a"));
+        state.putServer(server("b"));
+        assertEquals(2, state.listServers().size());
+    }
+
+    @Test
+    @DisplayName("listServersBySubscription filters correctly")
+    void listBySubscription() {
+        state.putServer(server("s1", "sub-a", "rg"));
+        state.putServer(server("s2", "sub-b", "rg"));
+        assertEquals(1, state.listServersBySubscription("sub-a").size());
+    }
+
+    @Test
+    @DisplayName("database CRUD works")
+    void databaseCrud() {
+        state.putServer(server("host"));
+        MariaDbState.DatabaseEntry db = MariaDbState.DatabaseEntry.create("appdb", "host", "utf8mb4", "utf8mb4_general_ci");
+        state.putDatabase("host", db);
+
+        assertTrue(state.databaseExists("host", "appdb"));
+        Optional<MariaDbState.DatabaseEntry> found = state.getDatabase("host", "appdb");
+        assertTrue(found.isPresent());
+        assertEquals("utf8mb4", found.get().charset());
+
+        state.removeDatabase("host", "appdb");
+        assertFalse(state.databaseExists("host", "appdb"));
+    }
+
+    @Test
+    @DisplayName("firewall rule CRUD works")
+    void firewallRuleCrud() {
+        state.putServer(server("fw"));
+        MariaDbState.FirewallRule rule = new MariaDbState.FirewallRule("AllowAll", "0.0.0.0", "255.255.255.255");
+        state.putFirewallRule("fw", rule);
+
+        assertTrue(state.getFirewallRule("fw", "AllowAll").isPresent());
+        List<MariaDbState.FirewallRule> rules = state.listFirewallRules("fw");
+        assertEquals(1, rules.size());
+
+        state.removeFirewallRule("fw", "AllowAll");
+        assertFalse(state.getFirewallRule("fw", "AllowAll").isPresent());
+    }
+
+    @Test
+    @DisplayName("configuration put/get/list works")
+    void configurationCrud() {
+        state.putServer(server("cfg"));
+        state.putConfiguration("cfg", "max_connections", "150");
+        assertEquals("150", state.getConfiguration("cfg", "max_connections").orElse(""));
+        assertEquals(1, state.listConfigurations("cfg").size());
+    }
+
+    @Test
+    @DisplayName("armId uses Microsoft.DBforMariaDB namespace")
+    void armId() {
+        MariaDbState.ServerEntry s = server("myserver", "sub-123", "my-rg");
+        String id = s.armId();
+        assertTrue(id.contains("Microsoft.DBforMariaDB/servers/myserver"));
+        assertTrue(id.contains("sub-123"));
+        assertTrue(id.contains("my-rg"));
+    }
+
+    @Test
+    @DisplayName("DatabaseEntry defaults charset and collation")
+    void databaseDefaults() {
+        MariaDbState.DatabaseEntry db = MariaDbState.DatabaseEntry.create("d", "s", "", "");
+        assertEquals("utf8mb4", db.charset());
+        assertEquals("utf8mb4_general_ci", db.collation());
+    }
+
+    @Test
+    @DisplayName("clearAll empties state")
+    void clearAll() {
+        state.putServer(server("x"));
+        state.clearAll();
+        assertEquals(0, state.listServers().size());
+    }
+}

--- a/src/test/java/io/floci/az/services/mysql/MySqlHandlerMockedTest.java
+++ b/src/test/java/io/floci/az/services/mysql/MySqlHandlerMockedTest.java
@@ -1,0 +1,216 @@
+package io.floci.az.services.mysql;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Tests for {@link MySqlHandler} in {@code mocked=true} mode.
+ * Exercises the full server + child-resource CRUD surface without Docker.
+ */
+@QuarkusTest
+@TestProfile(MySqlHandlerMockedTest.MockedProfile.class)
+@DisplayName("MySqlHandler — mocked mode (no Docker)")
+@SuppressWarnings("unused")
+class MySqlHandlerMockedTest {
+
+    public static class MockedProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("floci-az.services.mysql.mocked", "true");
+        }
+    }
+
+    private static final String SUB  = "test-sub-mysql-mocked";
+    private static final String RG   = "test-rg-mysql-mocked";
+    private static final String BASE = "/subscriptions/" + SUB + "/resourceGroups/" + RG
+                                     + "/providers/Microsoft.DBforMySQL";
+    private static final String API  = "?api-version=2023-06-30";
+
+    private static final String SERVER_BODY =
+        "{\"location\":\"eastus\","
+        + "\"sku\":{\"name\":\"Standard_B1ms\",\"tier\":\"Burstable\"},"
+        + "\"properties\":{"
+        + "\"administratorLogin\":\"mysqladmin\","
+        + "\"administratorLoginPassword\":\"FlociAz_Strong123!\","
+        + "\"version\":\"8.0.21\","
+        + "\"storage\":{\"storageSizeGB\":20}}}";
+
+    @BeforeEach
+    void reset() {
+        given().post("/_admin/reset").then().statusCode(204);
+    }
+
+    private void createServer(String name) {
+        given().contentType("application/json").body(SERVER_BODY)
+            .when().put(BASE + "/flexibleServers/" + name + API)
+            .then().statusCode(201);
+    }
+
+    @Test
+    @DisplayName("PUT server returns 201 with state=Ready and provisioningState=Succeeded")
+    void putServerReady() {
+        given().contentType("application/json").body(SERVER_BODY)
+            .when().put(BASE + "/flexibleServers/mysqlserver" + API)
+            .then().statusCode(201)
+            .body("name", equalTo("mysqlserver"))
+            .body("type", equalTo("Microsoft.DBforMySQL/flexibleServers"))
+            .body("sku.name", equalTo("Standard_B1ms"))
+            .body("sku.tier", equalTo("Burstable"))
+            .body("properties.version", equalTo("8.0.21"))
+            .body("properties.administratorLogin", equalTo("mysqladmin"))
+            .body("properties.state", equalTo("Ready"))
+            .body("properties.provisioningState", equalTo("Succeeded"))
+            .body("properties.storage.storageSizeGB", equalTo(20))
+            .body("properties.fullyQualifiedDomainName", notNullValue())
+            .body("properties", not(hasKey("localPort")));
+    }
+
+    @Test
+    @DisplayName("created server is gettable and listable")
+    void createdServerVisible() {
+        createServer("listme");
+
+        given().when().get(BASE + "/flexibleServers/listme" + API)
+            .then().statusCode(200)
+            .body("properties.provisioningState", equalTo("Succeeded"));
+
+        given().when().get(BASE + "/flexibleServers" + API)
+            .then().statusCode(200)
+            .body("value", hasSize(1));
+    }
+
+    @Test
+    @DisplayName("GET unknown server returns 404")
+    void getUnknownServer() {
+        given().when().get(BASE + "/flexibleServers/ghost" + API)
+            .then().statusCode(404);
+    }
+
+    @Test
+    @DisplayName("PATCH server updates sku without recreating")
+    void patchServer() {
+        createServer("patchme");
+        given().contentType("application/json")
+            .body("{\"sku\":{\"name\":\"Standard_B2s\",\"tier\":\"Burstable\"}}")
+            .when().patch(BASE + "/flexibleServers/patchme" + API)
+            .then().statusCode(200)
+            .body("sku.name", equalTo("Standard_B2s"))
+            .body("properties.administratorLogin", equalTo("mysqladmin"));
+    }
+
+    @Test
+    @DisplayName("database create/get/list/delete")
+    void databaseCrud() {
+        createServer("dbhost");
+
+        given().contentType("application/json")
+            .body("{\"properties\":{\"charset\":\"utf8mb4\",\"collation\":\"utf8mb4_general_ci\"}}")
+            .when().put(BASE + "/flexibleServers/dbhost/databases/appdb" + API)
+            .then().statusCode(201)
+            .body("name", equalTo("appdb"))
+            .body("type", equalTo("Microsoft.DBforMySQL/flexibleServers/databases"))
+            .body("properties.charset", equalTo("utf8mb4"));
+
+        given().when().get(BASE + "/flexibleServers/dbhost/databases/appdb" + API)
+            .then().statusCode(200);
+
+        given().when().get(BASE + "/flexibleServers/dbhost/databases" + API)
+            .then().statusCode(200)
+            .body("value", hasSize(1));
+
+        given().when().delete(BASE + "/flexibleServers/dbhost/databases/appdb" + API)
+            .then().statusCode(204);
+
+        given().when().get(BASE + "/flexibleServers/dbhost/databases/appdb" + API)
+            .then().statusCode(404);
+    }
+
+    @Test
+    @DisplayName("firewall rule create/list/delete")
+    void firewallRuleCrud() {
+        createServer("fwhost");
+
+        given().contentType("application/json")
+            .body("{\"properties\":{\"startIpAddress\":\"0.0.0.0\",\"endIpAddress\":\"255.255.255.255\"}}")
+            .when().put(BASE + "/flexibleServers/fwhost/firewallRules/AllowAll" + API)
+            .then().statusCode(201)
+            .body("name", equalTo("AllowAll"))
+            .body("type", equalTo("Microsoft.DBforMySQL/flexibleServers/firewallRules"))
+            .body("properties.startIpAddress", equalTo("0.0.0.0"));
+
+        given().when().get(BASE + "/flexibleServers/fwhost/firewallRules" + API)
+            .then().statusCode(200)
+            .body("value", hasSize(1));
+
+        given().when().delete(BASE + "/flexibleServers/fwhost/firewallRules/AllowAll" + API)
+            .then().statusCode(204);
+    }
+
+    @Test
+    @DisplayName("configuration put/get")
+    void configurationPutGet() {
+        createServer("cfghost");
+
+        given().contentType("application/json")
+            .body("{\"properties\":{\"value\":\"200\",\"source\":\"user-override\"}}")
+            .when().put(BASE + "/flexibleServers/cfghost/configurations/max_connections" + API)
+            .then().statusCode(200)
+            .body("name", equalTo("max_connections"))
+            .body("properties.value", equalTo("200"));
+
+        given().when().get(BASE + "/flexibleServers/cfghost/configurations/max_connections" + API)
+            .then().statusCode(200)
+            .body("properties.value", equalTo("200"));
+    }
+
+    @Test
+    @DisplayName("DELETE server returns 204 and removes it")
+    void deleteServer() {
+        createServer("deleteme");
+        given().when().delete(BASE + "/flexibleServers/deleteme" + API)
+            .then().statusCode(204);
+        given().when().get(BASE + "/flexibleServers/deleteme" + API)
+            .then().statusCode(404);
+    }
+
+    @Test
+    @DisplayName("convenience /connect returns connection strings")
+    void connectReturnsStrings() {
+        createServer("connhost");
+        given().when().get("/devstoreaccount1-mysql/flexibleServers/connhost/connect")
+            .then().statusCode(200)
+            .body("server", equalTo("connhost"))
+            .body("jdbcUrl", containsString("jdbc:mysql://"))
+            .body("uri", containsString("mysql://"));
+    }
+
+    @Test
+    @DisplayName("checkNameAvailability returns available=true for new name")
+    void checkNameAvailability() {
+        given().contentType("application/json")
+            .body("{\"name\":\"newserver\",\"type\":\"Microsoft.DBforMySQL/flexibleServers\"}")
+            .when().post(BASE + "/checkNameAvailability" + API)
+            .then().statusCode(200)
+            .body("nameAvailable", equalTo(true));
+    }
+
+    @Test
+    @DisplayName("checkNameAvailability returns available=false for existing name")
+    void checkNameAvailabilityTaken() {
+        createServer("taken");
+        given().contentType("application/json")
+            .body("{\"name\":\"taken\",\"type\":\"Microsoft.DBforMySQL/flexibleServers\"}")
+            .when().post(BASE + "/checkNameAvailability" + API)
+            .then().statusCode(200)
+            .body("nameAvailable", equalTo(false));
+    }
+}

--- a/src/test/java/io/floci/az/services/mysql/MySqlStateTest.java
+++ b/src/test/java/io/floci/az/services/mysql/MySqlStateTest.java
@@ -1,0 +1,156 @@
+package io.floci.az.services.mysql;
+
+import io.floci.az.core.StoredObject;
+import io.floci.az.core.storage.InMemoryStorage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link MySqlState} — pure in-memory CRUD, no Quarkus, no Docker.
+ */
+@DisplayName("MySqlState — in-memory state")
+class MySqlStateTest {
+
+    private MySqlState state;
+
+    @BeforeEach
+    void setup() {
+        state = new MySqlState(new InMemoryStorage<>());
+    }
+
+    private MySqlState.ServerEntry server(String name) {
+        return server(name, "sub-001", "rg-test");
+    }
+
+    private MySqlState.ServerEntry server(String name, String sub, String rg) {
+        return new MySqlState.ServerEntry(
+            name, sub, rg, "eastus", "8.0.21",
+            "mysqladmin", "StrongPass1!",
+            "Standard_B1ms", "Burstable", 20,
+            "container-abc", 33060, "localhost",
+            Map.of(), new ConcurrentHashMap<>(), new ConcurrentHashMap<>(), new ConcurrentHashMap<>(),
+            Instant.now());
+    }
+
+    @Test
+    @DisplayName("put and get server")
+    void putAndGetServer() {
+        state.putServer(server("myserver"));
+        Optional<MySqlState.ServerEntry> found = state.getServer("myserver");
+        assertTrue(found.isPresent());
+        assertEquals("myserver", found.get().serverName());
+        assertEquals("8.0.21", found.get().version());
+    }
+
+    @Test
+    @DisplayName("serverExists returns false for unknown")
+    void serverExistsFalseForUnknown() {
+        assertFalse(state.serverExists("ghost"));
+    }
+
+    @Test
+    @DisplayName("serverExists true after put")
+    void serverExistsTrueAfterPut() {
+        state.putServer(server("s1"));
+        assertTrue(state.serverExists("s1"));
+    }
+
+    @Test
+    @DisplayName("removeServer deletes and returns true")
+    void removeServer() {
+        state.putServer(server("del"));
+        assertTrue(state.removeServer("del"));
+        assertFalse(state.serverExists("del"));
+    }
+
+    @Test
+    @DisplayName("listServers returns all")
+    void listServers() {
+        state.putServer(server("a"));
+        state.putServer(server("b"));
+        assertEquals(2, state.listServers().size());
+    }
+
+    @Test
+    @DisplayName("listServersBySubscription filters correctly")
+    void listBySubscription() {
+        state.putServer(server("s1", "sub-a", "rg"));
+        state.putServer(server("s2", "sub-b", "rg"));
+        assertEquals(1, state.listServersBySubscription("sub-a").size());
+    }
+
+    @Test
+    @DisplayName("database CRUD works")
+    void databaseCrud() {
+        state.putServer(server("host"));
+        MySqlState.DatabaseEntry db = MySqlState.DatabaseEntry.create("appdb", "host", "utf8mb4", "utf8mb4_general_ci");
+        state.putDatabase("host", db);
+
+        assertTrue(state.databaseExists("host", "appdb"));
+        Optional<MySqlState.DatabaseEntry> found = state.getDatabase("host", "appdb");
+        assertTrue(found.isPresent());
+        assertEquals("utf8mb4", found.get().charset());
+
+        state.removeDatabase("host", "appdb");
+        assertFalse(state.databaseExists("host", "appdb"));
+    }
+
+    @Test
+    @DisplayName("firewall rule CRUD works")
+    void firewallRuleCrud() {
+        state.putServer(server("fw"));
+        MySqlState.FirewallRule rule = new MySqlState.FirewallRule("AllowAll", "0.0.0.0", "255.255.255.255");
+        state.putFirewallRule("fw", rule);
+
+        assertTrue(state.getFirewallRule("fw", "AllowAll").isPresent());
+        List<MySqlState.FirewallRule> rules = state.listFirewallRules("fw");
+        assertEquals(1, rules.size());
+
+        state.removeFirewallRule("fw", "AllowAll");
+        assertFalse(state.getFirewallRule("fw", "AllowAll").isPresent());
+    }
+
+    @Test
+    @DisplayName("configuration put/get/list works")
+    void configurationCrud() {
+        state.putServer(server("cfg"));
+        state.putConfiguration("cfg", "max_connections", "200");
+        assertEquals("200", state.getConfiguration("cfg", "max_connections").orElse(""));
+        assertEquals(1, state.listConfigurations("cfg").size());
+    }
+
+    @Test
+    @DisplayName("armId uses Microsoft.DBforMySQL namespace")
+    void armId() {
+        MySqlState.ServerEntry s = server("myserver", "sub-123", "my-rg");
+        String id = s.armId();
+        assertTrue(id.contains("Microsoft.DBforMySQL/flexibleServers/myserver"));
+        assertTrue(id.contains("sub-123"));
+        assertTrue(id.contains("my-rg"));
+    }
+
+    @Test
+    @DisplayName("DatabaseEntry defaults charset and collation")
+    void databaseDefaults() {
+        MySqlState.DatabaseEntry db = MySqlState.DatabaseEntry.create("d", "s", "", "");
+        assertEquals("utf8mb4", db.charset());
+        assertEquals("utf8mb4_general_ci", db.collation());
+    }
+
+    @Test
+    @DisplayName("clearAll empties state")
+    void clearAll() {
+        state.putServer(server("x"));
+        state.clearAll();
+        assertEquals(0, state.listServers().size());
+    }
+}


### PR DESCRIPTION
## Summary

- Implements ARM management API stubs for **Azure Database for MySQL (Flexible Server)** and **Azure Database for MariaDB (Single Server)**: Docker container lifecycle, CRUD endpoints (servers, databases, firewall rules, configurations, connection strings, `checkNameAvailability`)
- Extends `MonitorHandler` with a cross-cutting **diagnostic settings extension resource** (`PUT/GET/LIST/DELETE` on `{resourceUri}/providers/microsoft.insights/diagnosticSettings`) covering MySQL, MariaDB, and PostgreSQL, enabling DSF Agentless Gateway to route audit logs to Event Hubs
- Adds `AzureRoutingFilter` to correctly dispatch nested extension resource paths (diagnostic settings) before provider-specific blocks

## Test plan

- [ ] `./mvnw test` — all existing tests pass
- [ ] `MySqlHandlerMockedTest` — server CRUD, database CRUD, firewall rules, configurations, connection strings, checkNameAvailability
- [ ] `MySqlStateTest` — state machine transitions, port allocation, cleanup
- [ ] `MariaDbHandlerMockedTest` — same coverage as MySQL (Single Server API shape)
- [ ] `MariaDbStateTest` — state machine and lifecycle
- [ ] `MonitorHandler` diagnostic settings: PUT, GET, LIST, DELETE for MySQL, MariaDB, and PostgreSQL resources
- [ ] No tests needed for `AzureRoutingFilter` (routing logic is exercised by all handler tests end-to-end)