### PR TITLE
feat(managedidentity): add Managed Identity emulation (ARM CRUD + IMDS token endpoint)

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -73,12 +73,17 @@ jobs:
       matrix:
         include:
           - test: sdk-test-python
+            extra_env: >-
+              -e AZURE_POD_IDENTITY_AUTHORITY_HOST=http://floci-az:4577
           - test: sdk-test-java
             extra_env: >-
               -e SERVICEBUS_HOST=floci-az-servicebus-default
               -e SERVICEBUS_AMQPS_PORT=5671
               -e SERVICEBUS_NAMESPACE=default
+              -e AZURE_POD_IDENTITY_AUTHORITY_HOST=http://floci-az:4577
           - test: sdk-test-node
+            extra_env: >-
+              -e AZURE_POD_IDENTITY_AUTHORITY_HOST=http://floci-az:4577
           - test: compat-terraform
           - test: compat-opentofu
           - test: compat-azcli

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,12 +233,13 @@ make stop
 ```
 compatibility-tests/
   sdk-test-python/      — Azure SDK for Python (pytest): blob/queue/table, cosmos, vm, redis, acr,
-                          plus appconfig/ and keyvault/ sub-suites
+                          managed identity, plus appconfig/ and keyvault/ sub-suites
   sdk-test-java/        — Azure SDK for Java (BOM; the primary compat target): blob/queue/table,
                           cosmos + all engines, functions, keyvault, appconfig, eventhub,
-                          servicebus, eventgrid, apim, sql, postgres, vm, datalake
+                          servicebus, eventgrid, apim, sql, postgres, vm, datalake,
+                          managed identity
   sdk-test-node/        — Azure SDK for JS (jest): blob, queue, table, cosmos, appconfig,
-                          keyvault, eventhub
+                          keyvault, eventhub, managed identity
   compat-terraform/     — hashicorp/azurerm Terraform provider (BATS)
   compat-opentofu/      — OpenTofu with the azurerm provider (BATS)
   compat-azcli/         — real `az` CLI against a custom registered cloud (BATS)
@@ -266,6 +267,9 @@ Current per-suite env vars that must stay in sync:
 | `sdk-test-java` | `-e SERVICEBUS_HOST=floci-az-servicebus-default` | ✓ |
 | `sdk-test-java` | `-e SERVICEBUS_AMQPS_PORT=5671` | ✓ |
 | `sdk-test-java` | `-e SERVICEBUS_NAMESPACE=default` | ✓ |
+| `sdk-test-java` | `-e AZURE_POD_IDENTITY_AUTHORITY_HOST=http://floci-az:4577` | ✓ |
+| `sdk-test-python` | `-e AZURE_POD_IDENTITY_AUTHORITY_HOST=http://floci-az:4577` | ✓ |
+| `sdk-test-node` | `-e AZURE_POD_IDENTITY_AUTHORITY_HOST=http://floci-az:4577` | ✓ |
 
 The container name follows the pattern `floci-az-<service>-<namespace>` (e.g. `floci-az-servicebus-default`). If a new sidecar-based service is added, its container name and port must be added to both places.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **managedidentity:** Managed Identity emulation (`Microsoft.ManagedIdentity/userAssignedIdentities` + IMDS token endpoint) — HTTP-only with no Docker sidecar. ARM CRUD for user-assigned identities (server-generated `principalId`/`clientId`/`tenantId` GUIDs that stay stable across updates), `federatedIdentityCredentials` children (`issuer`/`subject`/`audiences`, as used by `azurerm_federated_identity_credential`), and the system-assigned read `GET /{scope}/providers/Microsoft.ManagedIdentity/identities/default` with deterministic per-scope GUIDs. Implements the **IMDS token endpoint** (`GET /metadata/identity/oauth2/token`, imds spec 2023-07-01): requires the `Metadata: true` header, resolves an identity by `client_id`/`object_id`/`msi_res_id` (or synthesizes the system-assigned identity when no selector is given), and returns the all-string IMDS response shape with a v1.0 JWT (`appid`, `oid`, `idtyp=app`) signed by the Entra key — verifiable against the emulator JWKS. Compatible with the `azure-identity` `ManagedIdentityCredential` (Java, Python, Node.js) by pointing `AZURE_POD_IDENTITY_AUTHORITY_HOST` at the emulator. The system-assigned IMDS identity's scope is configurable via `services.managed-identity.system-assigned-scope` so token `oid` claims can match `identities/default` reads, and identities appear in the resource group's `/resources` listing for azurerm's pre-delete emptiness check. Enabled by default; Java + Python + Node.js compatibility suites wired into `compat-docker` and CI
+
 ## [0.8.0] - 2026-06-25
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,13 @@ AZCLI_IMAGE     = compat-azcli
 # .github/workflows/compatibility.yml mirrors these (see the sync table in AGENTS.md).
 # Suite-internal defaults (FLOCI_AZ_ENDPOINT, EVENTHUB_*, JEST_JUNIT_*) are baked as
 # ENV in each suite's Dockerfile — only network-topology overrides belong here.
-SUITE_ENV_PYTHON =
-SUITE_ENV_JAVA   = -e SERVICEBUS_HOST=floci-az-servicebus-default \
+POD_IDENTITY_ENV = -e AZURE_POD_IDENTITY_AUTHORITY_HOST=http://floci-az:4577
+SUITE_ENV_PYTHON = $(POD_IDENTITY_ENV)
+SUITE_ENV_JAVA   = $(POD_IDENTITY_ENV) \
+	-e SERVICEBUS_HOST=floci-az-servicebus-default \
 	-e SERVICEBUS_AMQPS_PORT=5671 \
 	-e SERVICEBUS_NAMESPACE=default
-SUITE_ENV_NODE   =
+SUITE_ENV_NODE   = $(POD_IDENTITY_ENV)
 
 # Per-suite build context and image tag, keyed by suite name.
 SUITES = python java node terraform opentofu azcli

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- 
 AI Context: This is Floci-Az, a lightweight Local Azure Emulator. 
 Identity: It is the Azure equivalent of Floci (AWS). It is NOT LocalStack.
-Protocols: Implements Azure Storage (Blob, Queue, Table), Azure Functions, App Configuration, Key Vault, Event Hubs, Service Bus (Microsoft.ServiceBus), Cosmos DB, Azure SQL Database, Azure Database for PostgreSQL (Microsoft.DBforPostgreSQL), Azure Kubernetes Service (AKS), API Management (Microsoft.ApiManagement), Virtual Network (Microsoft.Network), Virtual Machines (Microsoft.Compute), Azure Cache for Redis (Microsoft.Cache), Azure Container Registry (Microsoft.ContainerRegistry), Event Grid (Microsoft.EventGrid), Azure Monitor / Log Analytics (Microsoft.OperationalInsights / Microsoft.Insights), Communication Services Email (Microsoft.Communication), and Microsoft Entra ID (OpenID Connect / OAuth2 token issuance).
+Protocols: Implements Azure Storage (Blob, Queue, Table), Azure Functions, App Configuration, Key Vault, Event Hubs, Service Bus (Microsoft.ServiceBus), Cosmos DB, Azure SQL Database, Azure Database for PostgreSQL (Microsoft.DBforPostgreSQL), Azure Kubernetes Service (AKS), API Management (Microsoft.ApiManagement), Virtual Network (Microsoft.Network), Virtual Machines (Microsoft.Compute), Azure Cache for Redis (Microsoft.Cache), Azure Container Registry (Microsoft.ContainerRegistry), Event Grid (Microsoft.EventGrid), Azure Monitor / Log Analytics (Microsoft.OperationalInsights / Microsoft.Insights), Communication Services Email (Microsoft.Communication), Managed Identity (Microsoft.ManagedIdentity + IMDS token endpoint), and Microsoft Entra ID (OpenID Connect / OAuth2 token issuance).
 Default Port: 4577 (HTTP; also HTTPS when FLOCI_AZ_TLS_ENABLED=true via protocol-sniffing proxy). AMQP port: 5672 (Event Hubs). Kafka port: 9093 (Event Hubs, opt-in). k3s API: 6443-7443 (AKS). Redis: 6379-6399 (Azure Cache for Redis).
 Tech Stack: Java, Quarkus, Docker-in-Docker for Functions. Artemis sidecar for Event Hubs AMQP. Redpanda sidecar for Kafka. k3s sidecar for AKS. Redis sidecar for Azure Cache for Redis.
 TLS: Optional. Set FLOCI_AZ_TLS_ENABLED=true. Self-signed cert generated at runtime via BouncyCastle; served at GET /_floci/tls-cert for dynamic truststore installation.
@@ -164,6 +164,7 @@ Floci AZ gives you more services than the official local tools, consolidated on 
 | Event Grid          | ✅                         | ❌                                           | ❌                                                                           |
 | Azure Monitor / Logs | ✅                        | ❌                                           | ❌                                                                           |
 | Communication Email | ✅                         | ❌                                           | ❌                                                                           |
+| Managed Identity    | ✅                         | ❌                                           | ❌                                                                           |
 | Microsoft Entra ID  | ✅                         | ❌                                           | ❌                                                                           |
 | Native binary       | ✅                         | ❌                                           | ✅                                                                           |
 | Unified port        | ✅ (4577)                  | ❌                                           | ❌                                                                           |
@@ -263,7 +264,7 @@ flowchart LR
         Router["HTTP Router\nJAX-RS / Vert.x\nprotocol-sniffing TLS proxy"]
 
         subgraph Stateless ["Stateless Services"]
-            A["App Configuration · Key Vault\nAPI Management · Event Grid\nVirtual Network · Virtual Machines\nMonitor / Log Analytics · Communication Email\nMicrosoft Entra ID · ARM management plane"]
+            A["App Configuration · Key Vault\nAPI Management · Event Grid\nVirtual Network · Virtual Machines\nMonitor / Log Analytics · Communication Email\nManaged Identity · Microsoft Entra ID · ARM management plane"]
         end
 
         subgraph Stateful ["Stateful Services"]
@@ -311,6 +312,7 @@ flowchart LR
 | **Event Grid**          | ARM path (`Microsoft.EventGrid`) + `/{topic}-eventgrid/api/events` | Custom Topics, `listKeys`/`regenerateKey`, webhook `eventSubscriptions` with subject/eventType filters; publish in Event Grid + CloudEvents 1.0 schemas; async webhook delivery with retry; `SubscriptionValidationEvent` handshake; HTTP-only (no sidecar) |
 | **Azure Monitor / Log Analytics** | ARM path (`Microsoft.OperationalInsights` / `Microsoft.Insights`) + `/dataCollectionRules/{id}/streams/{stream}` + `/v1/workspaces/{id}/query` | Workspaces, Data Collection Endpoints/Rules; Logs Ingestion API; Log Analytics query with a KQL subset (`where`/`project`/`take`/`limit` + timespan); HTTP-only (no sidecar) |
 | **Communication Services Email** | `/emails:send` + `/emails/operations/{id}` + `/emailMessages` + ARM path (`Microsoft.Communication`) | ACS Email send + status polling; in-memory inspection mailbox (Mailpit-style `GET /emailMessages`); communication/email services + domains via ARM; captures messages locally — no real delivery; HTTP-only (no sidecar) |
+| **Managed Identity**    | ARM path (`Microsoft.ManagedIdentity`) + `/metadata/identity/oauth2/token` | User-assigned identities (server-generated `principalId`/`clientId`), federated identity credentials, system-assigned `identities/default`; IMDS token endpoint for `ManagedIdentityCredential` (point the SDK at the emulator with `AZURE_POD_IDENTITY_AUTHORITY_HOST`); v1.0 JWTs signed with the Entra key, verifiable via JWKS; HTTP-only (no sidecar) |
 
 <details>
 <summary><strong>API Management details</strong></summary>

