### PR TITLE
docs(services): flesh out blob/queue/table docs and add ARM reference

### DIFF
--- a/docs/services/arm.md
+++ b/docs/services/arm.md
@@ -48,7 +48,15 @@ GET    /subscriptions/{sub}/resourceGroups
 GET    /subscriptions/{sub}/resources
 GET    /subscriptions/{sub}/providers[/{namespace}]
 POST   /subscriptions/{sub}/providers/{namespace}/checkNameAvailability
+
+# ARM shells (bridge to the live data-plane handlers)
+PUT    /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.Storage/storageAccounts/{name}
+PUT    /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.KeyVault/vaults/{name}
 ```
+
+`azurerm_storage_account` and `azurerm_key_vault` resolve to those two provider paths; the storage
+account returns the well-known development key and the vault's `vaultUri` points at the live
+[Key Vault](key-vault.md) data plane.
 
 ## Quickstart
 
@@ -91,7 +99,7 @@ floci-az:
 | `enabled` | `FLOCI_AZ_SERVICES_ARM_ENABLED` | `true` | Enables the ARM management plane. Disabling it turns off every ARM-based service |
 
 The subscription and tenant GUIDs are fixed
-(`00000000-0000-0000-0000-000000000001` / `…000000000002`) and shared with the
+(`00000000-0000-0000-0000-000000000001` / `00000000-0000-0000-0000-000000000002`) and shared with the
 [Entra ID](entra.md) and [Managed Identity](managed-identity.md) emulation.
 
 ## Intentional deviations

--- a/docs/services/arm.md
+++ b/docs/services/arm.md
@@ -1,0 +1,107 @@
+# Azure Resource Manager (ARM)
+
+The central management-plane handler. It serves the generic ARM surface —
+subscriptions, resource groups, and the resource/provider listings — that the
+`hashicorp/azurerm` Terraform provider, OpenTofu, and the Azure CLI expect, and it acts as the
+fallthrough for management-plane paths not claimed by a more specific handler (AKS, SQL, Redis,
+Managed Identity, and the other `Microsoft.*` providers).
+
+> **HTTP-only — no Docker.** All ARM resource state is in-memory and ephemeral; it does not persist
+> across restarts regardless of `storage.mode`, matching how the other control-plane resources
+> behave.
+
+!!! note "Disabling ARM disables the management plane"
+    `arm.enabled: false` turns off `/subscriptions` and `/providers` routing, which the
+    provider-specific ARM services (Redis, SQL, AKS, …) depend on. Leave it enabled unless you are
+    deliberately testing a data-plane-only configuration.
+
+---
+
+## Features
+
+- **Subscription** — `GET /subscriptions` (enumeration, used by `az login`) and
+  `GET /subscriptions/{sub}`; a single fixed subscription and tenant GUID
+- **Resource groups** — CreateOrUpdate, Get, Delete, List
+  (`/subscriptions/{sub}/resourceGroups/{rg}`); accepts both `resourceGroups` and the lowercase
+  `resourcegroups` spelling
+- **Storage accounts** — an ARM shell that bridges `Microsoft.Storage/storageAccounts` to the live
+  [Blob](blob.md) and [Queue](queue.md) backends, returning the well-known development account key
+- **Key vaults** — an ARM shell for `Microsoft.KeyVault/vaults` whose `vaultUri` points at the
+  live [Key Vault](key-vault.md) handler
+- **Resource & provider listing** — `GET /subscriptions/{sub}/resources`,
+  `GET /subscriptions/{sub}/providers[/{namespace}]`, and
+  `POST .../{namespace}/checkNameAvailability`
+- **Provider fallthrough** — management-plane paths for providers without a dedicated handler are
+  answered here so Terraform reads and dependency lookups resolve
+
+## Endpoints
+
+```
+GET    /subscriptions
+GET    /subscriptions/{sub}
+
+PUT    /subscriptions/{sub}/resourceGroups/{rg}
+GET    /subscriptions/{sub}/resourceGroups/{rg}
+DELETE /subscriptions/{sub}/resourceGroups/{rg}
+GET    /subscriptions/{sub}/resourceGroups
+
+GET    /subscriptions/{sub}/resources
+GET    /subscriptions/{sub}/providers[/{namespace}]
+POST   /subscriptions/{sub}/providers/{namespace}/checkNameAvailability
+```
+
+## Quickstart
+
+Point Terraform at the emulator with a minimal `azurerm` provider block (see the
+[Terraform guide](../terraform.md) for the full skip-provider-registration setup):
+
+```hcl
+provider "azurerm" {
+  features {}
+  skip_provider_registration = true
+  # metadata_host / endpoints redirected at localhost:4577 — see the Terraform guide
+}
+
+resource "azurerm_resource_group" "example" {
+  name     = "my-rg"
+  location = "eastus"
+}
+```
+
+Or drive it directly:
+
+```bash
+curl -s -X PUT \
+  "http://localhost:4577/subscriptions/00000000-0000-0000-0000-000000000001/resourceGroups/my-rg?api-version=2021-04-01" \
+  -H "Content-Type: application/json" \
+  -d '{"location":"eastus"}'
+```
+
+## Configuration
+
+```yaml
+floci-az:
+  services:
+    arm:
+      enabled: true
+```
+
+| Property | Env var | Default | Description |
+|---|---|---|---|
+| `enabled` | `FLOCI_AZ_SERVICES_ARM_ENABLED` | `true` | Enables the ARM management plane. Disabling it turns off every ARM-based service |
+
+The subscription and tenant GUIDs are fixed
+(`00000000-0000-0000-0000-000000000001` / `…000000000002`) and shared with the
+[Entra ID](entra.md) and [Managed Identity](managed-identity.md) emulation.
+
+## Intentional deviations
+
+- **A single fixed subscription and tenant** — the emulator does not model multiple subscriptions.
+- **ARM state is in-memory** — resource groups and the ARM shells do not persist across restarts.
+- **Resource-group deletion does not cascade** — deleting a group leaves resources created under it
+  behind (they still appear in `GET .../resources`, so Terraform's
+  `prevent_deletion_if_contains_resources` works).
+- **`checkNameAvailability` always reports `nameAvailable: true`** — the emulator does not track
+  global name uniqueness.
+- **Shared Key / ARM auth is accepted but not verified** — any bearer token or Shared Key is
+  honored, consistent with the rest of the emulator's permissive dev auth.

--- a/docs/services/blob.md
+++ b/docs/services/blob.md
@@ -1,12 +1,85 @@
 # Blob Storage
 
-Compatible with `azure-storage-blob` SDKs and Azurite connection strings.
+Compatible with the `azure-storage-blob` SDKs (Java, Python, Node.js), the Azure CLI
+(`az storage blob`), and Azurite-style connection strings. Speaks the Azure Storage Blob REST
+protocol with Shared Key authentication and XML responses.
+
+> **HTTP-only — no Docker.** Data is held by the configured [storage backend](../configuration/storage.md)
+> (`memory` by default; `persistent`, `hybrid`, or `wal` for durability).
+
+---
 
 ## Features
-- Container CRUD
-- Blob Upload/Download/Delete
-- List Blobs
-- Metadata support
+
+- **Containers** — Create, Get properties, Delete, List (`?comp=list`); duplicate create returns
+  `409 ContainerAlreadyExists`
+- **Blobs** — Put (upload), Get (download), Delete, List within a container; overwrite semantics
+- **Block blobs** — staged block upload (`?comp=block`) followed by commit (`?comp=blocklist`) for
+  large payloads, in addition to single-request `Put Blob`
+- **Range download** — `Range: bytes=…` returns `206 Partial Content`
+- **Conditional download** — `If-Match` / `If-None-Match` honored; a stale ETag is rejected
+- **Metadata** — `x-ms-meta-*` set on upload and returned on Get, round-tripped exactly
+- **Not-found semantics** — missing blob/container returns the Azure `404 BlobNotFound` /
+  `ContainerNotFound` XML error shape
 
 ## Endpoint
-`http://localhost:4577/{accountName}`
+
+```
+http://localhost:4577/{account}/{container}                  # container operations
+http://localhost:4577/{account}/{container}/{blob}           # blob operations
+```
+
+The account also answers at the host-style address `{account}.blob.core.windows.net` (and the Data
+Lake Gen2 alias `{account}.dfs.core.windows.net`, which maps to the same blob backend) when the
+`Host` header is set, matching how the SDKs address storage endpoints.
+
+## Quickstart
+
+=== "Python"
+
+    ```python
+    from azure.storage.blob import BlobServiceClient
+
+    conn = ("DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;"
+            "AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMh0==;"
+            "BlobEndpoint=http://localhost:4577/devstoreaccount1;")
+    svc = BlobServiceClient.from_connection_string(conn)
+    container = svc.create_container("my-container")
+    container.upload_blob("hello.txt", b"hello world")
+    print(container.download_blob("hello.txt").readall())
+    ```
+
+=== "Azure CLI"
+
+    ```bash
+    az storage container create --name my-container \
+      --connection-string "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=...;BlobEndpoint=http://localhost:4577/devstoreaccount1;"
+    ```
+
+The well-known Azurite development key (`Eby8vdM0…`) is accepted; any account name works.
+
+## Configuration
+
+```yaml
+floci-az:
+  services:
+    blob:
+      enabled: true
+  storage:
+    services:
+      blob:
+        # mode: wal            # override the global storage.mode for blob only
+        flush-interval-ms: 5000
+```
+
+| Property | Env var | Default | Description |
+|---|---|---|---|
+| `enabled` | `FLOCI_AZ_SERVICES_BLOB_ENABLED` | `true` | Enables the Blob Storage service |
+| `storage.services.blob.mode` | `FLOCI_AZ_STORAGE_SERVICES_BLOB_MODE` | *(inherits `storage.mode`)* | Per-service backend override (`memory` / `persistent` / `hybrid` / `wal`) |
+
+## Intentional deviations
+
+- **Shared Key signatures are accepted but not cryptographically verified** — the emulator is a
+  local dev target; any well-formed `Authorization` header (or the Azurite key) is honored.
+- **No SAS enforcement** — SAS query parameters are parsed but not validated.
+- **Snapshots, versioning, leases, and tiering are not modeled.**

