### PR TITLE
fix(core): unify ARM provider dispatch and parse ARM bodies strictly

### DIFF
--- a/src/main/java/io/floci/az/core/arm/ArmProviderService.java
+++ b/src/main/java/io/floci/az/core/arm/ArmProviderService.java
@@ -1,0 +1,40 @@
+package io.floci.az.core.arm;
+
+import io.floci.az.core.AzureRequest;
+import jakarta.ws.rs.core.Response;
+
+import java.util.Set;
+
+/**
+ * A management-plane handler for one or more ARM provider namespaces, dispatched by
+ * {@code ArmHandler}. Implementers are discovered via CDI ({@code Instance<ArmProviderService>}) and
+ * assembled into a namespace → service map at startup, replacing the hand-maintained if-ladder that
+ * used to route {@code /providers/Microsoft.X/} paths.
+ *
+ * <p>This is the "ArmHandler lane": the routing filter forwards the whole ARM path to {@code ArmHandler}
+ * (serviceType {@code arm}), which extracts the subscription and delegates here. Contrast the "filter
+ * lane", where a full service declares {@code .provider(...)} in its {@code ServiceRoutes} and is
+ * dispatched directly by the filter to {@code handle()}. A service belongs in exactly one lane.
+ */
+public interface ArmProviderService {
+
+    /** The ARM provider namespaces this service owns, e.g. {@code Microsoft.Network}. */
+    Set<String> providerNamespaces();
+
+    /**
+     * Handles an ARM management-plane request under one of {@link #providerNamespaces()}.
+     *
+     * @param sub the subscription id, already extracted from the path by {@code ArmHandler} — so
+     *            implementers never re-parse it (the inconsistency A6 removed from Event Grid)
+     */
+    Response handleArm(AzureRequest req, String path, String method, String sub);
+
+    /**
+     * Whether this provider is currently served. When {@code false}, {@code ArmHandler} answers the
+     * ARM {@code 404} it would for an unknown provider. Defaults to enabled; a service whose config flag
+     * gates its ARM plane (e.g. Network) overrides this.
+     */
+    default boolean armEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/io/floci/az/services/apim/ApiManagementHandler.java
+++ b/src/main/java/io/floci/az/services/apim/ApiManagementHandler.java
@@ -5,15 +5,17 @@ import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
 import io.floci.az.core.ServiceRoutes;
 import io.floci.az.core.Resettable;
+import io.floci.az.core.arm.ArmProviderService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @ApplicationScoped
-public class ApiManagementHandler implements AzureServiceHandler, Resettable {
+public class ApiManagementHandler implements AzureServiceHandler, Resettable, ArmProviderService {
 
     private final ApiManagementGateway gateway;
     private final ApiManagementService service;
@@ -54,10 +56,16 @@ public class ApiManagementHandler implements AzureServiceHandler, Resettable {
     }
 
     @Override
+    public Set<String> providerNamespaces() {
+        return Set.of("Microsoft.ApiManagement");
+    }
+
+    @Override
     public Response handle(AzureRequest request) {
         return gateway.handle(request);
     }
 
+    @Override
     public Response handleArm(AzureRequest request, String path, String method, String sub) {
         return service.handleArm(request, path, method, sub);
     }

--- a/src/main/java/io/floci/az/services/apim/ApiManagementService.java
+++ b/src/main/java/io/floci/az/services/apim/ApiManagementService.java
@@ -679,7 +679,7 @@ public class ApiManagementService {
     }
 
     private Map<String, Object> parseBody(AzureRequest request) {
-        return ArmJson.parseBodyLenient(request);
+        return ArmJson.parseBodyStrict(request);
     }
 
     private static Map<String, Object> stripInternal(Map<String, Object> resource) {

--- a/src/main/java/io/floci/az/services/arm/ArmHandler.java
+++ b/src/main/java/io/floci/az/services/arm/ArmHandler.java
@@ -14,8 +14,11 @@ import io.floci.az.services.queue.QueueServiceHandler;
 import io.floci.az.core.arm.ArmErrors;
 import io.floci.az.core.arm.ArmJson;
 import io.floci.az.core.arm.ArmPaths;
+import io.floci.az.core.arm.ArmProviderService;
 import io.floci.az.core.arm.ArmResources;
+import jakarta.annotation.PostConstruct;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
@@ -64,11 +67,16 @@ public class ArmHandler implements AzureServiceHandler {
     private final MonitorHandler monitorHandler;
     private final ManagedIdentityHandler managedIdentityHandler;
 
+    /** provider namespace → owning ArmProviderService, assembled from CDI at startup. */
+    private final Instance<ArmProviderService> providerServices;
+    private final Map<String, ArmProviderService> providerLane = new HashMap<>();
+
     @Inject
     public ArmHandler(EmulatorConfig config, BlobServiceHandler blobHandler, QueueServiceHandler queueHandler,
                       FunctionsServiceHandler functionsHandler, ApiManagementHandler apiManagementHandler,
                       NetworkHandler networkHandler, MonitorHandler monitorHandler,
-                      ManagedIdentityHandler managedIdentityHandler) {
+                      ManagedIdentityHandler managedIdentityHandler,
+                      Instance<ArmProviderService> providerServices) {
         this.config               = config;
         this.blobHandler          = blobHandler;
         this.queueHandler         = queueHandler;
@@ -77,6 +85,25 @@ public class ArmHandler implements AzureServiceHandler {
         this.networkHandler       = networkHandler;
         this.monitorHandler       = monitorHandler;
         this.managedIdentityHandler = managedIdentityHandler;
+        this.providerServices     = providerServices;
+    }
+
+    /**
+     * Builds the provider-namespace → service map. Two services claiming the same namespace is a wiring
+     * bug that would otherwise resolve by arbitrary CDI order — fail fast at startup.
+     */
+    @PostConstruct
+    void buildProviderLane() {
+        for (ArmProviderService service : providerServices) {
+            for (String namespace : service.providerNamespaces()) {
+                ArmProviderService previous = providerLane.putIfAbsent(namespace, service);
+                if (previous != null) {
+                    throw new IllegalStateException("Two ArmProviderService beans claim " + namespace
+                        + ": " + previous.getClass().getSimpleName() + " and " + service.getClass().getSimpleName());
+                }
+            }
+        }
+        LOG.infof("ARM provider lane: %d namespaces → %s", providerLane.size(), providerLane.keySet());
     }
 
     @Override
@@ -92,6 +119,17 @@ public class ArmHandler implements AzureServiceHandler {
 
     @Override
     public Response handle(AzureRequest req) {
+        // ARM-plane handlers (Network/APIM/Monitor/EventGrid) parse the body strictly; a malformed
+        // body surfaces here as the real ARM 400 InvalidRequestContent rather than a lenient no-op.
+        try {
+            return dispatch(req);
+        } catch (ArmJson.InvalidBodyException e) {
+            return ArmErrors.error(400, "InvalidRequestContent",
+                    "The request content was invalid and could not be deserialized.");
+        }
+    }
+
+    private Response dispatch(AzureRequest req) {
         String path   = req.resourcePath();
         String method = req.method().toUpperCase();
 
@@ -247,6 +285,8 @@ public class ArmHandler implements AzureServiceHandler {
     // ── Provider-level routing ────────────────────────────────────────────────
 
     private Response handleProviders(AzureRequest req, String path, String method, String sub) {
+        // Inline ARM shells that bridge to data-plane handlers (Storage/KeyVault) or functions
+        // provisioning (Web) — coupled to those subsystems, so they stay here rather than in the lane.
         if (path.contains("/providers/Microsoft.Storage/")) {
             return handleStorage(req, path, method, sub);
         }
@@ -256,22 +296,23 @@ public class ArmHandler implements AzureServiceHandler {
         if (path.contains("/providers/Microsoft.Web/")) {
             return handleWeb(req, path, method, sub);
         }
-        if (path.contains("/providers/Microsoft.Network/")) {
-            if (!config.services().network().enabled()) {
-                return armNotFound(path);
-            }
-            return networkHandler.handleArm(req, path, method, sub);
-        }
-        if (path.contains("/providers/Microsoft.ApiManagement/")) {
-            return apiManagementHandler.handleArm(req, path, method, sub);
-        }
-        if (path.contains("/providers/Microsoft.OperationalInsights/")) {
-            return monitorHandler.handleArm(req, path, method, sub);
-        }
-        if (path.contains("/providers/Microsoft.Insights/")) {
-            return monitorHandler.handleArm(req, path, method, sub);
+        // Delegating providers (Network/APIM/Monitor/EventGrid), via the ArmProviderService lane.
+        ArmProviderService provider = providerLane.get(providerNamespace(path));
+        if (provider != null) {
+            return provider.armEnabled() ? provider.handleArm(req, path, method, sub) : armNotFound(path);
         }
         return armNotFound(path);
+    }
+
+    /** The {@code Microsoft.X} namespace segment immediately after {@code /providers/}, or "" if none. */
+    private static String providerNamespace(String path) {
+        int marker = path.indexOf("/providers/");
+        if (marker < 0) {
+            return "";
+        }
+        String rest = path.substring(marker + "/providers/".length());
+        int slash = rest.indexOf('/');
+        return slash < 0 ? rest : rest.substring(0, slash);
     }
 
     // ── Function Apps ────────────────────────────────────────────────────────

--- a/src/main/java/io/floci/az/services/arm/ArmHandler.java
+++ b/src/main/java/io/floci/az/services/arm/ArmHandler.java
@@ -9,7 +9,6 @@ import io.floci.az.services.functions.FunctionRuntime;
 import io.floci.az.services.functions.FunctionsServiceHandler;
 import io.floci.az.services.managedidentity.ManagedIdentityHandler;
 import io.floci.az.services.network.NetworkHandler;
-import io.floci.az.services.monitor.MonitorHandler;
 import io.floci.az.services.queue.QueueServiceHandler;
 import io.floci.az.core.arm.ArmErrors;
 import io.floci.az.core.arm.ArmJson;
@@ -64,7 +63,6 @@ public class ArmHandler implements AzureServiceHandler {
     private final FunctionsServiceHandler functionsHandler;
     private final ApiManagementHandler apiManagementHandler;
     private final NetworkHandler networkHandler;
-    private final MonitorHandler monitorHandler;
     private final ManagedIdentityHandler managedIdentityHandler;
 
     /** provider namespace → owning ArmProviderService, assembled from CDI at startup. */
@@ -74,8 +72,7 @@ public class ArmHandler implements AzureServiceHandler {
     @Inject
     public ArmHandler(EmulatorConfig config, BlobServiceHandler blobHandler, QueueServiceHandler queueHandler,
                       FunctionsServiceHandler functionsHandler, ApiManagementHandler apiManagementHandler,
-                      NetworkHandler networkHandler, MonitorHandler monitorHandler,
-                      ManagedIdentityHandler managedIdentityHandler,
+                      NetworkHandler networkHandler, ManagedIdentityHandler managedIdentityHandler,
                       Instance<ArmProviderService> providerServices) {
         this.config               = config;
         this.blobHandler          = blobHandler;
@@ -83,7 +80,6 @@ public class ArmHandler implements AzureServiceHandler {
         this.functionsHandler     = functionsHandler;
         this.apiManagementHandler = apiManagementHandler;
         this.networkHandler       = networkHandler;
-        this.monitorHandler       = monitorHandler;
         this.managedIdentityHandler = managedIdentityHandler;
         this.providerServices     = providerServices;
     }
@@ -136,6 +132,9 @@ public class ArmHandler implements AzureServiceHandler {
         LOG.debugf("ArmHandler %s %s", method, path);
 
         // ── Network Provider (subscription & resource-group levels) ───────────
+        // Network is dispatched here, NOT via the providerLane map: subscription-scoped Network list
+        // paths (no /resourceGroups/) must be caught before the resource-group branch below, and the
+        // map lane is reached only from inside that branch. This block owns Network's enabled-guard.
         if (path.contains("/providers/Microsoft.Network/")) {
             if (!config.services().network().enabled()) {
                 return armNotFound(path);

--- a/src/main/java/io/floci/az/services/eventgrid/EventGridHandler.java
+++ b/src/main/java/io/floci/az/services/eventgrid/EventGridHandler.java
@@ -5,25 +5,29 @@ import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
 import io.floci.az.core.ServiceRoutes;
 import io.floci.az.core.Resettable;
+import io.floci.az.core.arm.ArmProviderService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 
+import java.util.Set;
+
 /**
- * Azure Event Grid handler. Serves both planes for {@code serviceType="eventgrid"}:
+ * Azure Event Grid handler, split across the two ARM lanes:
  * <ul>
- *   <li>Control plane — ARM paths containing {@code /providers/Microsoft.EventGrid/}
- *       (topics + classic scoped eventSubscriptions) → {@link EventGridService}.</li>
- *   <li>Data plane — {@code POST /api/events} reached via the {@code {topic}-eventgrid}
- *       account suffix → {@link EventGridPublisher}.</li>
+ *   <li>Control plane — {@code /providers/Microsoft.EventGrid/} (topics + classic scoped
+ *       eventSubscriptions). Reached through the ArmHandler lane via {@link ArmProviderService};
+ *       {@code ArmHandler} extracts the subscription and passes it in, so this handler no longer
+ *       re-parses it. Delegates to {@link EventGridService}.</li>
+ *   <li>Data plane — {@code POST /api/events} reached via the {@code {topic}-eventgrid} account
+ *       suffix (the filter lane) → {@link EventGridPublisher}.</li>
  * </ul>
  */
 @ApplicationScoped
-public class EventGridHandler implements AzureServiceHandler, Resettable {
+public class EventGridHandler implements AzureServiceHandler, Resettable, ArmProviderService {
 
     private static final Logger LOG = Logger.getLogger(EventGridHandler.class);
-    private static final String ARM_MARKER = "/providers/Microsoft.EventGrid/";
 
     private final EventGridService service;
     private final EventGridPublisher publisher;
@@ -52,11 +56,11 @@ public class EventGridHandler implements AzureServiceHandler, Resettable {
     @Override
 
     public ServiceRoutes routes() {
+        // Only the data-plane account suffix. The control plane is claimed via ArmProviderService
+        // (providerNamespaces), routed through the ArmHandler lane — not the filter's provider table.
         return ServiceRoutes.builder()
                 .account("-eventgrid", "eventgrid")
-                .provider("Microsoft.EventGrid")
                 .build();
-
     }
 
     @Override
@@ -65,15 +69,25 @@ public class EventGridHandler implements AzureServiceHandler, Resettable {
     }
 
     @Override
+    public Set<String> providerNamespaces() {
+        return Set.of("Microsoft.EventGrid");
+    }
+
+    @Override
+    public boolean armEnabled() {
+        return config.services().eventGrid().enabled();
+    }
+
+    /** Control plane (ArmHandler lane): {@code sub} is supplied by ArmHandler. */
+    @Override
+    public Response handleArm(AzureRequest req, String path, String method, String sub) {
+        return service.handleArm(req, path, method.toUpperCase(), sub);
+    }
+
+    @Override
     public Response handle(AzureRequest req) {
+        // Data plane only: {topic}-eventgrid/api/events (control plane arrives via handleArm).
         String method = req.method().toUpperCase();
-
-        // Control plane: the routing filter forwards the full ARM path as resourcePath.
-        if (req.resourcePath().contains(ARM_MARKER)) {
-            return service.handleArm(req, req.resourcePath(), method);
-        }
-
-        // Data plane: {topic}-eventgrid/api/events
         String path = stripQuery(req.resourcePath());
         if (path.equals("api/events") && "POST".equals(method)) {
             return publisher.publish(req, req.accountName());

--- a/src/main/java/io/floci/az/services/eventgrid/EventGridService.java
+++ b/src/main/java/io/floci/az/services/eventgrid/EventGridService.java
@@ -56,7 +56,7 @@ public class EventGridService {
 
     // ── ARM dispatch ──────────────────────────────────────────────────────────
 
-    public Response handleArm(AzureRequest req, String path, String method) {
+    public Response handleArm(AzureRequest req, String path, String method, String sub) {
         int esIdx = path.indexOf(ES_MARKER);
         if (esIdx >= 0) {
             String scope = normalizeId(path.substring(0, esIdx));
@@ -73,7 +73,6 @@ public class EventGridService {
             return notFound(path);
         }
 
-        String sub = extractSegment(path, "subscriptions");
         String rg = extractSegment(path, "resourceGroups");
 
         if (seg.length == 1) {
@@ -385,7 +384,7 @@ public class EventGridService {
     // ── Generic parsing helpers ──────────────────────────────────────────────────
 
     private Map<String, Object> parseBody(AzureRequest req) {
-        return ArmJson.parseBodyLenient(req);
+        return ArmJson.parseBodyStrict(req);
     }
 
     private static Map<String, Object> cast(Object value) {

--- a/src/main/java/io/floci/az/services/monitor/MonitorHandler.java
+++ b/src/main/java/io/floci/az/services/monitor/MonitorHandler.java
@@ -10,6 +10,7 @@ import io.floci.az.core.StoredObject;
 import io.floci.az.core.storage.StorageBackend;
 import io.floci.az.core.storage.StorageFactory;
 import io.floci.az.core.arm.ArmJson;
+import io.floci.az.core.arm.ArmProviderService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.MediaType;
@@ -24,7 +25,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 @ApplicationScoped
-public class MonitorHandler implements AzureServiceHandler, Resettable {
+public class MonitorHandler implements AzureServiceHandler, Resettable, ArmProviderService {
 
     private static final Logger LOG = Logger.getLogger(MonitorHandler.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();
@@ -78,6 +79,12 @@ public class MonitorHandler implements AzureServiceHandler, Resettable {
         return Response.status(404).entity("Not Found").build();
     }
 
+    @Override
+    public Set<String> providerNamespaces() {
+        return Set.of("Microsoft.OperationalInsights", "Microsoft.Insights");
+    }
+
+    @Override
     public Response handleArm(AzureRequest req, String path, String method, String sub) {
         LOG.debugf("MonitorHandler ARM-plane %s /%s", method, path);
 
@@ -508,7 +515,7 @@ public class MonitorHandler implements AzureServiceHandler, Resettable {
     }
 
     private Map<String, Object> parseBody(AzureRequest req) {
-        return ArmJson.parseBodyLenient(req);
+        return ArmJson.parseBodyStrict(req);
     }
 
     public void clearAll() {

--- a/src/main/java/io/floci/az/services/network/NetworkHandler.java
+++ b/src/main/java/io/floci/az/services/network/NetworkHandler.java
@@ -1,24 +1,40 @@
 package io.floci.az.services.network;
 
+import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.Resettable;
+import io.floci.az.core.arm.ArmProviderService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @ApplicationScoped
-public class NetworkHandler implements Resettable {
+public class NetworkHandler implements Resettable, ArmProviderService {
 
     private final NetworkService service;
+    private final EmulatorConfig config;
 
     @Inject
-    public NetworkHandler(NetworkService service) {
+    public NetworkHandler(NetworkService service, EmulatorConfig config) {
         this.service = service;
+        this.config = config;
     }
 
+    @Override
+    public Set<String> providerNamespaces() {
+        return Set.of("Microsoft.Network");
+    }
+
+    @Override
+    public boolean armEnabled() {
+        return config.services().network().enabled();
+    }
+
+    @Override
     public Response handleArm(AzureRequest request, String path, String method, String sub) {
         return service.handleArm(request, path, method, sub);
     }

--- a/src/main/java/io/floci/az/services/network/NetworkHandler.java
+++ b/src/main/java/io/floci/az/services/network/NetworkHandler.java
@@ -1,40 +1,31 @@
 package io.floci.az.services.network;
 
-import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.Resettable;
-import io.floci.az.core.arm.ArmProviderService;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
+/**
+ * Network is intentionally NOT an {@link io.floci.az.core.arm.ArmProviderService}. It is dispatched by
+ * the dedicated early block in {@code ArmHandler.dispatch()} rather than the provider-lane map, because
+ * subscription-scoped Network list paths (no {@code /resourceGroups/}) must be intercepted before the
+ * resource-group branch — which the map lane, reached only from that branch, cannot do. {@code ArmHandler}
+ * calls {@link #handleArm} directly and applies the {@code network().enabled()} guard there.
+ */
 @ApplicationScoped
-public class NetworkHandler implements Resettable, ArmProviderService {
+public class NetworkHandler implements Resettable {
 
     private final NetworkService service;
-    private final EmulatorConfig config;
 
     @Inject
-    public NetworkHandler(NetworkService service, EmulatorConfig config) {
+    public NetworkHandler(NetworkService service) {
         this.service = service;
-        this.config = config;
     }
 
-    @Override
-    public Set<String> providerNamespaces() {
-        return Set.of("Microsoft.Network");
-    }
-
-    @Override
-    public boolean armEnabled() {
-        return config.services().network().enabled();
-    }
-
-    @Override
     public Response handleArm(AzureRequest request, String path, String method, String sub) {
         return service.handleArm(request, path, method, sub);
     }

--- a/src/main/java/io/floci/az/services/network/NetworkService.java
+++ b/src/main/java/io/floci/az/services/network/NetworkService.java
@@ -195,7 +195,7 @@ public class NetworkService {
     }
 
     private Map<String, Object> parseBody(AzureRequest request) {
-        return ArmJson.parseBodyLenient(request);
+        return ArmJson.parseBodyStrict(request);
     }
 
     private static Map<String, Object> cast(Object o) {

--- a/src/test/java/io/floci/az/core/RoutingTableAssemblyTest.java
+++ b/src/test/java/io/floci/az/core/RoutingTableAssemblyTest.java
@@ -65,7 +65,11 @@ class RoutingTableAssemblyTest {
         Map.entry("-email", "email")
     );
 
-    /** A4's PROVIDER_ROUTES, verbatim, as marker → serviceType. */
+    /**
+     * A4's PROVIDER_ROUTES minus {@code Microsoft.EventGrid}: A6 moved Event Grid's control plane out
+     * of the filter's provider lane into the ArmHandler lane (it implements {@code ArmProviderService}),
+     * so it is no longer a filter provider route. Every other entry is unchanged from A4.
+     */
     private static final Set<Map.Entry<String, String>> GOLDEN_PROVIDER_ROUTES = Set.of(
         Map.entry("/providers/Microsoft.ManagedIdentity/", "managedidentity"),
         Map.entry("/providers/Microsoft.ContainerService/", "aks"),
@@ -74,8 +78,7 @@ class RoutingTableAssemblyTest {
         Map.entry("/providers/Microsoft.DBforPostgreSQL/", "postgres"),
         Map.entry("/providers/Microsoft.Compute/", "vm"),
         Map.entry("/providers/Microsoft.Cache/", "redis"),
-        Map.entry("/providers/Microsoft.Communication/", "email"),
-        Map.entry("/providers/Microsoft.EventGrid/", "eventgrid")
+        Map.entry("/providers/Microsoft.Communication/", "email")
     );
 
     private static Set<Map.Entry<String, String>> asEntries(List<SuffixRoute> routes) {

--- a/src/test/java/io/floci/az/services/arm/ArmStrictBodyTest.java
+++ b/src/test/java/io/floci/az/services/arm/ArmStrictBodyTest.java
@@ -1,0 +1,67 @@
+package io.floci.az.services.arm;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * A6 behavior change: ARM-plane providers now parse the request body strictly. A malformed /
+ * non-deserializable JSON body returns the real ARM {@code 400 InvalidRequestContent} rather than
+ * being silently swallowed by lenient parsing.
+ *
+ * <p>Contract confirmed from {@code az} CLI recordings
+ * ({@code netappfiles/.../test_account_changekeyvault_fails.yaml}) and the reservations ARM error
+ * enum: {@code 400 Bad Request}, body
+ * {@code {"error":{"code":"InvalidRequestContent","message":"The request content was invalid and
+ * could not be deserialized..."}}}. Matches the pre-existing ManagedIdentity precedent.</p>
+ */
+@QuarkusTest
+@DisplayName("ARM providers — malformed body returns 400 InvalidRequestContent")
+class ArmStrictBodyTest {
+
+    private static final String RG = "/subscriptions/sub-a6/resourceGroups/rg-a6";
+    private static final String MALFORMED = "{ this is not valid json";
+
+    private void assertMalformedBodyRejected(String armPath, String apiVersion) {
+        given()
+            .contentType("application/json")
+            .body(MALFORMED)
+            .when().put(RG + armPath + "?api-version=" + apiVersion)
+            .then().statusCode(400)
+            .body(containsString("InvalidRequestContent"))
+            .body(containsString("could not be deserialized"));
+    }
+
+    @Test
+    void networkRejectsMalformedBody() {
+        assertMalformedBodyRejected("/providers/Microsoft.Network/virtualNetworks/vnet-a6", "2023-09-01");
+    }
+
+    @Test
+    void apiManagementRejectsMalformedBody() {
+        assertMalformedBodyRejected("/providers/Microsoft.ApiManagement/service/apim-a6", "2022-08-01");
+    }
+
+    @Test
+    void monitorWorkspaceRejectsMalformedBody() {
+        assertMalformedBodyRejected("/providers/Microsoft.OperationalInsights/workspaces/law-a6", "2022-10-01");
+    }
+
+    @Test
+    void eventGridRejectsMalformedBody() {
+        // Also exercises the A6 lane move: Event Grid's control plane now flows through ArmHandler.
+        assertMalformedBodyRejected("/providers/Microsoft.EventGrid/topics/topic-a6", "2022-06-15");
+    }
+
+    /** An empty body is NOT a deserialization failure — parseBodyStrict yields an empty map. */
+    @Test
+    void emptyBodyIsNotRejectedAsMalformed() {
+        given()
+            .contentType("application/json")
+            .when().put(RG + "/providers/Microsoft.EventGrid/topics/topic-empty?api-version=2022-06-15")
+            .then().statusCode(org.hamcrest.Matchers.not(400));
+    }
+}


### PR DESCRIPTION
## Summary

Replace `ArmHandler`'s hand-maintained provider if-ladder with a CDI-assembled `namespace → service` map, and switch the ARM-plane handlers to strict body parsing so a malformed body returns the real ARM `400 InvalidRequestContent`.

**Dispatch unification** — new `core/arm/ArmProviderService` (`providerNamespaces()` + `handleArm(req,path,method,sub)` + default `armEnabled()`). Network/APIM/Monitor implement it; their 4-arg `handleArm` was already the right shape. `ArmHandler` injects `Instance<ArmProviderService>`, builds the map at `@PostConstruct` (fail-fast on duplicate namespace), and `handleProviders`' four delegating if-blocks collapse to one lookup. Inline Storage/KeyVault/Web stay in `ArmHandler`.

**Event Grid lane move** (fixes its "missing sub") — Event Grid's control plane leaves the filter's provider lane for the ArmHandler lane; `ArmHandler` now supplies `sub`, so `EventGridService.handleArm` stops self-extracting it. Data plane (`-eventgrid` suffix) stays filter-routed.

**Strict parse (behaviour change)** — Network/APIM/Monitor/EventGrid switch `parseBodyLenient → parseBodyStrict`; a malformed body returns `400 InvalidRequestContent`. Empty body is not an error. Scoped to these four; Storage/KeyVault/Web + `ArmHandler`'s own RG/subscription PUTs stay lenient (follow-up).

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

**Corrected behaviour:** a malformed/non-deserializable ARM PUT/PATCH body was silently accepted (lenient parse → no-op); it now returns `400 Bad Request` with `{"error":{"code":"InvalidRequestContent","message":"The request content was invalid and could not be deserialized."}}`. Contract confirmed from `az` CLI recordings (`netappfiles/.../test_account_{changekeyvault,transitionCMK}_fails.yaml`, both `code: 400`) and the reservations ARM error enum; matches the existing ManagedIdentity precedent.

All six compatibility suites diff **per-test identical** against the published pre-A4 baseline — no real client sends a malformed body, so the new 400 changes no existing flow.

## Checklist

- [x] `./mvnw test` passes locally (321)
- [x] New or updated integration test added (`ArmStrictBodyTest`; Event Grid lane move covered by `EventGridHandlerTest`)
- [x] Commit messages follow Conventional Commits

---

### Reviewer notes

- **Two lanes, documented in `ArmProviderService` javadoc.** Filter lane (`.provider(...)` in `routes()` → `handle()`) vs ArmHandler lane (`ArmProviderService.handleArm` with `sub` supplied). A service is in exactly one lane; Event Grid moved from the first to the second.
- **The early `Microsoft.Network` block in `handle()` is deliberately kept** — it intercepts RG-scoped Network paths before the resource-group branch (`contains("/resourcegroups")`) would swallow them. Network's map entry covers the subscription-scoped paths.
- Builds on #115 (merged): the `ArmProviderService` map reuses the same fail-fast-on-duplicate pattern #115 added for the routing tables.
