### PR TITLE
chore(config): document postgres and sql-storage defaults in application.yml

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -60,6 +60,8 @@ floci-az:
         flush-interval-ms: 5000
       service-bus:
         flush-interval-ms: 5000
+      sql:
+        flush-interval-ms: 5000
       monitor:
         flush-interval-ms: 5000
 
@@ -134,6 +136,12 @@ floci-az:
       # accept-eula: "Y"     # Must be set to "Y" to accept the Microsoft SQL Server EULA
       image: "mcr.microsoft.com/azure-sql-edge:latest"
       sa-password: "FlociAz_Strong123!"
+      startup-timeout-seconds: 60
+      default-port: 0        # 0 = OS picks a free port per server (recommended)
+    postgres:               # Azure Database for PostgreSQL (Flexible Server). No EULA (postgres image is PostgreSQL-licensed).
+      enabled: true
+      mocked: false         # false = back servers with a real postgres container. true = no Docker; servers are pure ARM state (no live endpoint)
+      image: "postgres:17-alpine"
       startup-timeout-seconds: 60
       default-port: 0        # 0 = OS picks a free port per server (recommended)
     service-bus:


### PR DESCRIPTION
## Summary

Two config blocks existed only as `@WithDefault`s with no presence in `application.yml`, so the file did not document them and anyone overriding them had no template to copy.

- `services.postgres:` — postgres was **entirely absent** from the services block, running on defaults only. Now mirrors `PostgresServiceConfig` (enabled, mocked, image, startup-timeout-seconds, default-port), placed after `services.sql`.
- `storage.services.sql:` — the flush-interval entry `StorageFactory.serviceConfig` already reads for the sql backend, but `application.yml` never listed it.

**Zero behaviour change** — the added values equal the existing defaults.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## Azure Compatibility

No protocol change. Documentation of existing defaults only.

## Checklist

- [x] `./mvnw clean test` passes locally (308)
- [ ] New or updated integration test added — *not applicable; a throwaway `@TestProfile` was used to verify the new postgres keys actually bind (a mistyped key is silently ignored), then removed. `make run` boots with the new blocks.*
- [x] Commit messages follow Conventional Commits
