### PR TITLE
fix(build): restore docker/Dockerfile.jvm-package for local compat builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ require-emulator:
 compat-network:
 	@docker network inspect $(COMPAT_NETWORK) >/dev/null 2>&1 || docker network create $(COMPAT_NETWORK)
 
+# JVM image for the local dev loop; CI builds the native image via docker/Dockerfile.native-package.
 compat-build:
 	$(MVN) clean package -DskipTests -q
 	docker build -f docker/Dockerfile.jvm-package -t $(FLOCI_AZ_IMAGE) .

--- a/docker/Dockerfile.jvm-package
+++ b/docker/Dockerfile.jvm-package
@@ -1,0 +1,63 @@
+FROM eclipse-temurin:25-jre-alpine
+
+ARG VERSION=latest
+
+ENV FLOCI_AZ_VERSION=${VERSION}
+ENV FLOCI_AZ_STORAGE_PERSISTENT_PATH=/app/data
+ENV FLOCI_AZ_SERVICES_FUNCTIONS_CODE_PATH=/app/data/functions
+
+ENV GOSU_VERSION=1.17
+ENV GOSU_AMD64_SHA256=bbc4136d03ab138b1ad66fa4fc051bafc6cc7ffae632b069a53657279a450de3
+ENV GOSU_ARM64_SHA256=c3805a85d17f4454c23d7059bcb97e1ec1af272b90126e79ed002342de08389b
+RUN set -eux; \
+    apk add --no-cache shadow ca-certificates; \
+    useradd -r -u 1001 -g root -d /app -s /sbin/nologin floci; \
+    arch="$(apk --print-arch)"; \
+    case "$arch" in \
+        x86_64) gosuArch='amd64'; gosuSha256="$GOSU_AMD64_SHA256" ;; \
+        aarch64) gosuArch='arm64'; gosuSha256="$GOSU_ARM64_SHA256" ;; \
+        *) echo >&2 "unsupported arch: $arch"; exit 1 ;; \
+    esac; \
+    wget -q -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${gosuArch}"; \
+    echo "${gosuSha256}  /usr/local/bin/gosu" | sha256sum -c -; \
+    chmod +x /usr/local/bin/gosu; \
+    gosu --version; \
+    gosu nobody true
+
+WORKDIR /app
+
+RUN mkdir -p /app/data \
+    && chown 1001:root /app \
+    && chmod "g+rwX" /app \
+    && chown 1001:root /app/data
+
+COPY --chown=1001:root target/quarkus-app quarkus-app/
+
+COPY --chmod=755 docker/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
+VOLUME /app/data
+
+LABEL org.opencontainers.image.title="Floci AZ" \
+      org.opencontainers.image.description="Local Azure emulator — open-source Azure SDK compatible emulator" \
+      org.opencontainers.image.url="https://floci.io" \
+      org.opencontainers.image.source="https://github.com/floci-io/floci-az" \
+      org.opencontainers.image.licenses="MIT" \
+      org.opencontainers.image.vendor="Floci" \
+      description="Local Azure emulator — open-source Azure SDK compatible emulator" \
+      io.k8s.description="Local Azure emulator — open-source Azure SDK compatible emulator" \
+      io.k8s.display-name="Floci AZ" \
+      io.openshift.expose-services="4577:tcp" \
+      io.openshift.tags="floci-az azure-emulator" \
+      maintainer="Floci <https://github.com/floci-io/floci-az>" \
+      name="floci/floci-az" \
+      summary="Local Azure emulator — open-source Azure SDK compatible emulator" \
+      url="https://floci.io" \
+      vendor="Floci"
+
+EXPOSE 4577
+
+HEALTHCHECK --interval=5s --timeout=3s --retries=5 \
+    CMD wget -q --spider http://localhost:4577/_floci/health || exit 1
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["java", "--enable-native-access=ALL-UNNAMED", "-jar", "/app/quarkus-app/quarkus-run.jar"]


### PR DESCRIPTION
## Summary

PR #95 moved CI to the native image and deleted `docker/Dockerfile.jvm-package`, but the Makefile's `compat-build` target still references it — so every Docker-based make target (`test-*-compat`, `test-blob*`, `compat-docker`, `test`) fails on a clean checkout with `failed to read dockerfile: open Dockerfile.jvm-package: no such file or directory`.

Restores the file byte-identical to the pre-#95 version and adds one Makefile comment documenting the split: the JVM image is the fast local dev loop; CI keeps building the native image via `docker/Dockerfile.native-package` (untouched, and this file is deliberately NOT added to `compatibility.yml`'s path triggers).

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

Build tooling only — no emulator or wire-protocol behavior changes. The incorrect behavior was the entire local Docker test surface being broken since #95.

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added — none needed: the fix is exercised by every Docker-based make target (`make compat-build` + full `compat-docker` run verified green)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)