### PR TITLE
feat: add ADLS user delegation key vending

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ flowchart LR
 
 | Service                 | Routing                      | Notable operations                                                                                                                                                                                                    |
 |-------------------------|------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Blob Storage**        | `/{account}/`                | Create/delete containers, upload/download/delete blobs, list blobs                                                                                                                                                    |
+| **Blob Storage**        | `/{account}/`                | Create/delete containers, upload/download/delete blobs, list blobs; ADLS Gen2 DFS host alias and user delegation key vending                                                                                          |
 | **Queue Storage**       | `/{account}-queue/`          | Create/delete queues, send/receive/peek/delete messages, visibility timeout                                                                                                                                           |
 | **Table Storage**       | `/{account}-table/`          | Create/delete tables, insert/get/update/upsert/delete entities; OData `$filter` / `$select` / `$top`; server-side pagination (continuation tokens); ETag optimistic concurrency; Entity Group Transactions (`$batch`) |
 | **Azure Functions**     | `/{account}-functions/`      | Deploy & invoke HTTP-triggered functions (node, python, java, dotnet); warm-container pool                                                                                                                            |
@@ -420,6 +420,7 @@ Floci AZ uses path-style routing:
 | Service           | Endpoint                                              | Notes |
 |-------------------|-------------------------------------------------------|-------|
 | Blob              | `http://localhost:4577/{accountName}`                 | |
+| Data Lake Storage Gen2 | `http://localhost:4577/{accountName}`            | Use the `{accountName}.dfs.core.windows.net` Host header; maps to the Blob backend and supports Java DataLake SDK path flows |
 | Queue             | `http://localhost:4577/{accountName}-queue`           | |
 | Table             | `http://localhost:4577/{accountName}-table`           | |
 | Functions         | `http://localhost:4577/{accountName}-functions`       | |

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/DataLakeCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/DataLakeCompatibilityTest.java
@@ -1,17 +1,27 @@
 package io.floci.az.compat;
 
+import com.azure.core.credential.AccessToken;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.util.Context;
 import com.azure.storage.common.StorageSharedKeyCredential;
 import com.azure.storage.file.datalake.DataLakeFileClient;
 import com.azure.storage.file.datalake.DataLakeFileSystemClient;
 import com.azure.storage.file.datalake.DataLakeServiceClient;
 import com.azure.storage.file.datalake.DataLakeServiceClientBuilder;
+import com.azure.storage.file.datalake.models.UserDelegationKey;
+import com.azure.storage.file.datalake.sas.DataLakeServiceSasSignatureValues;
+import com.azure.storage.file.datalake.sas.FileSystemSasPermission;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
+import reactor.core.publisher.Mono;
 
+import java.time.OffsetDateTime;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -26,10 +36,7 @@ class DataLakeCompatibilityTest {
         client = new DataLakeServiceClientBuilder()
                 .endpoint(EmulatorConfig.httpBase())
                 .credential(new StorageSharedKeyCredential(EmulatorConfig.ACCOUNT, EmulatorConfig.DEV_KEY))
-                .addPolicy((context, next) -> {
-                    context.getHttpRequest().setHeader("Host", EmulatorConfig.ACCOUNT + ".dfs.core.windows.net");
-                    return next.process();
-                })
+                .addPolicy(dfsHostPolicy())
                 .buildClient();
     }
 
