### PR TITLE
chore(core): extract shared ARM helpers into core/arm

### DIFF
--- a/src/main/java/io/floci/az/core/arm/ArmErrors.java
+++ b/src/main/java/io/floci/az/core/arm/ArmErrors.java
@@ -1,0 +1,28 @@
+package io.floci.az.core.arm;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import java.util.Map;
+
+/**
+ * ARM CloudError responses — {@code {"error":{"code":"...","message":"..."}}}.
+ * The management-plane counterpart of {@code core/AzureErrorResponse} (which covers
+ * the storage data-plane XML/JSON shape).
+ */
+public final class ArmErrors {
+
+    private ArmErrors() {
+    }
+
+    public static Response error(int status, String code, String message) {
+        return Response.status(status)
+                .entity(Map.of("error", Map.of("code", code, "message", message)))
+                .type(MediaType.APPLICATION_JSON)
+                .build();
+    }
+
+    public static Response notFound(String message) {
+        return error(404, "ResourceNotFound", message);
+    }
+}

--- a/src/main/java/io/floci/az/core/arm/ArmJson.java
+++ b/src/main/java/io/floci/az/core/arm/ArmJson.java
@@ -1,0 +1,92 @@
+package io.floci.az.core.arm;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.floci.az.core.AzureRequest;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/** JSON request-body helpers shared by ARM-style handlers. */
+public final class ArmJson {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private ArmJson() {
+    }
+
+    /** Signals an unparseable request body; map to an ARM {@code 400 InvalidRequestContent}. */
+    public static final class InvalidBodyException extends RuntimeException {
+        public InvalidBodyException(Throwable cause) {
+            super(cause);
+        }
+    }
+
+    /**
+     * Parses the body, degrading to an immutable empty map when the body is missing or
+     * malformed — the historical tolerant behavior of the ARM-plane handlers.
+     */
+    @SuppressWarnings("unchecked")
+    public static Map<String, Object> parseBodyLenient(AzureRequest req) {
+        InputStream body = req.bodyStream();
+        try {
+            if (body == null || body.available() == 0) {
+                return Map.of();
+            }
+            return MAPPER.readValue(body, Map.class);
+        } catch (IOException e) {
+            return Map.of();
+        }
+    }
+
+    /**
+     * Parses the body, degrading to a fresh mutable map when the body is missing or
+     * malformed — for handlers that mutate the parsed map in place.
+     */
+    public static Map<String, Object> parseBodyMutable(AzureRequest req) {
+        InputStream body = req.bodyStream();
+        if (body == null) {
+            return new LinkedHashMap<>();
+        }
+        try {
+            return MAPPER.readValue(body, new TypeReference<>() {});
+        } catch (IOException e) {
+            return new LinkedHashMap<>();
+        }
+    }
+
+    /**
+     * Parses the body strictly: an absent body yields an empty map, a malformed one
+     * throws {@link InvalidBodyException} (real ARM answers {@code 400 InvalidRequestContent}).
+     */
+    @SuppressWarnings("unchecked")
+    public static Map<String, Object> parseBodyStrict(AzureRequest req) {
+        InputStream body = req.bodyStream();
+        byte[] bytes;
+        try {
+            bytes = body == null ? new byte[0] : body.readAllBytes();
+        } catch (IOException e) {
+            throw new InvalidBodyException(e);
+        }
+        if (bytes.length == 0) {
+            return Map.of();
+        }
+        try {
+            return MAPPER.readValue(bytes, Map.class);
+        } catch (IOException e) {
+            throw new InvalidBodyException(e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public static Map<String, Object> cast(Object value) {
+        return value instanceof Map<?, ?> m ? (Map<String, Object>) m : Map.of();
+    }
+
+    public static String string(Map<String, Object> map, String key, String defaultValue) {
+        Object v = map.get(key);
+        return v instanceof String s ? s : defaultValue;
+    }
+}

--- a/src/main/java/io/floci/az/core/arm/ArmPaths.java
+++ b/src/main/java/io/floci/az/core/arm/ArmPaths.java
@@ -1,0 +1,86 @@
+package io.floci.az.core.arm;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Path helpers for ARM management-plane URLs
+ * ({@code subscriptions/{sub}/resourceGroups/{rg}/providers/{ns}/{type}/{name}/...}).
+ *
+ * <p>Miss fallbacks are caller-supplied: services key their in-memory stores by these
+ * values, so the historical per-service fallbacks ("unknown" for the ARM-plane services,
+ * "default" for the sidecar services) must be preserved verbatim. Unifying them would
+ * silently change storage keys for malformed paths — that is a protocol-level decision,
+ * not a refactor.
+ */
+public final class ArmPaths {
+
+    /** Compiled {@link #resourceName} patterns, keyed by resource type (a small, fixed set). */
+    private static final ConcurrentMap<String, Pattern> RESOURCE_NAME_PATTERNS = new ConcurrentHashMap<>();
+
+    private ArmPaths() {
+    }
+
+    /** Segment after the case-sensitive {@code subscriptions} segment. */
+    public static Optional<String> subscription(String path) {
+        return segmentAfter(path, "subscriptions", false);
+    }
+
+    public static String subscription(String path, String fallback) {
+        return subscription(path).orElse(fallback);
+    }
+
+    /** Segment after the case-insensitive {@code resourceGroups} segment. */
+    public static Optional<String> resourceGroup(String path) {
+        return segmentAfter(path, "resourcegroups", true);
+    }
+
+    public static String resourceGroup(String path, String fallback) {
+        return resourceGroup(path).orElse(fallback);
+    }
+
+    /** Segment after the given case-insensitive segment. */
+    public static String segmentAfter(String path, String segment, String fallback) {
+        return segmentAfter(path, segment, true).orElse(fallback);
+    }
+
+    /** First path segment captured after {@code /{resourceType}/}. */
+    public static Optional<String> resourceName(String path, String resourceType) {
+        Pattern p = RESOURCE_NAME_PATTERNS.computeIfAbsent(resourceType,
+                t -> Pattern.compile("/" + Pattern.quote(t) + "/([^/?]+)"));
+        Matcher m = p.matcher(path);
+        return m.find() ? Optional.of(m.group(1)) : Optional.empty();
+    }
+
+    public static String resourceName(String path, String resourceType, String fallback) {
+        return resourceName(path, resourceType).orElse(fallback);
+    }
+
+    /** Remainder after the last occurrence of {@code marker}, query string stripped. */
+    public static String afterSegment(String path, String marker, String fallback) {
+        int idx = path == null ? -1 : path.lastIndexOf(marker);
+        if (idx < 0) {
+            return fallback;
+        }
+        String rest = path.substring(idx + marker.length());
+        int q = rest.indexOf('?');
+        return q >= 0 ? rest.substring(0, q) : rest;
+    }
+
+    private static Optional<String> segmentAfter(String path, String segment, boolean ignoreCase) {
+        if (path == null) {
+            return Optional.empty();
+        }
+        String[] parts = path.split("/");
+        for (int i = 0; i < parts.length - 1; i++) {
+            boolean match = ignoreCase ? segment.equalsIgnoreCase(parts[i]) : segment.equals(parts[i]);
+            if (match) {
+                return Optional.of(parts[i + 1]);
+            }
+        }
+        return Optional.empty();
+    }
+}

--- a/src/main/java/io/floci/az/core/arm/ArmResources.java
+++ b/src/main/java/io/floci/az/core/arm/ArmResources.java
@@ -1,0 +1,25 @@
+package io.floci.az.core.arm;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Conventions for ARM resources held as maps: services smuggle their storage keys as
+ * underscore-prefixed entries and strip them before returning the resource on the wire.
+ */
+public final class ArmResources {
+
+    public static final String SUB_KEY = "_sub";
+    public static final String RG_KEY = "_rg";
+
+    private ArmResources() {
+    }
+
+    /** Copy of the resource without the internal routing keys. */
+    public static Map<String, Object> stripInternal(Map<String, Object> resource) {
+        Map<String, Object> copy = new LinkedHashMap<>(resource);
+        copy.remove(SUB_KEY);
+        copy.remove(RG_KEY);
+        return copy;
+    }
+}

--- a/src/main/java/io/floci/az/services/acr/AcrHandler.java
+++ b/src/main/java/io/floci/az/services/acr/AcrHandler.java
@@ -12,6 +12,8 @@ import io.floci.az.core.StoredObject;
 import io.floci.az.core.storage.StorageBackend;
 import io.floci.az.core.storage.StorageFactory;
 import io.floci.az.services.acr.AcrModels.Registry;
+import io.floci.az.core.arm.ArmErrors;
+import io.floci.az.core.arm.ArmPaths;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -488,21 +490,11 @@ public class AcrHandler implements AzureServiceHandler, Resettable {
     }
 
     private static String extractSubscriptionId(String fullPath) {
-        if (fullPath == null) { return "default"; }
-        String[] parts = fullPath.split("/");
-        for (int i = 0; i < parts.length - 1; i++) {
-            if ("subscriptions".equalsIgnoreCase(parts[i])) { return parts[i + 1]; }
-        }
-        return "default";
+        return ArmPaths.segmentAfter(fullPath, "subscriptions", "default");
     }
 
     private static String extractResourceGroup(String fullPath) {
-        if (fullPath == null) { return "default"; }
-        String[] parts = fullPath.split("/");
-        for (int i = 0; i < parts.length - 1; i++) {
-            if ("resourcegroups".equalsIgnoreCase(parts[i])) { return parts[i + 1]; }
-        }
-        return "default";
+        return ArmPaths.resourceGroup(fullPath, "default");
     }
 
     private static String segment(String path, int index) {
@@ -534,15 +526,11 @@ public class AcrHandler implements AzureServiceHandler, Resettable {
     // ── Standard error responses ─────────────────────────────────────────────────
 
     private static Response notFound(String message) {
-        return Response.status(404).entity(Map.of(
-                "error", Map.of("code", "ResourceNotFound", "message", message)))
-                .type("application/json").build();
+        return ArmErrors.notFound(message);
     }
 
     private static Response badRequest(String message) {
-        return Response.status(400).entity(Map.of(
-                "error", Map.of("code", "InvalidRequest", "message", message)))
-                .type("application/json").build();
+        return ArmErrors.error(400, "InvalidRequest", message);
     }
 
     private static Response methodNotAllowed() {

--- a/src/main/java/io/floci/az/services/aks/AksHandler.java
+++ b/src/main/java/io/floci/az/services/aks/AksHandler.java
@@ -13,6 +13,8 @@ import io.floci.az.core.storage.StorageBackend;
 import io.floci.az.core.storage.StorageFactory;
 import io.floci.az.services.aks.AksModels.AgentPoolProfile;
 import io.floci.az.services.aks.AksModels.ManagedCluster;
+import io.floci.az.core.arm.ArmErrors;
+import io.floci.az.core.arm.ArmPaths;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -573,21 +575,11 @@ public class AksHandler implements AzureServiceHandler, Resettable {
     }
 
     private static String extractSubscriptionId(String fullPath) {
-        if (fullPath == null) { return "default"; }
-        String[] parts = fullPath.split("/");
-        for (int i = 0; i < parts.length - 1; i++) {
-            if ("subscriptions".equalsIgnoreCase(parts[i])) { return parts[i + 1]; }
-        }
-        return "default";
+        return ArmPaths.segmentAfter(fullPath, "subscriptions", "default");
     }
 
     private static String extractResourceGroup(String fullPath) {
-        if (fullPath == null) { return "default"; }
-        String[] parts = fullPath.split("/");
-        for (int i = 0; i < parts.length - 1; i++) {
-            if ("resourcegroups".equalsIgnoreCase(parts[i])) { return parts[i + 1]; }
-        }
-        return "default";
+        return ArmPaths.resourceGroup(fullPath, "default");
     }
 
     private static String segment(String path, int index) {
@@ -619,15 +611,11 @@ public class AksHandler implements AzureServiceHandler, Resettable {
     // ── Standard error responses ───────────────────────────────────────────────
 
     private static Response notFound(String message) {
-        return Response.status(404).entity(Map.of(
-                "error", Map.of("code", "ResourceNotFound", "message", message)))
-                .type("application/json").build();
+        return ArmErrors.notFound(message);
     }
 
     private static Response badRequest(String message) {
-        return Response.status(400).entity(Map.of(
-                "error", Map.of("code", "InvalidRequest", "message", message)))
-                .type("application/json").build();
+        return ArmErrors.error(400, "InvalidRequest", message);
     }
 
     private static Response methodNotAllowed() {

--- a/src/main/java/io/floci/az/services/apim/ApiManagementGateway.java
+++ b/src/main/java/io/floci/az/services/apim/ApiManagementGateway.java
@@ -1,6 +1,8 @@
 package io.floci.az.services.apim;
 
 import io.floci.az.core.AzureRequest;
+import io.floci.az.core.arm.ArmErrors;
+import io.floci.az.core.arm.ArmJson;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
@@ -396,9 +398,8 @@ public class ApiManagementGateway {
         return request.headers().getHeaderString(name);
     }
 
-    @SuppressWarnings("unchecked")
     private static Map<String, Object> cast(Object value) {
-        return value instanceof Map<?, ?> m ? (Map<String, Object>) m : Map.of();
+        return ArmJson.cast(value);
     }
 
     private static String stringValue(Object value) {
@@ -410,10 +411,7 @@ public class ApiManagementGateway {
     }
 
     private Response notFound(String message) {
-        return Response.status(404).entity(Map.of("error", Map.of(
-                "code", "ResourceNotFound",
-                "message", message
-        ))).build();
+        return ArmErrors.notFound(message);
     }
 
     private Response unauthorized(String message) {

--- a/src/main/java/io/floci/az/services/apim/ApiManagementService.java
+++ b/src/main/java/io/floci/az/services/apim/ApiManagementService.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
+import io.floci.az.core.arm.ArmErrors;
+import io.floci.az.core.arm.ArmJson;
+import io.floci.az.core.arm.ArmPaths;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
@@ -637,33 +640,19 @@ public class ApiManagementService {
     }
 
     private static String extractRg(String path) {
-        String[] parts = path.split("/");
-        for (int i = 0; i < parts.length - 1; i++) {
-            if ("resourcegroups".equalsIgnoreCase(parts[i])) {
-                return parts[i + 1];
-            }
-        }
-        return "unknown";
+        return ArmPaths.resourceGroup(path, "unknown");
     }
 
     private static String extractAfter(String path, String marker) {
-        int idx = path.lastIndexOf(marker);
-        if (idx < 0) {
-            return "unknown";
-        }
-        String rest = path.substring(idx + marker.length());
-        int q = rest.indexOf('?');
-        return q >= 0 ? rest.substring(0, q) : rest;
+        return ArmPaths.afterSegment(path, marker, "unknown");
     }
 
-    @SuppressWarnings("unchecked")
     private static Map<String, Object> cast(Object value) {
-        return value instanceof Map<?, ?> m ? (Map<String, Object>) m : Map.of();
+        return ArmJson.cast(value);
     }
 
     private static String bodyString(Map<String, Object> map, String key, String defaultValue) {
-        Object value = map.get(key);
-        return value instanceof String s ? s : defaultValue;
+        return ArmJson.string(map, key, defaultValue);
     }
 
     private static String stringValue(Object value) {
@@ -689,16 +678,8 @@ public class ApiManagementService {
         return method.toLowerCase() + (cleanPath.isBlank() ? "" : "-" + cleanPath);
     }
 
-    @SuppressWarnings("unchecked")
     private Map<String, Object> parseBody(AzureRequest request) {
-        try {
-            if (request.bodyStream() == null || request.bodyStream().available() == 0) {
-                return Map.of();
-            }
-            return MAPPER.readValue(request.bodyStream(), Map.class);
-        } catch (IOException e) {
-            return Map.of();
-        }
+        return ArmJson.parseBodyLenient(request);
     }
 
     private static Map<String, Object> stripInternal(Map<String, Object> resource) {
@@ -719,10 +700,7 @@ public class ApiManagementService {
     }
 
     private Response notFound(String message) {
-        return Response.status(404).entity(Map.of("error", Map.of(
-                "code", "ResourceNotFound",
-                "message", message
-        ))).build();
+        return ArmErrors.notFound(message);
     }
 
     private static String serviceKey(String sub, String rg, String serviceName) {

--- a/src/main/java/io/floci/az/services/appconfig/AppConfigHandler.java
+++ b/src/main/java/io/floci/az/services/appconfig/AppConfigHandler.java
@@ -11,6 +11,7 @@ import io.floci.az.core.storage.StorageBackend;
 import io.floci.az.core.storage.StorageFactory;
 import io.floci.az.services.appconfig.AppConfigModels.OperationDetails;
 import io.floci.az.services.appconfig.AppConfigModels.Page;
+import io.floci.az.core.arm.ArmJson;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
@@ -954,11 +955,7 @@ public class AppConfigHandler implements AzureServiceHandler, Resettable {
     }
 
     private Map<String, Object> parseBody(AzureRequest req) {
-        try {
-            return MAPPER.readValue(req.bodyStream(), new TypeReference<>() {});
-        } catch (IOException e) {
-            return new LinkedHashMap<>();
-        }
+        return ArmJson.parseBodyMutable(req);
     }
 
     private byte[] toBytes(Object obj) {

--- a/src/main/java/io/floci/az/services/arm/ArmHandler.java
+++ b/src/main/java/io/floci/az/services/arm/ArmHandler.java
@@ -1,6 +1,5 @@
 package io.floci.az.services.arm;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
@@ -11,16 +10,17 @@ import io.floci.az.services.functions.FunctionsServiceHandler;
 import io.floci.az.services.network.NetworkHandler;
 import io.floci.az.services.monitor.MonitorHandler;
 import io.floci.az.services.queue.QueueServiceHandler;
+import io.floci.az.core.arm.ArmErrors;
+import io.floci.az.core.arm.ArmJson;
+import io.floci.az.core.arm.ArmPaths;
+import io.floci.az.core.arm.ArmResources;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 
-import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * ARM management-plane handler for Azure Resource Manager paths that are not
@@ -41,7 +41,6 @@ import java.util.regex.Pattern;
 public class ArmHandler implements AzureServiceHandler {
 
     private static final Logger LOG = Logger.getLogger(ArmHandler.class);
-    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     static final String FAKE_STORAGE_KEY =
             "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMh0==";
@@ -666,33 +665,19 @@ public class ArmHandler implements AzureServiceHandler {
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private static String extractSub(String path) {
-        String[] parts = path.split("/");
-        for (int i = 0; i < parts.length - 1; i++) {
-            if ("subscriptions".equals(parts[i])) return parts[i + 1];
-        }
-        return "unknown";
+        return ArmPaths.subscription(path, "unknown");
     }
 
     private static String extractRg(String path) {
-        String[] parts = path.split("/");
-        for (int i = 0; i < parts.length - 1; i++) {
-            if ("resourcegroups".equalsIgnoreCase(parts[i])) return parts[i + 1];
-        }
-        return "unknown";
+        return ArmPaths.resourceGroup(path, "unknown");
     }
 
     private static String extractResourceName(String path, String resourceType) {
-        Pattern p = Pattern.compile("/" + Pattern.quote(resourceType) + "/([^/?]+)");
-        Matcher m = p.matcher(path);
-        return m.find() ? m.group(1) : "unknown";
+        return ArmPaths.resourceName(path, resourceType, "unknown");
     }
 
     private static String extractAfter(String path, String marker) {
-        int idx = path.lastIndexOf(marker);
-        if (idx < 0) return "unknown";
-        String rest = path.substring(idx + marker.length());
-        int q = rest.indexOf('?');
-        return q >= 0 ? rest.substring(0, q) : rest;
+        return ArmPaths.afterSegment(path, marker, "unknown");
     }
 
     private static String rgKey(String sub, String rg)               { return sub + "/" + rg; }
@@ -700,33 +685,20 @@ public class ArmHandler implements AzureServiceHandler {
     private static String kvKey(String sub, String rg, String name)  { return sub + "/" + rg + "/kv/" + name; }
     private static String webAppKey(String sub, String rg, String name) { return sub + "/" + rg + "/web/" + name; }
 
-    @SuppressWarnings("unchecked")
     private static Map<String, Object> cast(Object o) {
-        return o instanceof Map<?, ?> m ? (Map<String, Object>) m : Map.of();
+        return ArmJson.cast(o);
     }
 
     private static String bodyString(Map<String, Object> map, String key, String defaultValue) {
-        Object v = map.get(key);
-        return v instanceof String s ? s : defaultValue;
+        return ArmJson.string(map, key, defaultValue);
     }
 
-    @SuppressWarnings("unchecked")
     private Map<String, Object> parseBody(AzureRequest req) {
-        try {
-            if (req.bodyStream() == null || req.bodyStream().available() == 0) {
-                return Map.of();
-            }
-            return MAPPER.readValue(req.bodyStream(), Map.class);
-        } catch (IOException e) {
-            return Map.of();
-        }
+        return ArmJson.parseBodyLenient(req);
     }
 
     private static Map<String, Object> stripInternal(Map<String, Object> resource) {
-        Map<String, Object> copy = new LinkedHashMap<>(resource);
-        copy.remove("_sub");
-        copy.remove("_rg");
-        return copy;
+        return ArmResources.stripInternal(resource);
     }
 
     /**
@@ -758,9 +730,6 @@ public class ArmHandler implements AzureServiceHandler {
     }
 
     private Response armNotFound(String path) {
-        return Response.status(404).entity(Map.of("error", Map.of(
-                "code",    "ResourceNotFound",
-                "message", "Resource not found: " + path
-        ))).build();
+        return ArmErrors.notFound("Resource not found: " + path);
     }
 }

--- a/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
@@ -9,6 +9,7 @@ import io.floci.az.core.Resettable;
 import io.floci.az.core.StoredObject;
 import io.floci.az.core.storage.StorageBackend;
 import io.floci.az.core.storage.StorageFactory;
+import io.floci.az.core.arm.ArmJson;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
@@ -1104,11 +1105,7 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
     }
 
     private Map<String, Object> parseBody(AzureRequest req) {
-        try {
-            return MAPPER.readValue(req.bodyStream(), new TypeReference<>() {});
-        } catch (IOException e) {
-            return new LinkedHashMap<>();
-        }
+        return ArmJson.parseBodyMutable(req);
     }
 
     /**

--- a/src/main/java/io/floci/az/services/email/EmailHandler.java
+++ b/src/main/java/io/floci/az/services/email/EmailHandler.java
@@ -13,6 +13,8 @@ import io.floci.az.core.storage.InMemoryStorage;
 import io.floci.az.core.storage.StorageBackend;
 import io.floci.az.services.email.EmailModels.CapturedEmail;
 import io.floci.az.services.email.EmailModels.EmailSendRequest;
+import io.floci.az.core.arm.ArmErrors;
+import io.floci.az.core.arm.ArmJson;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
@@ -437,34 +439,25 @@ public class EmailHandler implements AzureServiceHandler, Resettable {
     }
 
     private static String bodyString(Map<String, Object> map, String key, String defaultValue) {
-        Object v = map.get(key);
-        return v instanceof String s ? s : defaultValue;
+        return ArmJson.string(map, key, defaultValue);
     }
 
-    @SuppressWarnings("unchecked")
     private static Map<String, Object> bodyMap(Map<String, Object> map, String key) {
-        Object v = map.get(key);
-        return v instanceof Map<?,?> m ? (Map<String, Object>) m : Map.of();
+        return ArmJson.cast(map.get(key));
     }
 
     // ── Standard error responses ─────────────────────────────────────────────
 
     private static Response notFound(String message) {
-        return Response.status(404).entity(Map.of(
-                "error", Map.of("code", "ResourceNotFound", "message", message)))
-                .type("application/json").build();
+        return ArmErrors.notFound(message);
     }
 
     private static Response badRequest(String message) {
-        return Response.status(400).entity(Map.of(
-                "error", Map.of("code", "InvalidRequest", "message", message)))
-                .type("application/json").build();
+        return ArmErrors.error(400, "InvalidRequest", message);
     }
 
     private static Response serverError(String message) {
-        return Response.status(500).entity(Map.of(
-                "error", Map.of("code", "InternalError", "message", message)))
-                .type("application/json").build();
+        return ArmErrors.error(500, "InternalError", message);
     }
 
     /** Wipes all email data — used by {@code POST /_admin/reset}. */

--- a/src/main/java/io/floci/az/services/eventgrid/EventGridPublisher.java
+++ b/src/main/java/io/floci/az/services/eventgrid/EventGridPublisher.java
@@ -6,6 +6,7 @@ import io.floci.az.core.AzureRequest;
 import io.floci.az.services.eventgrid.EventGridModels.EventSubscription;
 import io.floci.az.services.eventgrid.EventGridModels.Filter;
 import io.floci.az.services.eventgrid.EventGridModels.Topic;
+import io.floci.az.core.arm.ArmErrors;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
@@ -184,7 +185,6 @@ public class EventGridPublisher {
     }
 
     private static Response error(int status, String code, String message) {
-        return Response.status(status).entity(Map.of("error", Map.of(
-                "code", code, "message", message))).build();
+        return ArmErrors.error(status, code, message);
     }
 }

--- a/src/main/java/io/floci/az/services/eventgrid/EventGridService.java
+++ b/src/main/java/io/floci/az/services/eventgrid/EventGridService.java
@@ -10,6 +10,8 @@ import io.floci.az.services.eventgrid.EventGridModels.EventSubscription;
 import io.floci.az.services.eventgrid.EventGridModels.Filter;
 import io.floci.az.services.eventgrid.EventGridModels.RetryPolicy;
 import io.floci.az.services.eventgrid.EventGridModels.Topic;
+import io.floci.az.core.arm.ArmErrors;
+import io.floci.az.core.arm.ArmJson;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
@@ -382,21 +384,12 @@ public class EventGridService {
 
     // ── Generic parsing helpers ──────────────────────────────────────────────────
 
-    @SuppressWarnings("unchecked")
     private Map<String, Object> parseBody(AzureRequest req) {
-        try {
-            if (req.bodyStream() == null || req.bodyStream().available() == 0) {
-                return Map.of();
-            }
-            return MAPPER.readValue(req.bodyStream(), Map.class);
-        } catch (IOException e) {
-            return Map.of();
-        }
+        return ArmJson.parseBodyLenient(req);
     }
 
-    @SuppressWarnings("unchecked")
     private static Map<String, Object> cast(Object value) {
-        return value instanceof Map<?, ?> m ? (Map<String, Object>) m : Map.of();
+        return ArmJson.cast(value);
     }
 
     private static String stringOr(Object value, String fallback) {
@@ -456,14 +449,10 @@ public class EventGridService {
     }
 
     private static Response notFound(String resource) {
-        return Response.status(404).entity(Map.of("error", Map.of(
-                "code", "ResourceNotFound",
-                "message", "Resource not found: " + resource))).build();
+        return ArmErrors.notFound("Resource not found: " + resource);
     }
 
     private static Response badRequest(String message) {
-        return Response.status(400).entity(Map.of("error", Map.of(
-                "code", "InvalidRequest",
-                "message", message))).build();
+        return ArmErrors.error(400, "InvalidRequest", message);
     }
 }

--- a/src/main/java/io/floci/az/services/keyvault/KeyVaultHandler.java
+++ b/src/main/java/io/floci/az/services/keyvault/KeyVaultHandler.java
@@ -10,6 +10,7 @@ import io.floci.az.core.Resettable;
 import io.floci.az.core.StoredObject;
 import io.floci.az.core.storage.StorageBackend;
 import io.floci.az.core.storage.StorageFactory;
+import io.floci.az.core.arm.ArmJson;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
@@ -604,11 +605,7 @@ public class KeyVaultHandler implements AzureServiceHandler, Resettable {
     }
 
     private Map<String, Object> parseBody(AzureRequest req) {
-        try {
-            return MAPPER.readValue(req.bodyStream(), new TypeReference<>() {});
-        } catch (IOException e) {
-            return new LinkedHashMap<>();
-        }
+        return ArmJson.parseBodyMutable(req);
     }
 
     private byte[] toBytes(Object obj) {

--- a/src/main/java/io/floci/az/services/monitor/MonitorHandler.java
+++ b/src/main/java/io/floci/az/services/monitor/MonitorHandler.java
@@ -9,6 +9,7 @@ import io.floci.az.core.Resettable;
 import io.floci.az.core.StoredObject;
 import io.floci.az.core.storage.StorageBackend;
 import io.floci.az.core.storage.StorageFactory;
+import io.floci.az.core.arm.ArmJson;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.MediaType;
@@ -501,16 +502,8 @@ public class MonitorHandler implements AzureServiceHandler, Resettable {
         }
     }
 
-    @SuppressWarnings("unchecked")
     private Map<String, Object> parseBody(AzureRequest req) {
-        try {
-            if (req.bodyStream() == null || req.bodyStream().available() == 0) {
-                return Map.of();
-            }
-            return MAPPER.readValue(req.bodyStream(), Map.class);
-        } catch (IOException e) {
-            return Map.of();
-        }
+        return ArmJson.parseBodyLenient(req);
     }
 
     public void clearAll() {

--- a/src/main/java/io/floci/az/services/network/NetworkService.java
+++ b/src/main/java/io/floci/az/services/network/NetworkService.java
@@ -1,12 +1,14 @@
 package io.floci.az.services.network;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.floci.az.core.AzureRequest;
+import io.floci.az.core.arm.ArmErrors;
+import io.floci.az.core.arm.ArmJson;
+import io.floci.az.core.arm.ArmPaths;
+import io.floci.az.core.arm.ArmResources;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -15,7 +17,6 @@ import java.util.Map;
 @ApplicationScoped
 public class NetworkService {
 
-    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private final Map<String, Map<String, Object>> resources;
 
@@ -171,59 +172,31 @@ public class NetworkService {
     }
 
     private static String extractRg(String path) {
-        String[] parts = path.split("/");
-        for (int i = 0; i < parts.length - 1; i++) {
-            if ("resourcegroups".equalsIgnoreCase(parts[i])) {
-                return parts[i + 1];
-            }
-        }
-        return "unknown";
+        return ArmPaths.resourceGroup(path, "unknown");
     }
 
     private static String extractAfter(String path, String marker) {
-        int idx = path.lastIndexOf(marker);
-        if (idx < 0) {
-            return "unknown";
-        }
-        String rest = path.substring(idx + marker.length());
-        int q = rest.indexOf('?');
-        return q >= 0 ? rest.substring(0, q) : rest;
+        return ArmPaths.afterSegment(path, marker, "unknown");
     }
 
-    @SuppressWarnings("unchecked")
     private Map<String, Object> parseBody(AzureRequest request) {
-        try {
-            if (request.bodyStream() == null || request.bodyStream().available() == 0) {
-                return Map.of();
-            }
-            return MAPPER.readValue(request.bodyStream(), Map.class);
-        } catch (IOException e) {
-            return Map.of();
-        }
+        return ArmJson.parseBodyLenient(request);
     }
 
-    @SuppressWarnings("unchecked")
     private static Map<String, Object> cast(Object o) {
-        return o instanceof Map<?, ?> m ? (Map<String, Object>) m : Map.of();
+        return ArmJson.cast(o);
     }
 
     private static String bodyString(Map<String, Object> map, String key, String defaultValue) {
-        Object v = map.get(key);
-        return v instanceof String s ? s : defaultValue;
+        return ArmJson.string(map, key, defaultValue);
     }
 
     private static Map<String, Object> stripInternal(Map<String, Object> resource) {
-        Map<String, Object> copy = new LinkedHashMap<>(resource);
-        copy.remove("_sub");
-        copy.remove("_rg");
-        return copy;
+        return ArmResources.stripInternal(resource);
     }
 
     private Response notFound(String path) {
-        return Response.status(404).entity(Map.of("error", Map.of(
-                "code", "ResourceNotFound",
-                "message", "Resource not found: " + path
-        ))).build();
+        return ArmErrors.notFound("Resource not found: " + path);
     }
 
     // ── Azure DNS Support ───────────────────────────────────────────────────

--- a/src/main/java/io/floci/az/services/postgres/PostgresHandler.java
+++ b/src/main/java/io/floci/az/services/postgres/PostgresHandler.java
@@ -6,6 +6,8 @@ import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
 import io.floci.az.core.Resettable;
+import io.floci.az.core.arm.ArmErrors;
+import io.floci.az.core.arm.ArmPaths;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
@@ -516,21 +518,11 @@ public class PostgresHandler implements AzureServiceHandler, Resettable {
     }
 
     private static String extractSubscriptionId(String fullPath) {
-        if (fullPath == null) return "default";
-        String[] parts = fullPath.split("/");
-        for (int i = 0; i < parts.length - 1; i++) {
-            if ("subscriptions".equalsIgnoreCase(parts[i])) return parts[i + 1];
-        }
-        return "default";
+        return ArmPaths.segmentAfter(fullPath, "subscriptions", "default");
     }
 
     private static String extractResourceGroup(String fullPath) {
-        if (fullPath == null) return "default";
-        String[] parts = fullPath.split("/");
-        for (int i = 0; i < parts.length - 1; i++) {
-            if ("resourcegroups".equalsIgnoreCase(parts[i])) return parts[i + 1];
-        }
-        return "default";
+        return ArmPaths.resourceGroup(fullPath, "default");
     }
 
     /** Returns the n-th slash-separated segment of a path (0-based). */
@@ -560,13 +552,11 @@ public class PostgresHandler implements AzureServiceHandler, Resettable {
     // ── Standard error responses ──────────────────────────────────────────────
 
     private static Response notFound(String message) {
-        return Response.status(404).entity(Map.of(
-            "error", Map.of("code", "ResourceNotFound", "message", message))).build();
+        return ArmErrors.notFound(message);
     }
 
     private static Response badRequest(String message) {
-        return Response.status(400).entity(Map.of(
-            "error", Map.of("code", "InvalidRequest", "message", message))).build();
+        return ArmErrors.error(400, "InvalidRequest", message);
     }
 
     private static Response methodNotAllowed() {

--- a/src/main/java/io/floci/az/services/redis/RedisHandler.java
+++ b/src/main/java/io/floci/az/services/redis/RedisHandler.java
@@ -12,6 +12,8 @@ import io.floci.az.core.StoredObject;
 import io.floci.az.core.storage.StorageBackend;
 import io.floci.az.core.storage.StorageFactory;
 import io.floci.az.services.redis.RedisModels.RedisCache;
+import io.floci.az.core.arm.ArmErrors;
+import io.floci.az.core.arm.ArmPaths;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -440,21 +442,11 @@ public class RedisHandler implements AzureServiceHandler, Resettable {
     }
 
     private static String extractSubscriptionId(String fullPath) {
-        if (fullPath == null) { return "default"; }
-        String[] parts = fullPath.split("/");
-        for (int i = 0; i < parts.length - 1; i++) {
-            if ("subscriptions".equalsIgnoreCase(parts[i])) { return parts[i + 1]; }
-        }
-        return "default";
+        return ArmPaths.segmentAfter(fullPath, "subscriptions", "default");
     }
 
     private static String extractResourceGroup(String fullPath) {
-        if (fullPath == null) { return "default"; }
-        String[] parts = fullPath.split("/");
-        for (int i = 0; i < parts.length - 1; i++) {
-            if ("resourcegroups".equalsIgnoreCase(parts[i])) { return parts[i + 1]; }
-        }
-        return "default";
+        return ArmPaths.resourceGroup(fullPath, "default");
     }
 
     private static String segment(String path, int index) {
@@ -486,15 +478,11 @@ public class RedisHandler implements AzureServiceHandler, Resettable {
     // ── Standard error responses ─────────────────────────────────────────────────
 
     private static Response notFound(String message) {
-        return Response.status(404).entity(Map.of(
-                "error", Map.of("code", "ResourceNotFound", "message", message)))
-                .type("application/json").build();
+        return ArmErrors.notFound(message);
     }
 
     private static Response badRequest(String message) {
-        return Response.status(400).entity(Map.of(
-                "error", Map.of("code", "InvalidRequest", "message", message)))
-                .type("application/json").build();
+        return ArmErrors.error(400, "InvalidRequest", message);
     }
 
     private static Response methodNotAllowed() {

--- a/src/main/java/io/floci/az/services/sql/SqlHandler.java
+++ b/src/main/java/io/floci/az/services/sql/SqlHandler.java
@@ -7,6 +7,8 @@ import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
 import io.floci.az.core.Resettable;
+import io.floci.az.core.arm.ArmErrors;
+import io.floci.az.core.arm.ArmPaths;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
@@ -528,21 +530,11 @@ public class SqlHandler implements AzureServiceHandler, Resettable {
     }
 
     private static String extractSubscriptionId(String fullPath) {
-        if (fullPath == null) return "default";
-        String[] parts = fullPath.split("/");
-        for (int i = 0; i < parts.length - 1; i++) {
-            if ("subscriptions".equalsIgnoreCase(parts[i])) return parts[i + 1];
-        }
-        return "default";
+        return ArmPaths.segmentAfter(fullPath, "subscriptions", "default");
     }
 
     private static String extractResourceGroup(String fullPath) {
-        if (fullPath == null) return "default";
-        String[] parts = fullPath.split("/");
-        for (int i = 0; i < parts.length - 1; i++) {
-            if ("resourcegroups".equalsIgnoreCase(parts[i])) return parts[i + 1];
-        }
-        return "default";
+        return ArmPaths.resourceGroup(fullPath, "default");
     }
 
     private static String serverArmId(String fullPath, String serverName) {
@@ -579,13 +571,11 @@ public class SqlHandler implements AzureServiceHandler, Resettable {
     // ── Standard error responses ──────────────────────────────────────────────
 
     private static Response notFound(String message) {
-        return Response.status(404).entity(Map.of(
-            "error", Map.of("code", "ResourceNotFound", "message", message))).build();
+        return ArmErrors.notFound(message);
     }
 
     private static Response badRequest(String message) {
-        return Response.status(400).entity(Map.of(
-            "error", Map.of("code", "InvalidRequest", "message", message))).build();
+        return ArmErrors.error(400, "InvalidRequest", message);
     }
 
     private static Response methodNotAllowed() {

--- a/src/main/java/io/floci/az/services/vm/VmHandler.java
+++ b/src/main/java/io/floci/az/services/vm/VmHandler.java
@@ -13,6 +13,8 @@ import io.floci.az.core.storage.StorageBackend;
 import io.floci.az.core.storage.StorageFactory;
 import io.floci.az.services.vm.VmModels.PowerState;
 import io.floci.az.services.vm.VmModels.VirtualMachine;
+import io.floci.az.core.arm.ArmErrors;
+import io.floci.az.core.arm.ArmPaths;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -470,12 +472,7 @@ public class VmHandler implements AzureServiceHandler, Resettable {
     }
 
     private static String segmentAfter(String fullPath, String marker) {
-        if (fullPath == null) { return "default"; }
-        String[] parts = fullPath.split("/");
-        for (int i = 0; i < parts.length - 1; i++) {
-            if (marker.equalsIgnoreCase(parts[i])) { return parts[i + 1]; }
-        }
-        return "default";
+        return ArmPaths.segmentAfter(fullPath, marker, "default");
     }
 
     private static String segment(String path, int index) {
@@ -524,21 +521,15 @@ public class VmHandler implements AzureServiceHandler, Resettable {
     // ── Standard ARM error responses ──────────────────────────────────────────────
 
     private static Response armNotFound(String message) {
-        return Response.status(404).entity(Map.of(
-                "error", Map.of("code", "ResourceNotFound", "message", message)))
-                .type("application/json").build();
+        return ArmErrors.notFound(message);
     }
 
     private static Response badRequest(String message) {
-        return Response.status(400).entity(Map.of(
-                "error", Map.of("code", "InvalidRequest", "message", message)))
-                .type("application/json").build();
+        return ArmErrors.error(400, "InvalidRequest", message);
     }
 
     private static Response methodNotAllowed() {
-        return Response.status(405).entity(Map.of(
-                "error", Map.of("code", "MethodNotAllowed", "message", "Method not allowed")))
-                .type("application/json").build();
+        return ArmErrors.error(405, "MethodNotAllowed", "Method not allowed");
     }
 
     /** Wipes all VM data — used by {@code POST /_admin/reset}. */

--- a/src/test/java/io/floci/az/core/arm/ArmJsonTest.java
+++ b/src/test/java/io/floci/az/core/arm/ArmJsonTest.java
@@ -1,0 +1,65 @@
+package io.floci.az.core.arm;
+
+import io.floci.az.core.AzureRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("ArmJson — request body parsing variants")
+class ArmJsonTest {
+
+    private static AzureRequest request(String body) {
+        InputStream stream = body == null ? null
+                : new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8));
+        return new AzureRequest("PUT", "acct", "arm", "path", null, stream, Map.of(), null, false);
+    }
+
+    @Test
+    void lenientParsesValidJson() {
+        assertEquals("eastus", ArmJson.parseBodyLenient(request("{\"location\":\"eastus\"}")).get("location"));
+    }
+
+    @Test
+    void lenientDegradesToEmptyMapOnMissingOrMalformed() {
+        assertEquals(Map.of(), ArmJson.parseBodyLenient(request(null)));
+        assertEquals(Map.of(), ArmJson.parseBodyLenient(request("")));
+        assertEquals(Map.of(), ArmJson.parseBodyLenient(request("{not json")));
+    }
+
+    @Test
+    void mutableVariantReturnsMutableMapOnMiss() {
+        Map<String, Object> parsed = ArmJson.parseBodyMutable(request("{not json"));
+        parsed.put("k", "v");
+        assertEquals("v", parsed.get("k"));
+
+        // A null body stream must degrade the same way, not throw.
+        Map<String, Object> fromNull = ArmJson.parseBodyMutable(request(null));
+        fromNull.put("k", "v");
+        assertEquals("v", fromNull.get("k"));
+    }
+
+    @Test
+    void strictThrowsOnMalformedButToleratesEmpty() {
+        assertEquals(Map.of(), ArmJson.parseBodyStrict(request(null)));
+        assertEquals(Map.of(), ArmJson.parseBodyStrict(request("")));
+        assertThrows(ArmJson.InvalidBodyException.class,
+                () -> ArmJson.parseBodyStrict(request("{not json")));
+    }
+
+    @Test
+    void castAndStringHelpers() {
+        assertEquals(Map.of(), ArmJson.cast("not a map"));
+        assertEquals(Map.of(), ArmJson.cast(null));
+        assertTrue(ArmJson.cast(Map.of("a", 1)).containsKey("a"));
+        assertEquals("x", ArmJson.string(Map.of("k", "x"), "k", "d"));
+        assertEquals("d", ArmJson.string(Map.of("k", 42), "k", "d"));
+    }
+}

--- a/src/test/java/io/floci/az/core/arm/ArmPathsTest.java
+++ b/src/test/java/io/floci/az/core/arm/ArmPathsTest.java
@@ -1,0 +1,62 @@
+package io.floci.az.core.arm;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@DisplayName("ArmPaths — ARM management-plane path parsing")
+class ArmPathsTest {
+
+    private static final String PATH =
+            "subscriptions/sub-1/resourceGroups/rg-1/providers/Microsoft.Cache/redis/cache1?api-version=2024-03-01";
+
+    @Test
+    void extractsSubscriptionAndResourceGroup() {
+        assertEquals("sub-1", ArmPaths.subscription(PATH, "unknown"));
+        assertEquals("rg-1", ArmPaths.resourceGroup(PATH, "unknown"));
+    }
+
+    @Test
+    void resourceGroupSegmentIsCaseInsensitive() {
+        assertEquals("rg-1", ArmPaths.resourceGroup("subscriptions/s/resourcegroups/rg-1/x", "unknown"));
+        assertEquals("rg-1", ArmPaths.resourceGroup("subscriptions/s/ResourceGroups/rg-1/x", "unknown"));
+    }
+
+    @Test
+    void subscriptionSegmentStaysCaseSensitive() {
+        // Historical ArmHandler behavior: "Subscriptions" (capitalised) does not match.
+        assertEquals("unknown", ArmPaths.subscription("Subscriptions/s/resourceGroups/rg/x", "unknown"));
+    }
+
+    @Test
+    void fallbacksAreCallerSupplied() {
+        assertEquals("unknown", ArmPaths.resourceGroup("subscriptions/s/providers/x", "unknown"));
+        assertEquals("default", ArmPaths.resourceGroup("subscriptions/s/providers/x", "default"));
+        assertEquals(Optional.empty(), ArmPaths.resourceGroup(null));
+    }
+
+    @Test
+    void resourceNameCapturesSegmentAfterCollection() {
+        assertEquals("cache1", ArmPaths.resourceName(PATH, "redis", "unknown"));
+        assertEquals("unknown", ArmPaths.resourceName(PATH, "servers", "unknown"));
+        // Query separator terminates the captured name.
+        assertEquals("cache1", ArmPaths.resourceName("providers/Microsoft.Cache/redis/cache1?x=1", "redis", "unknown"));
+    }
+
+    @Test
+    void afterSegmentReturnsRemainderWithoutQuery() {
+        assertEquals("redis/cache1",
+                ArmPaths.afterSegment(PATH, "/providers/Microsoft.Cache/", "unknown"));
+        assertEquals("unknown", ArmPaths.afterSegment(PATH, "/providers/Microsoft.Sql/", "unknown"));
+    }
+
+    @Test
+    void segmentAfterMatchesCaseInsensitively() {
+        assertEquals("sub-1", ArmPaths.segmentAfter(PATH, "SUBSCRIPTIONS", "default"));
+        assertEquals("default", ArmPaths.segmentAfter("no/match/here", "subscriptions", "default"));
+        assertEquals("default", ArmPaths.segmentAfter(null, "subscriptions", "default"));
+    }
+}


### PR DESCRIPTION
## Summary

The ARM-plane and sidecar services each carried private copies of the same path/JSON/error helpers, with real drift: `extractRg` existed in 10 variants across two fallback conventions, `parseBody` in 9, and 11 services hand-rolled the same CloudError JSON builder. This extracts a shared `core/arm` package — `ArmPaths` (path parsing with caller-supplied fallbacks), `ArmJson` (three body-parse variants + `cast`/`string`), `ArmErrors` (the `{"error":{"code","message"}}` builder), `ArmResources` (`_sub`/`_rg` keys + `stripInternal`) — and turns **57 service-local helper bodies across 17 services into one-line delegations**, so every call site keeps its exact historical semantics.

Behavior-preserving variant map:

- fallback `"unknown"`: arm, network, apim (ARM-plane convention)
- fallback `"default"`: redis, acr, aks, postgres, sql, vm (sidecar convention)
- `parseBody` lenient/immutable (`Map.of()` on miss): arm, network, apim, monitor, eventgrid
- `parseBody` lenient/mutable (`LinkedHashMap` on miss — callers mutate): keyvault, cosmos, appconfig
- `parseBodyStrict` (`400 InvalidRequestContent` semantics): no callers yet — landing pad for the planned ARM-plane strict-parse switch and the managed-identity feature branch
- untouched by design (different wire shapes): servicebus/eventhub flat `{"error":"msg"}` errors, cosmos data-plane errors, functions `AzureErrorResponse`, sidecar flat `methodNotAllowed`, apim's specialized `stripInternal`

Subtleties preserved verbatim and pinned by unit tests: `subscriptions` segment matching stays case-sensitive in `ArmHandler` and case-insensitive in sidecars; `resourceGroups` is case-insensitive everywhere. The fallback values are caller-supplied on purpose — services key their in-memory stores by them, so unifying `"unknown"`/`"default"` would silently change storage keys for malformed paths (a protocol decision, not a refactor).

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## Azure Compatibility

Behavior-preserving by construction: the rewiring was applied by a script asserting exactly one match per method signature, each call site keeps its historical fallback/leniency, and the consolidated error builder emits the identical CloudError JSON (explicit `application/json` matches what JAX-RS already negotiated for Map entities). Verified with `./mvnw test` (263 incl. 12 new `ArmPaths`/`ArmJson` tests) plus the ARM-heavy compat suites — terraform, opentofu, azcli — all green on this exact head.

## Checklist

- [x] `./mvnw test` passes locally (263/263)
- [x] New or updated integration test added (`ArmPathsTest`, `ArmJsonTest` — pin the case-sensitivity and fallback semantics)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