--- a/docs/services/blob.md
+++ b/docs/services/blob.md
@@ -76,6 +76,7 @@ floci-az:
 |---|---|---|---|
 | `enabled` | `FLOCI_AZ_SERVICES_BLOB_ENABLED` | `true` | Enables the Blob Storage service |
 | `storage.services.blob.mode` | `FLOCI_AZ_STORAGE_SERVICES_BLOB_MODE` | *(inherits `storage.mode`)* | Per-service backend override (`memory` / `persistent` / `hybrid` / `wal`) |
+| `storage.services.blob.flush-interval-ms` | `FLOCI_AZ_STORAGE_SERVICES_BLOB_FLUSH_INTERVAL_MS` | `5000` | Background flush-to-disk interval for the `hybrid` mode only; ignored by `memory` / `persistent` / `wal` (`wal` compacts on `storage.wal.compaction-interval-ms` instead) |
 
 ## Intentional deviations
 

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -4,6 +4,7 @@ Floci-AZ provides emulation for several core Azure services.
 
 | Service | Endpoint | Implementation Status |
 |---|---|---|
+| **Azure Resource Manager** | `/subscriptions/...` + `/providers/...` | ✅ Subscriptions, resource groups, resource/provider listing; management-plane fallthrough for the `Microsoft.*` providers |
 | **Blob Storage** | `/{account}/` | ✅ Full CRUD |
 | **Queue Storage** | `/{account}-queue/` | ✅ Full CRUD |
 | **Table Storage** | `/{account}-table/` | ✅ Full CRUD |

