### PR TITLE
fix(core): reset all services via Resettable self-registration

### DIFF
--- a/src/main/java/io/floci/az/core/AdminController.java
+++ b/src/main/java/io/floci/az/core/AdminController.java
@@ -1,51 +1,25 @@
 package io.floci.az.core;
 
-import io.floci.az.services.appconfig.AppConfigHandler;
-import io.floci.az.services.acr.AcrHandler;
-import io.floci.az.services.aks.AksHandler;
-import io.floci.az.services.blob.BlobServiceHandler;
-import io.floci.az.services.cosmos.CosmosHandler;
-import io.floci.az.services.eventgrid.EventGridHandler;
-import io.floci.az.services.eventhub.EventHubHandler;
-import io.floci.az.services.functions.FunctionsServiceHandler;
-import io.floci.az.services.keyvault.KeyVaultHandler;
-import io.floci.az.services.network.NetworkHandler;
-import io.floci.az.services.queue.QueueServiceHandler;
-import io.floci.az.services.redis.RedisHandler;
-import io.floci.az.services.servicebus.ServiceBusHandler;
-import io.floci.az.services.sql.SqlHandler;
-import io.floci.az.services.postgres.PostgresHandler;
-import io.floci.az.services.table.TableServiceHandler;
-import io.floci.az.services.vm.VmHandler;
-import io.floci.az.services.monitor.MonitorHandler;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
 import java.util.List;
 
 @Path("/_admin")
 @Produces(MediaType.APPLICATION_JSON)
 public class AdminController {
 
-    @Inject AppConfigHandler        appConfigHandler;
-    @Inject AcrHandler              acrHandler;
-    @Inject AksHandler              aksHandler;
-    @Inject BlobServiceHandler      blobHandler;
-    @Inject CosmosHandler           cosmosHandler;
-    @Inject EventHubHandler         eventHubHandler;
-    @Inject FunctionsServiceHandler functionsHandler;
-    @Inject KeyVaultHandler         keyVaultHandler;
-    @Inject NetworkHandler          networkHandler;
-    @Inject QueueServiceHandler     queueHandler;
-    @Inject ServiceBusHandler       serviceBusHandler;
-    @Inject SqlHandler              sqlHandler;
-    @Inject PostgresHandler         postgresHandler;
-    @Inject TableServiceHandler     tableHandler;
-    @Inject VmHandler               vmHandler;
-    @Inject RedisHandler            redisHandler;
-    @Inject MonitorHandler          monitorHandler;
-    @Inject EventGridHandler        eventGridHandler;
+    private static final Logger LOG = Logger.getLogger(AdminController.class);
+
+    private final Instance<Resettable> resettables;
+
+    @Inject
+    public AdminController(Instance<Resettable> resettables) {
+        this.resettables = resettables;
+    }
 
     @GET
     @Path("/accounts")
@@ -60,35 +34,26 @@ public class AdminController {
     }
 
     /**
-     * Wipes all emulator state across every service.
-     * Stops any running sidecar containers (SQL Server, Artemis, Redpanda) before clearing.
-     * Intended for test isolation — call at the start of each test suite.
+     * Wipes all emulator state across every service. Every state-holding
+     * component self-registers by implementing {@link Resettable}; each
+     * {@code clearAll()} is self-contained (services with sidecar containers
+     * stop them themselves). The reset is best-effort: a failing handler is
+     * logged and skipped so the remaining services still get cleared — CDI
+     * iteration order is non-deterministic, so one failure must not decide
+     * which services reset. Intended for test isolation — call at the start
+     * of each test suite.
      */
     @POST
     @Path("/reset")
     public Response reset() {
-        // Services backed by StorageBackend — just clear the store
-        appConfigHandler.clearAll();
-        acrHandler.clearAll();
-        aksHandler.clearAll();
-        blobHandler.clearAll();
-        cosmosHandler.clearAll();
-        functionsHandler.clearAll();
-        keyVaultHandler.clearAll();
-        networkHandler.clearAll();
-        queueHandler.clearAll();
-        serviceBusHandler.clearAll();
-        tableHandler.clearAll();
-        vmHandler.clearAll();
-        redisHandler.clearAll();
-        monitorHandler.clearAll();
-        eventGridHandler.clearAll();
-
-        // Docker-backed services — stop containers first, then clear state
-        sqlHandler.clearAll();
-        postgresHandler.clearAll();
-        eventHubHandler.clearAll();
-
+        for (Resettable resettable : resettables) {
+            try {
+                resettable.clearAll();
+            } catch (Exception e) {
+                LOG.errorf(e, "Reset failed for %s — continuing with remaining services",
+                        resettable.getClass().getSimpleName());
+            }
+        }
         return Response.noContent().build();
     }
 }

