### PR TITLE
chore(core): let handlers describe their own routes and enablement

### DIFF
--- a/src/main/java/io/floci/az/core/AzureRoutingFilter.java
+++ b/src/main/java/io/floci/az/core/AzureRoutingFilter.java
@@ -4,6 +4,7 @@ import io.floci.az.core.auth.AuthPipeline;
 import io.floci.az.services.arm.ArmHandler;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Vertx;
+import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.container.ContainerRequestContext;
@@ -22,6 +23,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
+
+import io.floci.az.core.ServiceRoutes.SuffixRoute;
 
 @ApplicationScoped
 public class AzureRoutingFilter {
@@ -131,49 +134,92 @@ public class AzureRoutingFilter {
         "secrets", "certificates", "keys", "deletedsecrets", "deletedcertificates", "deletedkeys"
     );
 
-    /** A suffix of a host name or of an account name that identifies a service. */
-    private record SuffixRoute(String suffix, String serviceType) {}
+    /**
+     * A resolved ARM provider route: the pre-built {@code /providers/<namespace>/} marker, the service
+     * type of the handler that claimed it, and the handler's guard.
+     */
+    private record ResolvedProvider(String marker, String serviceType, Predicate<String> guard) {}
 
-    // Host-suffix → serviceType for data-plane requests reaching {account}.<suffix>.
-    // Suffixes are mutually exclusive, so match order is irrelevant. DFS maps to blob.
-    private static final List<SuffixRoute> HOST_ROUTES = List.of(
-        new SuffixRoute(".vault.azure.net", "keyvault"),
-        new SuffixRoute(".communication.azure.com", "email"),
-        new SuffixRoute(".blob.core.windows.net", "blob"),
-        new SuffixRoute(".dfs.core.windows.net", "blob"),
-        new SuffixRoute(".queue.core.windows.net", "queue"),
-        new SuffixRoute(".servicebus.windows.net", "servicebus")
+    // ── Routing tables, assembled from the handlers at startup ──────────────────
+
+    /** Host-suffix → serviceType. Suffixes are mutually exclusive; DFS maps to blob. */
+    private volatile List<SuffixRoute> hostRoutes = List.of();
+
+    /**
+     * Account-name suffix → serviceType (e.g. {@code {account}-queue → queue}), sorted longest-first.
+     * Any suffix that is a string-suffix of another is always shorter, so length-descending gives the
+     * required most-specific-first match ({@code -cosmos-table} must beat {@code -table}).
+     */
+    private volatile List<SuffixRoute> accountSuffixRoutes = List.of();
+
+    /**
+     * ARM provider routes, guarded routes first. Managed Identity is the only guarded route, and it
+     * must be tried before the broader providers: an {@code identities/default} scope may itself be a
+     * Compute/ContainerService resource, and Managed Identity's {@code /providers/} segment is always
+     * the last one. Handler discovery order is arbitrary, so guarded-first is what makes this
+     * deterministic; the namespace tiebreak keeps the rest stable.
+     */
+    private volatile List<ResolvedProvider> providerRoutes = List.of();
+
+    /** Service types dispatched by a stage directly rather than named in a handler's routing table. */
+    private static final Set<String> LITERAL_ROUTE_SERVICE_TYPES = Set.of(
+        "managedidentity", "entra", "monitor", "keyvault", "email", "arm", "servicebus", "cosmos",
+        "blob", "queue" // the storage fallback in resolveStorageServiceType
     );
 
-    // Account-name suffix → serviceType (e.g. {account}-queue → queue). Sorted longest-suffix-first
-    // at class init: any suffix that is a string-suffix of another is always shorter, so
-    // length-descending preserves the required most-specific-first match without hand-coded ordering.
-    private static final List<SuffixRoute> ACCOUNT_SUFFIX_ROUTES = longestFirst(
-        new SuffixRoute("-cosmos-mongo", "cosmos-mongo"),
-        new SuffixRoute("-cosmos-table", "cosmos-table"),
-        new SuffixRoute("-cosmos-cassandra", "cosmos-cassandra"),
-        new SuffixRoute("-cosmos-gremlin", "cosmos-gremlin"),
-        new SuffixRoute("-cosmos-postgresql", "cosmos-postgresql"),
-        new SuffixRoute("-cosmos-nosql", "cosmos-nosql"),
-        new SuffixRoute("-cosmos", "cosmos"),
-        new SuffixRoute("-queue", "queue"),
-        new SuffixRoute("-table", "table"),
-        new SuffixRoute("-functions", "functions"),
-        new SuffixRoute("-appconfig", "appconfig"),
-        new SuffixRoute("-keyvault", "keyvault"),
-        new SuffixRoute("-eventgrid", "eventgrid"),
-        new SuffixRoute("-eventhub", "eventhub"),
-        new SuffixRoute("-sql", "sql"),
-        new SuffixRoute("-postgres", "postgres"),
-        new SuffixRoute("-servicebus", "servicebus"),
-        new SuffixRoute("-apim", "apim"),
-        new SuffixRoute("-email", "email")
-    );
+    /**
+     * Assembles the dispatch tables from every registered handler's {@link ServiceRoutes}. Two handlers
+     * claiming the same host or account suffix is a wiring bug that would otherwise resolve by
+     * discovery order — fail fast at startup instead.
+     */
+    @PostConstruct
+    void buildRoutingTables() {
+        List<SuffixRoute> hosts = new ArrayList<>();
+        List<SuffixRoute> accounts = new ArrayList<>();
+        List<ResolvedProvider> providers = new ArrayList<>();
 
-    private static List<SuffixRoute> longestFirst(SuffixRoute... routes) {
-        List<SuffixRoute> sorted = new ArrayList<>(List.of(routes));
-        sorted.sort(Comparator.comparingInt((SuffixRoute r) -> r.suffix().length()).reversed());
-        return List.copyOf(sorted);
+        for (AzureServiceHandler handler : serviceRegistry.handlers()) {
+            ServiceRoutes routes = handler.routes();
+            for (String hostSuffix : routes.hostSuffixes()) {
+                hosts.add(new SuffixRoute(hostSuffix, handler.getServiceType()));
+            }
+            accounts.addAll(routes.accountSuffixes());
+            for (ServiceRoutes.ProviderRoute provider : routes.providers()) {
+                providers.add(new ResolvedProvider(provider.marker(), handler.getServiceType(), provider.guard()));
+            }
+        }
+
+        rejectDuplicateSuffixes("host", hosts);
+        rejectDuplicateSuffixes("account", accounts);
+
+        hosts.sort(LONGEST_SUFFIX_FIRST);
+        accounts.sort(LONGEST_SUFFIX_FIRST);
+        providers.sort(GUARDED_FIRST_THEN_MARKER);
+
+        this.hostRoutes = List.copyOf(hosts);
+        this.accountSuffixRoutes = List.copyOf(accounts);
+        this.providerRoutes = List.copyOf(providers);
+
+        LOGGER.infof("Routing tables: %d host, %d account-suffix, %d ARM provider routes",
+            hostRoutes.size(), accountSuffixRoutes.size(), providerRoutes.size());
+    }
+
+    private static final Comparator<SuffixRoute> LONGEST_SUFFIX_FIRST =
+        Comparator.comparingInt((SuffixRoute route) -> route.suffix().length()).reversed();
+
+    private static final Comparator<ResolvedProvider> GUARDED_FIRST_THEN_MARKER =
+        Comparator.comparing((ResolvedProvider route) -> route.guard() == ServiceRoutes.ProviderRoute.ALWAYS)
+                  .thenComparing(ResolvedProvider::marker);
+
+    static void rejectDuplicateSuffixes(String kind, List<SuffixRoute> routes) {
+        Map<String, String> claimedBy = new HashMap<>();
+        for (SuffixRoute route : routes) {
+            String previous = claimedBy.putIfAbsent(route.suffix(), route.serviceType());
+            if (previous != null) {
+                throw new IllegalStateException("Two handlers claim the same " + kind + " suffix '"
+                    + route.suffix() + "': " + previous + " and " + route.serviceType());
+            }
+        }
     }
 
     /** Returns the route whose suffix {@code value} ends with, or {@code null} if none matches. */
@@ -190,56 +236,32 @@ public class AzureRoutingFilter {
         return value.substring(0, value.length() - route.suffix().length());
     }
 
-    /**
-     * An ARM management-plane provider route. {@code marker} is the pre-built
-     * {@code /providers/<namespace>/} path fragment; {@code guard} is an extra condition beyond the
-     * marker being present.
-     */
-    private record ProviderRoute(String marker, String serviceType, Predicate<String> guard) {
-        static ProviderRoute of(String namespace, String serviceType, Predicate<String> guard) {
-            return new ProviderRoute("/providers/" + namespace + "/", serviceType, guard);
-        }
+    // ── Table accessors (package-private, for the equivalence/drift tests) ──────
+
+    List<SuffixRoute> hostRoutes() {
+        return hostRoutes;
     }
 
-    private static final Predicate<String> ALWAYS = path -> true;
+    List<SuffixRoute> accountSuffixRoutes() {
+        return accountSuffixRoutes;
+    }
 
-    // Managed Identity is checked before the other providers: an identities/default scope may itself
-    // be a Compute/ContainerService/... resource, and the ManagedIdentity segment is always the last
-    // /providers/ segment. Nested children scoped to an identity (role assignments, locks) have a
-    // LATER /providers/ segment and must fall through to ArmHandler instead of being captured here.
-    private static final Predicate<String> MANAGED_IDENTITY_IS_LEAF = path -> {
-        int marker = path.indexOf("/providers/Microsoft.ManagedIdentity/");
-        return marker >= 0 && path.indexOf("/providers/", marker + 1) < 0;
-    };
-
-    private static final List<ProviderRoute> PROVIDER_ROUTES = List.of(
-        ProviderRoute.of("Microsoft.ManagedIdentity", "managedidentity", MANAGED_IDENTITY_IS_LEAF),
-        ProviderRoute.of("Microsoft.ContainerService", "aks", ALWAYS),
-        ProviderRoute.of("Microsoft.ContainerRegistry", "acr", ALWAYS),
-        ProviderRoute.of("Microsoft.Sql", "sql", ALWAYS),
-        ProviderRoute.of("Microsoft.DBforPostgreSQL", "postgres", ALWAYS),
-        ProviderRoute.of("Microsoft.Compute", "vm", ALWAYS),
-        ProviderRoute.of("Microsoft.Cache", "redis", ALWAYS),
-        ProviderRoute.of("Microsoft.Communication", "email", ALWAYS),
-        ProviderRoute.of("Microsoft.EventGrid", "eventgrid", ALWAYS)
-    );
-
-    /** Service types dispatched by a stage directly rather than named in a routing table. */
-    private static final Set<String> LITERAL_ROUTE_SERVICE_TYPES = Set.of(
-        "managedidentity", "entra", "monitor", "keyvault", "email", "arm", "servicebus", "cosmos",
-        "blob", "queue" // the storage fallback in resolveStorageServiceType
-    );
+    /** ARM provider routes as {@code marker → serviceType}, in match order. */
+    List<Map.Entry<String, String>> providerRoutesInMatchOrder() {
+        return providerRoutes.stream()
+                .map(route -> Map.entry(route.marker(), route.serviceType()))
+                .toList();
+    }
 
     /**
      * Every service type the routing tables and stages can produce. Exposed for the drift test that
-     * asserts each one actually resolves to a registered handler — a typo in a table would otherwise
-     * surface only as a puzzling {@code 501 NotImplemented} at runtime.
+     * asserts each one actually resolves to a registered handler.
      */
-    static Set<String> routedServiceTypes() {
+    Set<String> routedServiceTypes() {
         Set<String> types = new java.util.TreeSet<>(LITERAL_ROUTE_SERVICE_TYPES);
-        HOST_ROUTES.forEach(route -> types.add(route.serviceType()));
-        ACCOUNT_SUFFIX_ROUTES.forEach(route -> types.add(route.serviceType()));
-        PROVIDER_ROUTES.forEach(route -> types.add(route.serviceType()));
+        hostRoutes.forEach(route -> types.add(route.serviceType()));
+        accountSuffixRoutes.forEach(route -> types.add(route.serviceType()));
+        providerRoutes.forEach(route -> types.add(route.serviceType()));
         return types;
     }
 
@@ -315,7 +337,7 @@ public class AzureRoutingFilter {
         if (ctx.host() == null) {
             return Fallthrough.TO_NEXT_STAGE;
         }
-        SuffixRoute route = matchSuffix(HOST_ROUTES, ctx.host());
+        SuffixRoute route = matchSuffix(hostRoutes, ctx.host());
         if (route == null) {
             return Fallthrough.TO_NEXT_STAGE;
         }
@@ -406,7 +428,7 @@ public class AzureRoutingFilter {
 
     /**
      * ARM management-plane provider routing: {@code subscriptions/{sub}/.../providers/Microsoft.X/...}.
-     * Iterated in {@link #PROVIDER_ROUTES} order: Managed Identity is first and guarded so its provider
+     * Iterated in {@link #providerRoutes} order (guarded first): Managed Identity is guarded so its provider
      * segment must be the last {@code /providers/} in the path — identity-scoped children (role
      * assignments, locks, ...) have a later segment and fall through to {@link #routeArmGeneric}. All of
      * these must precede the generic ARM stage, which would otherwise swallow every path.
@@ -415,7 +437,7 @@ public class AzureRoutingFilter {
         if (!ctx.path().startsWith("subscriptions/")) {
             return Fallthrough.TO_NEXT_STAGE;
         }
-        for (ProviderRoute route : PROVIDER_ROUTES) {
+        for (ResolvedProvider route : providerRoutes) {
             if (!ctx.path().contains(route.marker()) || !route.guard().test(ctx.path())) {
                 continue;
             }
@@ -496,7 +518,7 @@ public class AzureRoutingFilter {
         String resourcePath = ctx.resourcePath();
 
         String serviceType;
-        SuffixRoute route = matchSuffix(ACCOUNT_SUFFIX_ROUTES, accountName);
+        SuffixRoute route = matchSuffix(accountSuffixRoutes, accountName);
         if (route != null) {
             serviceType = route.serviceType();
             accountName = stripSuffix(accountName, route);

--- a/src/main/java/io/floci/az/core/AzureRoutingFilter.java
+++ b/src/main/java/io/floci/az/core/AzureRoutingFilter.java
@@ -138,7 +138,7 @@ public class AzureRoutingFilter {
      * A resolved ARM provider route: the pre-built {@code /providers/<namespace>/} marker, the service
      * type of the handler that claimed it, and the handler's guard.
      */
-    private record ResolvedProvider(String marker, String serviceType, Predicate<String> guard) {}
+    record ResolvedProvider(String marker, String serviceType, Predicate<String> guard) {}
 
     // ── Routing tables, assembled from the handlers at startup ──────────────────
 
@@ -191,6 +191,7 @@ public class AzureRoutingFilter {
 
         rejectDuplicateSuffixes("host", hosts);
         rejectDuplicateSuffixes("account", accounts);
+        rejectDuplicateProviders(providers);
 
         hosts.sort(LONGEST_SUFFIX_FIRST);
         accounts.sort(LONGEST_SUFFIX_FIRST);
@@ -218,6 +219,22 @@ public class AzureRoutingFilter {
             if (previous != null) {
                 throw new IllegalStateException("Two handlers claim the same " + kind + " suffix '"
                     + route.suffix() + "': " + previous + " and " + route.serviceType());
+            }
+        }
+    }
+
+    /**
+     * Fails fast when two handlers claim the same ARM provider namespace — the provider counterpart of
+     * {@link #rejectDuplicateSuffixes}. Without this, a duplicate would resolve silently by the
+     * guarded-first / marker sort order instead of surfacing the wiring bug.
+     */
+    static void rejectDuplicateProviders(List<ResolvedProvider> providers) {
+        Map<String, String> claimedBy = new HashMap<>();
+        for (ResolvedProvider provider : providers) {
+            String previous = claimedBy.putIfAbsent(provider.marker(), provider.serviceType());
+            if (previous != null) {
+                throw new IllegalStateException("Two handlers claim the same ARM provider '"
+                    + provider.marker() + "': " + previous + " and " + provider.serviceType());
             }
         }
     }

--- a/src/main/java/io/floci/az/core/AzureServiceHandler.java
+++ b/src/main/java/io/floci/az/core/AzureServiceHandler.java
@@ -15,4 +15,29 @@ public interface AzureServiceHandler {
     default boolean handlesServiceType(String serviceType) {
         return getServiceType().equals(serviceType);
     }
+
+    /**
+     * The host suffixes, account-name suffixes and ARM provider namespaces this handler claims.
+     * {@link AzureRoutingFilter} assembles its dispatch tables from every handler at startup.
+     * Handlers reachable only through path-shape stages (Entra, Monitor, ...) keep the default.
+     */
+    default ServiceRoutes routes() {
+        return ServiceRoutes.NONE;
+    }
+
+    /**
+     * Whether this handler currently serves {@code serviceType}. Handlers own their enablement so that
+     * adding a service does not mean editing a central switch.
+     *
+     * <p>The parameter exists for the one multi-type handler: {@code CosmosEngineHandler} serves six
+     * engine types whose enabled-state differs at runtime. Single-type handlers ignore it and simply
+     * return their config flag.</p>
+     *
+     * <p>Must stay cheap and side-effect free — {@link AzureServiceRegistry} calls this on every
+     * dispatch and deliberately does <em>not</em> cache the result, because Cosmos engine enablement
+     * changes while the emulator runs.</p>
+     */
+    default boolean enabled(String serviceType) {
+        return true;
+    }
 }

--- a/src/main/java/io/floci/az/core/AzureServiceRegistry.java
+++ b/src/main/java/io/floci/az/core/AzureServiceRegistry.java
@@ -1,7 +1,5 @@
 package io.floci.az.core;
 
-import io.floci.az.config.EmulatorConfig;
-import io.floci.az.services.cosmos.engine.CosmosLifecycleManager;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
@@ -17,8 +15,6 @@ import java.util.concurrent.ConcurrentHashMap;
 public class AzureServiceRegistry {
 
     private final List<AzureServiceHandler> handlers;
-    private final EmulatorConfig config;
-    private final CosmosLifecycleManager cosmosLifecycleManager;
 
     /**
      * serviceType → handler, memoised. Handler selection is a pure function of the service type (the
@@ -29,11 +25,7 @@ public class AzureServiceRegistry {
     private final Map<String, Optional<AzureServiceHandler>> handlerByServiceType = new ConcurrentHashMap<>();
 
     @Inject
-    AzureServiceRegistry(Instance<AzureServiceHandler> all, EmulatorConfig config,
-                         CosmosLifecycleManager cosmosLifecycleManager) {
-        this.config = config;
-        this.cosmosLifecycleManager = cosmosLifecycleManager;
-
+    AzureServiceRegistry(Instance<AzureServiceHandler> all) {
         List<AzureServiceHandler> discovered = new ArrayList<>();
         for (AzureServiceHandler h : all) {
             discovered.add(h);
@@ -41,38 +33,21 @@ public class AzureServiceRegistry {
         this.handlers = List.copyOf(discovered);
     }
 
+    /**
+     * Whether {@code serviceType} is currently served. Delegates to the owning handler, so enablement
+     * lives next to the service rather than in a central switch.
+     *
+     * <p>Deliberately NOT memoised, unlike {@link #lookup}: Cosmos engine enablement changes while the
+     * emulator runs. An unknown service type has no handler and is therefore not enabled — callers that
+     * need to tell "unknown" from "disabled" apart use {@link #isKnown}.</p>
+     */
     public boolean isEnabled(String serviceType) {
-        return switch (serviceType) {
-            case "blob"      -> config.services().blob().enabled();
-            case "queue"     -> config.services().queue().enabled();
-            case "table"     -> config.services().table().enabled();
-            case "functions"  -> config.services().functions().enabled();
-            case "appconfig"  -> config.services().appConfig().enabled();
-            case "cosmos"     -> config.services().cosmos().enabled();
-            case "keyvault"   -> config.services().keyVault().enabled();
-            case "eventhub"   -> config.services().eventHub().enabled();
-            case "sql"        -> config.services().sql().enabled();
-            case "postgres"   -> config.services().postgres().enabled();
-            case "servicebus" -> config.services().serviceBus().enabled();
-            case "aks"        -> config.services().aks().enabled();
-            case "vm"         -> config.services().vm().enabled();
-            case "apim"       -> config.services().apim().enabled();
-            case "redis"      -> config.services().redis().enabled();
-            case "acr"        -> config.services().acr().enabled();
-            case "email"      -> config.services().email().enabled();
-            case "monitor"    -> config.services().monitor().enabled();
-            case "entra"      -> config.services().entra().enabled();
-            case "arm"        -> config.services().arm().enabled();
-            case "eventgrid"  -> config.services().eventGrid().enabled();
-            case "managedidentity" -> config.services().managedIdentity().enabled();
-            case "cosmos-engine" -> config.services().cosmos().enabled();
-            case "cosmos-mongo", "cosmos-table", "cosmos-cassandra",
-                 "cosmos-gremlin", "cosmos-postgresql", "cosmos-nosql" ->
-                config.services().cosmos().enabled() &&
-                cosmosLifecycleManager.isEnabled(serviceType);
-            default           -> true;
+        return lookup(serviceType).map(handler -> handler.enabled(serviceType)).orElse(false);
+    }
 
-        };
+    /** Every discovered handler, in CDI discovery order. Used to assemble the routing tables. */
+    public List<AzureServiceHandler> handlers() {
+        return handlers;
     }
 
     /** True when some handler implements {@code serviceType}, regardless of whether it is enabled. */

--- a/src/main/java/io/floci/az/core/ServiceRoutes.java
+++ b/src/main/java/io/floci/az/core/ServiceRoutes.java
@@ -1,0 +1,93 @@
+package io.floci.az.core;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * The routes a service handler claims. Handlers describe themselves; {@link AzureRoutingFilter}
+ * assembles its dispatch tables from every registered handler at startup, so adding a service no
+ * longer means editing hand-maintained tables in the filter.
+ *
+ * @param hostSuffixes    host suffixes routed to this handler, e.g. {@code .blob.core.windows.net}.
+ *                        The resolved service type is always the handler's own {@code getServiceType()} —
+ *                        {@code BlobServiceHandler} claims both {@code .blob.} and {@code .dfs.} and both
+ *                        resolve to {@code blob}.
+ * @param accountSuffixes account-name suffixes, each with an explicit service type. Explicit because
+ *                        {@code CosmosEngineHandler} maps six suffixes to six different service types
+ *                        ({@code -cosmos-mongo → cosmos-mongo}), which its own type cannot express.
+ * @param providers       ARM provider namespaces served by this handler.
+ */
+public record ServiceRoutes(
+    List<String> hostSuffixes,
+    List<SuffixRoute> accountSuffixes,
+    List<ProviderRoute> providers
+) {
+
+    public static final ServiceRoutes NONE = new ServiceRoutes(List.of(), List.of(), List.of());
+
+    public ServiceRoutes {
+        hostSuffixes = List.copyOf(hostSuffixes);
+        accountSuffixes = List.copyOf(accountSuffixes);
+        providers = List.copyOf(providers);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** A host-name or account-name suffix that identifies a service. */
+    public record SuffixRoute(String suffix, String serviceType) {}
+
+    /**
+     * An ARM management-plane provider namespace served by a handler.
+     *
+     * @param namespace the provider namespace, e.g. {@code Microsoft.Cache}
+     * @param guard     an extra condition on the full request path beyond the namespace being present.
+     *                  Managed Identity uses this to require that its {@code /providers/} segment is the
+     *                  last one, so identity-scoped children (role assignments, locks) fall through to
+     *                  the generic ARM handler instead of being captured.
+     */
+    public record ProviderRoute(String namespace, Predicate<String> guard) {
+        public static final Predicate<String> ALWAYS = path -> true;
+
+        public ProviderRoute(String namespace) {
+            this(namespace, ALWAYS);
+        }
+
+        /** The pre-built {@code /providers/<namespace>/} path fragment, matched against request paths. */
+        public String marker() {
+            return "/providers/" + namespace + "/";
+        }
+    }
+
+    public static final class Builder {
+        private final List<String> hostSuffixes = new java.util.ArrayList<>();
+        private final List<SuffixRoute> accountSuffixes = new java.util.ArrayList<>();
+        private final List<ProviderRoute> providers = new java.util.ArrayList<>();
+
+        public Builder host(String suffix) {
+            hostSuffixes.add(suffix);
+            return this;
+        }
+
+        /** Account suffix resolving to the handler's own service type. */
+        public Builder account(String suffix, String serviceType) {
+            accountSuffixes.add(new SuffixRoute(suffix, serviceType));
+            return this;
+        }
+
+        public Builder provider(String namespace) {
+            providers.add(new ProviderRoute(namespace));
+            return this;
+        }
+
+        public Builder provider(String namespace, Predicate<String> guard) {
+            providers.add(new ProviderRoute(namespace, guard));
+            return this;
+        }
+
+        public ServiceRoutes build() {
+            return new ServiceRoutes(hostSuffixes, accountSuffixes, providers);
+        }
+    }
+}

--- a/src/main/java/io/floci/az/services/acr/AcrHandler.java
+++ b/src/main/java/io/floci/az/services/acr/AcrHandler.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.ServiceRoutes;
 import io.floci.az.core.Resettable;
 import io.floci.az.core.StoredObject;
 import io.floci.az.core.storage.StorageBackend;
@@ -109,6 +110,18 @@ public class AcrHandler implements AzureServiceHandler, Resettable {
 
     @Override
     public String getServiceType() { return "acr"; }
+
+    @Override
+    public boolean enabled(String serviceType) {
+        return config.services().acr().enabled();
+    }
+
+    @Override
+    public ServiceRoutes routes() {
+        return ServiceRoutes.builder()
+                .provider("Microsoft.ContainerRegistry")
+                .build();
+    }
 
     @Override
     public boolean canHandle(AzureRequest req) { return "acr".equals(req.serviceType()); }

--- a/src/main/java/io/floci/az/services/aks/AksHandler.java
+++ b/src/main/java/io/floci/az/services/aks/AksHandler.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.ServiceRoutes;
 import io.floci.az.core.Resettable;
 import io.floci.az.core.StoredObject;
 import io.floci.az.core.storage.StorageBackend;
@@ -104,6 +105,18 @@ public class AksHandler implements AzureServiceHandler, Resettable {
 
     @Override
     public String getServiceType() { return "aks"; }
+
+    @Override
+    public boolean enabled(String serviceType) {
+        return config.services().aks().enabled();
+    }
+
+    @Override
+    public ServiceRoutes routes() {
+        return ServiceRoutes.builder()
+                .provider("Microsoft.ContainerService")
+                .build();
+    }
 
     @Override
     public boolean canHandle(AzureRequest req) { return "aks".equals(req.serviceType()); }

--- a/src/main/java/io/floci/az/services/apim/ApiManagementHandler.java
+++ b/src/main/java/io/floci/az/services/apim/ApiManagementHandler.java
@@ -1,7 +1,9 @@
 package io.floci.az.services.apim;
 
+import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.ServiceRoutes;
 import io.floci.az.core.Resettable;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -16,8 +18,12 @@ public class ApiManagementHandler implements AzureServiceHandler, Resettable {
     private final ApiManagementGateway gateway;
     private final ApiManagementService service;
 
+    private final EmulatorConfig config;
+
+
     @Inject
-    public ApiManagementHandler(ApiManagementGateway gateway, ApiManagementService service) {
+    public ApiManagementHandler(ApiManagementGateway gateway, ApiManagementService service, EmulatorConfig config) {
+        this.config = config;
         this.gateway = gateway;
         this.service = service;
     }
@@ -25,6 +31,21 @@ public class ApiManagementHandler implements AzureServiceHandler, Resettable {
     @Override
     public String getServiceType() {
         return "apim";
+    }
+
+    @Override
+    public boolean enabled(String serviceType) {
+        return config.services().apim().enabled();
+    }
+
+
+    @Override
+
+    public ServiceRoutes routes() {
+        return ServiceRoutes.builder()
+                .account("-apim", "apim")
+                .build();
+
     }
 
     @Override

--- a/src/main/java/io/floci/az/services/appconfig/AppConfigHandler.java
+++ b/src/main/java/io/floci/az/services/appconfig/AppConfigHandler.java
@@ -3,8 +3,10 @@ package io.floci.az.services.appconfig;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.ServiceRoutes;
 import io.floci.az.core.Resettable;
 import io.floci.az.core.StoredObject;
 import io.floci.az.core.storage.StorageBackend;
@@ -53,8 +55,12 @@ public class AppConfigHandler implements AzureServiceHandler, Resettable {
     private final StorageBackend<String, StoredObject> store;
     private final SyncTokens syncTokens;
 
+    private final EmulatorConfig config;
+
+
     @Inject
-    public AppConfigHandler(StorageFactory factory, SyncTokens syncTokens) {
+    public AppConfigHandler(StorageFactory factory, SyncTokens syncTokens, EmulatorConfig config) {
+        this.config = config;
         this.store = factory.create("appconfig");
         this.syncTokens = syncTokens;
     }
@@ -62,6 +68,21 @@ public class AppConfigHandler implements AzureServiceHandler, Resettable {
     @Override
     public String getServiceType() {
         return "appconfig";
+    }
+
+    @Override
+    public boolean enabled(String serviceType) {
+        return config.services().appConfig().enabled();
+    }
+
+
+    @Override
+
+    public ServiceRoutes routes() {
+        return ServiceRoutes.builder()
+                .account("-appconfig", "appconfig")
+                .build();
+
     }
 
     @Override

--- a/src/main/java/io/floci/az/services/arm/ArmHandler.java
+++ b/src/main/java/io/floci/az/services/arm/ArmHandler.java
@@ -83,6 +83,11 @@ public class ArmHandler implements AzureServiceHandler {
     public String getServiceType() { return "arm"; }
 
     @Override
+    public boolean enabled(String serviceType) {
+        return config.services().arm().enabled();
+    }
+
+    @Override
     public boolean canHandle(AzureRequest req) { return "arm".equals(req.serviceType()); }
 
     @Override

--- a/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
+++ b/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
@@ -1,8 +1,10 @@
 package io.floci.az.services.blob;
 
 import io.floci.az.core.AzureErrorResponse;
+import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.ServiceRoutes;
 import io.floci.az.core.Resettable;
 import io.floci.az.core.StoredObject;
 import io.floci.az.core.XmlBuilder;
@@ -49,14 +51,34 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
 
     private final StorageBackend<String, StoredObject> store;
 
+    private final EmulatorConfig config;
+
+
     @Inject
-    public BlobServiceHandler(StorageFactory storageFactory) {
+    public BlobServiceHandler(StorageFactory storageFactory, EmulatorConfig config) {
+        this.config = config;
         this.store = storageFactory.create("blob");
     }
 
     @Override
     public String getServiceType() {
         return "blob";
+    }
+
+    @Override
+    public boolean enabled(String serviceType) {
+        return config.services().blob().enabled();
+    }
+
+
+    @Override
+
+    public ServiceRoutes routes() {
+        return ServiceRoutes.builder()
+                .host(".blob.core.windows.net")
+                .host(".dfs.core.windows.net")   // Data Lake Gen2 shares the blob handler
+                .build();
+
     }
 
     @Override

--- a/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
@@ -3,8 +3,10 @@ package io.floci.az.services.cosmos;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.ServiceRoutes;
 import io.floci.az.core.Resettable;
 import io.floci.az.core.StoredObject;
 import io.floci.az.core.storage.StorageBackend;
@@ -46,12 +48,28 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
     private final StorageBackend<String, StoredObject> store;
     private final CosmosQueryEngine queryEngine = new CosmosQueryEngine();
 
+    private final EmulatorConfig config;
+
+
     @Inject
-    public CosmosHandler(StorageFactory factory) {
+    public CosmosHandler(StorageFactory factory, EmulatorConfig config) {
+        this.config = config;
         this.store = factory.create("cosmos");
     }
 
     @Override public String getServiceType()              { return "cosmos"; }
+
+    @Override
+    public boolean enabled(String serviceType) {
+        return config.services().cosmos().enabled();
+    }
+
+    @Override
+    public ServiceRoutes routes() {
+        return ServiceRoutes.builder()
+                .account("-cosmos", "cosmos")
+                .build();
+    }
     @Override public boolean canHandle(AzureRequest req)  { return "cosmos".equals(req.serviceType()); }
 
     @Override

--- a/src/main/java/io/floci/az/services/cosmos/engine/CosmosEngineHandler.java
+++ b/src/main/java/io/floci/az/services/cosmos/engine/CosmosEngineHandler.java
@@ -1,7 +1,11 @@
 package io.floci.az.services.cosmos.engine;
 
+import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.ServiceRoutes;
+
+import java.util.List;
 import io.floci.az.services.cosmos.CosmosHandler;
 import io.floci.az.services.cosmos.table.CosmosTableApiHandler;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -36,14 +40,63 @@ public class CosmosEngineHandler implements AzureServiceHandler {
 
     private static final Logger LOG = Logger.getLogger(CosmosEngineHandler.class);
 
-    @Inject CosmosLifecycleManager  lifecycleManager;
-    @Inject CosmosEngineRegistry    registry;
-    @Inject CosmosTableApiHandler   tableApiHandler;
-    @Inject CosmosHandler           cosmosHandler;
+    /** The engine service types this handler serves, one per {@code -cosmos-<engine>} account suffix. */
+    private static final List<String> ENGINE_SERVICE_TYPES = List.of(
+        "cosmos-mongo", "cosmos-table", "cosmos-cassandra",
+        "cosmos-gremlin", "cosmos-postgresql", "cosmos-nosql"
+    );
+
+    private final CosmosLifecycleManager lifecycleManager;
+    private final CosmosEngineRegistry registry;
+    private final CosmosTableApiHandler tableApiHandler;
+    private final CosmosHandler cosmosHandler;
+    private final EmulatorConfig config;
+
+    @Inject
+    public CosmosEngineHandler(CosmosLifecycleManager lifecycleManager, CosmosEngineRegistry registry,
+                               CosmosTableApiHandler tableApiHandler, CosmosHandler cosmosHandler,
+                               EmulatorConfig config) {
+        this.lifecycleManager = lifecycleManager;
+        this.registry = registry;
+        this.tableApiHandler = tableApiHandler;
+        this.cosmosHandler = cosmosHandler;
+        this.config = config;
+    }
 
     @Override
     public String getServiceType() {
         return "cosmos-engine";
+    }
+
+    /**
+     * Enablement is per engine, not per handler: {@code cosmos-mongo} may be up while
+     * {@code cosmos-gremlin} is not, and the lifecycle manager's answer changes while the emulator
+     * runs. This is why {@link AzureServiceHandler#enabled(String)} takes the service type and why
+     * {@link io.floci.az.core.AzureServiceRegistry} must never cache the result.
+     *
+     * <p>{@code cosmos-engine} is this handler's own {@code getServiceType()} and is not a routable
+     * engine — it is gated on the Cosmos service flag alone, matching the pre-A5 registry switch.</p>
+     */
+    @Override
+    public boolean enabled(String serviceType) {
+        if (!config.services().cosmos().enabled()) {
+            return false;
+        }
+        return getServiceType().equals(serviceType) || lifecycleManager.isEnabled(serviceType);
+    }
+
+    /**
+     * The one multi-type handler: each {@code -cosmos-<engine>} account suffix resolves to its own
+     * service type, which {@link #getServiceType()} cannot express. Ordering against the plain
+     * {@code -cosmos} suffix is handled by the filter, which sorts all account suffixes longest-first.
+     */
+    @Override
+    public ServiceRoutes routes() {
+        ServiceRoutes.Builder routes = ServiceRoutes.builder();
+        for (String engine : ENGINE_SERVICE_TYPES) {
+            routes.account("-" + engine, engine);
+        }
+        return routes.build();
     }
 
     @Override

--- a/src/main/java/io/floci/az/services/email/EmailHandler.java
+++ b/src/main/java/io/floci/az/services/email/EmailHandler.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.ServiceRoutes;
 import io.floci.az.core.Resettable;
 import io.floci.az.core.StoredObject;
 import io.floci.az.core.storage.InMemoryStorage;
@@ -75,6 +76,20 @@ public class EmailHandler implements AzureServiceHandler, Resettable {
 
     @Override
     public String getServiceType() { return "email"; }
+
+    @Override
+    public boolean enabled(String serviceType) {
+        return config.services().email().enabled();
+    }
+
+    @Override
+    public ServiceRoutes routes() {
+        return ServiceRoutes.builder()
+                .host(".communication.azure.com")
+                .account("-email", "email")
+                .provider("Microsoft.Communication")
+                .build();
+    }
 
     @Override
     public boolean canHandle(AzureRequest req) { return "email".equals(req.serviceType()); }

--- a/src/main/java/io/floci/az/services/entra/EntraServiceHandler.java
+++ b/src/main/java/io/floci/az/services/entra/EntraServiceHandler.java
@@ -64,6 +64,11 @@ public class EntraServiceHandler implements AzureServiceHandler {
 
     @Override public String getServiceType() { return "entra"; }
 
+    @Override
+    public boolean enabled(String serviceType) {
+        return config.services().entra().enabled();
+    }
+
     @Override public boolean canHandle(AzureRequest request) {
         return "entra".equals(request.serviceType());
     }

--- a/src/main/java/io/floci/az/services/eventgrid/EventGridHandler.java
+++ b/src/main/java/io/floci/az/services/eventgrid/EventGridHandler.java
@@ -1,7 +1,9 @@
 package io.floci.az.services.eventgrid;
 
+import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.ServiceRoutes;
 import io.floci.az.core.Resettable;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -26,8 +28,12 @@ public class EventGridHandler implements AzureServiceHandler, Resettable {
     private final EventGridService service;
     private final EventGridPublisher publisher;
 
+    private final EmulatorConfig config;
+
+
     @Inject
-    public EventGridHandler(EventGridService service, EventGridPublisher publisher) {
+    public EventGridHandler(EventGridService service, EventGridPublisher publisher, EmulatorConfig config) {
+        this.config = config;
         this.service = service;
         this.publisher = publisher;
     }
@@ -35,6 +41,22 @@ public class EventGridHandler implements AzureServiceHandler, Resettable {
     @Override
     public String getServiceType() {
         return "eventgrid";
+    }
+
+    @Override
+    public boolean enabled(String serviceType) {
+        return config.services().eventGrid().enabled();
+    }
+
+
+    @Override
+
+    public ServiceRoutes routes() {
+        return ServiceRoutes.builder()
+                .account("-eventgrid", "eventgrid")
+                .provider("Microsoft.EventGrid")
+                .build();
+
     }
 
     @Override

--- a/src/main/java/io/floci/az/services/eventhub/EventHubHandler.java
+++ b/src/main/java/io/floci/az/services/eventhub/EventHubHandler.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.ServiceRoutes;
 import io.floci.az.core.Resettable;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -65,6 +66,21 @@ public class EventHubHandler implements AzureServiceHandler, Resettable {
     @Override
     public String getServiceType() {
         return "eventhub";
+    }
+
+    @Override
+    public boolean enabled(String serviceType) {
+        return config.services().eventHub().enabled();
+    }
+
+
+    @Override
+
+    public ServiceRoutes routes() {
+        return ServiceRoutes.builder()
+                .account("-eventhub", "eventhub")
+                .build();
+
     }
 
     @Override

--- a/src/main/java/io/floci/az/services/functions/FunctionsServiceHandler.java
+++ b/src/main/java/io/floci/az/services/functions/FunctionsServiceHandler.java
@@ -7,6 +7,7 @@ import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureErrorResponse;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.ServiceRoutes;
 import io.floci.az.core.Resettable;
 import io.floci.az.core.StoredObject;
 import io.floci.az.core.storage.StorageBackend;
@@ -60,6 +61,18 @@ public class FunctionsServiceHandler implements AzureServiceHandler, Resettable 
     }
 
     @Override public String getServiceType() { return "functions"; }
+
+    @Override
+    public boolean enabled(String serviceType) {
+        return config.services().functions().enabled();
+    }
+
+    @Override
+    public ServiceRoutes routes() {
+        return ServiceRoutes.builder()
+                .account("-functions", "functions")
+                .build();
+    }
 
     @Override public boolean canHandle(AzureRequest request) {
         return "functions".equals(request.serviceType());

--- a/src/main/java/io/floci/az/services/keyvault/KeyVaultHandler.java
+++ b/src/main/java/io/floci/az/services/keyvault/KeyVaultHandler.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.ServiceRoutes;
 import io.floci.az.core.Resettable;
 import io.floci.az.core.StoredObject;
 import io.floci.az.core.storage.StorageBackend;
@@ -42,6 +43,22 @@ public class KeyVaultHandler implements AzureServiceHandler, Resettable {
     @Override
     public String getServiceType() {
         return "keyvault";
+    }
+
+    @Override
+    public boolean enabled(String serviceType) {
+        return config.services().keyVault().enabled();
+    }
+
+
+    @Override
+
+    public ServiceRoutes routes() {
+        return ServiceRoutes.builder()
+                .host(".vault.azure.net")
+                .account("-keyvault", "keyvault")
+                .build();
+
     }
 
     @Override

--- a/src/main/java/io/floci/az/services/managedidentity/ManagedIdentityHandler.java
+++ b/src/main/java/io/floci/az/services/managedidentity/ManagedIdentityHandler.java
@@ -3,6 +3,7 @@ package io.floci.az.services.managedidentity;
 import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.ServiceRoutes;
 import io.floci.az.core.RequestUrls;
 import io.floci.az.core.Resettable;
 import io.floci.az.core.arm.ArmErrors;
@@ -61,6 +62,31 @@ public class ManagedIdentityHandler implements AzureServiceHandler, Resettable {
     @Override
     public String getServiceType() {
         return "managedidentity";
+    }
+
+    @Override
+    public boolean enabled(String serviceType) {
+        return config.services().managedIdentity().enabled();
+    }
+
+    /**
+     * Managed Identity is the only guarded provider route. An {@code identities/default} scope may
+     * itself sit under a Compute/ContainerService resource, and this provider's segment is always the
+     * last {@code /providers/} segment. Nested children scoped to an identity (role assignments, locks)
+     * carry a LATER {@code /providers/} segment and must fall through to the generic ARM handler rather
+     * than be captured here. The guard also makes this route win over broader providers in the same
+     * path — the filter orders guarded routes ahead of unguarded ones.
+     */
+    @Override
+    public ServiceRoutes routes() {
+        return ServiceRoutes.builder()
+                .provider("Microsoft.ManagedIdentity", ManagedIdentityHandler::isLeafProviderSegment)
+                .build();
+    }
+
+    private static boolean isLeafProviderSegment(String path) {
+        int marker = path.indexOf(PROVIDER_MARKER);
+        return marker >= 0 && path.indexOf("/providers/", marker + 1) < 0;
     }
 
     @Override

--- a/src/main/java/io/floci/az/services/monitor/MonitorHandler.java
+++ b/src/main/java/io/floci/az/services/monitor/MonitorHandler.java
@@ -53,6 +53,11 @@ public class MonitorHandler implements AzureServiceHandler, Resettable {
     }
 
     @Override
+    public boolean enabled(String serviceType) {
+        return config.services().monitor().enabled();
+    }
+
+    @Override
     public boolean canHandle(AzureRequest request) {
         return "monitor".equals(request.serviceType());
     }

--- a/src/main/java/io/floci/az/services/postgres/PostgresHandler.java
+++ b/src/main/java/io/floci/az/services/postgres/PostgresHandler.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.ServiceRoutes;
 import io.floci.az.core.Resettable;
 import io.floci.az.core.arm.ArmErrors;
 import io.floci.az.core.arm.ArmPaths;
@@ -64,6 +65,19 @@ public class PostgresHandler implements AzureServiceHandler, Resettable {
     private final ConcurrentHashMap<String, Object> startLocks = new ConcurrentHashMap<>();
 
     @Override public String getServiceType()           { return "postgres"; }
+
+    @Override
+    public boolean enabled(String serviceType) {
+        return config.services().postgres().enabled();
+    }
+
+    @Override
+    public ServiceRoutes routes() {
+        return ServiceRoutes.builder()
+                .account("-postgres", "postgres")
+                .provider("Microsoft.DBforPostgreSQL")
+                .build();
+    }
     @Override public boolean canHandle(AzureRequest r) { return "postgres".equals(r.serviceType()); }
 
     @Override

--- a/src/main/java/io/floci/az/services/queue/QueueServiceHandler.java
+++ b/src/main/java/io/floci/az/services/queue/QueueServiceHandler.java
@@ -2,8 +2,10 @@ package io.floci.az.services.queue;
 
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
 import io.floci.az.core.AzureErrorResponse;
+import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.ServiceRoutes;
 import io.floci.az.core.Resettable;
 import io.floci.az.core.StoredObject;
 import io.floci.az.core.XmlBuilder;
@@ -41,14 +43,34 @@ public class QueueServiceHandler implements AzureServiceHandler, Resettable {
     private final StorageBackend<String, StoredObject> store;
     private final XmlMapper xmlMapper = new XmlMapper();
 
+    private final EmulatorConfig config;
+
+
     @Inject
-    public QueueServiceHandler(StorageFactory storageFactory) {
+    public QueueServiceHandler(StorageFactory storageFactory, EmulatorConfig config) {
+        this.config = config;
         this.store = storageFactory.create("queue");
     }
 
     @Override
     public String getServiceType() {
         return "queue";
+    }
+
+    @Override
+    public boolean enabled(String serviceType) {
+        return config.services().queue().enabled();
+    }
+
+
+    @Override
+
+    public ServiceRoutes routes() {
+        return ServiceRoutes.builder()
+                .host(".queue.core.windows.net")
+                .account("-queue", "queue")
+                .build();
+
     }
 
     @Override

--- a/src/main/java/io/floci/az/services/redis/RedisHandler.java
+++ b/src/main/java/io/floci/az/services/redis/RedisHandler.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.ServiceRoutes;
 import io.floci.az.core.Resettable;
 import io.floci.az.core.StoredObject;
 import io.floci.az.core.storage.StorageBackend;
@@ -111,6 +112,18 @@ public class RedisHandler implements AzureServiceHandler, Resettable {
 
     @Override
     public String getServiceType() { return "redis"; }
+
+    @Override
+    public boolean enabled(String serviceType) {
+        return config.services().redis().enabled();
+    }
+
+    @Override
+    public ServiceRoutes routes() {
+        return ServiceRoutes.builder()
+                .provider("Microsoft.Cache")
+                .build();
+    }
 
     @Override
     public boolean canHandle(AzureRequest req) { return "redis".equals(req.serviceType()); }

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.ServiceRoutes;
 import io.floci.az.core.Resettable;
 import io.floci.az.core.StoredObject;
 import io.floci.az.core.storage.StorageBackend;
@@ -88,6 +89,22 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
     @Override
     public String getServiceType() {
         return "servicebus";
+    }
+
+    @Override
+    public boolean enabled(String serviceType) {
+        return config.services().serviceBus().enabled();
+    }
+
+
+    @Override
+
+    public ServiceRoutes routes() {
+        return ServiceRoutes.builder()
+                .host(".servicebus.windows.net")
+                .account("-servicebus", "servicebus")
+                .build();
+
     }
 
     @Override

--- a/src/main/java/io/floci/az/services/sql/SqlHandler.java
+++ b/src/main/java/io/floci/az/services/sql/SqlHandler.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.ServiceRoutes;
 import io.floci.az.core.Resettable;
 import io.floci.az.core.arm.ArmErrors;
 import io.floci.az.core.arm.ArmPaths;
@@ -59,6 +60,19 @@ public class SqlHandler implements AzureServiceHandler, Resettable {
     private final ConcurrentHashMap<String, Object> startLocks = new ConcurrentHashMap<>();
 
     @Override public String getServiceType()           { return "sql"; }
+
+    @Override
+    public boolean enabled(String serviceType) {
+        return config.services().sql().enabled();
+    }
+
+    @Override
+    public ServiceRoutes routes() {
+        return ServiceRoutes.builder()
+                .account("-sql", "sql")
+                .provider("Microsoft.Sql")
+                .build();
+    }
     @Override public boolean canHandle(AzureRequest r) { return "sql".equals(r.serviceType()); }
 
     @Override

--- a/src/main/java/io/floci/az/services/table/TableServiceHandler.java
+++ b/src/main/java/io/floci/az/services/table/TableServiceHandler.java
@@ -2,8 +2,10 @@ package io.floci.az.services.table;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.floci.az.core.AzureErrorResponse;
+import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.ServiceRoutes;
 import io.floci.az.core.Resettable;
 import io.floci.az.core.StoredObject;
 import io.floci.az.core.storage.StorageBackend;
@@ -39,14 +41,33 @@ public class TableServiceHandler implements AzureServiceHandler, Resettable {
     private final StorageBackend<String, StoredObject> store;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
+    private final EmulatorConfig config;
+
+
     @Inject
-    public TableServiceHandler(StorageFactory storageFactory) {
+    public TableServiceHandler(StorageFactory storageFactory, EmulatorConfig config) {
+        this.config = config;
         this.store = storageFactory.create("table");
     }
 
     @Override
     public String getServiceType() {
         return "table";
+    }
+
+    @Override
+    public boolean enabled(String serviceType) {
+        return config.services().table().enabled();
+    }
+
+
+    @Override
+
+    public ServiceRoutes routes() {
+        return ServiceRoutes.builder()
+                .account("-table", "table")
+                .build();
+
     }
 
     @Override

--- a/src/main/java/io/floci/az/services/vm/VmHandler.java
+++ b/src/main/java/io/floci/az/services/vm/VmHandler.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.ServiceRoutes;
 import io.floci.az.core.Resettable;
 import io.floci.az.core.StoredObject;
 import io.floci.az.core.storage.StorageBackend;
@@ -110,6 +111,18 @@ public class VmHandler implements AzureServiceHandler, Resettable {
 
     @Override
     public String getServiceType() { return "vm"; }
+
+    @Override
+    public boolean enabled(String serviceType) {
+        return config.services().vm().enabled();
+    }
+
+    @Override
+    public ServiceRoutes routes() {
+        return ServiceRoutes.builder()
+                .provider("Microsoft.Compute")
+                .build();
+    }
 
     @Override
     public boolean canHandle(AzureRequest req) { return "vm".equals(req.serviceType()); }

--- a/src/test/java/io/floci/az/core/AzureServiceRegistryTest.java
+++ b/src/test/java/io/floci/az/core/AzureServiceRegistryTest.java
@@ -20,6 +20,9 @@ class AzureServiceRegistryTest {
     @Inject
     AzureServiceRegistry registry;
 
+    @Inject
+    AzureRoutingFilter filter;
+
     /**
      * Guards against drift between the routing tables and the handler set. {@code isEnabled} ends in
      * {@code default -> true}, so a service type that no handler implements is reported as "enabled"
@@ -28,7 +31,7 @@ class AzureServiceRegistryTest {
      */
     @Test
     void everyRoutedServiceTypeHasARegisteredHandler() {
-        Set<String> routed = AzureRoutingFilter.routedServiceTypes();
+        Set<String> routed = filter.routedServiceTypes();
         // Without this the loop below would pass vacuously if the tables ever came back empty.
         assertTrue(routed.size() > 20, "expected the full routing surface, got " + routed);
 
@@ -58,6 +61,29 @@ class AzureServiceRegistryTest {
         assertTrue(!registry.isKnown("no-such-service"));
         // Repeat: the negative answer is memoised as an empty Optional, not recomputed into a NPE.
         assertTrue(registry.resolve("no-such-service").isEmpty());
+    }
+
+    /**
+     * {@code AzureServiceHandler.enabled} defaults to {@code true}. That default is a convenience for
+     * the interface, not a licence to skip it: a handler that forgets to override it can never be turned
+     * off by config, silently reinstating the {@code default -> true} wart that A5 removed from the
+     * registry switch. Every registered handler must state its own enablement.
+     */
+    @Test
+    void everyHandlerOverridesEnabled() throws Exception {
+        List<String> inheriting = new ArrayList<>();
+        for (AzureServiceHandler handler : registry.handlers()) {
+            // Unwrap the Arc client proxy to reach the real handler class.
+            Class<?> actual = handler.getClass().getSuperclass() != null
+                    && handler.getClass().getSimpleName().endsWith("_ClientProxy")
+                    ? handler.getClass().getSuperclass()
+                    : handler.getClass();
+            if (actual.getMethod("enabled", String.class).getDeclaringClass() == AzureServiceHandler.class) {
+                inheriting.add(actual.getSimpleName());
+            }
+        }
+        assertEquals(List.of(), inheriting,
+            "these handlers inherit the permissive default enabled(): " + inheriting);
     }
 
     /** Memoised lookup must return the same handler instance every time. */

--- a/src/test/java/io/floci/az/core/RoutingTableAssemblyTest.java
+++ b/src/test/java/io/floci/az/core/RoutingTableAssemblyTest.java
@@ -1,0 +1,167 @@
+package io.floci.az.core;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.floci.az.core.ServiceRoutes.SuffixRoute;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Equivalence net for A5: the tables {@link AzureRoutingFilter} now assembles from each handler's
+ * {@link ServiceRoutes} must match, entry for entry, the hand-maintained tables that lived inside the
+ * filter after A4. The A4 tables are reproduced here verbatim as the golden — this is the whole safety
+ * argument for deleting them from the filter.
+ *
+ * <p>Ordering is asserted as an <em>invariant</em> rather than a literal sequence, because handler
+ * discovery order is arbitrary: what matters is that account suffixes match longest-first
+ * ({@code -cosmos-table} must beat {@code -table}) and that the guarded Managed Identity provider is
+ * tried before the broader providers.</p>
+ */
+@QuarkusTest
+@DisplayName("AzureRoutingFilter — tables assembled from handlers match A4's static tables")
+class RoutingTableAssemblyTest {
+
+    @Inject
+    AzureRoutingFilter filter;
+
+    /** A4's HOST_ROUTES, verbatim. */
+    private static final Set<Map.Entry<String, String>> GOLDEN_HOST_ROUTES = Set.of(
+        Map.entry(".vault.azure.net", "keyvault"),
+        Map.entry(".communication.azure.com", "email"),
+        Map.entry(".blob.core.windows.net", "blob"),
+        Map.entry(".dfs.core.windows.net", "blob"),
+        Map.entry(".queue.core.windows.net", "queue"),
+        Map.entry(".servicebus.windows.net", "servicebus")
+    );
+
+    /** A4's ACCOUNT_SUFFIX_ROUTES, verbatim (pre-sort). */
+    private static final Set<Map.Entry<String, String>> GOLDEN_ACCOUNT_ROUTES = Set.of(
+        Map.entry("-cosmos-mongo", "cosmos-mongo"),
+        Map.entry("-cosmos-table", "cosmos-table"),
+        Map.entry("-cosmos-cassandra", "cosmos-cassandra"),
+        Map.entry("-cosmos-gremlin", "cosmos-gremlin"),
+        Map.entry("-cosmos-postgresql", "cosmos-postgresql"),
+        Map.entry("-cosmos-nosql", "cosmos-nosql"),
+        Map.entry("-cosmos", "cosmos"),
+        Map.entry("-queue", "queue"),
+        Map.entry("-table", "table"),
+        Map.entry("-functions", "functions"),
+        Map.entry("-appconfig", "appconfig"),
+        Map.entry("-keyvault", "keyvault"),
+        Map.entry("-eventgrid", "eventgrid"),
+        Map.entry("-eventhub", "eventhub"),
+        Map.entry("-sql", "sql"),
+        Map.entry("-postgres", "postgres"),
+        Map.entry("-servicebus", "servicebus"),
+        Map.entry("-apim", "apim"),
+        Map.entry("-email", "email")
+    );
+
+    /** A4's PROVIDER_ROUTES, verbatim, as marker → serviceType. */
+    private static final Set<Map.Entry<String, String>> GOLDEN_PROVIDER_ROUTES = Set.of(
+        Map.entry("/providers/Microsoft.ManagedIdentity/", "managedidentity"),
+        Map.entry("/providers/Microsoft.ContainerService/", "aks"),
+        Map.entry("/providers/Microsoft.ContainerRegistry/", "acr"),
+        Map.entry("/providers/Microsoft.Sql/", "sql"),
+        Map.entry("/providers/Microsoft.DBforPostgreSQL/", "postgres"),
+        Map.entry("/providers/Microsoft.Compute/", "vm"),
+        Map.entry("/providers/Microsoft.Cache/", "redis"),
+        Map.entry("/providers/Microsoft.Communication/", "email"),
+        Map.entry("/providers/Microsoft.EventGrid/", "eventgrid")
+    );
+
+    private static Set<Map.Entry<String, String>> asEntries(List<SuffixRoute> routes) {
+        return routes.stream()
+                .map(route -> Map.entry(route.suffix(), route.serviceType()))
+                .collect(Collectors.toSet());
+    }
+
+    @Test
+    void hostRoutesMatchA4() {
+        assertEquals(GOLDEN_HOST_ROUTES, asEntries(filter.hostRoutes()));
+        assertEquals(6, filter.hostRoutes().size(), "no duplicate host suffixes");
+    }
+
+    @Test
+    void accountSuffixRoutesMatchA4() {
+        assertEquals(GOLDEN_ACCOUNT_ROUTES, asEntries(filter.accountSuffixRoutes()));
+        assertEquals(19, filter.accountSuffixRoutes().size(), "no duplicate account suffixes");
+    }
+
+    @Test
+    void providerRoutesMatchA4() {
+        assertEquals(GOLDEN_PROVIDER_ROUTES, Set.copyOf(filter.providerRoutesInMatchOrder()));
+    }
+
+    /**
+     * The load-bearing ordering invariant. A shorter suffix must never be tried before a longer one, or
+     * {@code devstoreaccount1-cosmos-table} would resolve to {@code table} instead of {@code cosmos-table}.
+     */
+    @Test
+    void accountSuffixesAreMatchedLongestFirst() {
+        List<SuffixRoute> routes = filter.accountSuffixRoutes();
+        for (int i = 1; i < routes.size(); i++) {
+            int previous = routes.get(i - 1).suffix().length();
+            int current = routes.get(i).suffix().length();
+            assertTrue(previous >= current,
+                "account suffixes must be longest-first, but " + routes.get(i - 1).suffix()
+                    + " (" + previous + ") precedes " + routes.get(i).suffix() + " (" + current + ")");
+        }
+        int cosmosTable = indexOfSuffix(routes, "-cosmos-table");
+        int table = indexOfSuffix(routes, "-table");
+        assertTrue(cosmosTable < table, "-cosmos-table must be tried before -table");
+    }
+
+    /**
+     * Managed Identity's guarded route must be tried before the broader providers: a path may carry both
+     * a Compute/ContainerService segment and a trailing ManagedIdentity segment. Handler discovery order
+     * is arbitrary, so the filter's guarded-first sort is what guarantees this.
+     */
+    @Test
+    void guardedManagedIdentityProviderIsTriedFirst() {
+        List<Map.Entry<String, String>> providers = filter.providerRoutesInMatchOrder();
+        assertEquals("managedidentity", providers.get(0).getValue(),
+            "the guarded Managed Identity route must sort first, got " + providers);
+    }
+
+    /**
+     * Two handlers claiming the same suffix would otherwise resolve by CDI discovery order — a
+     * nondeterministic wiring bug. Startup must fail loudly instead.
+     */
+    @Test
+    void duplicateSuffixClaimedByTwoHandlersFailsFast() {
+        List<SuffixRoute> clashing = List.of(
+            new SuffixRoute("-queue", "queue"),
+            new SuffixRoute("-queue", "someOtherService")
+        );
+        IllegalStateException failure = org.junit.jupiter.api.Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> AzureRoutingFilter.rejectDuplicateSuffixes("account", clashing));
+        assertTrue(failure.getMessage().contains("-queue"), failure.getMessage());
+        assertTrue(failure.getMessage().contains("someOtherService"), failure.getMessage());
+    }
+
+    /** The happy path must not throw — otherwise the guard above would be vacuous. */
+    @Test
+    void distinctSuffixesPassTheDuplicateCheck() {
+        AzureRoutingFilter.rejectDuplicateSuffixes("account",
+            List.of(new SuffixRoute("-queue", "queue"), new SuffixRoute("-table", "table")));
+    }
+
+    private static int indexOfSuffix(List<SuffixRoute> routes, String suffix) {
+        for (int i = 0; i < routes.size(); i++) {
+            if (routes.get(i).suffix().equals(suffix)) {
+                return i;
+            }
+        }
+        throw new AssertionError("suffix not present in assembled table: " + suffix);
+    }
+}

--- a/src/test/java/io/floci/az/core/RoutingTableAssemblyTest.java
+++ b/src/test/java/io/floci/az/core/RoutingTableAssemblyTest.java
@@ -156,6 +156,34 @@ class RoutingTableAssemblyTest {
             List.of(new SuffixRoute("-queue", "queue"), new SuffixRoute("-table", "table")));
     }
 
+    /**
+     * The provider counterpart of the suffix guard. Two handlers claiming the same {@code Microsoft.X}
+     * namespace must fail loudly at startup rather than resolve silently by sort order — otherwise the
+     * ARM provider table reintroduces the exact nondeterminism the suffix guards remove.
+     */
+    @Test
+    void duplicateProviderNamespaceFailsFast() {
+        var always = ServiceRoutes.ProviderRoute.ALWAYS;
+        List<AzureRoutingFilter.ResolvedProvider> clashing = List.of(
+            new AzureRoutingFilter.ResolvedProvider("/providers/Microsoft.Cache/", "redis", always),
+            new AzureRoutingFilter.ResolvedProvider("/providers/Microsoft.Cache/", "someOtherService", always)
+        );
+        IllegalStateException failure = org.junit.jupiter.api.Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> AzureRoutingFilter.rejectDuplicateProviders(clashing));
+        assertTrue(failure.getMessage().contains("Microsoft.Cache"), failure.getMessage());
+        assertTrue(failure.getMessage().contains("someOtherService"), failure.getMessage());
+    }
+
+    /** Distinct provider namespaces must pass — otherwise the guard above would be vacuous. */
+    @Test
+    void distinctProvidersPassTheDuplicateCheck() {
+        var always = ServiceRoutes.ProviderRoute.ALWAYS;
+        AzureRoutingFilter.rejectDuplicateProviders(List.of(
+            new AzureRoutingFilter.ResolvedProvider("/providers/Microsoft.Cache/", "redis", always),
+            new AzureRoutingFilter.ResolvedProvider("/providers/Microsoft.Sql/", "sql", always)));
+    }
+
     private static int indexOfSuffix(List<SuffixRoute> routes, String suffix) {
         for (int i = 0; i < routes.size(); i++) {
             if (routes.get(i).suffix().equals(suffix)) {


### PR DESCRIPTION
## Summary

Adding a service meant editing six hand-maintained sites. Four are now derived from the handler itself: the three routing tables in `AzureRoutingFilter` and the 24-case `isEnabled` switch in `AzureServiceRegistry`. Handlers declare `routes()` and `enabled(serviceType)`; the filter assembles its tables at `@PostConstruct`.

This removes two silent-failure modes:

1. `isEnabled` ended in `default -> true`, so a typo'd service type read as **enabled**, then failed to resolve and surfaced as a puzzling `501 NotImplemented` rather than a loud failure.
2. Two handlers claiming the same host or account suffix resolved by arbitrary CDI discovery order. That now fails fast at startup.

Follows #114 (A5 in the structural roadmap, stacked on A4's tables).

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## Azure Compatibility

No wire-protocol change. All six compatibility suites diff **per-test identical** (182/182 normalized outcomes) against the published `floci/floci-az:latest`. The packaged image logs `Routing tables: 6 host, 19 account-suffix, 9 ARM provider routes` — matching the pre-change static tables exactly.

## Checklist

- [x] `./mvnw test` passes locally (316 tests)
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

---

### Reviewer notes

**Ordering is enforced by sorting, not by declaration order — this is load-bearing.** CDI discovery order is arbitrary, so naively concatenating each handler's routes would have made two precedences nondeterministic *across JVM runs*:

- account suffixes must match longest-first, or `devstoreaccount1-cosmos-table` resolves to `table` instead of `cosmos-table`;
- the guarded `Microsoft.ManagedIdentity` provider must be tried before `Microsoft.Compute`/`Microsoft.ContainerService`, since a path may carry both and MI's `/providers/` segment is always the last one.

Both are asserted as *invariants* in `RoutingTableAssemblyTest` rather than as literal sequences. A flaky-months-later bug, avoided.

**`enabled()` takes a serviceType, and is deliberately not memoised.** `CosmosEngineHandler` is the one multi-type handler: it serves six engines whose enabled-state differs at runtime (`cosmos-mongo` may be up while `cosmos-gremlin` is not). `AzureServiceRegistry` memoises `lookup()` — handler selection is a pure function of the string — but caching `enabled()` would freeze engine state at first call.

**Both new tests were verified non-vacuous.** Commenting out one handler's `.account("-apim", ...)` fails `RoutingTableAssemblyTest` by name; deleting `AcrHandler`'s `enabled()` override fails `everyHandlerOverridesEnabled` by name.

**Deliberately out of scope.** `StorageFactory.serviceConfig` and `BannerLogger` still hold per-service knowledge, but neither can misroute a request — a missing `StorageFactory` case degrades to "no persistence config". `BannerLogger` in particular is not a uniform per-service line (`functions` prints `mocked`, `cosmos` enumerates engines, `eventhub` prints AMQP + Kafka ports), so folding it into a registry loop would add a third interface responsibility and change user-visible startup output for no correctness gain.