@@ -44,5 +51,52 @@ class DataLakeCompatibilityTest {
         assertTrue(file.exists());
 
         client.deleteFileSystem(name);
+    }
+
+    @Test
+    @DisplayName("user delegation key: SDK-generated SAS can create path through dfs endpoint")
+    void userDelegationKeyCanGenerateUsableDfsSas() throws Exception {
+        OffsetDateTime start = OffsetDateTime.now().minusMinutes(5);
+        OffsetDateTime expiry = OffsetDateTime.now().plusHours(1);
+        EmulatorConfig.installEmulatorTlsCert();
+        DataLakeServiceClient bearerClient = new DataLakeServiceClientBuilder()
+                .endpoint(EmulatorConfig.httpBase().replaceFirst("^http://", "https://"))
+                .credential(request -> Mono.just(new AccessToken("fake-token", expiry)))
+                .addPolicy(dfsHostPolicy())
+                .buildClient();
+
+        UserDelegationKey key = bearerClient.getUserDelegationKey(start, expiry);
+        assertEquals("b", key.getSignedService());
+        assertNotNull(key.getValue());
+
+        String name = "test-" + UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+        DataLakeFileSystemClient fileSystem = bearerClient.createFileSystem(name);
+        FileSystemSasPermission permissions = new FileSystemSasPermission()
+                .setCreatePermission(true)
+                .setReadPermission(true)
+                .setWritePermission(true);
+        DataLakeServiceSasSignatureValues values = new DataLakeServiceSasSignatureValues(expiry, permissions)
+                .setStartTime(start);
+        String sas = fileSystem.generateUserDelegationSas(values, key, EmulatorConfig.ACCOUNT, Context.NONE);
+        assertTrue(sas.contains("sig="));
+
+        DataLakeServiceClient sasClient = new DataLakeServiceClientBuilder()
+                .endpoint(EmulatorConfig.httpBase())
+                .sasToken(sas)
+                .addPolicy(dfsHostPolicy())
+                .buildClient();
+        DataLakeFileSystemClient sasFileSystem = sasClient.getFileSystemClient(name);
+        DataLakeFileClient file = sasFileSystem.createFile("dir/sas-file.txt");
+
+        assertTrue(file.exists());
+
+        bearerClient.deleteFileSystem(name);
+    }
+
+    private static HttpPipelinePolicy dfsHostPolicy() {
+        return (context, next) -> {
+            context.getHttpRequest().setHeader("Host", EmulatorConfig.ACCOUNT + ".dfs.core.windows.net");
+            return next.process();
+        };
     }
 }

--- a/docs/services/blob.md
+++ b/docs/services/blob.md
@@ -1,8 +1,9 @@
 # Blob Storage
 
-Compatible with the `azure-storage-blob` SDKs (Java, Python, Node.js), the Azure CLI
-(`az storage blob`), and Azurite-style connection strings. Speaks the Azure Storage Blob REST
-protocol with Shared Key authentication and XML responses.
+Compatible with the `azure-storage-blob` SDKs (Java, Python, Node.js), focused Java
+`azure-storage-file-datalake` SDK flows, the Azure CLI (`az storage blob`), and Azurite-style
+connection strings. Speaks the Azure Storage Blob REST protocol with Shared Key authentication,
+Blob XML responses, and the Data Lake Storage Gen2 DFS host alias.
 
 > **HTTP-only — no Docker.** Data is held by the configured [storage backend](../configuration/storage.md)
 > (`memory` by default; `persistent`, `hybrid`, or `wal` for durability).
@@ -16,6 +17,11 @@ protocol with Shared Key authentication and XML responses.
 - **Blobs** — Put (upload), Get (download), Delete, List within a container; overwrite semantics
 - **Block blobs** — staged block upload (`?comp=block`) followed by commit (`?comp=blocklist`) for
   large payloads, in addition to single-request `Put Blob`
+- **Data Lake Storage Gen2 endpoint alias** — the `{account}.dfs.core.windows.net` host maps to the
+  Blob backend so ADLS SDK path clients can create, read, write, and delete paths through the same
+  local data store
+- **User delegation key vending** — `POST ?restype=service&comp=userdelegationkey` returns
+  deterministic Azure-shaped XML for SDK-generated user delegation SAS flows
 - **Range download** — `Range: bytes=…` returns `206 Partial Content`
 - **Conditional download** — `If-Match` / `If-None-Match` honored; a stale ETag is rejected
 - **Metadata** — `x-ms-meta-*` set on upload and returned on Get, round-tripped exactly
@@ -32,6 +38,9 @@ http://localhost:4577/{account}/{container}/{blob}           # blob operations
 The account also answers at the host-style address `{account}.blob.core.windows.net` (and the Data
 Lake Gen2 alias `{account}.dfs.core.windows.net`, which maps to the same blob backend) when the
 `Host` header is set, matching how the SDKs address storage endpoints.