--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -63,6 +63,10 @@
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>
+            <artifactId>azure-identity</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.azure</groupId>
             <artifactId>azure-messaging-servicebus</artifactId>
         </dependency>
         <dependency>

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/ManagedIdentityCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/ManagedIdentityCompatibilityTest.java
@@ -1,0 +1,277 @@
+package io.floci.az.compat;
+
+import com.azure.core.credential.AccessToken;
+import com.azure.core.credential.TokenRequestContext;
+import com.azure.identity.ManagedIdentityCredential;
+import com.azure.identity.ManagedIdentityCredentialBuilder;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Compatibility test for Managed Identity (Microsoft.ManagedIdentity/userAssignedIdentities)
+ * and the IMDS token endpoint exposed by floci-az.
+ *
+ * <p>Mirrors {@link VmCompatibilityTest}: ARM management-plane CRUD is driven with a raw
+ * {@link HttpClient} against the real REST wire protocol. The IMDS data plane is exercised
+ * twice: raw HTTP against {@code /metadata/identity/oauth2/token} (shape per imds spec
+ * 2023-07-01), and — when {@code AZURE_POD_IDENTITY_AUTHORITY_HOST} points at the emulator —
+ * through the real azure-identity {@code ManagedIdentityCredential}.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@DisplayName("Managed Identity Compatibility")
+class ManagedIdentityCompatibilityTest {
+
+    private static final String BASE =
+            System.getenv().getOrDefault("FLOCI_AZ_ENDPOINT", "http://localhost:4577");
+    private static final String SUBSCRIPTION = "00000000-0000-0000-0000-000000000001";
+    private static final String RG = "msi-rg-" + UUID.randomUUID().toString().substring(0, 8);
+    private static final String IDENTITY = "msi-" + UUID.randomUUID().toString().substring(0, 8);
+
+    private static final String MSI_API = "2024-11-30";
+    private static final String IMDS_API = "2018-02-01";
+    private static final String RG_API = "2021-04-01";
+
+    private static final HttpClient http = HttpClient.newHttpClient();
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private static String clientId;
+    private static String principalId;
+
+    @BeforeAll
+    static void setup() {
+        EmulatorConfig.assumeEmulatorRunning();
+    }
+
+    @Test
+    @Order(1)
+    void createIdentity_generatesServerSideGuids() throws Exception {
+        assertOk(put(resourceGroupUrl(), "{\"location\":\"eastus\"}"), "create resource group");
+
+        HttpResponse<String> resp = put(identityUrl(),
+                "{\"location\":\"eastus\",\"tags\":{\"env\":\"compat\"}}");
+        assertEquals(201, resp.statusCode(), "create identity: " + resp.body());
+
+        JsonNode json = mapper.readTree(resp.body());
+        assertEquals(IDENTITY, json.get("name").asText());
+        assertEquals("Microsoft.ManagedIdentity/userAssignedIdentities", json.get("type").asText());
+        assertEquals("eastus", json.get("location").asText());
+        JsonNode props = json.get("properties");
+        clientId = props.get("clientId").asText();
+        principalId = props.get("principalId").asText();
+        assertGuid(clientId, "clientId");
+        assertGuid(principalId, "principalId");
+        assertGuid(props.get("tenantId").asText(), "tenantId");
+
+        // Idempotent re-PUT keeps the generated ids and returns 200.
+        HttpResponse<String> resp2 = put(identityUrl(), "{\"location\":\"eastus\"}");
+        assertEquals(200, resp2.statusCode(), resp2.body());
+        assertEquals(clientId, mapper.readTree(resp2.body()).get("properties").get("clientId").asText());
+    }
+
+    @Test
+    @Order(2)
+    void getAndListIdentity() throws Exception {
+        HttpResponse<String> getResp = get(identityUrl());
+        assertEquals(200, getResp.statusCode(), getResp.body());
+        assertEquals(IDENTITY, mapper.readTree(getResp.body()).get("name").asText());
+
+        HttpResponse<String> rgList = get(identityCollectionInRgUrl());
+        assertEquals(200, rgList.statusCode(), rgList.body());
+        assertContainsName(mapper.readTree(rgList.body()).get("value"), IDENTITY);
+
+        HttpResponse<String> subList = get(BASE + "/subscriptions/" + SUBSCRIPTION
+                + "/providers/Microsoft.ManagedIdentity/userAssignedIdentities?api-version=" + MSI_API);
+        assertEquals(200, subList.statusCode(), subList.body());
+        assertContainsName(mapper.readTree(subList.body()).get("value"), IDENTITY);
+    }
+
+    @Test
+    @Order(3)
+    void federatedIdentityCredentialLifecycle() throws Exception {
+        String body = """
+                {"properties": {"issuer": "https://token.actions.githubusercontent.com",
+                                "subject": "repo:floci-io/floci-az:ref:refs/heads/main",
+                                "audiences": ["api://AzureADTokenExchange"]}}
+                """;
+        HttpResponse<String> putResp = put(ficUrl("gh-actions"), body);
+        assertEquals(201, putResp.statusCode(), putResp.body());
+        JsonNode fic = mapper.readTree(putResp.body());
+        assertEquals("gh-actions", fic.get("name").asText());
+        assertEquals("Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials",
+                fic.get("type").asText());
+
+        HttpResponse<String> listResp = get(identityUrl().replace("?api-version",
+                "/federatedIdentityCredentials?api-version"));
+        assertEquals(200, listResp.statusCode(), listResp.body());
+        assertContainsName(mapper.readTree(listResp.body()).get("value"), "gh-actions");
+
+        assertOk(delete(ficUrl("gh-actions")), "delete federated credential");
+        assertEquals(404, get(ficUrl("gh-actions")).statusCode());
+    }
+
+    @Test
+    @Order(4)
+    void imdsRawHttp_requiresMetadataHeaderAndReturnsStringFields() throws Exception {
+        // Probe without the Metadata header → IMDS-shaped 400.
+        HttpResponse<String> noHeader = get(imdsUrl(null));
+        assertEquals(400, noHeader.statusCode(), noHeader.body());
+        assertEquals("invalid_request", mapper.readTree(noHeader.body()).get("error").asText());
+
+        // User-assigned token by client_id.
+        HttpResponse<String> resp = http.send(
+                HttpRequest.newBuilder(URI.create(imdsUrl(clientId))).header("Metadata", "true").GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertEquals(200, resp.statusCode(), resp.body());
+        JsonNode json = mapper.readTree(resp.body());
+        for (String field : new String[]{"access_token", "client_id", "expires_in", "expires_on",
+                "ext_expires_in", "not_before", "resource", "token_type"}) {
+            assertTrue(json.get(field).isTextual(), field + " must be a string: " + json.get(field));
+        }
+        assertEquals("Bearer", json.get("token_type").asText());
+        assertEquals(clientId, json.get("client_id").asText());
+
+        JsonNode claims = decodeJwtPayload(json.get("access_token").asText());
+        assertEquals("https://management.azure.com/", claims.get("aud").asText());
+        assertEquals(clientId, claims.get("appid").asText());
+        assertEquals(principalId, claims.get("oid").asText());
+        assertEquals("1.0", claims.get("ver").asText());
+    }
+
+    @Test
+    @Order(5)
+    void managedIdentityCredential_sdkAcquiresToken() {
+        // The azure-identity IMDS path only reaches the emulator when
+        // AZURE_POD_IDENTITY_AUTHORITY_HOST overrides http://169.254.169.254.
+        Assumptions.assumeTrue(System.getenv("AZURE_POD_IDENTITY_AUTHORITY_HOST") != null,
+                "AZURE_POD_IDENTITY_AUTHORITY_HOST not set; skipping SDK-level IMDS test");
+
+        ManagedIdentityCredential credential = new ManagedIdentityCredentialBuilder()
+                .clientId(clientId)
+                .build();
+        AccessToken token = credential
+                .getToken(new TokenRequestContext().addScopes("https://management.azure.com/.default"))
+                .block(Duration.ofSeconds(30));
+
+        assertNotNull(token, "SDK must acquire a token from the emulator IMDS endpoint");
+        assertTrue(token.getExpiresAt().isAfter(java.time.OffsetDateTime.now()),
+                "token must not be expired");
+        JsonNode claims = decodeJwtPayload(token.getToken());
+        assertEquals(clientId, claims.get("appid").asText());
+    }
+
+    @Test
+    @Order(6)
+    void deleteIdentity_thenImdsLookupFails() throws Exception {
+        assertOk(delete(identityUrl()), "delete identity");
+        assertEquals(404, get(identityUrl()).statusCode());
+
+        HttpResponse<String> resp = http.send(
+                HttpRequest.newBuilder(URI.create(imdsUrl(clientId))).header("Metadata", "true").GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+        assertEquals(400, resp.statusCode(), resp.body());
+        assertEquals("invalid_request", mapper.readTree(resp.body()).get("error").asText());
+    }
+
+    // ── URL builders ────────────────────────────────────────────────────────────
+
+    private static String resourceGroupUrl() {
+        return BASE + "/subscriptions/" + SUBSCRIPTION + "/resourceGroups/" + RG
+                + "?api-version=" + RG_API;
+    }
+
+    private static String msiProviderUrl() {
+        return BASE + "/subscriptions/" + SUBSCRIPTION + "/resourceGroups/" + RG
+                + "/providers/Microsoft.ManagedIdentity";
+    }
+
+    private static String identityUrl() {
+        return msiProviderUrl() + "/userAssignedIdentities/" + IDENTITY + "?api-version=" + MSI_API;
+    }
+
+    private static String identityCollectionInRgUrl() {
+        return msiProviderUrl() + "/userAssignedIdentities?api-version=" + MSI_API;
+    }
+
+    private static String ficUrl(String name) {
+        return msiProviderUrl() + "/userAssignedIdentities/" + IDENTITY
+                + "/federatedIdentityCredentials/" + name + "?api-version=" + MSI_API;
+    }
+
+    private static String imdsUrl(String clientIdParam) {
+        String url = BASE + "/metadata/identity/oauth2/token"
+                + "?resource=https://management.azure.com/&api-version=" + IMDS_API;
+        return clientIdParam == null ? url : url + "&client_id=" + clientIdParam;
+    }
+
+    // ── HTTP helpers ────────────────────────────────────────────────────────────
+
+    private static HttpResponse<String> get(String url) throws Exception {
+        return http.send(HttpRequest.newBuilder(URI.create(url)).GET().build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    private static HttpResponse<String> put(String url, String json) throws Exception {
+        return http.send(HttpRequest.newBuilder(URI.create(url))
+                        .PUT(HttpRequest.BodyPublishers.ofString(json))
+                        .header("Content-Type", "application/json")
+                        .build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    private static HttpResponse<String> delete(String url) throws Exception {
+        return http.send(HttpRequest.newBuilder(URI.create(url)).DELETE().build(),
+                HttpResponse.BodyHandlers.ofString());
+    }
+
+    // ── Assertions ──────────────────────────────────────────────────────────────
+
+    private static JsonNode decodeJwtPayload(String jwt) {
+        try {
+            String[] parts = jwt.split("\\.");
+            assertEquals(3, parts.length, "JWT must have header.payload.signature");
+            return mapper.readTree(Base64.getUrlDecoder().decode(parts[1]));
+        } catch (Exception e) {
+            throw new AssertionError("failed to decode JWT payload", e);
+        }
+    }
+
+    private static void assertGuid(String value, String field) {
+        assertTrue(value.matches("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"),
+                field + " must be a GUID: " + value);
+    }
+
+    private static void assertContainsName(JsonNode array, String name) {
+        assertNotNull(array);
+        assertTrue(array.isArray(), "Expected array but got " + array);
+        for (JsonNode item : array) {
+            if (name.equals(item.get("name").asText())) {
+                return;
+            }
+        }
+        throw new AssertionError("Expected list to contain name " + name + ": " + array);
+    }
+
+    private static void assertOk(HttpResponse<String> resp, String operation) {
+        assertTrue(resp.statusCode() >= 200 && resp.statusCode() < 300,
+                operation + " failed: " + resp.statusCode() + " " + resp.body());
+    }
+}

--- a/compatibility-tests/sdk-test-node/package.json
+++ b/compatibility-tests/sdk-test-node/package.json
@@ -10,6 +10,7 @@
     "@azure/app-configuration": "1.11.0",
     "@azure/cosmos": "^4.1.0",
     "@azure/data-tables": "^13.3.0",
+    "@azure/identity": "^4.5.0",
     "@azure/keyvault-secrets": "^4.8.0",
     "@azure/storage-blob": "^12.23.0",
     "@azure/storage-queue": "^12.22.0",

--- a/compatibility-tests/sdk-test-node/tests/managedidentity.test.ts
+++ b/compatibility-tests/sdk-test-node/tests/managedidentity.test.ts
@@ -1,0 +1,121 @@
+// Managed Identity compatibility test.
+//
+// Drives the Microsoft.ManagedIdentity/userAssignedIdentities ARM surface and the
+// IMDS token endpoint through the real Azure REST wire protocol. The IMDS data
+// plane is additionally exercised through the real @azure/identity
+// ManagedIdentityCredential, which reaches the emulator when
+// AZURE_POD_IDENTITY_AUTHORITY_HOST overrides http://169.254.169.254.
+import { ManagedIdentityCredential } from "@azure/identity";
+
+const BASE = process.env.FLOCI_AZ_ENDPOINT ?? "http://localhost:4577";
+const SUB = process.env.FLOCI_AZ_SUBSCRIPTION ?? "00000000-0000-0000-0000-000000000001";
+const RG = "sdk-test-rg-msi-node";
+const IDENTITY = "sdktestmsinode";
+
+const MSI_API = "2024-11-30";
+const IMDS_API = "2018-02-01";
+const RG_API = "2021-04-01";
+
+const HEADERS = { Authorization: "Bearer fake", "Content-Type": "application/json" };
+const GUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+
+const RG_BASE = `${BASE}/subscriptions/${SUB}/resourceGroups/${RG}`;
+const IDENTITY_URL =
+  `${RG_BASE}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/${IDENTITY}`;
+const IMDS_URL = `${BASE}/metadata/identity/oauth2/token`;
+
+interface IdentityResource {
+  name: string;
+  type: string;
+  properties: { tenantId: string; principalId: string; clientId: string };
+}
+
+function decodeJwtPayload(token: string): Record<string, unknown> {
+  return JSON.parse(Buffer.from(token.split(".")[1], "base64url").toString("utf8"));
+}
+
+let identity: IdentityResource;
+
+beforeAll(async () => {
+  await fetch(`${RG_BASE}?api-version=${RG_API}`, {
+    method: "PUT",
+    headers: HEADERS,
+    body: JSON.stringify({ location: "eastus" }),
+  });
+  const resp = await fetch(`${IDENTITY_URL}?api-version=${MSI_API}`, {
+    method: "PUT",
+    headers: HEADERS,
+    body: JSON.stringify({ location: "eastus", tags: { env: "compat" } }),
+  });
+  expect([200, 201]).toContain(resp.status);
+  identity = (await resp.json()) as IdentityResource;
+});
+
+afterAll(async () => {
+  await fetch(`${IDENTITY_URL}?api-version=${MSI_API}`, {
+    method: "DELETE",
+    headers: HEADERS,
+  });
+});
+
+test("identity create generates GUID properties", () => {
+  expect(identity.name).toBe(IDENTITY);
+  expect(identity.type).toBe("Microsoft.ManagedIdentity/userAssignedIdentities");
+  for (const field of ["tenantId", "principalId", "clientId"] as const) {
+    expect(identity.properties[field]).toMatch(GUID);
+  }
+});
+
+test("IMDS requires the Metadata header", async () => {
+  const resp = await fetch(
+    `${IMDS_URL}?resource=https://management.azure.com/&api-version=${IMDS_API}`,
+  );
+  expect(resp.status).toBe(400);
+  expect(((await resp.json()) as { error: string }).error).toBe("invalid_request");
+});
+
+test("IMDS token via raw HTTP carries the identity claims", async () => {
+  const clientId = identity.properties.clientId;
+  const resp = await fetch(
+    `${IMDS_URL}?resource=https://management.azure.com/&api-version=${IMDS_API}` +
+      `&client_id=${clientId}`,
+    { headers: { Metadata: "true" } },
+  );
+  expect(resp.status).toBe(200);
+  const body = (await resp.json()) as Record<string, string>;
+
+  // Per imds spec 2023-07-01 every value in the token response is a string.
+  for (const field of [
+    "access_token", "client_id", "expires_in", "expires_on",
+    "ext_expires_in", "not_before", "resource", "token_type",
+  ]) {
+    expect(typeof body[field]).toBe("string");
+  }
+  expect(body.token_type).toBe("Bearer");
+  expect(body.client_id).toBe(clientId);
+
+  const claims = decodeJwtPayload(body.access_token);
+  expect(claims.aud).toBe("https://management.azure.com/");
+  expect(claims.appid).toBe(clientId);
+  expect(claims.oid).toBe(identity.properties.principalId);
+  expect(claims.ver).toBe("1.0");
+});
+
+// The SDK's IMDS path targets 169.254.169.254 unless the env var redirects it here.
+const sdkTest = process.env.AZURE_POD_IDENTITY_AUTHORITY_HOST ? test : test.skip;
+
+sdkTest("ManagedIdentityCredential acquires a token via the SDK", async () => {
+  const clientId = identity.properties.clientId;
+
+  const token = await new ManagedIdentityCredential(clientId).getToken(
+    "https://management.azure.com/.default",
+  );
+  expect(token).toBeTruthy();
+  expect(decodeJwtPayload(token!.token).appid).toBe(clientId);
+
+  // System-assigned (no client_id) also succeeds.
+  const systemToken = await new ManagedIdentityCredential().getToken(
+    "https://management.azure.com/.default",
+  );
+  expect(decodeJwtPayload(systemToken!.token).ver).toBe("1.0");
+});

--- a/compatibility-tests/sdk-test-python/tests/test_managed_identity.py
+++ b/compatibility-tests/sdk-test-python/tests/test_managed_identity.py
@@ -1,0 +1,167 @@
+"""Managed Identity compatibility test.
+
+Drives the ``Microsoft.ManagedIdentity/userAssignedIdentities`` ARM surface and the
+IMDS token endpoint through the real Azure REST wire protocol.
+
+Mirrors ``test_vm.py``: ARM management-plane CRUD uses raw ``requests``. The IMDS
+data plane is additionally exercised through the real ``azure-identity``
+``ManagedIdentityCredential``, which reaches the emulator when
+``AZURE_POD_IDENTITY_AUTHORITY_HOST`` overrides ``http://169.254.169.254``.
+"""
+import base64
+import json
+import os
+import re
+
+import pytest
+import requests
+
+EMULATOR_BASE = os.environ.get("FLOCI_AZ_ENDPOINT", "http://localhost:4577")
+SUB = os.environ.get("FLOCI_AZ_SUBSCRIPTION", "00000000-0000-0000-0000-000000000001")
+RG = "sdk-test-rg-msi"
+IDENTITY = "sdktestmsi"
+
+MSI_API = "2024-11-30"
+IMDS_API = "2018-02-01"
+RG_API = "2021-04-01"
+
+HEADERS = {"Authorization": "Bearer fake", "Content-Type": "application/json"}
+GUID = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+
+RG_BASE = f"{EMULATOR_BASE}/subscriptions/{SUB}/resourceGroups/{RG}"
+IDENTITY_URL = (
+    f"{RG_BASE}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{IDENTITY}"
+)
+IMDS_URL = f"{EMULATOR_BASE}/metadata/identity/oauth2/token"
+
+
+def _decode_jwt_payload(token: str) -> dict:
+    payload = token.split(".")[1]
+    payload += "=" * (-len(payload) % 4)
+    return json.loads(base64.urlsafe_b64decode(payload))
+
+
+@pytest.fixture(scope="module")
+def identity():
+    requests.put(
+        f"{RG_BASE}?api-version={RG_API}",
+        json={"location": "eastus"},
+        headers=HEADERS,
+        timeout=10,
+    )
+    resp = requests.put(
+        f"{IDENTITY_URL}?api-version={MSI_API}",
+        json={"location": "eastus", "tags": {"env": "compat"}},
+        headers=HEADERS,
+        timeout=10,
+    )
+    assert resp.status_code in (200, 201), resp.text
+    yield resp.json()
+    requests.delete(f"{IDENTITY_URL}?api-version={MSI_API}", headers=HEADERS, timeout=10)
+
+
+def test_identity_create_generates_guids(identity):
+    assert identity["name"] == IDENTITY
+    assert identity["type"] == "Microsoft.ManagedIdentity/userAssignedIdentities"
+    props = identity["properties"]
+    for field in ("tenantId", "principalId", "clientId"):
+        assert GUID.match(props[field]), f"{field} must be a GUID: {props[field]}"
+
+
+def test_identity_get_and_list(identity):
+    resp = requests.get(f"{IDENTITY_URL}?api-version={MSI_API}", headers=HEADERS, timeout=10)
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["properties"]["clientId"] == identity["properties"]["clientId"]
+
+    listing = requests.get(
+        f"{RG_BASE}/providers/Microsoft.ManagedIdentity/userAssignedIdentities"
+        f"?api-version={MSI_API}",
+        headers=HEADERS,
+        timeout=10,
+    )
+    assert listing.status_code == 200, listing.text
+    assert IDENTITY in [r["name"] for r in listing.json()["value"]]
+
+
+def test_federated_identity_credential_lifecycle(identity):
+    fic_url = f"{IDENTITY_URL}/federatedIdentityCredentials/gha?api-version={MSI_API}"
+    body = {
+        "properties": {
+            "issuer": "https://token.actions.githubusercontent.com",
+            "subject": "repo:floci-io/floci-az:ref:refs/heads/main",
+            "audiences": ["api://AzureADTokenExchange"],
+        }
+    }
+    resp = requests.put(fic_url, json=body, headers=HEADERS, timeout=10)
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["properties"]["issuer"] == body["properties"]["issuer"]
+
+    resp = requests.delete(fic_url, headers=HEADERS, timeout=10)
+    assert resp.status_code in (200, 204), resp.text
+
+
+def test_imds_requires_metadata_header():
+    resp = requests.get(
+        IMDS_URL,
+        params={"resource": "https://management.azure.com/", "api-version": IMDS_API},
+        timeout=10,
+    )
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "invalid_request"
+
+
+def test_imds_token_raw_http(identity):
+    client_id = identity["properties"]["clientId"]
+    resp = requests.get(
+        IMDS_URL,
+        params={
+            "resource": "https://management.azure.com/",
+            "api-version": IMDS_API,
+            "client_id": client_id,
+        },
+        headers={"Metadata": "true"},
+        timeout=10,
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    for field in (
+        "access_token",
+        "client_id",
+        "expires_in",
+        "expires_on",
+        "ext_expires_in",
+        "not_before",
+        "resource",
+        "token_type",
+    ):
+        assert isinstance(body[field], str), f"{field} must be a string"
+    assert body["token_type"] == "Bearer"
+    assert body["client_id"] == client_id
+
+    claims = _decode_jwt_payload(body["access_token"])
+    assert claims["aud"] == "https://management.azure.com/"
+    assert claims["appid"] == client_id
+    assert claims["oid"] == identity["properties"]["principalId"]
+    assert claims["ver"] == "1.0"
+
+
+@pytest.mark.skipif(
+    "AZURE_POD_IDENTITY_AUTHORITY_HOST" not in os.environ,
+    reason="AZURE_POD_IDENTITY_AUTHORITY_HOST not set; SDK IMDS path targets 169.254.169.254",
+)
+def test_managed_identity_credential_sdk(identity):
+    from azure.identity import ManagedIdentityCredential
+
+    client_id = identity["properties"]["clientId"]
+
+    token = ManagedIdentityCredential(client_id=client_id).get_token(
+        "https://management.azure.com/.default"
+    )
+    claims = _decode_jwt_payload(token.token)
+    assert claims["appid"] == client_id
+
+    # System-assigned (no client_id) also succeeds.
+    system_token = ManagedIdentityCredential().get_token(
+        "https://management.azure.com/.default"
+    )
+    assert _decode_jwt_payload(system_token.token)["ver"] == "1.0"

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -25,6 +25,7 @@ Floci-AZ provides emulation for several core Azure services.
 | **Event Grid** | ARM path (`Microsoft.EventGrid`) + `/{topic}-eventgrid/api/events` | ✅ Custom Topics, access keys, webhook event subscriptions with filters, publish (Event Grid + CloudEvents 1.0), async delivery with retry, subscription validation handshake |
 | **Azure Monitor / Log Analytics** | ARM path (`Microsoft.OperationalInsights` / `Microsoft.Insights`) + `/dataCollectionRules/...` + `/v1/workspaces/...` | ✅ Workspaces, Data Collection Endpoints/Rules; Logs Ingestion API; Log Analytics query with a KQL subset (`where`/`project`/`take`/`limit`, timespan) |
 | **Communication Services Email** | `/emails:send` + `/emailMessages` + ARM path (`Microsoft.Communication`) | ✅ ACS Email send + status polling; in-memory inspection mailbox (Mailpit-style); ARM communication/email services + domains. No real delivery |
+| **Managed Identity** | ARM path (`Microsoft.ManagedIdentity`) + `/metadata/identity/oauth2/token` | ✅ User-assigned identities + federated identity credentials, system-assigned `identities/default`, IMDS token endpoint (`ManagedIdentityCredential` via `AZURE_POD_IDENTITY_AUTHORITY_HOST`); tokens signed with the Entra key |
 
 ## Unified Endpoint
 

--- a/docs/services/managed-identity.md
+++ b/docs/services/managed-identity.md
@@ -1,0 +1,178 @@
+# Managed Identity
+
+Compatible with the `azure-identity` `ManagedIdentityCredential` (Java, Python, Node.js), the
+`Microsoft.ManagedIdentity` ARM management plane, and any HTTP client. Covers **user-assigned
+identities** (with federated identity credentials) and the **IMDS token endpoint** that
+applications use to acquire tokens without secrets.
+
+> **HTTP-only — no Docker.** ARM CRUD state is in-memory; IMDS tokens are minted with the same
+> RSA signing key as the [Entra ID](entra.md) emulation, so they verify against the emulator JWKS.
+
+---
+
+## Features
+
+- **User-assigned identities** — CreateOrUpdate, Get, Update (tags), Delete, List (by resource
+  group and by subscription); `principalId` / `clientId` / `tenantId` are server-generated GUIDs
+  that stay stable across updates (msi spec `2024-11-30`)
+- **Federated identity credentials** — CreateOrUpdate, Get, Delete, List with
+  `issuer` / `subject` / `audiences` (as used by `azurerm_federated_identity_credential`)
+- **System-assigned identity read** — `GET {scope}/providers/Microsoft.ManagedIdentity/identities/default`
+  returns deterministic per-scope GUIDs
+- **IMDS token endpoint** — `GET /metadata/identity/oauth2/token` (imds spec `2023-07-01`):
+  requires the `Metadata: true` header, accepts `resource` plus an optional `client_id` /
+  `object_id` / `msi_res_id` selector, and returns the all-string IMDS response shape. Any
+  `api-version` is accepted (SDKs send `2018-02-01`)
+- **Verifiable tokens** — v1.0 JWTs (`appid`, `oid`, `idtyp=app`) signed by the Entra key;
+  validate against `GET /common/discovery/v2.0/keys`
+
+---
+
+## Endpoints
+
+```
+PUT    /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{name}
+GET    /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{name}
+PATCH  /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{name}
+DELETE /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{name}
+GET    /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.ManagedIdentity/userAssignedIdentities
+GET    /subscriptions/{sub}/providers/Microsoft.ManagedIdentity/userAssignedIdentities
+
+PUT    .../userAssignedIdentities/{name}/federatedIdentityCredentials/{ficName}
+GET    .../userAssignedIdentities/{name}/federatedIdentityCredentials/{ficName}
+DELETE .../userAssignedIdentities/{name}/federatedIdentityCredentials/{ficName}
+GET    .../userAssignedIdentities/{name}/federatedIdentityCredentials
+
+GET    /{scope}/providers/Microsoft.ManagedIdentity/identities/default
+
+GET    /metadata/identity/oauth2/token?resource={resource}[&client_id=...]   # header: Metadata: true
+```
+
+---
+
+## Quickstart
+
+### 1 — Create a user-assigned identity
+
+```bash
+curl -s -X PUT \
+  "http://localhost:4577/subscriptions/my-sub/resourceGroups/my-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/my-identity?api-version=2024-11-30" \
+  -H "Content-Type: application/json" \
+  -d '{"location":"eastus"}'
+```
+
+```json
+{
+  "name": "my-identity",
+  "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+  "properties": {
+    "tenantId": "00000000-0000-0000-0000-000000000002",
+    "principalId": "e3b0c442-…",
+    "clientId": "9f86d081-…"
+  }
+}
+```
+
+### 2 — Acquire a token via IMDS (raw HTTP)
+
+```bash
+curl -s -H "Metadata: true" \
+  "http://localhost:4577/metadata/identity/oauth2/token?resource=https://management.azure.com/&api-version=2018-02-01&client_id={clientId}"
+```
+
+Omit `client_id` for a system-assigned token. All response values are strings, per the real
+IMDS contract:
+
+```json
+{
+  "access_token": "eyJ0…",
+  "client_id": "9f86d081-…",
+  "expires_in": "3599",
+  "expires_on": "1767225599",
+  "ext_expires_in": "3599",
+  "not_before": "1767221999",
+  "resource": "https://management.azure.com/",
+  "token_type": "Bearer"
+}
+```
+
+### 3 — Use `ManagedIdentityCredential` from the SDKs
+
+The azure-identity SDKs target `http://169.254.169.254` by default. Point them at the emulator
+with `AZURE_POD_IDENTITY_AUTHORITY_HOST` (honored by the Java, Python, and Node.js SDKs):
+
+```bash
+export AZURE_POD_IDENTITY_AUTHORITY_HOST=http://localhost:4577
+```
+
+=== "Python"
+
+    ```python
+    from azure.identity import ManagedIdentityCredential
+
+    credential = ManagedIdentityCredential(client_id="{clientId}")  # or no args for system-assigned
+    token = credential.get_token("https://management.azure.com/.default")
+    ```
+
+=== "Java"
+
+    ```java
+    ManagedIdentityCredential credential = new ManagedIdentityCredentialBuilder()
+            .clientId("{clientId}")
+            .build();
+    AccessToken token = credential
+            .getToken(new TokenRequestContext().addScopes("https://management.azure.com/.default"))
+            .block();
+    ```
+
+=== "Node.js"
+
+    ```javascript
+    const { ManagedIdentityCredential } = require("@azure/identity");
+
+    const credential = new ManagedIdentityCredential("{clientId}");
+    const token = await credential.getToken("https://management.azure.com/.default");
+    ```
+
+---
+
+## Configuration
+
+```yaml
+floci-az:
+  services:
+    managed-identity:
+      enabled: true
+      system-assigned-scope: subscriptions/00000000-0000-0000-0000-000000000001
+```
+
+| Property | Env var | Default | Description |
+|---|---|---|---|
+| `enabled` | `FLOCI_AZ_SERVICES_MANAGED_IDENTITY_ENABLED` | `true` | Enables the ARM provider and the IMDS endpoint |
+| `system-assigned-scope` | `FLOCI_AZ_SERVICES_MANAGED_IDENTITY_SYSTEM_ASSIGNED_SCOPE` | `subscriptions/00000000-0000-0000-0000-000000000001` | ARM scope that seeds the system-assigned IMDS identity's `principalId`/`clientId`. Set it to your resource's scope (e.g. `subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Compute/virtualMachines/{vm}`) so IMDS tokens match `GET {scope}/.../identities/default` reads |
+
+Token tenant, issuer, and lifetime follow the [Entra ID](entra.md) settings
+(`floci-az.services.entra.*`).
+
+---
+
+## Intentional deviations
+
+- **`clientSecretUrl` is synthetic** — real Azure returns a Key Vault-backed credential renewal
+  URL for `identities/default`; the emulator returns a placeholder URL under the emulator base.
+- **Any `api-version` is accepted** on both planes; real IMDS rejects unknown versions.
+- **`isolationScope` is not modeled** on user-assigned identities.
+- **Federated identity credentials are CRUD-only** — no token-exchange semantics.
+- **Unknown identities return** `400 {"error":"invalid_request","error_description":"Identity not found"}`,
+  matching real IMDS behavior for unassigned user identities.
+- **The system-assigned IMDS identity is not tied to a caller resource** — on real Azure, IMDS
+  runs on the resource and returns that resource's own identity. The emulator is not attached to
+  a resource, so system-assigned tokens are seeded from the configured `system-assigned-scope`
+  (default: the default subscription). `identities/default` reads for *other* scopes return
+  different (deterministic) GUIDs; set `system-assigned-scope` to your resource's scope when
+  your code compares an ARM-read `principalId` against the token's `oid`.
+- **Identity state is in-memory only** — like the rest of the ARM control plane, identities and
+  federated credentials do not persist across restarts, regardless of `storage.mode`.
+- **Resource-group deletion does not cascade** — deleting a resource group leaves its identities
+  behind (consistent with the other ARM resources in the emulator). Identities do appear in
+  `GET .../resourceGroups/{rg}/resources`, so `prevent_deletion_if_contains_resources` works.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,5 +90,6 @@ nav:
     - Event Grid: services/event-grid.md
     - Azure Monitor / Log Analytics: services/monitor.md
     - Communication Services Email: services/email.md
+    - Managed Identity: services/managed-identity.md
   - Contributing: contributing.md
   - Changelog: changelog.md

--- a/src/main/java/io/floci/az/config/EmulatorConfig.java
+++ b/src/main/java/io/floci/az/config/EmulatorConfig.java
@@ -133,6 +133,7 @@ public interface EmulatorConfig {
         ArmConfig              arm();
         NetworkConfig          network();
         EventGridConfig        eventGrid();
+        ManagedIdentityConfig  managedIdentity();
 
 
         /** Shared Docker network for sidecar containers (Artemis, Redpanda, etc.). */
@@ -178,6 +179,21 @@ public interface EmulatorConfig {
     interface NetworkConfig {
         @WithDefault("true")
         boolean enabled();
+    }
+
+    /** Microsoft.ManagedIdentity — user-assigned identities + IMDS token endpoint. */
+    interface ManagedIdentityConfig {
+        @WithDefault("true")
+        boolean enabled();
+
+        /**
+         * ARM scope that seeds the system-assigned IMDS identity's principalId/clientId.
+         * The emulator is not attached to a real Azure resource, so the "own" identity
+         * scope is configurable; point it at a resource's scope to make IMDS tokens match
+         * {@code GET {scope}/providers/Microsoft.ManagedIdentity/identities/default}.
+         */
+        @WithDefault("subscriptions/00000000-0000-0000-0000-000000000001")
+        String systemAssignedScope();
     }
 
     /** Microsoft Entra ID (Azure AD) emulation — local OpenID Connect provider. */

--- a/src/main/java/io/floci/az/core/AzureRoutingFilter.java
+++ b/src/main/java/io/floci/az/core/AzureRoutingFilter.java
@@ -217,6 +217,28 @@ public class AzureRoutingFilter {
             }
         }
 
+        // IMDS (Instance Metadata Service) — managed identity token endpoint:
+        //   metadata/identity/oauth2/token?resource=...   (header Metadata: true)
+        // Reached by azure-identity ManagedIdentityCredential when
+        // AZURE_POD_IDENTITY_AUTHORITY_HOST points at the emulator. Must precede the
+        // Entra block (the path also ends with oauth2/token). Skips the auth pipeline:
+        // IMDS requests carry no Authorization header.
+        if (path.startsWith("metadata/identity/")) {
+            Optional<AzureServiceHandler> miHandler = serviceRegistry.resolve("managedidentity");
+            if (miHandler.isPresent()) {
+                Map<String, String> miQueryParams = new HashMap<>();
+                requestContext.getUriInfo().getQueryParameters().forEach((k, v) -> miQueryParams.put(k, v.get(0)));
+                AzureRequest miRequest = new AzureRequest(
+                    requestContext.getMethod(), "managedidentity", "managedidentity",
+                    path, headers, requestContext.getEntityStream(), miQueryParams, null, secure);
+                LOGGER.infof("Dispatching IMDS request to ManagedIdentityHandler: %s %s",
+                    requestContext.getMethod(), path);
+                return miHandler.get().handle(miRequest);
+            }
+            // Managed Identity disabled: fall through to JAX-RS (404).
+            return null;
+        }
+
         // Microsoft Entra ID (OpenID Connect provider) — tenant-rooted paths at the ARM base URL:
         //   {tenant}/oauth2/v2.0/token, {tenant}/oauth2/token,
         //   {tenant}/discovery/v2.0/keys,
@@ -323,6 +345,25 @@ public class AzureRoutingFilter {
             if (emailHandler.isPresent()) {
                 LOGGER.infof("Routing email path to EmailHandler: %s %s", requestContext.getMethod(), path);
                 return emailHandler.get().handle(emailRequest);
+            }
+        }
+
+        // ---------------------------------------------------------------
+        // Managed Identity — ARM management-plane paths:
+        //   subscriptions/{sub}/[resourceGroups/{rg}/]providers/Microsoft.ManagedIdentity/userAssignedIdentities/...
+        //   {scope}/providers/Microsoft.ManagedIdentity/identities/default
+        // Checked before the other providers: the identities/default scope may itself
+        // be a Compute/ContainerService/... resource, and the ManagedIdentity provider
+        // segment is always the last one in the path. Nested children scoped to an
+        // identity (role assignments, locks, ...) have a later /providers/ segment and
+        // must keep falling through to ArmHandler.
+        // ---------------------------------------------------------------
+        int managedIdentityMarker = path.indexOf("/providers/Microsoft.ManagedIdentity/");
+        if (path.startsWith("subscriptions/") && managedIdentityMarker >= 0
+                && path.indexOf("/providers/", managedIdentityMarker + 1) < 0) {
+            Response response = dispatchManagementPlane(requestContext, "managedidentity", path, headers, secure);
+            if (response != null) {
+                return response;
             }
         }
 

--- a/src/main/java/io/floci/az/core/AzureServiceRegistry.java
+++ b/src/main/java/io/floci/az/core/AzureServiceRegistry.java
@@ -54,6 +54,7 @@ public class AzureServiceRegistry {
             case "entra"      -> config.services().entra().enabled();
             case "arm"        -> config.services().arm().enabled();
             case "eventgrid"  -> config.services().eventGrid().enabled();
+            case "managedidentity" -> config.services().managedIdentity().enabled();
             case "cosmos-engine" -> config.services().cosmos().enabled();
             case "cosmos-mongo", "cosmos-table", "cosmos-cassandra",
                  "cosmos-gremlin", "cosmos-postgresql", "cosmos-nosql" ->

--- a/src/main/java/io/floci/az/core/BannerLogger.java
+++ b/src/main/java/io/floci/az/core/BannerLogger.java
@@ -127,6 +127,9 @@ public class BannerLogger {
         sb.append(String.format("   %-9s [%s]  %s\n", "network",
                 config.services().network().enabled() ? "enabled " : "disabled",
                 "Microsoft.Network (vnet, subnet, nic, public-ip, nsg, dns)"));
+        sb.append(String.format("   %-9s [%s]  %s\n", "managedid",
+                config.services().managedIdentity().enabled() ? "enabled " : "disabled",
+                "Microsoft.ManagedIdentity (user-assigned identities + IMDS token endpoint)"));
         if (config.services().eventGrid().enabled()) {
             sb.append(serviceStatus("eventgrid", true, getStorageMode("eventgrid")));
         }

--- a/src/main/java/io/floci/az/core/RequestUrls.java
+++ b/src/main/java/io/floci/az/core/RequestUrls.java
@@ -1,0 +1,20 @@
+package io.floci.az.core;
+
+import io.floci.az.config.EmulatorConfig;
+
+/** URL helpers for handlers that echo the caller's origin back in generated URLs. */
+public final class RequestUrls {
+
+    private RequestUrls() {
+    }
+
+    /** Base URL as seen by the caller — Host header when present, configured base URL otherwise. */
+    public static String resolveBaseUrl(AzureRequest request, EmulatorConfig config) {
+        String host = request.headers() == null ? null : request.headers().getHeaderString("Host");
+        if (host == null || host.isBlank()) {
+            return config.effectiveBaseUrl();
+        }
+        String scheme = request.secure() ? "https" : "http";
+        return scheme + "://" + host;
+    }
+}

--- a/src/main/java/io/floci/az/services/arm/ArmHandler.java
+++ b/src/main/java/io/floci/az/services/arm/ArmHandler.java
@@ -7,6 +7,7 @@ import io.floci.az.services.apim.ApiManagementHandler;
 import io.floci.az.services.blob.BlobServiceHandler;
 import io.floci.az.services.functions.FunctionRuntime;
 import io.floci.az.services.functions.FunctionsServiceHandler;
+import io.floci.az.services.managedidentity.ManagedIdentityHandler;
 import io.floci.az.services.network.NetworkHandler;
 import io.floci.az.services.monitor.MonitorHandler;
 import io.floci.az.services.queue.QueueServiceHandler;
@@ -61,11 +62,13 @@ public class ArmHandler implements AzureServiceHandler {
     private final ApiManagementHandler apiManagementHandler;
     private final NetworkHandler networkHandler;
     private final MonitorHandler monitorHandler;
+    private final ManagedIdentityHandler managedIdentityHandler;
 
     @Inject
     public ArmHandler(EmulatorConfig config, BlobServiceHandler blobHandler, QueueServiceHandler queueHandler,
                       FunctionsServiceHandler functionsHandler, ApiManagementHandler apiManagementHandler,
-                      NetworkHandler networkHandler, MonitorHandler monitorHandler) {
+                      NetworkHandler networkHandler, MonitorHandler monitorHandler,
+                      ManagedIdentityHandler managedIdentityHandler) {
         this.config               = config;
         this.blobHandler          = blobHandler;
         this.queueHandler         = queueHandler;
@@ -73,6 +76,7 @@ public class ArmHandler implements AzureServiceHandler {
         this.apiManagementHandler = apiManagementHandler;
         this.networkHandler       = networkHandler;
         this.monitorHandler       = monitorHandler;
+        this.managedIdentityHandler = managedIdentityHandler;
     }
 
     @Override
@@ -221,6 +225,9 @@ public class ArmHandler implements AzureServiceHandler {
                 resources.addAll(networkHandler.listResources(sub, rg));
             }
             resources.addAll(apiManagementHandler.listServices(sub, rg));
+            if (config.services().managedIdentity().enabled()) {
+                resources.addAll(managedIdentityHandler.listResources(sub, rg));
+            }
             return Response.ok(Map.of("value", resources)).build();
         }
 

--- a/src/main/java/io/floci/az/services/entra/EntraServiceHandler.java
+++ b/src/main/java/io/floci/az/services/entra/EntraServiceHandler.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.RequestUrls;
 import io.floci.az.services.entra.EntraModels.AppRegistration;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -70,7 +71,7 @@ public class EntraServiceHandler implements AzureServiceHandler {
     @Override
     public Response handle(AzureRequest request) {
         String path = stripSlashes(request.resourcePath());
-        String baseUrl = resolveBaseUrl(request);
+        String baseUrl = RequestUrls.resolveBaseUrl(request, config);
         LOG.infof("EntraService: %s %s", request.method(), path);
 
         if (path.endsWith(".well-known/openid-configuration")) {
@@ -102,7 +103,7 @@ public class EntraServiceHandler implements AzureServiceHandler {
         String oid   = app != null
                 ? store.findServicePrincipalByAppId(appId).map(EntraModels.ServicePrincipal::objectId)
                        .orElse(app.objectId())
-                : deterministicGuid(appId);
+                : TokenIssuer.deterministicGuid(appId);
 
         String issuer = config.services().entra().issuer().orElse(
                 v2 ? baseUrl + "/" + effectiveTenant + "/v2.0"
@@ -119,7 +120,7 @@ public class EntraServiceHandler implements AzureServiceHandler {
             }
             case "password" -> {
                 String username = form.getOrDefault("username", "dev-user@floci-az.local");
-                String userOid  = deterministicGuid(username);
+                String userOid  = TokenIssuer.deterministicGuid(username);
                 String audience = v2 ? appId : firstScopeResource(scope, baseUrl);
                 String scp = normalizeScopes(scope);
                 String token = tokenIssuer.issue(new TokenIssuer.TokenSpec(
@@ -222,20 +223,6 @@ public class EntraServiceHandler implements AzureServiceHandler {
     private String tenantSegment(String path) {
         int slash = path.indexOf('/');
         return slash < 0 ? path : path.substring(0, slash);
-    }
-
-    private String resolveBaseUrl(AzureRequest request) {
-        String host = request.headers() == null ? null : request.headers().getHeaderString("Host");
-        if (host == null || host.isBlank()) {
-            return config.effectiveBaseUrl();
-        }
-        String scheme = request.secure() ? "https" : "http";
-        return scheme + "://" + host;
-    }
-
-    /** Stable GUID derived from an arbitrary identity string, for synthetic oid claims. */
-    private static String deterministicGuid(String seed) {
-        return UUID.nameUUIDFromBytes(seed.getBytes(StandardCharsets.UTF_8)).toString();
     }
 
     private static String stripSlashes(String path) {

--- a/src/main/java/io/floci/az/services/entra/TokenIssuer.java
+++ b/src/main/java/io/floci/az/services/entra/TokenIssuer.java
@@ -11,6 +11,7 @@ import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Base64;
+import java.util.UUID;
 
 /**
  * Mints RS256-signed Entra ID JWTs without a JWT library — JCA {@code Signature("SHA256withRSA")}
@@ -55,6 +56,11 @@ public class TokenIssuer {
         String idtyp,
         long lifetimeSeconds
     ) {}
+
+    /** Stable GUID derived from an arbitrary seed, for synthetic directory object ids. */
+    public static String deterministicGuid(String seed) {
+        return UUID.nameUUIDFromBytes(seed.getBytes(StandardCharsets.UTF_8)).toString();
+    }
 
     /** Returns the compact serialised, signed JWT. */
     public String issue(TokenSpec spec) {

--- a/src/main/java/io/floci/az/services/managedidentity/ManagedIdentityHandler.java
+++ b/src/main/java/io/floci/az/services/managedidentity/ManagedIdentityHandler.java
@@ -1,0 +1,438 @@
+package io.floci.az.services.managedidentity;
+
+import io.floci.az.config.EmulatorConfig;
+import io.floci.az.core.AzureRequest;
+import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.RequestUrls;
+import io.floci.az.core.Resettable;
+import io.floci.az.core.arm.ArmErrors;
+import io.floci.az.core.arm.ArmJson;
+import io.floci.az.core.arm.ArmPaths;
+import io.floci.az.core.arm.ArmResources;
+import io.floci.az.services.entra.TokenIssuer;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Microsoft.ManagedIdentity handler. Serves both planes for {@code serviceType="managedidentity"}:
+ * <ul>
+ *   <li>Control plane — ARM CRUD for {@code userAssignedIdentities} (+ child
+ *       {@code federatedIdentityCredentials}) and the system-assigned
+ *       {@code {scope}/providers/Microsoft.ManagedIdentity/identities/default} read.
+ *       Shapes per msi spec 2024-11-30.</li>
+ *   <li>Data plane — IMDS token endpoint {@code GET metadata/identity/oauth2/token}
+ *       (imds spec 2023-07-01), reached by azure-identity {@code ManagedIdentityCredential}
+ *       when {@code AZURE_POD_IDENTITY_AUTHORITY_HOST} points at the emulator. Tokens are
+ *       minted with the Entra signing key, so they verify against the emulator JWKS.</li>
+ * </ul>
+ */
+@ApplicationScoped
+public class ManagedIdentityHandler implements AzureServiceHandler, Resettable {
+
+    private static final Logger LOG = Logger.getLogger(ManagedIdentityHandler.class);
+
+    private static final String PROVIDER_MARKER = "/providers/Microsoft.ManagedIdentity/";
+    private static final String IDENTITY_TYPE = "Microsoft.ManagedIdentity/userAssignedIdentities";
+    private static final String FIC_TYPE = IDENTITY_TYPE + "/federatedIdentityCredentials";
+
+    private final EmulatorConfig config;
+    private final ManagedIdentityStore store;
+    private final TokenIssuer tokenIssuer;
+
+    @Inject
+    public ManagedIdentityHandler(EmulatorConfig config, ManagedIdentityStore store,
+                                  TokenIssuer tokenIssuer) {
+        this.config = config;
+        this.store = store;
+        this.tokenIssuer = tokenIssuer;
+    }
+
+    @Override
+    public String getServiceType() {
+        return "managedidentity";
+    }
+
+    @Override
+    public boolean canHandle(AzureRequest request) {
+        return "managedidentity".equals(request.serviceType());
+    }
+
+    @Override
+    public Response handle(AzureRequest req) {
+        String method = req.method().toUpperCase();
+        String path = stripQuery(req.resourcePath());
+
+        if (path.startsWith("metadata/identity/oauth2/token")) {
+            if (!"GET".equals(method)) {
+                // Per imds spec 2023-07-01 the token endpoint is GET-only.
+                return imdsError(405, "method_not_allowed", "Method not allowed: " + method);
+            }
+            return handleImdsToken(req);
+        }
+
+        // Children of another provider scoped to an identity (role assignments, locks, ...)
+        // are not ManagedIdentity resources — 404 like ArmHandler would.
+        int marker = path.indexOf(PROVIDER_MARKER);
+        if (marker >= 0 && path.indexOf("/providers/", marker + 1) >= 0) {
+            return ArmErrors.error(404, "ResourceNotFound", "Unsupported Managed Identity path: " + path);
+        }
+
+        try {
+            if (path.contains(PROVIDER_MARKER + "identities/default")) {
+                return getSystemAssignedIdentity(req, path, method);
+            }
+            if (path.contains("/federatedIdentityCredentials")) {
+                return handleFederatedCredential(req, path, method);
+            }
+            if (path.contains(PROVIDER_MARKER + "userAssignedIdentities")) {
+                return handleIdentity(req, path, method);
+            }
+        } catch (ArmJson.InvalidBodyException e) {
+            return ArmErrors.error(400, "InvalidRequestContent",
+                    "The request content was invalid and could not be deserialized.");
+        }
+        LOG.debugf("ManagedIdentity: unhandled %s /%s", method, path);
+        return ArmErrors.error(404, "ResourceNotFound", "Unsupported Managed Identity path: " + path);
+    }
+
+    @Override
+    public void clearAll() {
+        store.clearAll();
+    }
+
+    /** ARM-shaped identities in a resource group, for ArmHandler's RG resource listing. */
+    public List<Map<String, Object>> listResources(String sub, String rg) {
+        List<Map<String, Object>> result = new ArrayList<>();
+        for (Map<String, Object> resource : store.listIdentities()) {
+            if (sub.equalsIgnoreCase(String.valueOf(resource.get("_sub")))
+                    && rg.equalsIgnoreCase(String.valueOf(resource.get("_rg")))) {
+                result.add(ArmResources.stripInternal(resource));
+            }
+        }
+        return result;
+    }
+
+    // ── ARM: userAssignedIdentities ─────────────────────────────────────────────
+
+    private Response handleIdentity(AzureRequest req, String path, String method) {
+        String name = ArmPaths.resourceName(path, "userAssignedIdentities").orElse(null);
+        if (name == null) {
+            if (!"GET".equals(method)) {
+                return ArmErrors.error(405, "MethodNotAllowed", "Method not allowed on identity collection");
+            }
+            return listIdentities(path);
+        }
+
+        String sub = ArmPaths.subscription(path, "unknown");
+        String rg = ArmPaths.resourceGroup(path, "unknown");
+        String key = ManagedIdentityStore.identityKey(sub, rg, name);
+
+        return switch (method) {
+            case "PUT" -> putIdentity(req, sub, rg, name, key);
+            case "PATCH" -> patchIdentity(req, key);
+            case "GET" -> {
+                Map<String, Object> existing = store.getIdentity(key);
+                yield existing == null
+                        ? ArmErrors.error(404, "ResourceNotFound", "Resource not found: userAssignedIdentities/" + name)
+                        : Response.ok(ArmResources.stripInternal(existing)).build();
+            }
+            case "DELETE" -> {
+                Map<String, Object> removed = store.removeIdentity(key);
+                yield Response.status(removed == null ? 204 : 200).build();
+            }
+            default -> ArmErrors.error(405, "MethodNotAllowed", "Method not allowed: " + method);
+        };
+    }
+
+    private Response listIdentities(String path) {
+        String sub = ArmPaths.subscription(path, "unknown");
+        String rg = path.toLowerCase().contains("/resourcegroups/") ? ArmPaths.resourceGroup(path, "unknown") : null;
+        List<Map<String, Object>> value = new ArrayList<>();
+        for (Map<String, Object> resource : store.listIdentities()) {
+            if (!sub.equalsIgnoreCase(String.valueOf(resource.get("_sub")))) {
+                continue;
+            }
+            if (rg != null && !rg.equalsIgnoreCase(String.valueOf(resource.get("_rg")))) {
+                continue;
+            }
+            value.add(ArmResources.stripInternal(resource));
+        }
+        return Response.ok(Map.of("value", value)).build();
+    }
+
+    private Response putIdentity(AzureRequest req, String sub, String rg, String name, String key) {
+        Map<String, Object> body = ArmJson.parseBodyStrict(req);
+        Map<String, Object> existing = store.getIdentity(key);
+
+        Map<String, Object> properties = new LinkedHashMap<>();
+        if (existing != null && existing.get("properties") instanceof Map<?, ?> existingProps) {
+            properties.put("tenantId", existingProps.get("tenantId"));
+            properties.put("principalId", existingProps.get("principalId"));
+            properties.put("clientId", existingProps.get("clientId"));
+        } else {
+            properties.put("tenantId", config.services().entra().defaultTenantId());
+            properties.put("principalId", UUID.randomUUID().toString());
+            properties.put("clientId", UUID.randomUUID().toString());
+        }
+
+        Map<String, Object> resource = new LinkedHashMap<>();
+        resource.put("id", identityId(sub, rg, name));
+        resource.put("name", name);
+        resource.put("type", IDENTITY_TYPE);
+        resource.put("location", ArmJson.string(body, "location",
+                existing != null ? ArmJson.string(existing, "location", "eastus") : "eastus"));
+        // ARM PUT is full-replace for mutable properties: omitted tags clear existing ones
+        // (location is create-only per TrackedResource x-ms-mutability and stays).
+        resource.put("tags", body.getOrDefault("tags", Map.of()));
+        resource.put("properties", properties);
+        resource.put("_sub", sub);
+        resource.put("_rg", rg);
+
+        store.putIdentity(key, resource);
+        return Response.status(existing == null ? 201 : 200).entity(ArmResources.stripInternal(resource)).build();
+    }
+
+    private Response patchIdentity(AzureRequest req, String key) {
+        Map<String, Object> existing = store.getIdentity(key);
+        if (existing == null) {
+            return ArmErrors.error(404, "ResourceNotFound", "Resource not found");
+        }
+        Map<String, Object> body = ArmJson.parseBodyStrict(req);
+        // Copy-then-replace: never mutate the live stored map in place — the store's
+        // ConcurrentHashMap only guards its structure, not the LinkedHashMap values, so a
+        // concurrent PATCH/GET on the same identity could race on that map.
+        Map<String, Object> updated = new LinkedHashMap<>(existing);
+        if (body.get("tags") instanceof Map<?, ?> tags) {
+            updated.put("tags", tags);
+        }
+        store.putIdentity(key, updated);
+        return Response.ok(ArmResources.stripInternal(updated)).build();
+    }
+
+    // ── ARM: federatedIdentityCredentials ───────────────────────────────────────
+
+    private Response handleFederatedCredential(AzureRequest req, String path, String method) {
+        String sub = ArmPaths.subscription(path, "unknown");
+        String rg = ArmPaths.resourceGroup(path, "unknown");
+        String identityName = ArmPaths.resourceName(path, "userAssignedIdentities").orElse(null);
+        String identityKey = ManagedIdentityStore.identityKey(sub, rg, identityName == null ? "" : identityName);
+        if (identityName == null || !store.identityExists(identityKey)) {
+            return ArmErrors.error(404, "ResourceNotFound",
+                    "Resource not found: userAssignedIdentities/" + identityName);
+        }
+
+        String ficName = ArmPaths.resourceName(path, "federatedIdentityCredentials").orElse(null);
+        if (ficName == null) {
+            if (!"GET".equals(method)) {
+                return ArmErrors.error(405, "MethodNotAllowed", "Method not allowed on credential collection");
+            }
+            return Response.ok(Map.of("value", store.listFederatedCredentials(identityKey))).build();
+        }
+
+        String key = ManagedIdentityStore.ficKey(identityKey, ficName);
+        return switch (method) {
+            case "PUT" -> putFederatedCredential(req, sub, rg, identityName, ficName, key);
+            case "GET" -> {
+                Map<String, Object> existing = store.getFederatedCredential(key);
+                yield existing == null
+                        ? ArmErrors.error(404, "ResourceNotFound",
+                                "Resource not found: federatedIdentityCredentials/" + ficName)
+                        : Response.ok(existing).build();
+            }
+            case "DELETE" -> {
+                Map<String, Object> removed = store.removeFederatedCredential(key);
+                yield Response.status(removed == null ? 204 : 200).build();
+            }
+            default -> ArmErrors.error(405, "MethodNotAllowed", "Method not allowed: " + method);
+        };
+    }
+
+    private Response putFederatedCredential(AzureRequest req, String sub, String rg,
+                                            String identityName, String ficName, String key) {
+        Map<String, Object> body = ArmJson.parseBodyStrict(req);
+        Map<String, Object> bodyProps = ArmJson.cast(body.get("properties"));
+        String issuer = ArmJson.string(bodyProps, "issuer", null);
+        String subject = ArmJson.string(bodyProps, "subject", null);
+        Object audiences = bodyProps.get("audiences");
+        if (issuer == null || subject == null || !(audiences instanceof List<?>)) {
+            return ArmErrors.error(400, "BadRequest",
+                    "federatedIdentityCredential requires properties.issuer, properties.subject and properties.audiences");
+        }
+
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("issuer", issuer);
+        properties.put("subject", subject);
+        properties.put("audiences", audiences);
+
+        Map<String, Object> resource = new LinkedHashMap<>();
+        resource.put("id", identityId(sub, rg, identityName) + "/federatedIdentityCredentials/" + ficName);
+        resource.put("name", ficName);
+        resource.put("type", FIC_TYPE);
+        resource.put("properties", properties);
+
+        boolean existed = store.putFederatedCredential(key, resource);
+        return Response.status(existed ? 200 : 201).entity(resource).build();
+    }
+
+    // ── ARM: system-assigned identities/default ─────────────────────────────────
+
+    private Response getSystemAssignedIdentity(AzureRequest req, String path, String method) {
+        if (!"GET".equals(method)) {
+            return ArmErrors.error(405, "MethodNotAllowed", "Method not allowed: " + method);
+        }
+        String scope = path.substring(0, path.indexOf(PROVIDER_MARKER));
+        String id = "/" + scope + PROVIDER_MARKER + "identities/default";
+
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("tenantId", config.services().entra().defaultTenantId());
+        properties.put("principalId", systemPrincipalId(scope));
+        properties.put("clientId", systemClientId(scope));
+        // Synthetic: real Azure returns a Key Vault-backed credential renewal URL here.
+        properties.put("clientSecretUrl", resolveBaseUrl(req) + id + "/credentials");
+
+        Map<String, Object> resource = new LinkedHashMap<>();
+        resource.put("id", id);
+        resource.put("name", "default");
+        resource.put("type", "Microsoft.ManagedIdentity/identities");
+        resource.put("properties", properties);
+        return Response.ok(resource).build();
+    }
+
+    // ── IMDS token endpoint ─────────────────────────────────────────────────────
+
+    private Response handleImdsToken(AzureRequest req) {
+        String metadata = req.headers() == null ? null : req.headers().getHeaderString("Metadata");
+        if (!"true".equalsIgnoreCase(metadata)) {
+            return imdsError(400, "invalid_request", "Required metadata header not specified");
+        }
+
+        String resource = param(req, "resource");
+        if (resource == null) {
+            return imdsError(400, "invalid_request", "Required query parameter 'resource' is missing");
+        }
+
+        String clientId = param(req, "client_id");
+        String objectId = param(req, "object_id");
+        String msiResId = param(req, "msi_res_id");
+        int selectors = (clientId != null ? 1 : 0) + (objectId != null ? 1 : 0) + (msiResId != null ? 1 : 0);
+        if (selectors > 1) {
+            return imdsError(400, "invalid_request",
+                    "client_id, object_id and msi_res_id are mutually exclusive");
+        }
+
+        String principalId;
+        String appId;
+        if (clientId != null || objectId != null || msiResId != null) {
+            Optional<Map<String, Object>> selected;
+            if (clientId != null) {
+                selected = store.findByClientId(clientId);
+            } else if (objectId != null) {
+                selected = store.findByPrincipalId(objectId);
+            } else {
+                selected = store.findByResourceId(msiResId);
+            }
+            Map<String, Object> identity = selected.orElse(null);
+            if (identity == null) {
+                return imdsError(400, "invalid_request", "Identity not found");
+            }
+            principalId = identityProperty(identity, "principalId");
+            appId = identityProperty(identity, "clientId");
+        } else {
+            // System-assigned: same deterministic GUIDs as identities/default for the
+            // configured scope. The emulator is not attached to a real resource, so the
+            // "own" identity scope is a config knob rather than the caller's VM.
+            String scope = config.services().managedIdentity().systemAssignedScope();
+            principalId = systemPrincipalId(scope);
+            appId = systemClientId(scope);
+        }
+
+        String tenantId = config.services().entra().defaultTenantId();
+        String issuer = config.services().entra().issuer()
+                .orElse(resolveBaseUrl(req) + "/" + tenantId + "/");
+        long lifetime = config.services().entra().tokenLifetimeSeconds();
+        long now = Instant.now().getEpochSecond();
+
+        String token = tokenIssuer.issue(new TokenIssuer.TokenSpec(
+                tenantId, issuer, resource, principalId, principalId, appId, null,
+                "1.0", "app", lifetime));
+
+        // Per imds spec 2023-07-01 every value is a string.
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("access_token", token);
+        body.put("client_id", appId);
+        body.put("expires_in", String.valueOf(lifetime));
+        body.put("expires_on", String.valueOf(now + lifetime));
+        body.put("ext_expires_in", String.valueOf(lifetime));
+        body.put("not_before", String.valueOf(now));
+        body.put("resource", resource);
+        body.put("token_type", "Bearer");
+        if (objectId != null) {
+            body.put("object_id", objectId);
+        }
+        if (msiResId != null) {
+            body.put("msi_res_id", msiResId);
+        }
+        return Response.ok(body).type(MediaType.APPLICATION_JSON).build();
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────────
+
+    private String resolveBaseUrl(AzureRequest request) {
+        return RequestUrls.resolveBaseUrl(request, config);
+    }
+
+    private static String identityId(String sub, String rg, String name) {
+        return "/subscriptions/" + sub + "/resourceGroups/" + rg
+                + PROVIDER_MARKER + "userAssignedIdentities/" + name;
+    }
+
+    private static String identityProperty(Map<String, Object> identity, String key) {
+        return String.valueOf(ArmJson.cast(identity.get("properties")).get(key));
+    }
+
+    private static String systemPrincipalId(String scope) {
+        return TokenIssuer.deterministicGuid("msi-principal:" + scope.toLowerCase());
+    }
+
+    private static String systemClientId(String scope) {
+        return TokenIssuer.deterministicGuid("msi-client:" + scope.toLowerCase());
+    }
+
+    private static String param(AzureRequest req, String name) {
+        String value = req.queryParams() == null ? null : req.queryParams().get(name);
+        return value == null || value.isBlank() ? null : value;
+    }
+
+
+
+
+
+
+
+
+
+    private static String stripQuery(String path) {
+        int q = path.indexOf('?');
+        return q >= 0 ? path.substring(0, q) : path;
+    }
+
+
+    private static Response imdsError(int status, String code, String description) {
+        return Response.status(status)
+                .header("Www-Authenticate", "Basic realm=\"managed-identity\"")
+                .entity(Map.of("error", code, "error_description", description))
+                .type(MediaType.APPLICATION_JSON)
+                .build();
+    }
+}

--- a/src/main/java/io/floci/az/services/managedidentity/ManagedIdentityStore.java
+++ b/src/main/java/io/floci/az/services/managedidentity/ManagedIdentityStore.java
@@ -1,0 +1,102 @@
+package io.floci.az.services.managedidentity;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * In-memory ARM resource state for Microsoft.ManagedIdentity — no StorageBackend needed.
+ * All access goes through methods: the handler holds a normal-scoped client proxy, and
+ * direct field reads on a proxy would hit the proxy's own (empty) maps instead of this
+ * contextual instance.
+ */
+@ApplicationScoped
+public class ManagedIdentityStore {
+
+    private final Map<String, Map<String, Object>> identities = new ConcurrentHashMap<>();
+    private final Map<String, Map<String, Object>> federatedCredentials = new ConcurrentHashMap<>();
+
+    static String identityKey(String sub, String rg, String name) {
+        return sub.toLowerCase() + "/" + rg.toLowerCase() + "/" + name.toLowerCase();
+    }
+
+    static String ficKey(String identityKey, String ficName) {
+        return identityKey + "/fic/" + ficName.toLowerCase();
+    }
+
+    public Map<String, Object> getIdentity(String key) {
+        return identities.get(key);
+    }
+
+    public void putIdentity(String key, Map<String, Object> resource) {
+        identities.put(key, resource);
+    }
+
+    public Map<String, Object> removeIdentity(String key) {
+        // Clean the children first: if the same key is re-created between these two ops,
+        // the removeIf must not delete the new identity's freshly-added FICs.
+        federatedCredentials.keySet().removeIf(k -> k.startsWith(key + "/fic/"));
+        return identities.remove(key);
+    }
+
+    public List<Map<String, Object>> listIdentities() {
+        return new ArrayList<>(identities.values());
+    }
+
+    public boolean identityExists(String key) {
+        return identities.containsKey(key);
+    }
+
+    public Map<String, Object> getFederatedCredential(String key) {
+        return federatedCredentials.get(key);
+    }
+
+    public boolean putFederatedCredential(String key, Map<String, Object> resource) {
+        return federatedCredentials.put(key, resource) != null;
+    }
+
+    public Map<String, Object> removeFederatedCredential(String key) {
+        return federatedCredentials.remove(key);
+    }
+
+    public List<Map<String, Object>> listFederatedCredentials(String identityKey) {
+        String prefix = identityKey + "/fic/";
+        List<Map<String, Object>> result = new ArrayList<>();
+        federatedCredentials.forEach((k, v) -> {
+            if (k.startsWith(prefix)) {
+                result.add(v);
+            }
+        });
+        return result;
+    }
+
+    public Optional<Map<String, Object>> findByClientId(String clientId) {
+        return findByProperty("clientId", clientId);
+    }
+
+    public Optional<Map<String, Object>> findByPrincipalId(String principalId) {
+        return findByProperty("principalId", principalId);
+    }
+
+    public Optional<Map<String, Object>> findByResourceId(String armId) {
+        return identities.values().stream()
+                .filter(r -> armId.equalsIgnoreCase(String.valueOf(r.get("id"))))
+                .findFirst();
+    }
+
+    private Optional<Map<String, Object>> findByProperty(String key, String value) {
+        return identities.values().stream()
+                .filter(r -> r.get("properties") instanceof Map<?, ?> props
+                        && value.equalsIgnoreCase(String.valueOf(props.get(key))))
+                .findFirst();
+    }
+
+    public void clearAll() {
+        identities.clear();
+        federatedCredentials.clear();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -190,6 +190,11 @@ floci-az:
       enabled: true       # Microsoft.EventGrid — Custom Topics + webhook event subscriptions (HTTP pub/push)
       default-region: eastus
       max-delivery-attempts: 30
+    managed-identity:
+      enabled: true       # Microsoft.ManagedIdentity — user-assigned identities + IMDS token endpoint (tokens signed with the entra key)
+      # ARM scope that seeds the system-assigned IMDS identity; set it to your resource's
+      # scope so IMDS tokens match GET {scope}/.../identities/default reads.
+      system-assigned-scope: subscriptions/00000000-0000-0000-0000-000000000001
 
   auth:
     # dev: accept any credentials without signature validation

--- a/src/test/java/io/floci/az/services/managedidentity/ManagedIdentityDisabledTest.java
+++ b/src/test/java/io/floci/az/services/managedidentity/ManagedIdentityDisabledTest.java
@@ -1,0 +1,62 @@
+package io.floci.az.services.managedidentity;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Verifies that {@code floci-az.services.managed-identity.enabled=false} disables
+ * Microsoft.ManagedIdentity and the IMDS token endpoint while the rest of the ARM
+ * management plane keeps working.
+ */
+@QuarkusTest
+@TestProfile(ManagedIdentityDisabledTest.DisabledProfile.class)
+@DisplayName("Managed Identity disabled — ARM provider and IMDS gated off")
+@SuppressWarnings("unused")
+class ManagedIdentityDisabledTest {
+
+    public static class DisabledProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("floci-az.services.managed-identity.enabled", "false");
+        }
+    }
+
+    private static final String SUB  = "test-sub-msioff";
+    private static final String RG   = "test-rg-msioff";
+    private static final String BASE = "/subscriptions/" + SUB + "/resourceGroups/" + RG;
+    private static final String API  = "?api-version=2024-11-30";
+
+    @Test
+    @DisplayName("PUT userAssignedIdentity returns 404 when managed identity disabled")
+    void identityCreateGatedOff() {
+        given().contentType("application/json").body("{\"location\":\"eastus\"}")
+                .when().put(BASE + "/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1" + API)
+                .then().statusCode(404)
+                .body("error.code", equalTo("ResourceNotFound"));
+    }
+
+    @Test
+    @DisplayName("IMDS token endpoint returns 404 when managed identity disabled")
+    void imdsGatedOff() {
+        given().header("Metadata", "true")
+                .when().get("/metadata/identity/oauth2/token?resource=https://management.azure.com/&api-version=2018-02-01")
+                .then().statusCode(404);
+    }
+
+    @Test
+    @DisplayName("non-identity ARM (resource group) still works when managed identity disabled")
+    void resourceGroupStillWorks() {
+        given().contentType("application/json").body("{\"location\":\"eastus\"}")
+                .when().put(BASE + API)
+                .then().statusCode(anyOf(equalTo(200), equalTo(201)));
+    }
+}

--- a/src/test/java/io/floci/az/services/managedidentity/ManagedIdentityTest.java
+++ b/src/test/java/io/floci/az/services/managedidentity/ManagedIdentityTest.java
@@ -1,0 +1,368 @@
+package io.floci.az.services.managedidentity;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+@DisplayName("ManagedIdentityHandler - ARM userAssignedIdentities + IMDS token endpoint")
+class ManagedIdentityTest {
+
+    private static final String SUB = "test-sub-msi";
+    private static final String RG = "test-rg-msi";
+    private static final String API = "?api-version=2024-11-30";
+    private static final String BASE =
+            "/subscriptions/" + SUB + "/resourceGroups/" + RG
+                    + "/providers/Microsoft.ManagedIdentity/userAssignedIdentities";
+    private static final String IMDS = "/metadata/identity/oauth2/token";
+    private static final String UUID_PATTERN =
+            "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
+
+    private static final Base64.Decoder URL_DECODER = Base64.getUrlDecoder();
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeEach
+    void reset() {
+        given().when().post("/_admin/reset").then().statusCode(204);
+    }
+
+    // ── ARM CRUD ────────────────────────────────────────────────────────────────
+
+    @Test
+    void identityLifecycle() {
+        String body = """
+                {"location": "westus", "tags": {"env": "test"}}
+                """;
+
+        String clientId = given().contentType("application/json").body(body)
+                .when().put(BASE + "/id1" + API)
+                .then().statusCode(201)
+                .body("name", equalTo("id1"))
+                .body("type", equalTo("Microsoft.ManagedIdentity/userAssignedIdentities"))
+                .body("location", equalTo("westus"))
+                .body("tags.env", equalTo("test"))
+                .body("id", equalTo(BASE + "/id1"))
+                .body("properties.principalId", matchesPattern(UUID_PATTERN))
+                .body("properties.clientId", matchesPattern(UUID_PATTERN))
+                .body("properties.tenantId", matchesPattern(UUID_PATTERN))
+                .extract().path("properties.clientId");
+
+        // Re-PUT keeps the generated ids stable and returns 200.
+        given().contentType("application/json").body(body)
+                .when().put(BASE + "/id1" + API)
+                .then().statusCode(200)
+                .body("properties.clientId", equalTo(clientId));
+
+        given().when().get(BASE + "/id1" + API)
+                .then().statusCode(200)
+                .body("name", equalTo("id1"))
+                .body("properties.clientId", equalTo(clientId));
+
+        given().contentType("application/json").body("""
+                {"tags": {"env": "prod"}}
+                """)
+                .when().patch(BASE + "/id1" + API)
+                .then().statusCode(200)
+                .body("tags.env", equalTo("prod"))
+                .body("properties.clientId", equalTo(clientId));
+
+        given().when().get(BASE + API)
+                .then().statusCode(200)
+                .body("value", hasSize(1))
+                .body("value[0].name", equalTo("id1"));
+
+        given().when().get("/subscriptions/" + SUB
+                        + "/providers/Microsoft.ManagedIdentity/userAssignedIdentities" + API)
+                .then().statusCode(200)
+                .body("value", hasSize(1));
+
+        given().when().delete(BASE + "/id1" + API)
+                .then().statusCode(200);
+
+        given().when().get(BASE + "/id1" + API)
+                .then().statusCode(404)
+                .body("error.code", equalTo("ResourceNotFound"));
+    }
+
+    @Test
+    void putReplacesTagsWhenBodyOmitsThem() {
+        given().contentType("application/json")
+                .body("{\"location\": \"westus\", \"tags\": {\"env\": \"test\"}}")
+                .when().put(BASE + "/tagged" + API)
+                .then().statusCode(201)
+                .body("tags.env", equalTo("test"));
+
+        // ARM PUT is full-replace: omitting tags clears the existing ones.
+        given().contentType("application/json").body("{\"location\": \"westus\"}")
+                .when().put(BASE + "/tagged" + API)
+                .then().statusCode(200)
+                .body("tags", anEmptyMap());
+
+        given().when().get(BASE + "/tagged" + API)
+                .then().statusCode(200)
+                .body("tags", anEmptyMap());
+    }
+
+    @Test
+    void malformedJsonBodyIsRejected() {
+        given().contentType("application/json").body("{not json")
+                .when().put(BASE + "/broken" + API)
+                .then().statusCode(400)
+                .body("error.code", equalTo("InvalidRequestContent"));
+
+        given().when().get(BASE + "/broken" + API)
+                .then().statusCode(404);
+    }
+
+    @Test
+    void nestedChildProviderPathDoesNotTouchTheIdentity() {
+        given().contentType("application/json").body("{\"location\": \"eastus\"}")
+                .when().put(BASE + "/scoped" + API)
+                .then().statusCode(201);
+
+        // A role assignment scoped to the identity is not a ManagedIdentity resource:
+        // deleting it must 404 harmlessly instead of deleting the identity itself.
+        given().when().delete(BASE + "/scoped/providers/Microsoft.Authorization/roleAssignments/"
+                        + "22222222-2222-2222-2222-222222222222?api-version=2022-04-01")
+                .then().statusCode(404);
+
+        given().when().get(BASE + "/scoped" + API)
+                .then().statusCode(200)
+                .body("name", equalTo("scoped"));
+    }
+
+    @Test
+    void identityIsListedAmongResourceGroupResources() {
+        given().contentType("application/json").body("{\"location\": \"eastus\"}")
+                .when().put(BASE + "/rg-visible" + API)
+                .then().statusCode(201);
+
+        // azurerm checks this listing before deleting a resource group.
+        given().when().get("/subscriptions/" + SUB + "/resourceGroups/" + RG
+                        + "/resources?api-version=2021-04-01")
+                .then().statusCode(200)
+                .body("value.find { it.name == 'rg-visible' }.type",
+                        equalTo("Microsoft.ManagedIdentity/userAssignedIdentities"));
+    }
+
+    @Test
+    void federatedIdentityCredentialLifecycle() {
+        given().contentType("application/json").body("{\"location\": \"eastus\"}")
+                .when().put(BASE + "/id2" + API)
+                .then().statusCode(201);
+
+        String ficBody = """
+                {"properties": {"issuer": "https://token.actions.githubusercontent.com",
+                                "subject": "repo:org/repo:ref:refs/heads/main",
+                                "audiences": ["api://AzureADTokenExchange"]}}
+                """;
+
+        given().contentType("application/json").body(ficBody)
+                .when().put(BASE + "/id2/federatedIdentityCredentials/fic1" + API)
+                .then().statusCode(201)
+                .body("name", equalTo("fic1"))
+                .body("type", equalTo("Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials"))
+                .body("properties.issuer", equalTo("https://token.actions.githubusercontent.com"))
+                .body("properties.audiences", hasSize(1));
+
+        given().when().get(BASE + "/id2/federatedIdentityCredentials" + API)
+                .then().statusCode(200)
+                .body("value", hasSize(1))
+                .body("value[0].name", equalTo("fic1"));
+
+        // Missing required properties → 400 CloudError.
+        given().contentType("application/json").body("{\"properties\": {\"issuer\": \"x\"}}")
+                .when().put(BASE + "/id2/federatedIdentityCredentials/fic2" + API)
+                .then().statusCode(400)
+                .body("error.code", equalTo("BadRequest"));
+
+        // Parent identity must exist.
+        given().contentType("application/json").body(ficBody)
+                .when().put(BASE + "/missing/federatedIdentityCredentials/fic1" + API)
+                .then().statusCode(404);
+
+        given().when().delete(BASE + "/id2/federatedIdentityCredentials/fic1" + API)
+                .then().statusCode(200);
+
+        given().when().get(BASE + "/id2/federatedIdentityCredentials/fic1" + API)
+                .then().statusCode(404);
+    }
+
+    @Test
+    void systemAssignedIdentityDefaultRead() {
+        String scope = "/subscriptions/" + SUB + "/resourceGroups/" + RG
+                + "/providers/Microsoft.Compute/virtualMachines/vm1";
+
+        String principalId = given()
+                .when().get(scope + "/providers/Microsoft.ManagedIdentity/identities/default" + API)
+                .then().statusCode(200)
+                .body("name", equalTo("default"))
+                .body("type", equalTo("Microsoft.ManagedIdentity/identities"))
+                .body("properties.principalId", matchesPattern(UUID_PATTERN))
+                .body("properties.clientSecretUrl", notNullValue())
+                .extract().path("properties.principalId");
+
+        // Deterministic: same scope yields the same principal.
+        given().when().get(scope + "/providers/Microsoft.ManagedIdentity/identities/default" + API)
+                .then().statusCode(200)
+                .body("properties.principalId", equalTo(principalId));
+    }
+
+    // ── IMDS ────────────────────────────────────────────────────────────────────
+
+    @Test
+    void imdsRejectsMissingMetadataHeader() {
+        given().when().get(IMDS + "?resource=https://management.azure.com/&api-version=2018-02-01")
+                .then().statusCode(400)
+                .header("Www-Authenticate", startsWith("Basic realm="))
+                .body("error", equalTo("invalid_request"))
+                .body("error_description", equalTo("Required metadata header not specified"));
+    }
+
+    @Test
+    void imdsRejectsNonGetMethods() {
+        // Per imds spec 2023-07-01 the token endpoint is GET-only.
+        given().header("Metadata", "true")
+                .when().post(IMDS + "?resource=https://management.azure.com/&api-version=2018-02-01")
+                .then().statusCode(405)
+                .body("error", equalTo("method_not_allowed"));
+    }
+
+    @Test
+    void imdsSystemAssignedTokenMatchesIdentitiesDefault() throws Exception {
+        // The configured system-assigned scope (default subscription) must yield the same
+        // principal via ARM identities/default and via the IMDS token's oid claim.
+        String scope = "/subscriptions/00000000-0000-0000-0000-000000000001";
+        Map<String, String> armProps = given()
+                .when().get(scope + "/providers/Microsoft.ManagedIdentity/identities/default" + API)
+                .then().statusCode(200)
+                .extract().path("properties");
+
+        Map<String, Object> tokenBody = given().header("Metadata", "true")
+                .when().get(IMDS + "?resource=https://management.azure.com/&api-version=2018-02-01")
+                .then().statusCode(200)
+                .extract().as(new io.restassured.common.mapper.TypeRef<Map<String, Object>>() {});
+
+        assertEquals(armProps.get("clientId"), tokenBody.get("client_id"));
+        Map<?, ?> claims = mapper.readValue(
+                URL_DECODER.decode(((String) tokenBody.get("access_token")).split("\\.")[1]), Map.class);
+        assertEquals(armProps.get("principalId"), claims.get("oid"));
+    }
+
+    @Test
+    void imdsRejectsMissingResource() {
+        given().header("Metadata", "true")
+                .when().get(IMDS + "?api-version=2018-02-01")
+                .then().statusCode(400)
+                .body("error", equalTo("invalid_request"));
+    }
+
+    @Test
+    void imdsRejectsUnknownClientId() {
+        given().header("Metadata", "true")
+                .when().get(IMDS + "?resource=https://management.azure.com/"
+                        + "&client_id=11111111-1111-1111-1111-111111111111&api-version=2018-02-01")
+                .then().statusCode(400)
+                .body("error", equalTo("invalid_request"))
+                .body("error_description", equalTo("Identity not found"));
+    }
+
+    @Test
+    void imdsRejectsMultipleSelectors() {
+        given().header("Metadata", "true")
+                .when().get(IMDS + "?resource=https://management.azure.com/"
+                        + "&client_id=a&object_id=b&api-version=2018-02-01")
+                .then().statusCode(400)
+                .body("error", equalTo("invalid_request"));
+    }
+
+    @Test
+    void imdsSystemAssignedTokenHasAllStringFields() {
+        Map<String, Object> body = given().header("Metadata", "true")
+                .when().get(IMDS + "?resource=https://management.azure.com/&api-version=2018-02-01")
+                .then().statusCode(200)
+                .body("token_type", equalTo("Bearer"))
+                .body("resource", equalTo("https://management.azure.com/"))
+                .extract().as(new io.restassured.common.mapper.TypeRef<Map<String, Object>>() {});
+
+        // Per imds spec 2023-07-01 every value in the token response is a string.
+        for (String field : List.of("access_token", "client_id", "expires_in", "expires_on",
+                "ext_expires_in", "not_before", "resource", "token_type")) {
+            assertTrue(body.get(field) instanceof String, field + " must be a string");
+        }
+        long notBefore = Long.parseLong((String) body.get("not_before"));
+        long expiresOn = Long.parseLong((String) body.get("expires_on"));
+        assertEquals(Long.parseLong((String) body.get("expires_in")), expiresOn - notBefore);
+    }
+
+    @Test
+    void imdsUserAssignedTokenVerifiesAgainstJwks() throws Exception {
+        given().contentType("application/json").body("{\"location\": \"eastus\"}")
+                .when().put(BASE + "/token-id" + API)
+                .then().statusCode(201);
+
+        Map<String, String> identity = given().when().get(BASE + "/token-id" + API)
+                .then().statusCode(200).extract().path("properties");
+        String clientId = identity.get("clientId");
+        String principalId = identity.get("principalId");
+
+        String accessToken = given().header("Metadata", "true")
+                .when().get(IMDS + "?resource=https://vault.azure.net"
+                        + "&client_id=" + clientId + "&api-version=2018-02-01")
+                .then().statusCode(200)
+                .body("client_id", equalTo(clientId))
+                .extract().path("access_token");
+
+        String[] parts = accessToken.split("\\.");
+        assertEquals(3, parts.length);
+
+        Map<?, ?> claims = mapper.readValue(URL_DECODER.decode(parts[1]), Map.class);
+        assertEquals("https://vault.azure.net", claims.get("aud"));
+        assertEquals(clientId, claims.get("appid"), "v1.0 tokens carry appid");
+        assertEquals(principalId, claims.get("oid"));
+        assertEquals("1.0", claims.get("ver"));
+        assertEquals("app", claims.get("idtyp"));
+        assertNull(claims.get("scp"), "IMDS tokens are app-only, no scp");
+        assertTrue(String.valueOf(claims.get("iss")).contains(String.valueOf(claims.get("tid"))),
+                "v1 issuer embeds the tenant id");
+
+        // Signature verifies against the Entra JWKS the emulator already serves.
+        Map<String, Object> jwks = given().when().get("/common/discovery/v2.0/keys")
+                .then().statusCode(200)
+                .extract().as(new io.restassured.common.mapper.TypeRef<Map<String, Object>>() {});
+        @SuppressWarnings("unchecked")
+        Map<String, Object> key = ((List<Map<String, Object>>) jwks.get("keys")).get(0);
+        BigInteger n = new BigInteger(1, URL_DECODER.decode((String) key.get("n")));
+        BigInteger e = new BigInteger(1, URL_DECODER.decode((String) key.get("e")));
+        PublicKey pub = KeyFactory.getInstance("RSA").generatePublic(new RSAPublicKeySpec(n, e));
+
+        Signature verifier = Signature.getInstance("SHA256withRSA");
+        verifier.initVerify(pub);
+        verifier.update((parts[0] + "." + parts[1]).getBytes(StandardCharsets.US_ASCII));
+        assertTrue(verifier.verify(URL_DECODER.decode(parts[2])),
+                "IMDS token must verify against the emulator JWKS");
+    }
+}


### PR DESCRIPTION
## Summary

Adds `Microsoft.ManagedIdentity` + the IMDS token endpoint, HTTP-only (no sidecar):

- **ARM CRUD** for user-assigned identities (server-generated
  `principalId`/`clientId`/`tenantId` GUIDs, stable across updates; PUT is
  full-replace for tags per msi spec 2024-11-30), `federatedIdentityCredentials`
  children, and the system-assigned `GET {scope}/…/identities/default` read with
  deterministic per-scope GUIDs. Identities appear in the resource group's
  `/resources` listing (azurerm's pre-delete emptiness check). Malformed bodies
  answer `400 InvalidRequestContent`.
- **IMDS token endpoint** (`GET /metadata/identity/oauth2/token`, imds spec
  2023-07-01, GET-only, `Metadata: true` required): resolves an identity by
  `client_id`/`object_id`/`msi_res_id` or synthesizes the system-assigned one,
  and returns the all-string response with a v1.0 JWT (`appid`/`oid`/`idtyp=app`)
  signed by the Entra key — verifiable against the emulator JWKS. The
  system-assigned scope is configurable (`services.managed-identity.system-assigned-scope`)
  so token `oid` claims can match `identities/default` reads.
- Built on the shared plumbing this repo just landed: `Resettable`, `core/arm`
  (`parseBodyStrict`), `RequestUrls`, `TokenIssuer.deterministicGuid`; suite env
  flows through `POD_IDENTITY_ENV` → `SUITE_ENV_*` and the CI matrix.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

Shapes verified against the local msi 2024-12-30 / imds 2023-07-01 specs.
Verified end-to-end with `azure-identity` `ManagedIdentityCredential` in **Java,
Python, and Node.js** (via `AZURE_POD_IDENTITY_AUTHORITY_HOST`) — all three
suites include an SDK-level acquisition test. Intentional deviations documented
in `docs/services/managed-identity.md`.

## Checklist

- [x] `./mvnw test` passes locally (281/281)
- [x] New or updated integration test added (`ManagedIdentityTest` 15 tests +
      `ManagedIdentityDisabledTest`, plus Java/Python/Node compat suites)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