--- a/src/main/java/io/floci/az/core/Resettable.java
+++ b/src/main/java/io/floci/az/core/Resettable.java
@@ -1,0 +1,13 @@
+package io.floci.az.core;
+
+/**
+ * A state-holding service component that can wipe all of its emulator state.
+ * Implementations are discovered via CDI ({@code Instance<Resettable>}) and
+ * invoked by {@code POST /_admin/reset} in no particular order, so
+ * {@link #clearAll()} must be self-contained (a service that manages sidecar
+ * containers stops them itself) and idempotent.
+ */
+public interface Resettable {
+
+    void clearAll();
+}

--- a/src/main/java/io/floci/az/services/acr/AcrHandler.java
+++ b/src/main/java/io/floci/az/services/acr/AcrHandler.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.Resettable;
 import io.floci.az.core.StoredObject;
 import io.floci.az.core.storage.StorageBackend;
 import io.floci.az.core.storage.StorageFactory;
@@ -58,7 +59,7 @@ import java.util.concurrent.TimeUnit;
  * and {@code loginServer} is the cosmetic {@code {name}.azurecr.io} for management-plane fidelity.</p>
  */
 @ApplicationScoped
-public class AcrHandler implements AzureServiceHandler {
+public class AcrHandler implements AzureServiceHandler, Resettable {
 
     private static final Logger LOG = Logger.getLogger(AcrHandler.class);
 

--- a/src/main/java/io/floci/az/services/aks/AksHandler.java
+++ b/src/main/java/io/floci/az/services/aks/AksHandler.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.Resettable;
 import io.floci.az.core.StoredObject;
 import io.floci.az.core.storage.StorageBackend;
 import io.floci.az.core.storage.StorageFactory;
@@ -52,7 +53,7 @@ import java.util.concurrent.TimeUnit;
  * Clusters transition immediately to "Succeeded" with a synthetic kubeconfig pointing at localhost.</p>
  */
 @ApplicationScoped
-public class AksHandler implements AzureServiceHandler {
+public class AksHandler implements AzureServiceHandler, Resettable {
 
     private static final Logger LOG = Logger.getLogger(AksHandler.class);
 

--- a/src/main/java/io/floci/az/services/apim/ApiManagementHandler.java
+++ b/src/main/java/io/floci/az/services/apim/ApiManagementHandler.java
@@ -2,6 +2,7 @@ package io.floci.az.services.apim;
 
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.Resettable;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
@@ -10,7 +11,7 @@ import java.util.List;
 import java.util.Map;
 
 @ApplicationScoped
-public class ApiManagementHandler implements AzureServiceHandler {
+public class ApiManagementHandler implements AzureServiceHandler, Resettable {
 
     private final ApiManagementGateway gateway;
     private final ApiManagementService service;
@@ -46,5 +47,10 @@ public class ApiManagementHandler implements AzureServiceHandler {
 
     public List<Map<String, Object>> listSubscriptionServices(String sub) {
         return service.listSubscriptionServices(sub);
+    }
+
+    @Override
+    public void clearAll() {
+        service.clearAll();
     }
 }

--- a/src/main/java/io/floci/az/services/apim/ApiManagementService.java
+++ b/src/main/java/io/floci/az/services/apim/ApiManagementService.java
@@ -765,4 +765,16 @@ public class ApiManagementService {
         return UUID.nameUUIDFromBytes((subscriptionId + ":" + suffix).getBytes(StandardCharsets.UTF_8))
                 .toString().replace("-", "");
     }
+
+    public void clearAll() {
+        services.clear();
+        apis.clear();
+        operations.clear();
+        policies.clear();
+        products.clear();
+        subscriptions.clear();
+        namedValues.clear();
+        backends.clear();
+        productApis.clear();
+    }
 }

--- a/src/main/java/io/floci/az/services/appconfig/AppConfigHandler.java
+++ b/src/main/java/io/floci/az/services/appconfig/AppConfigHandler.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.Resettable;
 import io.floci.az.core.StoredObject;
 import io.floci.az.core.storage.StorageBackend;
 import io.floci.az.core.storage.StorageFactory;
@@ -27,7 +28,7 @@ import java.util.stream.Collectors;
 import static io.floci.az.services.appconfig.AppConfigModels.*;
 
 @ApplicationScoped
-public class AppConfigHandler implements AzureServiceHandler {
+public class AppConfigHandler implements AzureServiceHandler, Resettable {
 
     private static final Logger LOG = Logger.getLogger(AppConfigHandler.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();

--- a/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
+++ b/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
@@ -3,6 +3,7 @@ package io.floci.az.services.blob;
 import io.floci.az.core.AzureErrorResponse;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.Resettable;
 import io.floci.az.core.StoredObject;
 import io.floci.az.core.XmlBuilder;
 import io.floci.az.core.XmlUtils;
@@ -26,7 +27,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 @ApplicationScoped
-public class BlobServiceHandler implements AzureServiceHandler {
+public class BlobServiceHandler implements AzureServiceHandler, Resettable {
 
     private static final Logger LOGGER = Logger.getLogger(BlobServiceHandler.class);
     private static final DateTimeFormatter RFC1123_DATE_TIME = DateTimeFormatter

--- a/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.Resettable;
 import io.floci.az.core.StoredObject;
 import io.floci.az.core.storage.StorageBackend;
 import io.floci.az.core.storage.StorageFactory;
@@ -31,7 +32,7 @@ import java.util.stream.Collectors;
  *   Queries    — POST /dbs/{dbId}/colls/{collId}/docs with x-ms-documentdb-isquery: True
  */
 @ApplicationScoped
-public class CosmosHandler implements AzureServiceHandler {
+public class CosmosHandler implements AzureServiceHandler, Resettable {
 
     private static final Logger LOG = Logger.getLogger(CosmosHandler.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();

--- a/src/main/java/io/floci/az/services/email/EmailHandler.java
+++ b/src/main/java/io/floci/az/services/email/EmailHandler.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.Resettable;
 import io.floci.az.core.StoredObject;
 import io.floci.az.core.storage.InMemoryStorage;
 import io.floci.az.core.storage.StorageBackend;
@@ -47,7 +48,7 @@ import java.util.regex.Pattern;
  * <p>Emails are captured in-memory for local inspection; no actual delivery occurs.
  */
 @ApplicationScoped
-public class EmailHandler implements AzureServiceHandler {
+public class EmailHandler implements AzureServiceHandler, Resettable {
 
     private static final Logger LOG = Logger.getLogger(EmailHandler.class);
 

--- a/src/main/java/io/floci/az/services/eventgrid/EventGridHandler.java
+++ b/src/main/java/io/floci/az/services/eventgrid/EventGridHandler.java
@@ -2,6 +2,7 @@ package io.floci.az.services.eventgrid;
 
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.Resettable;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
@@ -17,7 +18,7 @@ import org.jboss.logging.Logger;
  * </ul>
  */
 @ApplicationScoped
-public class EventGridHandler implements AzureServiceHandler {
+public class EventGridHandler implements AzureServiceHandler, Resettable {
 
     private static final Logger LOG = Logger.getLogger(EventGridHandler.class);
     private static final String ARM_MARKER = "/providers/Microsoft.EventGrid/";

--- a/src/main/java/io/floci/az/services/eventhub/EventHubHandler.java
+++ b/src/main/java/io/floci/az/services/eventhub/EventHubHandler.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.Resettable;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
@@ -42,7 +43,7 @@ import java.util.Optional;
  * </pre>
  */
 @ApplicationScoped
-public class EventHubHandler implements AzureServiceHandler {
+public class EventHubHandler implements AzureServiceHandler, Resettable {
 
     private static final Logger LOG = Logger.getLogger(EventHubHandler.class);
 

--- a/src/main/java/io/floci/az/services/functions/FunctionsServiceHandler.java
+++ b/src/main/java/io/floci/az/services/functions/FunctionsServiceHandler.java
@@ -7,6 +7,7 @@ import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureErrorResponse;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.Resettable;
 import io.floci.az.core.StoredObject;
 import io.floci.az.core.storage.StorageBackend;
 import io.floci.az.core.storage.StorageFactory;
@@ -29,7 +30,7 @@ import java.util.stream.Collectors;
  *   Invocation  — /{account}-functions/api/{appName}/{funcName}
  */
 @ApplicationScoped
-public class FunctionsServiceHandler implements AzureServiceHandler {
+public class FunctionsServiceHandler implements AzureServiceHandler, Resettable {
 
     private static final Logger LOG = Logger.getLogger(FunctionsServiceHandler.class);
 

--- a/src/main/java/io/floci/az/services/keyvault/KeyVaultHandler.java
+++ b/src/main/java/io/floci/az/services/keyvault/KeyVaultHandler.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.Resettable;
 import io.floci.az.core.StoredObject;
 import io.floci.az.core.storage.StorageBackend;
 import io.floci.az.core.storage.StorageFactory;
@@ -20,7 +21,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 @ApplicationScoped
-public class KeyVaultHandler implements AzureServiceHandler {
+public class KeyVaultHandler implements AzureServiceHandler, Resettable {
 
     private static final Logger LOG = Logger.getLogger(KeyVaultHandler.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();

--- a/src/main/java/io/floci/az/services/monitor/MonitorHandler.java
+++ b/src/main/java/io/floci/az/services/monitor/MonitorHandler.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.Resettable;
 import io.floci.az.core.StoredObject;
 import io.floci.az.core.storage.StorageBackend;
 import io.floci.az.core.storage.StorageFactory;
@@ -22,7 +23,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 @ApplicationScoped
-public class MonitorHandler implements AzureServiceHandler {
+public class MonitorHandler implements AzureServiceHandler, Resettable {
 
     private static final Logger LOG = Logger.getLogger(MonitorHandler.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();

--- a/src/main/java/io/floci/az/services/network/NetworkHandler.java
+++ b/src/main/java/io/floci/az/services/network/NetworkHandler.java
@@ -1,6 +1,7 @@
 package io.floci.az.services.network;
 
 import io.floci.az.core.AzureRequest;
+import io.floci.az.core.Resettable;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
@@ -9,7 +10,7 @@ import java.util.List;
 import java.util.Map;
 
 @ApplicationScoped
-public class NetworkHandler {
+public class NetworkHandler implements Resettable {
 
     private final NetworkService service;
 
@@ -26,6 +27,7 @@ public class NetworkHandler {
         return service.listResources(sub, rg);
     }
 
+    @Override
     public void clearAll() {
         service.clearAll();
     }

--- a/src/main/java/io/floci/az/services/postgres/PostgresHandler.java
+++ b/src/main/java/io/floci/az/services/postgres/PostgresHandler.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.Resettable;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
@@ -45,7 +46,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * which the azurerm long-running-operation poller accepts as a terminal result.
  */
 @ApplicationScoped
-public class PostgresHandler implements AzureServiceHandler {
+public class PostgresHandler implements AzureServiceHandler, Resettable {
 
     private static final Logger LOG = Logger.getLogger(PostgresHandler.class);
 

--- a/src/main/java/io/floci/az/services/queue/QueueServiceHandler.java
+++ b/src/main/java/io/floci/az/services/queue/QueueServiceHandler.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import io.floci.az.core.AzureErrorResponse;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.Resettable;
 import io.floci.az.core.StoredObject;
 import io.floci.az.core.XmlBuilder;
 import io.floci.az.core.XmlUtils;
@@ -23,7 +24,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 @ApplicationScoped
-public class QueueServiceHandler implements AzureServiceHandler {
+public class QueueServiceHandler implements AzureServiceHandler, Resettable {
 
     private static final Logger LOGGER = Logger.getLogger(QueueServiceHandler.class);
     private static final DateTimeFormatter RFC1123_DATE_TIME = DateTimeFormatter

--- a/src/main/java/io/floci/az/services/redis/RedisHandler.java
+++ b/src/main/java/io/floci/az/services/redis/RedisHandler.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.Resettable;
 import io.floci.az.core.StoredObject;
 import io.floci.az.core.storage.StorageBackend;
 import io.floci.az.core.storage.StorageFactory;
@@ -56,7 +57,7 @@ import java.util.concurrent.TimeUnit;
  * standard Redis clients can connect to the sidecar.</p>
  */
 @ApplicationScoped
-public class RedisHandler implements AzureServiceHandler {
+public class RedisHandler implements AzureServiceHandler, Resettable {
 
     private static final Logger LOG = Logger.getLogger(RedisHandler.class);
 

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.Resettable;
 import io.floci.az.core.StoredObject;
 import io.floci.az.core.storage.StorageBackend;
 import io.floci.az.core.storage.StorageFactory;
@@ -54,7 +55,7 @@ import java.util.Optional;
  * </pre>
  */
 @ApplicationScoped
-public class ServiceBusHandler implements AzureServiceHandler {
+public class ServiceBusHandler implements AzureServiceHandler, Resettable {
 
     private static final Logger LOG = Logger.getLogger(ServiceBusHandler.class);
 

--- a/src/main/java/io/floci/az/services/sql/SqlHandler.java
+++ b/src/main/java/io/floci/az/services/sql/SqlHandler.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.Resettable;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
@@ -42,7 +43,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * </ul>
  */
 @ApplicationScoped
-public class SqlHandler implements AzureServiceHandler {
+public class SqlHandler implements AzureServiceHandler, Resettable {
 
     private static final Logger LOG = Logger.getLogger(SqlHandler.class);
 

--- a/src/main/java/io/floci/az/services/table/TableServiceHandler.java
+++ b/src/main/java/io/floci/az/services/table/TableServiceHandler.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.floci.az.core.AzureErrorResponse;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.Resettable;
 import io.floci.az.core.StoredObject;
 import io.floci.az.core.storage.StorageBackend;
 import io.floci.az.core.storage.StorageFactory;
@@ -23,7 +24,7 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 @ApplicationScoped
-public class TableServiceHandler implements AzureServiceHandler {
+public class TableServiceHandler implements AzureServiceHandler, Resettable {
 
     private static final Logger LOGGER = Logger.getLogger(TableServiceHandler.class);
 

--- a/src/main/java/io/floci/az/services/vm/VmHandler.java
+++ b/src/main/java/io/floci/az/services/vm/VmHandler.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.Resettable;
 import io.floci.az.core.StoredObject;
 import io.floci.az.core.storage.StorageBackend;
 import io.floci.az.core.storage.StorageFactory;
@@ -55,7 +56,7 @@ import java.util.concurrent.TimeUnit;
  * Power actions are pure state transitions. This keeps the service usable in CI without Docker.</p>
  */
 @ApplicationScoped
-public class VmHandler implements AzureServiceHandler {
+public class VmHandler implements AzureServiceHandler, Resettable {
 
     private static final Logger LOG = Logger.getLogger(VmHandler.class);
 

--- a/src/test/java/io/floci/az/core/AdminResetTest.java
+++ b/src/test/java/io/floci/az/core/AdminResetTest.java
@@ -1,0 +1,66 @@
+package io.floci.az.core;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+
+@QuarkusTest
+@DisplayName("/_admin/reset — every state-holding service self-registers via Resettable")
+class AdminResetTest {
+
+    private static final String APIM_SERVICE =
+            "/subscriptions/reset-sub/resourceGroups/reset-rg"
+                    + "/providers/Microsoft.ApiManagement/service/reset-apim?api-version=2024-05-01";
+
+    @Test
+    void resetClearsApimEmailAndAppConfigState() {
+        given().contentType("application/json").body("""
+                {
+                  "location": "eastus",
+                  "sku": {"name": "Developer", "capacity": 1},
+                  "properties": {"publisherEmail": "admin@example.com", "publisherName": "floci"}
+                }
+                """)
+                .when().put(APIM_SERVICE)
+                .then().statusCode(200)
+                .body("name", equalTo("reset-apim"));
+
+        given().contentType("application/json")
+                .body("{\"value\": \"reset-me\"}")
+                .when().put("/devstoreaccount1-appconfig/kv/reset-key?api-version=1.0")
+                .then().statusCode(200);
+
+        given().contentType("application/json").body("""
+                {
+                  "senderAddress": "noreply@reset.test",
+                  "content": {"subject": "reset-me", "plainText": "bye"},
+                  "recipients": {"to": [{"address": "dev@reset.test"}]}
+                }
+                """)
+                .when().post("/emails:send?api-version=2023-03-31")
+                .then().statusCode(202);
+
+        given().when().get("/emailMessages")
+                .then().statusCode(200)
+                .body("count", greaterThan(0));
+
+        given().when().post("/_admin/reset")
+                .then().statusCode(204);
+
+        // apim and email were both silently missing from reset before
+        // Resettable self-registration.
+        given().when().get(APIM_SERVICE)
+                .then().statusCode(404);
+
+        given().when().get("/emailMessages")
+                .then().statusCode(200)
+                .body("count", equalTo(0));
+
+        given().when().get("/devstoreaccount1-appconfig/kv/reset-key?api-version=1.0")
+                .then().statusCode(404);
+    }
+}


### PR DESCRIPTION
## Summary

`POST /_admin/reset` hand-listed 18 handlers and silently skipped **apim** and **email**, so their state survived test-isolation resets (apim had no `clearAll` at all; email had one that was never called).

State-holding handlers now implement a new `core/Resettable` interface and `AdminController` iterates CDI `Instance<Resettable>` — the same self-registration pattern `AuthPipeline` uses for `AuthVerifier`. A service registers for reset by existing; forgetting is no longer silently possible. ApiManagement gains its missing `clearAll` (handler delegating to the service, mirroring network/eventgrid).

**Behavior change (intentional):** apim and email state is now actually wiped by `/_admin/reset`.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

No wire-protocol changes — `/_admin/reset` is an emulator-internal endpoint. Each `clearAll()` implementation is unchanged; only the dispatch mechanism moved from a hand-maintained list to CDI discovery.

## Checklist

- [x] `./mvnw test` passes locally (251/251)
- [x] New or updated integration test added (`AdminResetTest`: creates an apim service + an appconfig key, resets, asserts both are gone — the apim half fails on main)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)