+
+ARM storage account responses include both `blob` and `dfs` primary endpoints so Data Lake SDK
+clients can discover the Gen2 endpoint shape.
 
 ## Quickstart
 

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -5,7 +5,7 @@ Floci-AZ provides emulation for several core Azure services.
 | Service | Endpoint | Implementation Status |
 |---|---|---|
 | **Azure Resource Manager** | `/subscriptions/...` + `/providers/...` | ✅ Subscriptions, resource groups, resource/provider listing; management-plane fallthrough for the `Microsoft.*` providers |
-| **Blob Storage** | `/{account}/` | ✅ Full CRUD |
+| **Blob Storage** | `/{account}/` | ✅ Full CRUD; ADLS Gen2 DFS host alias and user delegation key vending |
 | **Queue Storage** | `/{account}-queue/` | ✅ Full CRUD |
 | **Table Storage** | `/{account}-table/` | ✅ Full CRUD |
 | **Azure Functions** | `/{account}-functions/` | ✅ HTTP Triggers, Docker runtimes |

--- a/src/main/java/io/floci/az/services/arm/ArmHandler.java
+++ b/src/main/java/io/floci/az/services/arm/ArmHandler.java
@@ -508,6 +508,7 @@ public class ArmHandler implements AzureServiceHandler {
                 "provisioningState", "Succeeded",
                 "primaryEndpoints", Map.of(
                         "blob",  "http://" + account + ".blob.core.windows.net" + portStr + "/",
+                        "dfs",   "http://" + account + ".dfs.core.windows.net" + portStr + "/",
                         "queue", "http://" + account + ".queue.core.windows.net" + portStr + "/",
                         "table", "http://" + account + ".table.core.windows.net" + portStr + "/"),
                 "primaryLocation", location,

--- a/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
+++ b/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
@@ -2,6 +2,7 @@ package io.floci.az.services.blob;
 
 import io.floci.az.core.AzureErrorResponse;
 import io.floci.az.config.EmulatorConfig;
+import io.floci.az.core.AuthType;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
 import io.floci.az.core.ServiceRoutes;
@@ -53,10 +54,13 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
 
     private final EmulatorConfig config;
 
+    private final UserDelegationKeyService userDelegationKeyService;
 
     @Inject
-    public BlobServiceHandler(StorageFactory storageFactory, EmulatorConfig config) {
+    public BlobServiceHandler(StorageFactory storageFactory, EmulatorConfig config,
+                              UserDelegationKeyService userDelegationKeyService) {
         this.config = config;
+        this.userDelegationKeyService = userDelegationKeyService;
         this.store = storageFactory.create("blob");
     }
 
@@ -103,6 +107,9 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
         } else if (path.isEmpty() || path.equals("/")) {
             if ("GET".equalsIgnoreCase(method) && "list".equals(query.get("comp"))) {
                 response = listContainers(request);
+            } else if ("POST".equalsIgnoreCase(method) && "service".equals(query.get("restype"))
+                    && "userdelegationkey".equals(query.get("comp"))) {
+                response = getUserDelegationKey(request);
             } else if ("service".equals(query.get("restype")) && "properties".equals(query.get("comp"))) {
                 if ("GET".equalsIgnoreCase(method) || "HEAD".equalsIgnoreCase(method)) {
                     response = getBlobServiceProperties();
@@ -163,6 +170,16 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
                 .header("x-ms-version", request.headers().getHeaderString("x-ms-version"))
                 .header("Date", RFC1123_DATE_TIME.format(Instant.now()))
                 .build();
+    }
+
+    private Response getUserDelegationKey(AzureRequest request) {
+        if (request.authContext() == null || request.authContext().type() != AuthType.BEARER) {
+            return new AzureErrorResponse("AuthenticationFailed",
+                    "Server failed to authenticate the request. Make sure the value of Authorization header "
+                            + "is formed correctly including the signature.")
+                    .toXmlResponse(Response.Status.FORBIDDEN.getStatusCode());
+        }
+        return userDelegationKeyService.create(request);
     }
 
     private Response getBlobServiceProperties() {

--- a/src/main/java/io/floci/az/services/blob/UserDelegationKeyService.java
+++ b/src/main/java/io/floci/az/services/blob/UserDelegationKeyService.java
@@ -1,0 +1,131 @@
+package io.floci.az.services.blob;
+
+import io.floci.az.core.AzureErrorResponse;
+import io.floci.az.core.AzureRequest;
+import io.floci.az.core.XmlBuilder;
+import io.floci.az.core.XmlParser;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
+
+@ApplicationScoped
+public class UserDelegationKeyService {
+
+    private static final Logger LOG = Logger.getLogger(UserDelegationKeyService.class);
+    private static final Duration MAX_KEY_DURATION = Duration.ofDays(7);
+    private static final String DEFAULT_SIGNED_VERSION = "2024-11-04";
+    private static final String SIGNED_OBJECT_ID = "00000000-0000-0000-0000-000000000000";
+    private static final String SIGNED_TENANT_ID = "00000000-0000-0000-0000-000000000000";
+    private static final String SIGNING_KEY_PREFIX = "floci-az-user-delegation:";
+
+    public Response create(AzureRequest request) {
+        String body;
+        try {
+            body = new String(request.bodyStream().readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            LOG.errorf(e, "Failed reading user delegation key request body for account=%s", request.accountName());
+            return Response.serverError().build();
+        }
+
+        String startText = trimToNull(XmlParser.extractFirst(body, "Start", null));
+        String expiryText = trimToNull(XmlParser.extractFirst(body, "Expiry", null));
+        if (expiryText == null) {
+            return invalidXml("The XML specified is not syntactically valid.");
+        }
+
+        OffsetDateTime start = OffsetDateTime.now(ZoneOffset.UTC);
+        if (startText != null) {
+            start = parseTimestamp(startText);
+            if (start == null) {
+                return invalidXml("The XML specified is not syntactically valid.");
+            }
+        }
+
+        OffsetDateTime expiry = parseTimestamp(expiryText);
+        if (expiry == null) {
+            return invalidXml("The XML specified is not syntactically valid.");
+        }
+        if (!expiry.toInstant().isAfter(start.toInstant())) {
+            return outOfRange("The value for one of the XML nodes is not in the correct range.");
+        }
+        if (Duration.between(start.toInstant(), expiry.toInstant()).compareTo(MAX_KEY_DURATION) > 0) {
+            return outOfRange("User delegation key expiry must be within seven days of the start time.");
+        }
+
+        String signedVersion = trimToNull(request.headers().getHeaderString("x-ms-version"));
+        if (signedVersion == null) {
+            signedVersion = DEFAULT_SIGNED_VERSION;
+        }
+
+        String xml = new XmlBuilder()
+                .start("UserDelegationKey")
+                .elem("SignedOid", SIGNED_OBJECT_ID)
+                .elem("SignedTid", SIGNED_TENANT_ID)
+                .elem("SignedStart", format(start))
+                .elem("SignedExpiry", format(expiry))
+                .elem("SignedService", "b")
+                .elem("SignedVersion", signedVersion)
+                .elem("Value", signingKeyForAccount(request.accountName()))
+                .end("UserDelegationKey")
+                .build();
+        return Response.ok(xml, "application/xml").build();
+    }
+
+    public static String signingKeyForAccount(String accountName) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest((SIGNING_KEY_PREFIX + accountName).getBytes(StandardCharsets.UTF_8));
+            return Base64.getEncoder().encodeToString(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 digest is unavailable", e);
+        }
+    }
+
+    private static OffsetDateTime parseTimestamp(String value) {
+        try {
+            return OffsetDateTime.parse(value);
+        } catch (DateTimeParseException e) {
+            try {
+                return Instant.parse(value).atOffset(ZoneOffset.UTC);
+            } catch (DateTimeParseException ignored) {
+                return null;
+            }
+        }
+    }
+
+    private static String format(OffsetDateTime value) {
+        return DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(
+                value.withOffsetSameInstant(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS));
+    }
+
+    private static String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private static Response invalidXml(String message) {
+        return new AzureErrorResponse("InvalidXmlDocument", message)
+                .toXmlResponse(Response.Status.BAD_REQUEST.getStatusCode());
+    }
+
+    private static Response outOfRange(String message) {
+        return new AzureErrorResponse("OutOfRangeInput", message)
+                .toXmlResponse(Response.Status.BAD_REQUEST.getStatusCode());
+    }
+}

--- a/src/test/java/io/floci/az/services/BlobServiceTest.java
+++ b/src/test/java/io/floci/az/services/BlobServiceTest.java
@@ -1,9 +1,12 @@
 package io.floci.az.services;
 
+import io.floci.az.core.XmlParser;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -18,6 +21,7 @@ public class BlobServiceTest {
     private static final String CONTAINER = "test-container";
     private static final String BLOB = "test-blob.txt";
     private static final String BLOB_CONTENT = "Hello, Blob!";
+    private static final Pattern ISO_UTC_SECONDS = Pattern.compile("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z");
 
     @BeforeEach
     void reset() {
@@ -81,6 +85,135 @@ public class BlobServiceTest {
             .then()
             .statusCode(200)
             .body(equalTo(""));
+    }
+
+    @Test
+    void getUserDelegationKeyReturnsAzureXmlForBearerAuth() {
+        String xml = """
+                <KeyInfo>
+                  <Start>2026-07-15T10:00:00Z</Start>
+                  <Expiry>2026-07-15T11:00:00Z</Expiry>
+                </KeyInfo>
+                """;
+
+        String response = given()
+            .header("Authorization", "Bearer fake-token")
+            .header("x-ms-version", "2024-11-04")
+            .contentType("application/xml")
+            .body(xml)
+            .when().post("/{account}?restype=service&comp=userdelegationkey", ACCOUNT)
+            .then()
+            .statusCode(200)
+            .contentType(containsString("xml"))
+            .extract().asString();
+
+        assertThat(XmlParser.extractFirst(response, "SignedOid", null),
+                equalTo("00000000-0000-0000-0000-000000000000"));
+        assertThat(XmlParser.extractFirst(response, "SignedTid", null),
+                equalTo("00000000-0000-0000-0000-000000000000"));
+        assertThat(XmlParser.extractFirst(response, "SignedStart", null), equalTo("2026-07-15T10:00:00Z"));
+        assertThat(XmlParser.extractFirst(response, "SignedExpiry", null), equalTo("2026-07-15T11:00:00Z"));
+        assertThat(XmlParser.extractFirst(response, "SignedService", null), equalTo("b"));
+        assertThat(XmlParser.extractFirst(response, "SignedVersion", null), equalTo("2024-11-04"));
+        assertThat(XmlParser.extractFirst(response, "Value", null), not(isEmptyOrNullString()));
+    }
+
+    @Test
+    void getUserDelegationKeyDefaultsMissingStart() {
+        String expiry = OffsetDateTime.now(ZoneOffset.UTC).plusHours(1).withNano(0).toString();
+        String xml = """
+                <KeyInfo>
+                  <Expiry>%s</Expiry>
+                </KeyInfo>
+                """.formatted(expiry);
+
+        String response = given()
+            .header("Authorization", "Bearer fake-token")
+            .contentType("application/xml")
+            .body(xml)
+            .when().post("/{account}?restype=service&comp=userdelegationkey", ACCOUNT)
+            .then()
+            .statusCode(200)
+            .extract().asString();
+
+        assertThat(XmlParser.extractFirst(response, "SignedStart", null),
+                matchesPattern(ISO_UTC_SECONDS));
+        assertThat(XmlParser.extractFirst(response, "SignedExpiry", null), equalTo(expiry));
+    }
+
+    @Test
+    void getUserDelegationKeyRejectsMissingExpiry() {
+        given()
+            .header("Authorization", "Bearer fake-token")
+            .contentType("application/xml")
+            .body("<KeyInfo><Start>2026-07-15T10:00:00Z</Start></KeyInfo>")
+            .when().post("/{account}?restype=service&comp=userdelegationkey", ACCOUNT)
+            .then()
+            .statusCode(400)
+            .header("x-ms-error-code", "InvalidXmlDocument");
+    }
+
+    @Test
+    void getUserDelegationKeyRejectsMalformedTimestamp() {
+        given()
+            .header("Authorization", "Bearer fake-token")
+            .contentType("application/xml")
+            .body("<KeyInfo><Start>not-a-date</Start><Expiry>2026-07-15T11:00:00Z</Expiry></KeyInfo>")
+            .when().post("/{account}?restype=service&comp=userdelegationkey", ACCOUNT)
+            .then()
+            .statusCode(400)
+            .header("x-ms-error-code", "InvalidXmlDocument");
+    }
+
+    @Test
+    void getUserDelegationKeyRejectsExpiryBeforeStart() {
+        given()
+            .header("Authorization", "Bearer fake-token")
+            .contentType("application/xml")
+            .body("<KeyInfo><Start>2026-07-15T11:00:00Z</Start><Expiry>2026-07-15T10:00:00Z</Expiry></KeyInfo>")
+            .when().post("/{account}?restype=service&comp=userdelegationkey", ACCOUNT)
+            .then()
+            .statusCode(400)
+            .header("x-ms-error-code", "OutOfRangeInput");
+    }
+
+    @Test
+    void getUserDelegationKeyRejectsDurationsOverSevenDays() {
+        given()
+            .header("Authorization", "Bearer fake-token")
+            .contentType("application/xml")
+            .body("<KeyInfo><Start>2026-07-15T10:00:00Z</Start><Expiry>2026-07-23T10:00:00Z</Expiry></KeyInfo>")
+            .when().post("/{account}?restype=service&comp=userdelegationkey", ACCOUNT)
+            .then()
+            .statusCode(400)
+            .header("x-ms-error-code", "OutOfRangeInput");
+    }
+
+    @Test
+    void getUserDelegationKeyRequiresBearerAuth() {
+        String xml = """
+                <KeyInfo>
+                  <Start>2026-07-15T10:00:00Z</Start>
+                  <Expiry>2026-07-15T11:00:00Z</Expiry>
+                </KeyInfo>
+                """;
+
+        given()
+            .contentType("application/xml")
+            .body(xml)
+            .when().post("/{account}?restype=service&comp=userdelegationkey", ACCOUNT)
+            .then()
+            .statusCode(403)
+            .header("x-ms-error-code", "AuthenticationFailed");
+
+        given()
+            .header("Authorization", "SharedKey " + ACCOUNT + ":ignored")
+            .contentType("application/xml")
+            .body(xml)
+            .when().post("/{account}?restype=service&comp=userdelegationkey", ACCOUNT)
+            .then()
+            .statusCode(403)
+            .header("x-ms-error-code", "AuthenticationFailed");
     }
 
     @Test

--- a/src/test/java/io/floci/az/services/arm/ArmStorageAccountTest.java
+++ b/src/test/java/io/floci/az/services/arm/ArmStorageAccountTest.java
@@ -1,0 +1,28 @@
+package io.floci.az.services.arm;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+@QuarkusTest
+@DisplayName("ARM storage accounts")
+class ArmStorageAccountTest {
+
+    @Test
+    void storageAccountPrimaryEndpointsIncludeDfs() {
+        given()
+            .contentType("application/json")
+            .body("{\"location\":\"eastus\"}")
+            .when().put("/subscriptions/sub-cred-vending/resourceGroups/rg-cred-vending"
+                    + "/providers/Microsoft.Storage/storageAccounts/credvendingacct?api-version=2023-01-01")
+            .then()
+            .statusCode(200)
+            .body("properties.primaryEndpoints.blob",
+                    equalTo("http://credvendingacct.blob.core.windows.net/"))
+            .body("properties.primaryEndpoints.dfs",
+                    equalTo("http://credvendingacct.dfs.core.windows.net/"));
+    }
+}


### PR DESCRIPTION
Summary:
- Add Blob service getUserDelegationKey handling for bearer-authenticated ADLS clients.
- Return deterministic user delegation key XML and expose reusable per-account signing key material for scoped SAS validation.
- Add `dfs` to ARM storage account `primaryEndpoints`.
- Add Blob, ARM, and Java DataLake SDK compatibility coverage for SDK-generated SAS smoke.
- Bearer tokens are accepted according to the emulator's existing dev-mode auth behavior;
  account-bound bearer validation is out of scope for this PR and should be handled as a
  broader auth-hardening follow-up.

Type of change:
- [x] New feature

Azure Compatibility:
- Targeted Java Azure SDK DataLake compatibility suite using azure-storage-file-datalake from BOM 1.2.28.
- Verified SDK compatibility test source compiles against the target BOM with a repo-local Maven cache.

Checklist:
- [x] `./mvnw test` passes locally
- [x] New or updated integration test added.
- [x] Commit messages follow Conventional Commits.

Notes:
- Scoped SAS signature/resource/permission enforcement is intentionally left for PR2.