--- a/docs/services/queue.md
+++ b/docs/services/queue.md
@@ -78,6 +78,7 @@ floci-az:
 |---|---|---|---|
 | `enabled` | `FLOCI_AZ_SERVICES_QUEUE_ENABLED` | `true` | Enables the Queue Storage service |
 | `storage.services.queue.mode` | `FLOCI_AZ_STORAGE_SERVICES_QUEUE_MODE` | *(inherits `storage.mode`)* | Per-service backend override (`memory` / `persistent` / `hybrid` / `wal`) |
+| `storage.services.queue.flush-interval-ms` | `FLOCI_AZ_STORAGE_SERVICES_QUEUE_FLUSH_INTERVAL_MS` | `5000` | Background flush-to-disk interval for the `hybrid` mode only; ignored by `memory` / `persistent` / `wal` (`wal` compacts on `storage.wal.compaction-interval-ms` instead) |
 
 ## Intentional deviations
 

--- a/docs/services/queue.md
+++ b/docs/services/queue.md
@@ -1,12 +1,86 @@
 # Queue Storage
 
-Compatible with `azure-storage-queue` SDKs and Azurite connection strings.
+Compatible with the `azure-storage-queue` SDKs (Java, Python, Node.js), the Azure CLI
+(`az storage queue`), and Azurite-style connection strings. Speaks the Azure Storage Queue REST
+protocol with Shared Key authentication and XML responses.
+
+> **HTTP-only — no Docker.** Data is held by the configured [storage backend](../configuration/storage.md)
+> (`memory` by default; `persistent`, `hybrid`, or `wal` for durability).
+
+---
 
 ## Features
-- Queue CRUD
-- Send/Receive/Delete Messages
-- Peek Messages
-- Visibility Timeout
+
+- **Queues** — Create, Delete, Get/Set metadata; duplicate create is idempotent, missing queue
+  returns the Azure `404 QueueNotFound` shape
+- **Messages** — Enqueue (send), Dequeue (receive), Delete, Peek; multiple in-flight messages
+- **Peek is non-consuming** — `?peekonly=true` returns messages without advancing the dequeue count
+  or hiding them
+- **Visibility timeout** — a received message is hidden for its `visibilitytimeout` and reappears
+  after it elapses
+- **Pop-receipt validation** — delete/update require the current pop receipt; a stale receipt is
+  rejected, and updating a message rotates the receipt
+- **Message TTL** — messages expire and are removed after `messagettl`
+- **Update message** — replaces content and resets visibility, returning a fresh pop receipt
 
 ## Endpoint
-`http://localhost:4577/{accountName}-queue`
+
+```
+http://localhost:4577/{account}-queue/{queue}                    # queue operations
+http://localhost:4577/{account}-queue/{queue}/messages           # message operations
+```
+
+The account also answers at the host-style address `{account}.queue.core.windows.net` when the
+`Host` header is set.
+
+## Quickstart
+
+=== "Python"
+
+    ```python
+    from azure.storage.queue import QueueClient
+
+    conn = ("DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;"
+            "AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMh0==;"
+            "QueueEndpoint=http://localhost:4577/devstoreaccount1-queue;")
+    queue = QueueClient.from_connection_string(conn, "my-queue")
+    queue.create_queue()
+    queue.send_message("hello world")
+    msg = queue.receive_message()
+    print(msg.content)
+    queue.delete_message(msg)
+    ```
+
+=== "Azure CLI"
+
+    ```bash
+    az storage message put --queue-name my-queue --content "hello world" \
+      --connection-string "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=...;QueueEndpoint=http://localhost:4577/devstoreaccount1-queue;"
+    ```
+
+The well-known Azurite development key (`Eby8vdM0…`) is accepted; any account name works.
+
+## Configuration
+
+```yaml
+floci-az:
+  services:
+    queue:
+      enabled: true
+  storage:
+    services:
+      queue:
+        # mode: persistent     # override the global storage.mode for queue only
+        flush-interval-ms: 5000
+```
+
+| Property | Env var | Default | Description |
+|---|---|---|---|
+| `enabled` | `FLOCI_AZ_SERVICES_QUEUE_ENABLED` | `true` | Enables the Queue Storage service |
+| `storage.services.queue.mode` | `FLOCI_AZ_STORAGE_SERVICES_QUEUE_MODE` | *(inherits `storage.mode`)* | Per-service backend override (`memory` / `persistent` / `hybrid` / `wal`) |
+
+## Intentional deviations
+
+- **Shared Key signatures are accepted but not cryptographically verified.**
+- **No SAS enforcement** — SAS query parameters are parsed but not validated.
+- **Message dequeue count** is tracked but `maxDequeueCount` poison-message handling is not modeled.

--- a/docs/services/table.md
+++ b/docs/services/table.md
@@ -66,6 +66,7 @@ floci-az:
 |---|---|---|---|
 | `enabled` | `FLOCI_AZ_SERVICES_TABLE_ENABLED` | `true` | Enables the Table Storage service |
 | `storage.services.table.mode` | `FLOCI_AZ_STORAGE_SERVICES_TABLE_MODE` | *(inherits `storage.mode`)* | Per-service backend override (`memory` / `persistent` / `hybrid` / `wal`) |
+| `storage.services.table.flush-interval-ms` | `FLOCI_AZ_STORAGE_SERVICES_TABLE_FLUSH_INTERVAL_MS` | `5000` | Background flush-to-disk interval for the `hybrid` mode only; ignored by `memory` / `persistent` / `wal` (`wal` compacts on `storage.wal.compaction-interval-ms` instead) |
 
 ## Intentional deviations
 

--- a/docs/services/table.md
+++ b/docs/services/table.md
@@ -1,12 +1,76 @@
 # Table Storage
 
-Compatible with `azure-data-tables` SDKs and Azurite connection strings.
+Compatible with the `azure-data-tables` SDKs (Java, Python, Node.js) and Azurite-style connection
+strings. Speaks the Azure Table REST protocol with OData/JSON payloads and Shared Key
+authentication.
+
+> **HTTP-only — no Docker.** Data is held by the configured [storage backend](../configuration/storage.md)
+> (`memory` by default; `persistent`, `hybrid`, or `wal` for durability).
+
+---
 
 ## Features
-- Table CRUD
-- Entity Insert/Update/Delete/Upsert
-- Query Entities
-- OData filter support (basic)
+
+- **Tables** — Create, Delete, List; duplicate create returns `409 TableAlreadyExists`
+- **Entities** — Insert, Update (replace/merge), Upsert, Delete, Get by
+  `PartitionKey` + `RowKey`; missing entity returns the Azure `404 ResourceNotFound` shape
+- **Query** — `$filter` OData expressions: equality on `PartitionKey`/`RowKey`, numeric
+  comparisons, and combinations; `$select` projects a subset of properties
+- **Pagination** — large result sets are paged with continuation tokens
+  (`x-ms-continuation-Next*` headers)
+- **Optimistic concurrency** — `ETag` / `If-Match` on update and delete; a stale ETag is rejected
+- **Batch transactions** — `$batch` multipart change sets are applied atomically
 
 ## Endpoint
-`http://localhost:4577/{accountName}-table`
+
+```
+http://localhost:4577/{account}-table/Tables                                   # table operations
+http://localhost:4577/{account}-table/{table}(PartitionKey='p',RowKey='r')     # entity operations
+http://localhost:4577/{account}-table/$batch                                   # batch transactions
+```
+
+## Quickstart
+
+=== "Python"
+
+    ```python
+    from azure.data.tables import TableServiceClient
+
+    conn = ("DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;"
+            "AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMh0==;"
+            "TableEndpoint=http://localhost:4577/devstoreaccount1-table;")
+    svc = TableServiceClient.from_connection_string(conn)
+    table = svc.create_table("people")
+    table.upsert_entity({"PartitionKey": "team", "RowKey": "alice", "role": "eng"})
+    for e in table.query_entities("PartitionKey eq 'team'"):
+        print(e["RowKey"], e["role"])
+    ```
+
+The well-known Azurite development key (`Eby8vdM0…`) is accepted; any account name works.
+
+## Configuration
+
+```yaml
+floci-az:
+  services:
+    table:
+      enabled: true
+  storage:
+    services:
+      table:
+        # mode: persistent     # override the global storage.mode for table only
+        flush-interval-ms: 5000
+```
+
+| Property | Env var | Default | Description |
+|---|---|---|---|
+| `enabled` | `FLOCI_AZ_SERVICES_TABLE_ENABLED` | `true` | Enables the Table Storage service |
+| `storage.services.table.mode` | `FLOCI_AZ_STORAGE_SERVICES_TABLE_MODE` | *(inherits `storage.mode`)* | Per-service backend override (`memory` / `persistent` / `hybrid` / `wal`) |
+
+## Intentional deviations
+
+- **Shared Key signatures are accepted but not cryptographically verified.**
+- **The `$filter` grammar is a practical subset** — equality, numeric comparison, and basic
+  boolean composition are supported; full OData functions (`substringof`, `startswith`, datetime
+  arithmetic) are not.
+- **No SAS enforcement** — SAS query parameters are parsed but not validated.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,6 +69,7 @@ nav:
       - application.yml Reference: configuration/advanced/application-yml.md
   - Services:
     - Overview: services/index.md
+    - Azure Resource Manager: services/arm.md
     - Blob Storage: services/blob.md
     - Queue Storage: services/queue.md
     - Table Storage: services/table.md


### PR DESCRIPTION
## Summary

The blob, queue and table service pages were 12-line stubs; Azure Resource Manager had no page at all despite being the management plane every Terraform/CLI flow depends on.

- **blob / queue / table** — expanded to the `managed-identity.md` structure (features, endpoints, per-language quickstart, configuration table, intentional deviations).
- **new `services/arm.md`** — subscriptions, resource groups, the storage-account/key-vault ARM shells, resource/provider listing, provider fallthrough, and the "disabling ARM disables the management plane" caveat.
- **mkdocs.yml** nav entry (after Overview) + an ARM row in `services/index.md`.

Feature lists are **grounded in the compatibility-test coverage and the handlers, not invented** — block upload, range/conditional download, pop-receipt rotation, `$batch` transactions, `x-ms-continuation` paging. ARM claims (`checkNameAvailability` always available, no resource-group delete cascade, continuation header names) were checked against `ArmHandler`/`TableServiceHandler`; one wrong claim was corrected before commit.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## Azure Compatibility

Documentation only.

## Checklist

- [x] `mkdocs build --strict` passes with no link/nav warnings
- [ ] New or updated integration test added — *not applicable (docs-only)*
- [x] Commit messages follow Conventional Commits
