### PR TITLE
feat(cosmos): custom indexing policies with composite-index ORDER BY enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **cosmos:** custom container indexing policies with Azure-parity composite-index enforcement. A client-supplied `indexingPolicy` (included/excluded paths, composite indexes) on container create is normalized the way Azure does (defaults filled, composite path `order` defaulting to `ascending`), persisted, and returned on container read; container **replace** (`PUT /dbs/{db}/colls/{coll}`) is now supported for updating the policy, with `id` and `partitionKey` immutable as in Azure. Queries with an `ORDER BY` over two or more properties (or mixed sort directions) now fail with `400 BadRequest` ("The order by query does not have a corresponding composite index that it can be served from", code `SC2104`) unless the container has a composite index matching the clause exactly — same paths, same sequence, same length, directions matching exactly or all-inverted — so queries that would be rejected in production fail locally too ([#127](https://github.com/floci-io/floci-az/issues/127))
+
 ## [0.9.0] - 2026-07-09
 
 ### Added

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/CosmosCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/CosmosCompatibilityTest.java
@@ -388,6 +388,25 @@ class CosmosCompatibilityTest {
     }
 
     @Test
+    @DisplayName("container create with single-path composite index → CosmosException (400)")
+    void singlePathCompositeIndexRejected() {
+        String id = dbId();
+        client.createDatabase(id);
+        CosmosDatabase db = client.getDatabase(id);
+
+        CosmosContainerProperties props = new CosmosContainerProperties("bad", "/conversationId");
+        IndexingPolicy policy = new IndexingPolicy();
+        policy.setCompositeIndexes(List.of(List.of(
+            new CompositePath().setPath("/a").setOrder(CompositePathSortOrder.ASCENDING))));
+        props.setIndexingPolicy(policy);
+
+        CosmosException ex = assertThrows(CosmosException.class, () -> db.createContainer(props));
+        assertEquals(400, ex.getStatusCode());
+
+        db.delete();
+    }
+
+    @Test
     @DisplayName("multi-property ORDER BY with matching composite index succeeds")
     void multiPropertyOrderByWithCompositeIndexSucceeds() {
         String id = dbId();

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/CosmosCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/CosmosCompatibilityTest.java
@@ -291,4 +291,121 @@ class CosmosCompatibilityTest {
             () -> client.getDatabase("no-such-db-xyz").read());
         assertEquals(404, ex.getStatusCode());
     }
+
+    // --- Indexing policy & composite indexes (#127) ---
+    //
+    // These queries run against the in-memory handler (unlike the general SQL
+    // coverage in CosmosNoSqlEngineCompatibilityTest) because the composite-index
+    // ORDER BY validation is implemented handler-side.
+
+    private CosmosContainerProperties chatContainerProperties(boolean withCompositeIndex) {
+        CosmosContainerProperties props = new CosmosContainerProperties("chat", "/conversationId");
+        if (withCompositeIndex) {
+            props.setIndexingPolicy(compositeIndexPolicy());
+        }
+        return props;
+    }
+
+    private IndexingPolicy compositeIndexPolicy() {
+        IndexingPolicy policy = new IndexingPolicy();
+        policy.setIncludedPaths(List.of(new IncludedPath("/*")));
+        policy.setExcludedPaths(List.of(new ExcludedPath("/\"_etag\"/?")));
+        CompositePath conversationId = new CompositePath()
+            .setPath("/conversationId").setOrder(CompositePathSortOrder.ASCENDING);
+        CompositePath sequence = new CompositePath()
+            .setPath("/sequence").setOrder(CompositePathSortOrder.ASCENDING);
+        policy.setCompositeIndexes(List.of(List.of(conversationId, sequence)));
+        return policy;
+    }
+
+    private void insertMessage(CosmosContainer container, String id, String conversationId, int sequence) {
+        container.createItem(
+            doc(id, "chat", "conversationId", conversationId, "sequence", sequence),
+            new PartitionKey(conversationId), null);
+    }
+
+    @Test
+    @DisplayName("container create: custom indexing policy with composite indexes round-trips")
+    void containerIndexingPolicyRoundTrip() {
+        String id = dbId();
+        client.createDatabase(id);
+        CosmosDatabase db = client.getDatabase(id);
+
+        db.createContainer(chatContainerProperties(true));
+
+        CosmosContainerProperties read = db.getContainer("chat").read().getProperties();
+        List<List<CompositePath>> composites = read.getIndexingPolicy().getCompositeIndexes();
+        assertEquals(1, composites.size());
+        assertEquals("/conversationId", composites.get(0).get(0).getPath());
+        assertEquals("/sequence", composites.get(0).get(1).getPath());
+        assertEquals(CompositePathSortOrder.ASCENDING, composites.get(0).get(0).getOrder());
+
+        db.delete();
+    }
+
+    @Test
+    @DisplayName("container replace: adding a composite index persists")
+    void replaceContainerIndexingPolicy() {
+        String id = dbId();
+        client.createDatabase(id);
+        CosmosDatabase db = client.getDatabase(id);
+        db.createContainer(chatContainerProperties(false));
+        CosmosContainer container = db.getContainer("chat");
+
+        CosmosContainerProperties props = container.read().getProperties();
+        props.setIndexingPolicy(compositeIndexPolicy());
+        container.replace(props);
+
+        List<List<CompositePath>> composites =
+            container.read().getProperties().getIndexingPolicy().getCompositeIndexes();
+        assertEquals(1, composites.size());
+        assertEquals("/conversationId", composites.get(0).get(0).getPath());
+
+        db.delete();
+    }
+
+    @Test
+    @DisplayName("multi-property ORDER BY without composite index → CosmosException (400)")
+    void multiPropertyOrderByWithoutCompositeIndexFails() {
+        String id = dbId();
+        client.createDatabase(id);
+        CosmosDatabase db = client.getDatabase(id);
+        db.createContainer(chatContainerProperties(false));
+        CosmosContainer container = db.getContainer("chat");
+        insertMessage(container, "m1", "conv1", 2);
+        insertMessage(container, "m2", "conv1", 1);
+
+        CosmosException ex = assertThrows(CosmosException.class, () ->
+            container.queryItems(
+                "SELECT * FROM c ORDER BY c.conversationId, c.sequence",
+                new CosmosQueryRequestOptions(), Map.class)
+                .stream().toList());
+        assertEquals(400, ex.getStatusCode());
+        assertTrue(ex.getMessage().contains("composite index"),
+            "expected composite-index error, got: " + ex.getMessage());
+
+        db.delete();
+    }
+
+    @Test
+    @DisplayName("multi-property ORDER BY with matching composite index succeeds")
+    void multiPropertyOrderByWithCompositeIndexSucceeds() {
+        String id = dbId();
+        client.createDatabase(id);
+        CosmosDatabase db = client.getDatabase(id);
+        db.createContainer(chatContainerProperties(true));
+        CosmosContainer container = db.getContainer("chat");
+        insertMessage(container, "m1", "conv1", 2);
+        insertMessage(container, "m2", "conv1", 1);
+        insertMessage(container, "m3", "conv0", 5);
+
+        List<String> ids = container.queryItems(
+                "SELECT * FROM c ORDER BY c.conversationId, c.sequence",
+                new CosmosQueryRequestOptions(), Map.class)
+            .stream().map(m -> String.valueOf(m.get("id"))).toList();
+
+        assertEquals(List.of("m3", "m2", "m1"), ids);
+
+        db.delete();
+    }
 }

--- a/docs/services/cosmos.md
+++ b/docs/services/cosmos.md
@@ -5,13 +5,13 @@ Compatible with the `azure-cosmos` SDK (Java, Python, JavaScript, .NET).
 ## Features
 
 - **Databases** — create, get, list, delete (cascade-deletes all containers and documents)
-- **Containers** — create, get, list, delete; configurable partition key path; default indexing policy
+- **Containers** — create, replace, get, list, delete; configurable partition key path; custom indexing policies with composite indexes (persisted on create/replace and returned on read)
 - **Documents** — create, get, replace, delete, list; upsert via `x-ms-documentdb-is-upsert` header
 - **Queries** — in-process SQL engine with full Cosmos DB SQL dialect support:
   - `SELECT *`, `SELECT c.field1, c.field2`, `SELECT VALUE c.field`, `SELECT TOP n`
   - `WHERE` with `=`, `!=`, `<>`, `>`, `>=`, `<`, `<=`, `IN`, `BETWEEN`, `NOT`, `AND`, `OR`
   - `WHERE` functions: `IS_DEFINED`, `IS_NULL`, `IS_STRING`, `IS_NUMBER`, `IS_BOOL`, `IS_ARRAY`, `IS_OBJECT`, `CONTAINS`, `STARTSWITH`, `ENDSWITH`, `ARRAY_CONTAINS`
-  - `ORDER BY field [ASC|DESC]`, multiple fields
+  - `ORDER BY field [ASC|DESC]`, multiple fields — like Azure, an `ORDER BY` over two or more properties requires a matching composite index on the container, otherwise the query fails with `400 BadRequest` (error `SC2104`)
   - `OFFSET n LIMIT m` pagination
   - `SELECT VALUE COUNT(1)` aggregation
   - Named parameters (`@param`)
@@ -92,7 +92,39 @@ Default endpoint: `http://localhost:4577/devstoreaccount1-cosmos`
 | `POST` | `/dbs/{dbId}/colls` | Create a container |
 | `GET` | `/dbs/{dbId}/colls` | List containers |
 | `GET` | `/dbs/{dbId}/colls/{collId}` | Get a container |
+| `PUT` | `/dbs/{dbId}/colls/{collId}` | Replace a container (e.g. update the indexing policy) |
 | `DELETE` | `/dbs/{dbId}/colls/{collId}` | Delete a container (cascades to documents) |
+
+#### Indexing policies
+
+A custom `indexingPolicy` (included/excluded paths, composite indexes) supplied on container
+create or replace is normalized the way Azure does — missing fields are filled with defaults
+and composite-index path `order` defaults to `ascending` — then persisted and returned on
+container read. The `id` and `partitionKey` of a container are immutable on replace, matching Azure.
+
+Composite indexes are enforced for queries: an `ORDER BY` over two or more properties is only
+served when the container has a composite index whose paths match the `ORDER BY` clause exactly
+(same properties, same sequence, same length) with sort directions matching either exactly or
+exactly inverted on all paths. Queries without such an index fail with `400 BadRequest`
+("The order by query does not have a corresponding composite index that it can be served from"),
+so code that would break in production fails locally too.
+
+```json
+{
+  "id": "messages",
+  "partitionKey": { "paths": ["/conversationId"], "kind": "Hash" },
+  "indexingPolicy": {
+    "indexingMode": "consistent",
+    "automatic": true,
+    "includedPaths": [{ "path": "/*" }],
+    "excludedPaths": [{ "path": "/\"_etag\"/?" }],
+    "compositeIndexes": [[
+      { "path": "/conversationId", "order": "ascending" },
+      { "path": "/sequence", "order": "ascending" }
+    ]]
+  }
+}
+```
 
 ### Documents
 

--- a/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
@@ -120,6 +120,7 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         String collId = segs[3];
         if (segs.length == 4) return switch (m) {
             case "GET"    -> getContainer(req, dbId, collId);
+            case "PUT"    -> replaceContainer(req, dbId, collId);
             case "DELETE" -> deleteContainer(req, dbId, collId);
             default       -> notImplemented();
         };
@@ -299,6 +300,13 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         String key = collKey(req.accountName(), dbId, id);
         if (store.get(key).isPresent()) return errorResponse(409, "Conflict", "Container '" + id + "' already exists.");
 
+        Map<String, Object> indexingPolicy;
+        try {
+            indexingPolicy = CosmosIndexingPolicy.normalize(body.get("indexingPolicy"));
+        } catch (IllegalArgumentException e) {
+            return errorResponse(400, "BadRequest", e.getMessage());
+        }
+
         Instant now  = Instant.now();
         String  rid  = newRid(8);
         String  etag = newEtag();
@@ -316,7 +324,7 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         coll.put("_etag",          quoted(etag));
         coll.put("_ts",            now.getEpochSecond());
         coll.put("partitionKey",   pk);
-        coll.put("indexingPolicy", defaultIndexingPolicy());
+        coll.put("indexingPolicy", indexingPolicy);
         coll.put("_docs",          "docs/");
         coll.put("_sprocs",        "sprocs/");
         coll.put("_triggers",      "triggers/");
@@ -332,6 +340,52 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         Optional<StoredObject> found = store.get(collKey(req.accountName(), dbId, collId));
         if (found.isEmpty()) return notFound(collId);
         return cosmosResponse(parseData(found.get()), Response.Status.OK, found.get().etag());
+    }
+
+    /**
+     * PUT /dbs/{db}/colls/{coll} — replace container properties.
+     *
+     * <p>Azure only allows mutable settings such as the indexing policy to
+     * change on replace; the id and partition key are immutable.  SDKs use
+     * this to update the indexing policy of an existing container (e.g. to
+     * add composite indexes).</p>
+     */
+    private Response replaceContainer(AzureRequest req, String dbId, String collId) {
+        String key = collKey(req.accountName(), dbId, collId);
+        Optional<StoredObject> found = store.get(key);
+        if (found.isEmpty()) return notFound(collId);
+
+        Map<String, Object> body = parseBody(req);
+        Object bodyId = body.get("id");
+        if (bodyId != null && !collId.equals(String.valueOf(bodyId))) {
+            return errorResponse(400, "BadRequest",
+                    "The 'id' in the request body does not match the container being replaced.");
+        }
+
+        Map<String, Object> coll = parseData(found.get());
+        if (body.get("partitionKey") instanceof Map<?, ?> newPk
+                && coll.get("partitionKey") instanceof Map<?, ?> oldPk
+                && newPk.get("paths") != null
+                && !Objects.equals(newPk.get("paths"), oldPk.get("paths"))) {
+            return errorResponse(400, "BadRequest",
+                    "Changing the partition key of a container is not allowed.");
+        }
+
+        Map<String, Object> indexingPolicy;
+        try {
+            indexingPolicy = CosmosIndexingPolicy.normalize(body.get("indexingPolicy"));
+        } catch (IllegalArgumentException e) {
+            return errorResponse(400, "BadRequest", e.getMessage());
+        }
+
+        Instant now  = Instant.now();
+        String  etag = newEtag();
+        coll.put("indexingPolicy", indexingPolicy);
+        coll.put("_etag", quoted(etag));
+        coll.put("_ts",   now.getEpochSecond());
+
+        store.put(key, stored(key, coll, now, etag));
+        return cosmosResponse(coll, Response.Status.OK, etag, "dbs/" + dbId);
     }
 
     /**
@@ -847,10 +901,23 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
     // -----------------------------------------------------------------------
 
     private Response queryDocuments(AzureRequest req, String dbId, String collId) {
-        if (store.get(collKey(req.accountName(), dbId, collId)).isEmpty()) return notFound(collId);
+        Optional<StoredObject> collFound = store.get(collKey(req.accountName(), dbId, collId));
+        if (collFound.isEmpty()) return notFound(collId);
 
         Map<String, Object> body = parseBody(req);
         String sql = (String) body.getOrDefault("query", "SELECT * FROM c");
+
+        // Azure parity: an ORDER BY over two or more properties is only served
+        // when the container has a matching composite index; otherwise the
+        // service rejects the query with 400 (error code SC2104).
+        List<CosmosQueryEngine.OrderByField> orderBy = queryEngine.parseOrderBy(sql);
+        if (orderBy.size() > 1 && !CosmosIndexingPolicy.supportsOrderBy(
+                parseData(collFound.get()).get("indexingPolicy"), orderBy)) {
+            return errorResponse(400, "BadRequest",
+                    "Message: {\"errors\":[{\"severity\":\"Error\",\"code\":\"SC2104\",\"message\":"
+                    + "\"The order by query does not have a corresponding composite index "
+                    + "that it can be served from.\"}]}");
+        }
 
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> params = body.get("parameters") instanceof List<?> l
@@ -1156,15 +1223,6 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
     private byte[] toBytes(Object obj) {
         try { return MAPPER.writeValueAsBytes(obj); }
         catch (JsonProcessingException e) { return new byte[0]; }
-    }
-
-    private Map<String, Object> defaultIndexingPolicy() {
-        Map<String, Object> p = new LinkedHashMap<>();
-        p.put("automatic",    true);
-        p.put("indexingMode", "consistent");
-        p.put("includedPaths", List.of(Map.of("path", "/*")));
-        p.put("excludedPaths", List.of(Map.of("path", "/\"_etag\"/?")));
-        return p;
     }
 
     /**

--- a/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
@@ -907,27 +907,28 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         Map<String, Object> body = parseBody(req);
         String sql = (String) body.getOrDefault("query", "SELECT * FROM c");
 
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> params = body.get("parameters") instanceof List<?> l
+                ? (List<Map<String, Object>>) l : List.of();
+
+        CosmosQueryEngine.ParsedQuery parsed = queryEngine.prepare(sql, params);
+
         // Azure parity: an ORDER BY over two or more properties is only served
         // when the container has a matching composite index; otherwise the
         // service rejects the query with 400 (error code SC2104).
-        List<CosmosQueryEngine.OrderByField> orderBy = queryEngine.parseOrderBy(sql);
-        if (orderBy.size() > 1 && !CosmosIndexingPolicy.supportsOrderBy(
-                parseData(collFound.get()).get("indexingPolicy"), orderBy)) {
+        if (parsed.orderBy().size() > 1 && !CosmosIndexingPolicy.supportsOrderBy(
+                parseData(collFound.get()).get("indexingPolicy"), parsed.orderBy())) {
             return errorResponse(400, "BadRequest",
                     "Message: {\"errors\":[{\"severity\":\"Error\",\"code\":\"SC2104\",\"message\":"
                     + "\"The order by query does not have a corresponding composite index "
                     + "that it can be served from.\"}]}");
         }
 
-        @SuppressWarnings("unchecked")
-        List<Map<String, Object>> params = body.get("parameters") instanceof List<?> l
-                ? (List<Map<String, Object>>) l : List.of();
-
         String prefix = req.accountName() + K_DOC + dbId + "|" + collId + "|";
         List<Map<String, Object>> allDocs = store.scan(k -> k.startsWith(prefix))
                 .stream().map(this::parseData).collect(Collectors.toList());
 
-        CosmosQueryEngine.QueryResult result = queryEngine.execute(sql, params, allDocs);
+        CosmosQueryEngine.QueryResult result = queryEngine.execute(parsed, allDocs);
 
         // ---- Pagination ----
         int maxItemCount = parseMaxItemCount(req.headers().getHeaderString("x-ms-max-item-count"));

--- a/src/main/java/io/floci/az/services/cosmos/CosmosIndexingPolicy.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosIndexingPolicy.java
@@ -1,0 +1,157 @@
+package io.floci.az.services.cosmos;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Container indexing-policy handling for the Cosmos DB SQL API emulator.
+ *
+ * <p>Normalizes a client-supplied {@code indexingPolicy} the way Azure does on
+ * container create/replace (fills defaults, lowercases enum values, defaults
+ * composite-index path order to {@code ascending}) and implements the Azure
+ * rule that an {@code ORDER BY} over two or more properties can only be served
+ * by a composite index that matches the clause exactly:
+ * <ul>
+ *   <li>the composite index paths must match the ORDER BY properties in the
+ *       same sequence and with the same number of paths, and</li>
+ *   <li>the sort directions must match either exactly or exactly inverted
+ *       on all paths.</li>
+ * </ul>
+ *
+ * @see <a href="https://learn.microsoft.com/en-us/azure/cosmos-db/index-policy#composite-indexes">
+ *      Azure Cosmos DB composite indexes</a>
+ */
+final class CosmosIndexingPolicy {
+
+    private CosmosIndexingPolicy() {}
+
+    /** Azure's default indexing policy for new containers. */
+    static Map<String, Object> defaultPolicy() {
+        Map<String, Object> p = new LinkedHashMap<>();
+        p.put("automatic",     true);
+        p.put("indexingMode",  "consistent");
+        p.put("includedPaths", List.of(Map.of("path", "/*")));
+        p.put("excludedPaths", List.of(Map.of("path", "/\"_etag\"/?")));
+        return p;
+    }
+
+    /**
+     * Normalize a client-supplied indexing policy.  A missing or non-object
+     * policy yields the default policy.
+     *
+     * @throws IllegalArgumentException when the policy is invalid — callers
+     *   translate this into a 400 BadRequest
+     */
+    static Map<String, Object> normalize(Object raw) {
+        if (!(raw instanceof Map<?, ?> in)) return defaultPolicy();
+
+        Map<String, Object> p = new LinkedHashMap<>();
+        p.put("automatic", !(in.get("automatic") instanceof Boolean b) || b);
+
+        String mode = in.get("indexingMode") instanceof String s ? s.toLowerCase(Locale.ROOT) : "consistent";
+        if (!"consistent".equals(mode) && !"lazy".equals(mode) && !"none".equals(mode)) {
+            throw new IllegalArgumentException("The indexing mode '" + mode + "' is invalid. "
+                    + "Valid values are: 'consistent', 'lazy', 'none'.");
+        }
+        p.put("indexingMode", mode);
+
+        p.put("includedPaths", in.get("includedPaths") instanceof List<?> inc
+                ? List.copyOf(inc) : List.of(Map.of("path", "/*")));
+        p.put("excludedPaths", in.get("excludedPaths") instanceof List<?> exc
+                ? List.copyOf(exc) : List.of(Map.of("path", "/\"_etag\"/?")));
+
+        List<List<Map<String, Object>>> composites = normalizeComposites(in.get("compositeIndexes"));
+        if (!composites.isEmpty()) p.put("compositeIndexes", composites);
+        return p;
+    }
+
+    private static List<List<Map<String, Object>>> normalizeComposites(Object raw) {
+        if (!(raw instanceof List<?> outer)) return List.of();
+        List<List<Map<String, Object>>> result = new ArrayList<>();
+        for (Object idx : outer) {
+            if (!(idx instanceof List<?> paths)) {
+                throw new IllegalArgumentException("Each composite index must be an array of paths.");
+            }
+            if (paths.size() < 2) {
+                throw new IllegalArgumentException(
+                        "The indexing policy is invalid. A composite index must have at least 2 paths.");
+            }
+            List<Map<String, Object>> normPaths = new ArrayList<>();
+            for (Object entry : paths) {
+                if (!(entry instanceof Map<?, ?> pm)
+                        || !(pm.get("path") instanceof String path) || !path.startsWith("/")) {
+                    throw new IllegalArgumentException(
+                            "Each composite index path must be an object with a 'path' starting with '/'.");
+                }
+                String order = pm.get("order") instanceof String o ? o.toLowerCase(Locale.ROOT) : "ascending";
+                if (!"ascending".equals(order) && !"descending".equals(order)) {
+                    throw new IllegalArgumentException(
+                            "Composite index path order must be 'ascending' or 'descending'.");
+                }
+                Map<String, Object> norm = new LinkedHashMap<>();
+                norm.put("path",  path);
+                norm.put("order", order);
+                normPaths.add(norm);
+            }
+            result.add(normPaths);
+        }
+        return result;
+    }
+
+    /**
+     * Whether the container's indexing policy can serve the given ORDER BY
+     * clause.  Single-property ORDER BY is always served by the default range
+     * index; two or more properties require an exactly-matching composite
+     * index (same paths, same sequence, same length; directions matching
+     * exactly or all-inverted).
+     */
+    static boolean supportsOrderBy(Object policy, List<CosmosQueryEngine.OrderByField> orderBy) {
+        if (orderBy.size() < 2) return true;
+        if (!(policy instanceof Map<?, ?> pm)) return false;
+        if (!(pm.get("compositeIndexes") instanceof List<?> composites)) return false;
+
+        List<String>  wantPaths = orderBy.stream()
+                .map(f -> normalizeOrderByPath(f.path())).toList();
+        List<Boolean> wantAsc   = orderBy.stream()
+                .map(CosmosQueryEngine.OrderByField::asc).toList();
+
+        for (Object idx : composites) {
+            if (!(idx instanceof List<?> paths) || paths.size() != orderBy.size()) continue;
+            if (matches(paths, wantPaths, wantAsc, false)
+                    || matches(paths, wantPaths, wantAsc, true)) return true;
+        }
+        return false;
+    }
+
+    private static boolean matches(List<?> compositePaths, List<String> wantPaths,
+            List<Boolean> wantAsc, boolean inverted) {
+        for (int i = 0; i < compositePaths.size(); i++) {
+            if (!(compositePaths.get(i) instanceof Map<?, ?> pm)) return false;
+            if (!(pm.get("path") instanceof String rawPath)
+                    || !wantPaths.get(i).equals(normalizeCompositePath(rawPath))) return false;
+            boolean asc = !"descending".equalsIgnoreCase(String.valueOf(pm.get("order")));
+            if ((inverted ? !asc : asc) != wantAsc.get(i).booleanValue()) return false;
+        }
+        return true;
+    }
+
+    /** {@code "c.a.b"} → {@code "/a/b"} — strip the FROM alias, dots become slashes. */
+    static String normalizeOrderByPath(String expr) {
+        String path = expr.trim();
+        int dot = path.indexOf('.');
+        if (dot > 0 && path.substring(0, dot).matches("[a-zA-Z_][a-zA-Z0-9_]*")) {
+            path = path.substring(dot + 1);
+        }
+        return "/" + String.join("/", path.split("\\."));
+    }
+
+    /** {@code '/a/"b-c"/'} → {@code "/a/b-c"} — strip quote escapes and a trailing slash. */
+    static String normalizeCompositePath(String path) {
+        String p = path.trim().replace("\"", "");
+        if (p.endsWith("/")) p = p.substring(0, p.length() - 1);
+        return p;
+    }
+}

--- a/src/main/java/io/floci/az/services/cosmos/CosmosIndexingPolicy.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosIndexingPolicy.java
@@ -46,7 +46,10 @@ final class CosmosIndexingPolicy {
      *   translate this into a 400 BadRequest
      */
     static Map<String, Object> normalize(Object raw) {
-        if (!(raw instanceof Map<?, ?> in)) return defaultPolicy();
+        if (raw == null) return defaultPolicy();
+        if (!(raw instanceof Map<?, ?> in)) {
+            throw new IllegalArgumentException("The indexing policy must be a JSON object.");
+        }
 
         Map<String, Object> p = new LinkedHashMap<>();
         p.put("automatic", !(in.get("automatic") instanceof Boolean b) || b);

--- a/src/main/java/io/floci/az/services/cosmos/CosmosIndexingPolicy.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosIndexingPolicy.java
@@ -28,13 +28,18 @@ final class CosmosIndexingPolicy {
 
     private CosmosIndexingPolicy() {}
 
+    private static final List<Map<String, Object>> DEFAULT_INCLUDED_PATHS =
+            List.of(Map.of("path", "/*"));
+    private static final List<Map<String, Object>> DEFAULT_EXCLUDED_PATHS =
+            List.of(Map.of("path", "/\"_etag\"/?"));
+
     /** Azure's default indexing policy for new containers. */
     static Map<String, Object> defaultPolicy() {
         Map<String, Object> p = new LinkedHashMap<>();
         p.put("automatic",     true);
         p.put("indexingMode",  "consistent");
-        p.put("includedPaths", List.of(Map.of("path", "/*")));
-        p.put("excludedPaths", List.of(Map.of("path", "/\"_etag\"/?")));
+        p.put("includedPaths", DEFAULT_INCLUDED_PATHS);
+        p.put("excludedPaths", DEFAULT_EXCLUDED_PATHS);
         return p;
     }
 
@@ -62,9 +67,9 @@ final class CosmosIndexingPolicy {
         p.put("indexingMode", mode);
 
         p.put("includedPaths", in.get("includedPaths") instanceof List<?> inc
-                ? List.copyOf(inc) : List.of(Map.of("path", "/*")));
+                ? List.copyOf(inc) : DEFAULT_INCLUDED_PATHS);
         p.put("excludedPaths", in.get("excludedPaths") instanceof List<?> exc
-                ? List.copyOf(exc) : List.of(Map.of("path", "/\"_etag\"/?")));
+                ? List.copyOf(exc) : DEFAULT_EXCLUDED_PATHS);
 
         List<List<Map<String, Object>>> composites = normalizeComposites(in.get("compositeIndexes"));
         if (!composites.isEmpty()) p.put("compositeIndexes", composites);
@@ -143,11 +148,7 @@ final class CosmosIndexingPolicy {
 
     /** {@code "c.a.b"} → {@code "/a/b"} — strip the FROM alias, dots become slashes. */
     static String normalizeOrderByPath(String expr) {
-        String path = expr.trim();
-        int dot = path.indexOf('.');
-        if (dot > 0 && path.substring(0, dot).matches("[a-zA-Z_][a-zA-Z0-9_]*")) {
-            path = path.substring(dot + 1);
-        }
+        String path = CosmosQueryEngine.stripAlias(expr.trim());
         return "/" + String.join("/", path.split("\\."));
     }
 

--- a/src/main/java/io/floci/az/services/cosmos/CosmosQueryEngine.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosQueryEngine.java
@@ -66,16 +66,20 @@ public class CosmosQueryEngine {
     // Entry point
     // -----------------------------------------------------------------------
 
-    /** Parse just the ORDER BY clause of a query (used for composite-index validation). */
-    public List<OrderByField> parseOrderBy(String sql) {
-        return parse(normalizeWhitespace(sql)).orderBy();
+    /**
+     * Substitute parameters and parse the query once.  The result can be
+     * inspected (e.g. composite-index ORDER BY validation) and then passed to
+     * {@link #execute(ParsedQuery, List)} without re-parsing.
+     */
+    public ParsedQuery prepare(String sql, List<Map<String, Object>> params) {
+        return parse(normalizeWhitespace(substituteParams(sql, params)));
     }
 
     public QueryResult execute(String sql, List<Map<String, Object>> params, List<Map<String, Object>> documents) {
-        sql = normalizeWhitespace(substituteParams(sql, params));
+        return execute(prepare(sql, params), documents);
+    }
 
-        ParsedQuery q = parse(sql);
-
+    public QueryResult execute(ParsedQuery q, List<Map<String, Object>> documents) {
         List<Map<String, Object>> filtered = documents.stream()
                 .filter(doc -> q.whereClause() == null || evalExpr(doc, q.whereClause()))
                 .collect(Collectors.toCollection(ArrayList::new));
@@ -135,17 +139,22 @@ public class CosmosQueryEngine {
     // SQL parsing
     // -----------------------------------------------------------------------
 
+    private static final Pattern TOP_PATTERN =
+            Pattern.compile("(?i)\\bSELECT\\s+TOP\\s+(\\d+)");
+    private static final Pattern OFFSET_LIMIT_PATTERN =
+            Pattern.compile("(?i)\\bOFFSET\\s+(\\d+)\\s+LIMIT\\s+(\\d+)");
+
     ParsedQuery parse(String sql) {
         String upper = sql.toUpperCase();
 
         // TOP
         int top = -1;
-        Matcher topM = Pattern.compile("(?i)\\bSELECT\\s+TOP\\s+(\\d+)").matcher(sql);
+        Matcher topM = TOP_PATTERN.matcher(sql);
         if (topM.find()) top = Integer.parseInt(topM.group(1));
 
         // OFFSET … LIMIT …
         int offset = 0, limit = -1;
-        Matcher olM = Pattern.compile("(?i)\\bOFFSET\\s+(\\d+)\\s+LIMIT\\s+(\\d+)").matcher(sql);
+        Matcher olM = OFFSET_LIMIT_PATTERN.matcher(sql);
         if (olM.find()) {
             offset = Integer.parseInt(olM.group(1));
             limit  = Integer.parseInt(olM.group(2));
@@ -433,14 +442,23 @@ public class CosmosQueryEngine {
     // Field resolution
     // -----------------------------------------------------------------------
 
-    Object resolve(Map<String, Object> doc, String path) {
-        // Strip FROM alias prefix: "c.field" → "field"
+    /**
+     * Strip the FROM-alias prefix from a dotted path: {@code "c.field"} → {@code "field"}.
+     * Shared with the composite-index ORDER BY matcher so validation and
+     * execution always agree on what a property path is.
+     */
+    static String stripAlias(String path) {
         if (path.contains(".")) {
             String[] parts = path.split("\\.", 2);
             if (parts[0].matches("[a-zA-Z_][a-zA-Z0-9_]{0,9}")) {
-                path = parts[1];
+                return parts[1];
             }
         }
+        return path;
+    }
+
+    Object resolve(Map<String, Object> doc, String path) {
+        path = stripAlias(path);
         Object current = doc;
         for (String seg : path.split("\\.")) {
             if (current instanceof Map<?, ?> map) {

--- a/src/main/java/io/floci/az/services/cosmos/CosmosQueryEngine.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosQueryEngine.java
@@ -66,6 +66,11 @@ public class CosmosQueryEngine {
     // Entry point
     // -----------------------------------------------------------------------
 
+    /** Parse just the ORDER BY clause of a query (used for composite-index validation). */
+    public List<OrderByField> parseOrderBy(String sql) {
+        return parse(normalizeWhitespace(sql)).orderBy();
+    }
+
     public QueryResult execute(String sql, List<Map<String, Object>> params, List<Map<String, Object>> documents) {
         sql = normalizeWhitespace(substituteParams(sql, params));
 

--- a/src/main/java/io/floci/az/services/cosmos/CosmosQueryEngine.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosQueryEngine.java
@@ -629,13 +629,24 @@ public class CosmosQueryEngine {
     }
 
     private int indexOfKeyword(String upperSql, String keyword, int from) {
-        int idx = upperSql.indexOf(keyword, from);
-        while (idx >= 0) {
-            int end = idx + keyword.length();
-            boolean beforeOk = idx == 0 || !Character.isLetterOrDigit(upperSql.charAt(idx - 1));
-            boolean afterOk  = end >= upperSql.length() || !Character.isLetterOrDigit(upperSql.charAt(end));
-            if (beforeOk && afterOk) return idx;
-            idx = upperSql.indexOf(keyword, idx + 1);
+        // String-literal state must be tracked from position 0 — `from` may
+        // otherwise land inside a quoted value (e.g. WHERE c.x = 'order by').
+        boolean inStr = false;
+        char strCh = 0;
+        for (int i = 0; i < upperSql.length(); i++) {
+            char c = upperSql.charAt(i);
+            if (inStr) {
+                if (c == strCh) inStr = false;
+                continue;
+            }
+            if (c == '\'' || c == '"') { inStr = true; strCh = c; continue; }
+            if (i < from) continue;
+            if (upperSql.regionMatches(i, keyword, 0, keyword.length())) {
+                int end = i + keyword.length();
+                boolean beforeOk = i == 0 || !Character.isLetterOrDigit(upperSql.charAt(i - 1));
+                boolean afterOk  = end >= upperSql.length() || !Character.isLetterOrDigit(upperSql.charAt(end));
+                if (beforeOk && afterOk) return i;
+            }
         }
         return -1;
     }

--- a/src/main/java/io/floci/az/services/cosmos/CosmosQueryEngine.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosQueryEngine.java
@@ -589,7 +589,13 @@ public class CosmosQueryEngine {
 
     private String toLiteral(Object value) {
         if (value == null)             return "null";
-        if (value instanceof String s) return "'" + s.replace("'", "\\'") + "'";
+        // Escape embedded quotes with SQL-standard doubling ('') rather than a
+        // backslash escape.  A doubled quote keeps the string scanners' state
+        // balanced across the literal boundary (they exit then immediately
+        // re-enter string mode), so keyword detection — ORDER BY, AND/OR, IN —
+        // is not swallowed by a value such as "Alice's".  A backslash escape
+        // ('\'') would leave the scanners stuck inside a phantom string.
+        if (value instanceof String s) return "'" + s.replace("'", "''") + "'";
         if (value instanceof Boolean b) return b.toString();
         return String.valueOf(value);
     }
@@ -599,17 +605,26 @@ public class CosmosQueryEngine {
         if ("true".equalsIgnoreCase(s))  return Boolean.TRUE;
         if ("false".equalsIgnoreCase(s)) return Boolean.FALSE;
         if ((s.startsWith("'") && s.endsWith("'")) || (s.startsWith("\"") && s.endsWith("\"")))
-            return s.substring(1, s.length() - 1).replace("\\'", "'").replace("\\\"", "\"");
+            return stripQuotes(s);
         try { return Long.parseLong(s); }   catch (NumberFormatException ignored) {}
         try { return Double.parseDouble(s); } catch (NumberFormatException ignored) {}
         return s;
     }
 
+    /**
+     * Strip matching outer quotes and unescape the string-literal content:
+     * SQL-standard doubled quotes ({@code ''} → {@code '}) plus backslash
+     * escapes ({@code \'}, {@code \"}) for hand-written SQL.  Inverse of the
+     * escaping in {@link #toLiteral}.
+     */
     private String stripQuotes(String s) {
         if (s == null || s.length() < 2) return s;
         char f = s.charAt(0), l = s.charAt(s.length() - 1);
-        return (f == '\'' && l == '\'') || (f == '"' && l == '"')
-                ? s.substring(1, s.length() - 1) : s;
+        if ((f == '\'' && l == '\'') || (f == '"' && l == '"')) {
+            return s.substring(1, s.length() - 1)
+                    .replace("''", "'").replace("\\'", "'").replace("\\\"", "\"");
+        }
+        return s;
     }
 
     private String normalizeWhitespace(String s) {
@@ -717,7 +732,7 @@ public class CosmosQueryEngine {
         // String literal
         if ((expr.startsWith("'") && expr.endsWith("'"))
                 || (expr.startsWith("\"") && expr.endsWith("\""))) {
-            return expr.substring(1, expr.length() - 1);
+            return stripQuotes(expr);
         }
 
         // null / boolean keyword literals

--- a/src/test/java/io/floci/az/services/cosmos/CosmosContainerIndexingTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosContainerIndexingTest.java
@@ -353,6 +353,37 @@ public class CosmosContainerIndexingTest {
     }
 
     @Test
+    void paramValueWithApostropheStillEnforcesOrderBy() {
+        // "Alice's" substitutes to a literal with an escaped quote. Enforcement
+        // must not be bypassed: without a composite index the multi-property
+        // ORDER BY still fails 400 (SC2104).
+        createContainer("chat", null);
+        insertDoc("chat", "m1", "conv1", 1);
+
+        queryRaw("chat", """
+                {"query": "SELECT * FROM c WHERE c.name = @name ORDER BY c.conversationId, c.sequence",
+                 "parameters": [{"name": "@name", "value": "Alice's"}]}""")
+                .then().statusCode(400);
+    }
+
+    @Test
+    void paramValueWithApostropheServedAndSorted() {
+        createContainer("chat", COMPOSITE_POLICY);
+        insertRawDoc("chat", "conv1",
+                "{\"id\":\"m1\",\"conversationId\":\"conv1\",\"sequence\":2,\"name\":\"Alice's\"}");
+        insertRawDoc("chat", "conv1",
+                "{\"id\":\"m2\",\"conversationId\":\"conv1\",\"sequence\":1,\"name\":\"Alice's\"}");
+        insertRawDoc("chat", "conv1",
+                "{\"id\":\"m3\",\"conversationId\":\"conv1\",\"sequence\":9,\"name\":\"Bob\"}");
+
+        queryRaw("chat", """
+                {"query": "SELECT * FROM c WHERE c.name = @name ORDER BY c.conversationId, c.sequence",
+                 "parameters": [{"name": "@name", "value": "Alice's"}]}""")
+                .then().statusCode(200)
+                .body("Documents.id", contains("m2", "m1"));
+    }
+
+    @Test
     void orderByInsideStringLiteralDoesNotTriggerEnforcement() {
         createContainer("chat", null);
         insertRawDoc("chat", "conv1",

--- a/src/test/java/io/floci/az/services/cosmos/CosmosContainerIndexingTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosContainerIndexingTest.java
@@ -52,13 +52,8 @@ public class CosmosContainerIndexingTest {
     }
 
     private void insertDoc(String coll, String id, String conversationId, int sequence) {
-        String body = "{\"id\":\"" + id + "\",\"conversationId\":\"" + conversationId
-                + "\",\"sequence\":" + sequence + "}";
-        given().contentType("application/json")
-                .header("x-ms-documentdb-partitionkey", "[\"" + conversationId + "\"]")
-                .body(body)
-                .when().post(BASE + "/dbs/" + DB + "/colls/" + coll + "/docs")
-                .then().statusCode(201);
+        insertRawDoc(coll, conversationId, "{\"id\":\"" + id + "\",\"conversationId\":\""
+                + conversationId + "\",\"sequence\":" + sequence + "}");
     }
 
     private io.restassured.response.Response query(String coll, String sql) {

--- a/src/test/java/io/floci/az/services/cosmos/CosmosContainerIndexingTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosContainerIndexingTest.java
@@ -1,0 +1,236 @@
+package io.floci.az.services.cosmos;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.contains;
+
+/**
+ * HTTP-level tests for issue #127: custom indexing policies on container
+ * create/replace, and the Azure rule that a multi-property ORDER BY fails
+ * with 400 unless a matching composite index exists.
+ */
+@QuarkusTest
+public class CosmosContainerIndexingTest {
+
+    private static final String ACCT = "idxacct";
+    private static final String BASE = "/" + ACCT + "-cosmos";
+    private static final String DB   = "chatdb";
+
+    private static final String COMPOSITE_POLICY = """
+            {
+              "indexingMode": "consistent",
+              "automatic": true,
+              "includedPaths": [{"path": "/*"}],
+              "excludedPaths": [{"path": "/\\"_etag\\"/?"}],
+              "compositeIndexes": [[
+                {"path": "/conversationId", "order": "ascending"},
+                {"path": "/sequence", "order": "ascending"}
+              ]]
+            }""";
+
+    @BeforeEach
+    void reset() {
+        given().when().post("/_admin/reset").then().statusCode(204);
+        given().contentType("application/json").body("{\"id\":\"" + DB + "\"}")
+                .when().post(BASE + "/dbs").then().statusCode(201);
+    }
+
+    private void createContainer(String id, String indexingPolicyJson) {
+        String body = "{\"id\":\"" + id + "\","
+                + "\"partitionKey\":{\"paths\":[\"/conversationId\"],\"kind\":\"Hash\"}"
+                + (indexingPolicyJson == null ? "" : ",\"indexingPolicy\":" + indexingPolicyJson)
+                + "}";
+        given().contentType("application/json").body(body)
+                .when().post(BASE + "/dbs/" + DB + "/colls")
+                .then().statusCode(201);
+    }
+
+    private void insertDoc(String coll, String id, String conversationId, int sequence) {
+        String body = "{\"id\":\"" + id + "\",\"conversationId\":\"" + conversationId
+                + "\",\"sequence\":" + sequence + "}";
+        given().contentType("application/json")
+                .header("x-ms-documentdb-partitionkey", "[\"" + conversationId + "\"]")
+                .body(body)
+                .when().post(BASE + "/dbs/" + DB + "/colls/" + coll + "/docs")
+                .then().statusCode(201);
+    }
+
+    private io.restassured.response.Response query(String coll, String sql) {
+        return given().contentType("application/query+json")
+                .header("x-ms-documentdb-isquery", "True")
+                .body("{\"query\":\"" + sql + "\",\"parameters\":[]}")
+                .when().post(BASE + "/dbs/" + DB + "/colls/" + coll + "/docs");
+    }
+
+    // ------------------------------------------------------------------ create
+
+    @Test
+    void createContainerPersistsCustomIndexingPolicy() {
+        createContainer("chat", COMPOSITE_POLICY);
+
+        given().when().get(BASE + "/dbs/" + DB + "/colls/chat")
+                .then().statusCode(200)
+                .body("indexingPolicy.indexingMode", is("consistent"))
+                .body("indexingPolicy.compositeIndexes[0].path",
+                        contains("/conversationId", "/sequence"))
+                .body("indexingPolicy.compositeIndexes[0].order",
+                        contains("ascending", "ascending"));
+    }
+
+    @Test
+    void createContainerFillsCompositeOrderDefault() {
+        createContainer("chat", """
+                {"compositeIndexes": [[{"path": "/a"}, {"path": "/b", "order": "descending"}]]}""");
+
+        given().when().get(BASE + "/dbs/" + DB + "/colls/chat")
+                .then().statusCode(200)
+                .body("indexingPolicy.compositeIndexes[0].order",
+                        contains("ascending", "descending"));
+    }
+
+    @Test
+    void createContainerWithoutPolicyReturnsDefault() {
+        createContainer("plain", null);
+
+        given().when().get(BASE + "/dbs/" + DB + "/colls/plain")
+                .then().statusCode(200)
+                .body("indexingPolicy.indexingMode", is("consistent"))
+                .body("indexingPolicy.includedPaths[0].path", is("/*"))
+                .body("indexingPolicy.compositeIndexes", nullValue());
+    }
+
+    @Test
+    void createContainerWithSinglePathCompositeIndexFails() {
+        String body = "{\"id\":\"bad\",\"partitionKey\":{\"paths\":[\"/pk\"],\"kind\":\"Hash\"},"
+                + "\"indexingPolicy\":{\"compositeIndexes\":[[{\"path\":\"/a\"}]]}}";
+        given().contentType("application/json").body(body)
+                .when().post(BASE + "/dbs/" + DB + "/colls")
+                .then().statusCode(400)
+                .body("code", is("BadRequest"));
+    }
+
+    // ------------------------------------------------------------------ ORDER BY enforcement
+
+    @Test
+    void multiPropertyOrderByWithoutCompositeIndexReturns400() {
+        createContainer("chat", null);
+        insertDoc("chat", "m1", "conv1", 2);
+        insertDoc("chat", "m2", "conv1", 1);
+
+        query("chat", "SELECT * FROM c ORDER BY c.conversationId, c.sequence")
+                .then().statusCode(400)
+                .body("code", is("BadRequest"))
+                .body("message", containsString(
+                        "The order by query does not have a corresponding composite index"));
+    }
+
+    @Test
+    void multiPropertyOrderByWithMatchingCompositeIndexSucceeds() {
+        createContainer("chat", COMPOSITE_POLICY);
+        insertDoc("chat", "m1", "conv1", 2);
+        insertDoc("chat", "m2", "conv1", 1);
+        insertDoc("chat", "m3", "conv0", 5);
+
+        query("chat", "SELECT * FROM c ORDER BY c.conversationId, c.sequence")
+                .then().statusCode(200)
+                .body("Documents.id", contains("m3", "m2", "m1"));
+    }
+
+    @Test
+    void fullyInvertedOrderByServedByCompositeIndex() {
+        createContainer("chat", COMPOSITE_POLICY);
+        insertDoc("chat", "m1", "conv1", 1);
+        insertDoc("chat", "m2", "conv2", 1);
+
+        query("chat", "SELECT * FROM c ORDER BY c.conversationId DESC, c.sequence DESC")
+                .then().statusCode(200)
+                .body("Documents.id", contains("m2", "m1"));
+    }
+
+    @Test
+    void mixedDirectionOrderByWithoutMatchingCompositeReturns400() {
+        createContainer("chat", COMPOSITE_POLICY);
+        insertDoc("chat", "m1", "conv1", 1);
+
+        query("chat", "SELECT * FROM c ORDER BY c.conversationId ASC, c.sequence DESC")
+                .then().statusCode(400)
+                .body("message", containsString("composite index"));
+    }
+
+    @Test
+    void wrongSequenceOrderByReturns400() {
+        createContainer("chat", COMPOSITE_POLICY);
+        insertDoc("chat", "m1", "conv1", 1);
+
+        query("chat", "SELECT * FROM c ORDER BY c.sequence, c.conversationId")
+                .then().statusCode(400);
+    }
+
+    @Test
+    void singlePropertyOrderByAlwaysServed() {
+        createContainer("chat", null);
+        insertDoc("chat", "m1", "conv1", 2);
+        insertDoc("chat", "m2", "conv1", 1);
+
+        query("chat", "SELECT * FROM c ORDER BY c.sequence DESC")
+                .then().statusCode(200)
+                .body("Documents.id", contains("m1", "m2"));
+    }
+
+    // ------------------------------------------------------------------ replace
+
+    @Test
+    void replaceContainerAddsCompositeIndex() {
+        createContainer("chat", null);
+        insertDoc("chat", "m1", "conv1", 2);
+        insertDoc("chat", "m2", "conv1", 1);
+
+        query("chat", "SELECT * FROM c ORDER BY c.conversationId, c.sequence")
+                .then().statusCode(400);
+
+        String replaceBody = "{\"id\":\"chat\","
+                + "\"partitionKey\":{\"paths\":[\"/conversationId\"],\"kind\":\"Hash\"},"
+                + "\"indexingPolicy\":" + COMPOSITE_POLICY + "}";
+        given().contentType("application/json").body(replaceBody)
+                .when().put(BASE + "/dbs/" + DB + "/colls/chat")
+                .then().statusCode(200)
+                .body("indexingPolicy.compositeIndexes[0].path",
+                        contains("/conversationId", "/sequence"));
+
+        query("chat", "SELECT * FROM c ORDER BY c.conversationId, c.sequence")
+                .then().statusCode(200)
+                .body("Documents.id", contains("m2", "m1"));
+    }
+
+    @Test
+    void replaceContainerWithMismatchedIdFails() {
+        createContainer("chat", null);
+        given().contentType("application/json").body("{\"id\":\"other\"}")
+                .when().put(BASE + "/dbs/" + DB + "/colls/chat")
+                .then().statusCode(400);
+    }
+
+    @Test
+    void replaceContainerCannotChangePartitionKey() {
+        createContainer("chat", null);
+        String replaceBody = "{\"id\":\"chat\","
+                + "\"partitionKey\":{\"paths\":[\"/other\"],\"kind\":\"Hash\"}}";
+        given().contentType("application/json").body(replaceBody)
+                .when().put(BASE + "/dbs/" + DB + "/colls/chat")
+                .then().statusCode(400)
+                .body("message", containsString("partition key"));
+    }
+
+    @Test
+    void replaceUnknownContainerReturns404() {
+        given().contentType("application/json").body("{\"id\":\"ghost\"}")
+                .when().put(BASE + "/dbs/" + DB + "/colls/ghost")
+                .then().statusCode(404);
+    }
+}

--- a/src/test/java/io/floci/az/services/cosmos/CosmosContainerIndexingTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosContainerIndexingTest.java
@@ -62,10 +62,22 @@ public class CosmosContainerIndexingTest {
     }
 
     private io.restassured.response.Response query(String coll, String sql) {
+        return queryRaw(coll, "{\"query\":\"" + sql + "\",\"parameters\":[]}");
+    }
+
+    private io.restassured.response.Response queryRaw(String coll, String bodyJson) {
         return given().contentType("application/query+json")
                 .header("x-ms-documentdb-isquery", "True")
-                .body("{\"query\":\"" + sql + "\",\"parameters\":[]}")
+                .body(bodyJson)
                 .when().post(BASE + "/dbs/" + DB + "/colls/" + coll + "/docs");
+    }
+
+    private void insertRawDoc(String coll, String pk, String docJson) {
+        given().contentType("application/json")
+                .header("x-ms-documentdb-partitionkey", "[\"" + pk + "\"]")
+                .body(docJson)
+                .when().post(BASE + "/dbs/" + DB + "/colls/" + coll + "/docs")
+                .then().statusCode(201);
     }
 
     // ------------------------------------------------------------------ create
@@ -113,6 +125,53 @@ public class CosmosContainerIndexingTest {
                 .when().post(BASE + "/dbs/" + DB + "/colls")
                 .then().statusCode(400)
                 .body("code", is("BadRequest"));
+    }
+
+    @Test
+    void createContainerWithInvalidPolicyDoesNotCreateContainer() {
+        String body = "{\"id\":\"bad\",\"partitionKey\":{\"paths\":[\"/pk\"],\"kind\":\"Hash\"},"
+                + "\"indexingPolicy\":{\"indexingMode\":\"bogus\"}}";
+        given().contentType("application/json").body(body)
+                .when().post(BASE + "/dbs/" + DB + "/colls")
+                .then().statusCode(400);
+
+        given().when().get(BASE + "/dbs/" + DB + "/colls/bad")
+                .then().statusCode(404);
+    }
+
+    @Test
+    void createContainerWithNonObjectPolicyFails() {
+        String body = "{\"id\":\"bad\",\"partitionKey\":{\"paths\":[\"/pk\"],\"kind\":\"Hash\"},"
+                + "\"indexingPolicy\":\"not-an-object\"}";
+        given().contentType("application/json").body(body)
+                .when().post(BASE + "/dbs/" + DB + "/colls")
+                .then().statusCode(400)
+                .body("code", is("BadRequest"));
+    }
+
+    @Test
+    void createContainerPreservesCustomIncludedAndExcludedPaths() {
+        createContainer("chat", """
+                {"includedPaths": [{"path": "/conversationId/?"}],
+                 "excludedPaths": [{"path": "/*"}]}""");
+
+        given().when().get(BASE + "/dbs/" + DB + "/colls/chat")
+                .then().statusCode(200)
+                .body("indexingPolicy.includedPaths[0].path", is("/conversationId/?"))
+                .body("indexingPolicy.excludedPaths[0].path", is("/*"));
+    }
+
+    @Test
+    void createContainerWithEmptyCompositeIndexesOmitsThemAndRejectsMultiOrderBy() {
+        createContainer("chat", "{\"compositeIndexes\": []}");
+        insertDoc("chat", "m1", "conv1", 1);
+
+        given().when().get(BASE + "/dbs/" + DB + "/colls/chat")
+                .then().statusCode(200)
+                .body("indexingPolicy.compositeIndexes", nullValue());
+
+        query("chat", "SELECT * FROM c ORDER BY c.conversationId, c.sequence")
+                .then().statusCode(400);
     }
 
     // ------------------------------------------------------------------ ORDER BY enforcement
@@ -183,6 +242,133 @@ public class CosmosContainerIndexingTest {
                 .body("Documents.id", contains("m1", "m2"));
     }
 
+    @Test
+    void mixedDirectionCompositeServesMixedOrderByAndItsInverse() {
+        createContainer("chat", """
+                {"compositeIndexes": [[
+                  {"path": "/conversationId", "order": "ascending"},
+                  {"path": "/sequence", "order": "descending"}
+                ]]}""");
+        insertDoc("chat", "m1", "conv1", 1);
+        insertDoc("chat", "m2", "conv1", 2);
+
+        query("chat", "SELECT * FROM c ORDER BY c.conversationId ASC, c.sequence DESC")
+                .then().statusCode(200)
+                .body("Documents.id", contains("m2", "m1"));
+        query("chat", "SELECT * FROM c ORDER BY c.conversationId DESC, c.sequence ASC")
+                .then().statusCode(200)
+                .body("Documents.id", contains("m1", "m2"));
+        // same-direction pair not covered by an (asc, desc) index
+        query("chat", "SELECT * FROM c ORDER BY c.conversationId, c.sequence")
+                .then().statusCode(400);
+    }
+
+    @Test
+    void threePropertyOrderByRequiresThreePathComposite() {
+        createContainer("chat", """
+                {"compositeIndexes": [[
+                  {"path": "/conversationId"},
+                  {"path": "/sequence"},
+                  {"path": "/kind"}
+                ]]}""");
+        insertRawDoc("chat", "conv1",
+                "{\"id\":\"m1\",\"conversationId\":\"conv1\",\"sequence\":1,\"kind\":\"b\"}");
+        insertRawDoc("chat", "conv1",
+                "{\"id\":\"m2\",\"conversationId\":\"conv1\",\"sequence\":1,\"kind\":\"a\"}");
+
+        query("chat", "SELECT * FROM c ORDER BY c.conversationId, c.sequence, c.kind")
+                .then().statusCode(200)
+                .body("Documents.id", contains("m2", "m1"));
+
+        // two-property prefix of the three-path index is NOT served (Azure parity)
+        query("chat", "SELECT * FROM c ORDER BY c.conversationId, c.sequence")
+                .then().statusCode(400);
+    }
+
+    @Test
+    void secondOfMultipleCompositeIndexesServesQuery() {
+        createContainer("chat", """
+                {"compositeIndexes": [
+                  [{"path": "/x"}, {"path": "/y"}],
+                  [{"path": "/conversationId"}, {"path": "/sequence"}]
+                ]}""");
+        insertDoc("chat", "m1", "conv1", 2);
+        insertDoc("chat", "m2", "conv1", 1);
+
+        query("chat", "SELECT * FROM c ORDER BY c.conversationId, c.sequence")
+                .then().statusCode(200)
+                .body("Documents.id", contains("m2", "m1"));
+    }
+
+    @Test
+    void nestedPathCompositeIndexServesNestedOrderBy() {
+        createContainer("chat", """
+                {"compositeIndexes": [[
+                  {"path": "/conversationId"},
+                  {"path": "/meta/seq"}
+                ]]}""");
+        insertRawDoc("chat", "conv1",
+                "{\"id\":\"m1\",\"conversationId\":\"conv1\",\"meta\":{\"seq\":2}}");
+        insertRawDoc("chat", "conv1",
+                "{\"id\":\"m2\",\"conversationId\":\"conv1\",\"meta\":{\"seq\":1}}");
+
+        query("chat", "SELECT * FROM c ORDER BY c.conversationId, c.meta.seq")
+                .then().statusCode(200)
+                .body("Documents.id", contains("m2", "m1"));
+    }
+
+    @Test
+    void orderByWithOffsetLimitStillEnforcedAndServed() {
+        createContainer("chat", COMPOSITE_POLICY);
+        insertDoc("chat", "m1", "conv1", 1);
+        insertDoc("chat", "m2", "conv1", 2);
+        insertDoc("chat", "m3", "conv1", 3);
+
+        query("chat", "SELECT * FROM c ORDER BY c.conversationId, c.sequence OFFSET 1 LIMIT 1")
+                .then().statusCode(200)
+                .body("Documents.id", contains("m2"));
+
+        createContainer("plain", null);
+        insertDoc("plain", "p1", "conv1", 1);
+        query("plain", "SELECT * FROM c ORDER BY c.conversationId, c.sequence OFFSET 1 LIMIT 1")
+                .then().statusCode(400);
+    }
+
+    @Test
+    void lowercaseOrderByStillEnforced() {
+        createContainer("chat", null);
+        insertDoc("chat", "m1", "conv1", 1);
+
+        query("chat", "select * from c order by c.conversationId, c.sequence")
+                .then().statusCode(400);
+    }
+
+    @Test
+    void parameterizedWhereWithMultiPropertyOrderByServed() {
+        createContainer("chat", COMPOSITE_POLICY);
+        insertDoc("chat", "m1", "conv1", 2);
+        insertDoc("chat", "m2", "conv1", 1);
+        insertDoc("chat", "m3", "conv2", 1);
+
+        queryRaw("chat", """
+                {"query": "SELECT * FROM c WHERE c.conversationId = @conv ORDER BY c.conversationId, c.sequence",
+                 "parameters": [{"name": "@conv", "value": "conv1"}]}""")
+                .then().statusCode(200)
+                .body("Documents.id", contains("m2", "m1"));
+    }
+
+    @Test
+    void orderByInsideStringLiteralDoesNotTriggerEnforcement() {
+        createContainer("chat", null);
+        insertRawDoc("chat", "conv1",
+                "{\"id\":\"m1\",\"conversationId\":\"conv1\",\"note\":\"order by c.a, c.b\"}");
+
+        queryRaw("chat", """
+                {"query": "SELECT * FROM c WHERE c.note = 'order by c.a, c.b'", "parameters": []}""")
+                .then().statusCode(200)
+                .body("Documents.id", contains("m1"));
+    }
+
     // ------------------------------------------------------------------ replace
 
     @Test
@@ -232,5 +418,64 @@ public class CosmosContainerIndexingTest {
         given().contentType("application/json").body("{\"id\":\"ghost\"}")
                 .when().put(BASE + "/dbs/" + DB + "/colls/ghost")
                 .then().statusCode(404);
+    }
+
+    @Test
+    void replaceWithInvalidPolicyKeepsExistingPolicy() {
+        createContainer("chat", COMPOSITE_POLICY);
+        insertDoc("chat", "m1", "conv1", 1);
+        insertDoc("chat", "m2", "conv1", 2);
+
+        given().contentType("application/json")
+                .body("{\"id\":\"chat\",\"indexingPolicy\":{\"indexingMode\":\"bogus\"}}")
+                .when().put(BASE + "/dbs/" + DB + "/colls/chat")
+                .then().statusCode(400);
+
+        // old composite index survives the failed replace
+        given().when().get(BASE + "/dbs/" + DB + "/colls/chat")
+                .then().statusCode(200)
+                .body("indexingPolicy.compositeIndexes[0].path",
+                        contains("/conversationId", "/sequence"));
+        query("chat", "SELECT * FROM c ORDER BY c.conversationId, c.sequence")
+                .then().statusCode(200)
+                .body("Documents.id", contains("m1", "m2"));
+    }
+
+    @Test
+    void replaceWithoutPolicyResetsToDefault() {
+        createContainer("chat", COMPOSITE_POLICY);
+        insertDoc("chat", "m1", "conv1", 1);
+
+        String replaceBody = "{\"id\":\"chat\","
+                + "\"partitionKey\":{\"paths\":[\"/conversationId\"],\"kind\":\"Hash\"}}";
+        given().contentType("application/json").body(replaceBody)
+                .when().put(BASE + "/dbs/" + DB + "/colls/chat")
+                .then().statusCode(200)
+                .body("indexingPolicy.compositeIndexes", nullValue());
+
+        // composite index gone → multi-property ORDER BY now rejected, like Azure
+        query("chat", "SELECT * FROM c ORDER BY c.conversationId, c.sequence")
+                .then().statusCode(400);
+    }
+
+    @Test
+    void replaceKeepsDocumentsAndIdentity() {
+        createContainer("chat", null);
+        insertDoc("chat", "m1", "conv1", 1);
+
+        String ridBefore = given().when().get(BASE + "/dbs/" + DB + "/colls/chat")
+                .then().statusCode(200).extract().path("_rid");
+
+        String replaceBody = "{\"id\":\"chat\",\"indexingPolicy\":" + COMPOSITE_POLICY + "}";
+        given().contentType("application/json").body(replaceBody)
+                .when().put(BASE + "/dbs/" + DB + "/colls/chat")
+                .then().statusCode(200)
+                .body("_rid", is(ridBefore))
+                .body("partitionKey.paths[0]", is("/conversationId"));
+
+        given().header("x-ms-documentdb-partitionkey", "[\"conv1\"]")
+                .when().get(BASE + "/dbs/" + DB + "/colls/chat/docs/m1")
+                .then().statusCode(200)
+                .body("id", is("m1"));
     }
 }

--- a/src/test/java/io/floci/az/services/cosmos/CosmosIndexingPolicyTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosIndexingPolicyTest.java
@@ -53,6 +53,39 @@ class CosmosIndexingPolicyTest {
     }
 
     @Test
+    void noneAndLazyModesAccepted() {
+        assertEquals("none", CosmosIndexingPolicy.normalize(Map.of("indexingMode", "None")).get("indexingMode"));
+        assertEquals("lazy", CosmosIndexingPolicy.normalize(Map.of("indexingMode", "lazy")).get("indexingMode"));
+    }
+
+    @Test
+    void automaticFalsePreserved() {
+        assertEquals(false, CosmosIndexingPolicy.normalize(Map.of("automatic", false)).get("automatic"));
+    }
+
+    @Test
+    void customIncludedAndExcludedPathsPreserved() {
+        Map<String, Object> p = CosmosIndexingPolicy.normalize(Map.of(
+                "includedPaths", List.of(Map.of("path", "/conversationId/?")),
+                "excludedPaths", List.of(Map.of("path", "/*"))));
+        assertEquals(List.of(Map.of("path", "/conversationId/?")), p.get("includedPaths"));
+        assertEquals(List.of(Map.of("path", "/*")), p.get("excludedPaths"));
+    }
+
+    @Test
+    void nonObjectPolicyRejected() {
+        assertThrows(IllegalArgumentException.class, () -> CosmosIndexingPolicy.normalize("bogus"));
+        assertThrows(IllegalArgumentException.class, () -> CosmosIndexingPolicy.normalize(List.of()));
+        assertThrows(IllegalArgumentException.class, () -> CosmosIndexingPolicy.normalize(42));
+    }
+
+    @Test
+    void emptyCompositeIndexesOmittedFromPolicy() {
+        Map<String, Object> p = CosmosIndexingPolicy.normalize(Map.of("compositeIndexes", List.of()));
+        assertFalse(p.containsKey("compositeIndexes"));
+    }
+
+    @Test
     void invalidIndexingModeRejected() {
         assertThrows(IllegalArgumentException.class,
                 () -> CosmosIndexingPolicy.normalize(Map.of("indexingMode", "bogus")));
@@ -70,6 +103,27 @@ class CosmosIndexingPolicyTest {
         assertThrows(IllegalArgumentException.class,
                 () -> CosmosIndexingPolicy.normalize(
                         Map.of("compositeIndexes", List.of(List.of(path("a", null), path("/b", null))))));
+    }
+
+    @Test
+    void compositePathEntryMissingPathRejected() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CosmosIndexingPolicy.normalize(Map.of("compositeIndexes",
+                        List.of(List.of(Map.of("order", "ascending"), path("/b", null))))));
+    }
+
+    @Test
+    void compositeIndexNotAnArrayRejected() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CosmosIndexingPolicy.normalize(
+                        Map.of("compositeIndexes", List.of(Map.of("path", "/a")))));
+    }
+
+    @Test
+    void invalidCompositeOrderValueRejected() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CosmosIndexingPolicy.normalize(Map.of("compositeIndexes",
+                        List.of(List.of(path("/a", "up"), path("/b", null))))));
     }
 
     // ------------------------------------------------------------------ supportsOrderBy
@@ -117,6 +171,39 @@ class CosmosIndexingPolicyTest {
         Map<String, Object> p = policyWithComposite(
                 List.of(path("/a", "ascending"), path("/b", "ascending"), path("/c", "ascending")));
         assertFalse(CosmosIndexingPolicy.supportsOrderBy(p, List.of(ob("c.a", true), ob("c.b", true))));
+    }
+
+    @Test
+    void emptyCompositeIndexesDoNotServeMultiPropertyOrderBy() {
+        Map<String, Object> p = CosmosIndexingPolicy.normalize(Map.of("compositeIndexes", List.of()));
+        assertFalse(CosmosIndexingPolicy.supportsOrderBy(p, List.of(ob("c.a", true), ob("c.b", true))));
+    }
+
+    @Test
+    void pathMatchingIsCaseSensitive() {
+        Map<String, Object> p = policyWithComposite(
+                List.of(path("/ConversationId", "ascending"), path("/sequence", "ascending")));
+        assertFalse(CosmosIndexingPolicy.supportsOrderBy(p,
+                List.of(ob("c.conversationId", true), ob("c.sequence", true))));
+    }
+
+    @Test
+    void secondOfMultipleCompositeIndexesMatches() {
+        Map<String, Object> p = CosmosIndexingPolicy.normalize(Map.of("compositeIndexes", List.of(
+                List.of(path("/x", null), path("/y", null)),
+                List.of(path("/a", null), path("/b", "descending")))));
+        assertTrue(CosmosIndexingPolicy.supportsOrderBy(p, List.of(ob("c.a", true), ob("c.b", false))));
+    }
+
+    @Test
+    void threePropertyExactMatchSupported() {
+        Map<String, Object> p = policyWithComposite(
+                List.of(path("/a", null), path("/b", null), path("/c", "descending")));
+        assertTrue(CosmosIndexingPolicy.supportsOrderBy(p,
+                List.of(ob("c.a", true), ob("c.b", true), ob("c.c", false))));
+        // and fully inverted
+        assertTrue(CosmosIndexingPolicy.supportsOrderBy(p,
+                List.of(ob("c.a", false), ob("c.b", false), ob("c.c", true))));
     }
 
     @Test

--- a/src/test/java/io/floci/az/services/cosmos/CosmosIndexingPolicyTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosIndexingPolicyTest.java
@@ -1,0 +1,129 @@
+package io.floci.az.services.cosmos;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link CosmosIndexingPolicy}: normalization of
+ * client-supplied policies and the composite-index ORDER BY matching rule.
+ */
+class CosmosIndexingPolicyTest {
+
+    private static CosmosQueryEngine.OrderByField ob(String path, boolean asc) {
+        return new CosmosQueryEngine.OrderByField(path, asc);
+    }
+
+    private static Map<String, Object> policyWithComposite(List<Map<String, Object>> paths) {
+        return CosmosIndexingPolicy.normalize(Map.of("compositeIndexes", List.of(paths)));
+    }
+
+    private static Map<String, Object> path(String p, String order) {
+        return order == null ? Map.of("path", p) : Map.of("path", p, "order", order);
+    }
+
+    // ------------------------------------------------------------------ normalize
+
+    @Test
+    void missingPolicyYieldsDefault() {
+        Map<String, Object> p = CosmosIndexingPolicy.normalize(null);
+        assertEquals(true, p.get("automatic"));
+        assertEquals("consistent", p.get("indexingMode"));
+        assertEquals(List.of(Map.of("path", "/*")), p.get("includedPaths"));
+        assertFalse(p.containsKey("compositeIndexes"));
+    }
+
+    @Test
+    void compositeOrderDefaultsToAscending() {
+        Map<String, Object> p = policyWithComposite(List.of(path("/a", null), path("/b", "descending")));
+        @SuppressWarnings("unchecked")
+        List<List<Map<String, Object>>> composites =
+                (List<List<Map<String, Object>>>) p.get("compositeIndexes");
+        assertEquals("ascending",  composites.get(0).get(0).get("order"));
+        assertEquals("descending", composites.get(0).get(1).get("order"));
+    }
+
+    @Test
+    void indexingModeIsLowercased() {
+        Map<String, Object> p = CosmosIndexingPolicy.normalize(Map.of("indexingMode", "Consistent"));
+        assertEquals("consistent", p.get("indexingMode"));
+    }
+
+    @Test
+    void invalidIndexingModeRejected() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CosmosIndexingPolicy.normalize(Map.of("indexingMode", "bogus")));
+    }
+
+    @Test
+    void singlePathCompositeRejected() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CosmosIndexingPolicy.normalize(
+                        Map.of("compositeIndexes", List.of(List.of(path("/a", null))))));
+    }
+
+    @Test
+    void compositePathWithoutLeadingSlashRejected() {
+        assertThrows(IllegalArgumentException.class,
+                () -> CosmosIndexingPolicy.normalize(
+                        Map.of("compositeIndexes", List.of(List.of(path("a", null), path("/b", null))))));
+    }
+
+    // ------------------------------------------------------------------ supportsOrderBy
+
+    @Test
+    void singlePropertyOrderByAlwaysSupported() {
+        Map<String, Object> p = CosmosIndexingPolicy.defaultPolicy();
+        assertTrue(CosmosIndexingPolicy.supportsOrderBy(p, List.of(ob("c.a", true))));
+        assertTrue(CosmosIndexingPolicy.supportsOrderBy(p, List.of(ob("c.a", false))));
+    }
+
+    @Test
+    void multiPropertyOrderByWithoutCompositeIndexRejected() {
+        assertFalse(CosmosIndexingPolicy.supportsOrderBy(
+                CosmosIndexingPolicy.defaultPolicy(), List.of(ob("c.a", true), ob("c.b", true))));
+    }
+
+    @Test
+    void exactMatchSupported() {
+        Map<String, Object> p = policyWithComposite(List.of(path("/a", "ascending"), path("/b", "ascending")));
+        assertTrue(CosmosIndexingPolicy.supportsOrderBy(p, List.of(ob("c.a", true), ob("c.b", true))));
+    }
+
+    @Test
+    void fullyInvertedMatchSupported() {
+        Map<String, Object> p = policyWithComposite(List.of(path("/a", "ascending"), path("/b", "descending")));
+        assertTrue(CosmosIndexingPolicy.supportsOrderBy(p, List.of(ob("c.a", false), ob("c.b", true))));
+    }
+
+    @Test
+    void partiallyInvertedMatchRejected() {
+        Map<String, Object> p = policyWithComposite(List.of(path("/a", "ascending"), path("/b", "ascending")));
+        assertFalse(CosmosIndexingPolicy.supportsOrderBy(p, List.of(ob("c.a", true), ob("c.b", false))));
+    }
+
+    @Test
+    void wrongSequenceRejected() {
+        Map<String, Object> p = policyWithComposite(List.of(path("/a", "ascending"), path("/b", "ascending")));
+        assertFalse(CosmosIndexingPolicy.supportsOrderBy(p, List.of(ob("c.b", true), ob("c.a", true))));
+    }
+
+    @Test
+    void orderByPrefixOfLongerCompositeRejected() {
+        // Azure: (a, b, c) does NOT serve ORDER BY a, b — length must match exactly
+        Map<String, Object> p = policyWithComposite(
+                List.of(path("/a", "ascending"), path("/b", "ascending"), path("/c", "ascending")));
+        assertFalse(CosmosIndexingPolicy.supportsOrderBy(p, List.of(ob("c.a", true), ob("c.b", true))));
+    }
+
+    @Test
+    void nestedPathsAndQuotedSegmentsMatch() {
+        Map<String, Object> p = policyWithComposite(
+                List.of(path("/meta/\"created-at\"", "ascending"), path("/meta/seq", "ascending")));
+        assertTrue(CosmosIndexingPolicy.supportsOrderBy(p,
+                List.of(ob("c.meta.created-at", true), ob("c.meta.seq", true))));
+    }
+}

--- a/src/test/java/io/floci/az/services/cosmos/CosmosQueryEngineOrderByTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosQueryEngineOrderByTest.java
@@ -1,0 +1,82 @@
+package io.floci.az.services.cosmos;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link CosmosQueryEngine#parseOrderBy} — the parse feeding
+ * the composite-index validation must see the ORDER BY clause exactly as the
+ * execution path does, across casing, whitespace, and clause boundaries.
+ */
+class CosmosQueryEngineOrderByTest {
+
+    private final CosmosQueryEngine engine = new CosmosQueryEngine();
+
+    @Test
+    void noOrderByYieldsEmptyList() {
+        assertTrue(engine.parseOrderBy("SELECT * FROM c WHERE c.a = 1").isEmpty());
+    }
+
+    @Test
+    void singleFieldDefaultsToAscending() {
+        List<CosmosQueryEngine.OrderByField> ob = engine.parseOrderBy("SELECT * FROM c ORDER BY c.a");
+        assertEquals(1, ob.size());
+        assertEquals("c.a", ob.get(0).path());
+        assertTrue(ob.get(0).asc());
+    }
+
+    @Test
+    void explicitDirectionsParsed() {
+        List<CosmosQueryEngine.OrderByField> ob =
+                engine.parseOrderBy("SELECT * FROM c ORDER BY c.a ASC, c.b DESC");
+        assertEquals(2, ob.size());
+        assertTrue(ob.get(0).asc());
+        assertFalse(ob.get(1).asc());
+    }
+
+    @Test
+    void fieldSequencePreserved() {
+        List<CosmosQueryEngine.OrderByField> ob =
+                engine.parseOrderBy("SELECT * FROM c ORDER BY c.b, c.a, c.z");
+        assertEquals(List.of("c.b", "c.a", "c.z"),
+                ob.stream().map(CosmosQueryEngine.OrderByField::path).toList());
+    }
+
+    @Test
+    void clauseEndsAtOffset() {
+        List<CosmosQueryEngine.OrderByField> ob =
+                engine.parseOrderBy("SELECT * FROM c ORDER BY c.a, c.b OFFSET 5 LIMIT 10");
+        assertEquals(2, ob.size());
+        assertEquals("c.b", ob.get(1).path());
+    }
+
+    @Test
+    void lowercaseKeywordsParsed() {
+        List<CosmosQueryEngine.OrderByField> ob =
+                engine.parseOrderBy("select * from c order by c.a desc, c.b");
+        assertEquals(2, ob.size());
+        assertFalse(ob.get(0).asc());
+        assertTrue(ob.get(1).asc());
+    }
+
+    @Test
+    void extraWhitespaceAndNewlinesNormalized() {
+        List<CosmosQueryEngine.OrderByField> ob =
+                engine.parseOrderBy("SELECT *\n  FROM c\n  ORDER BY   c.a ,\n  c.b   DESC");
+        assertEquals(2, ob.size());
+        assertEquals("c.a", ob.get(0).path());
+        assertEquals("c.b", ob.get(1).path());
+        assertFalse(ob.get(1).asc());
+    }
+
+    @Test
+    void whereClauseDoesNotLeakIntoOrderBy() {
+        List<CosmosQueryEngine.OrderByField> ob = engine.parseOrderBy(
+                "SELECT * FROM c WHERE c.category = 'order by trap' ORDER BY c.a, c.b");
+        assertEquals(2, ob.size());
+        assertEquals("c.a", ob.get(0).path());
+    }
+}

--- a/src/test/java/io/floci/az/services/cosmos/CosmosQueryEngineOrderByTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosQueryEngineOrderByTest.java
@@ -3,6 +3,7 @@ package io.floci.az.services.cosmos;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -83,5 +84,33 @@ class CosmosQueryEngineOrderByTest {
                 "SELECT * FROM c WHERE c.category = 'order by trap' ORDER BY c.a, c.b");
         assertEquals(2, ob.size());
         assertEquals("c.a", ob.get(0).path());
+    }
+
+    @Test
+    void paramValueWithApostropheDoesNotSwallowOrderBy() {
+        // "Alice's" substitutes to a literal containing an escaped quote. A
+        // scanner that mishandles the escape stays in string mode through the
+        // ORDER BY clause, yielding an empty list and silently skipping both
+        // composite-index enforcement and sorting.
+        List<CosmosQueryEngine.OrderByField> ob = engine.prepare(
+                "SELECT * FROM c WHERE c.name = @name ORDER BY c.conversationId, c.sequence",
+                List.of(Map.of("name", "@name", "value", "Alice's"))).orderBy();
+        assertEquals(2, ob.size());
+        assertEquals("c.conversationId", ob.get(0).path());
+        assertEquals("c.sequence", ob.get(1).path());
+    }
+
+    @Test
+    void paramValueWithApostropheFiltersAndSortsCorrectly() {
+        List<Map<String, Object>> docs = List.of(
+                Map.of("id", "a", "name", "Alice's", "seq", 2),
+                Map.of("id", "b", "name", "Alice's", "seq", 1),
+                Map.of("id", "c", "name", "Bob", "seq", 9));
+        CosmosQueryEngine.QueryResult r = engine.execute(
+                "SELECT * FROM c WHERE c.name = @name ORDER BY c.seq",
+                List.of(Map.of("name", "@name", "value", "Alice's")), docs);
+        // Equality must match the un-escaped value, and the two matches sort by seq.
+        assertEquals(List.of("b", "a"),
+                r.items().stream().map(d -> ((Map<?, ?>) d).get("id")).toList());
     }
 }

--- a/src/test/java/io/floci/az/services/cosmos/CosmosQueryEngineOrderByTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosQueryEngineOrderByTest.java
@@ -7,22 +7,27 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
- * Unit tests for {@link CosmosQueryEngine#parseOrderBy} — the parse feeding
- * the composite-index validation must see the ORDER BY clause exactly as the
- * execution path does, across casing, whitespace, and clause boundaries.
+ * Unit tests for the ORDER BY clause of {@link CosmosQueryEngine#prepare} —
+ * the parse feeding the composite-index validation must see the ORDER BY
+ * clause exactly as the execution path does, across casing, whitespace, and
+ * clause boundaries.
  */
 class CosmosQueryEngineOrderByTest {
 
     private final CosmosQueryEngine engine = new CosmosQueryEngine();
 
+    private List<CosmosQueryEngine.OrderByField> parseOrderBy(String sql) {
+        return engine.prepare(sql, List.of()).orderBy();
+    }
+
     @Test
     void noOrderByYieldsEmptyList() {
-        assertTrue(engine.parseOrderBy("SELECT * FROM c WHERE c.a = 1").isEmpty());
+        assertTrue(parseOrderBy("SELECT * FROM c WHERE c.a = 1").isEmpty());
     }
 
     @Test
     void singleFieldDefaultsToAscending() {
-        List<CosmosQueryEngine.OrderByField> ob = engine.parseOrderBy("SELECT * FROM c ORDER BY c.a");
+        List<CosmosQueryEngine.OrderByField> ob = parseOrderBy("SELECT * FROM c ORDER BY c.a");
         assertEquals(1, ob.size());
         assertEquals("c.a", ob.get(0).path());
         assertTrue(ob.get(0).asc());
@@ -31,7 +36,7 @@ class CosmosQueryEngineOrderByTest {
     @Test
     void explicitDirectionsParsed() {
         List<CosmosQueryEngine.OrderByField> ob =
-                engine.parseOrderBy("SELECT * FROM c ORDER BY c.a ASC, c.b DESC");
+                parseOrderBy("SELECT * FROM c ORDER BY c.a ASC, c.b DESC");
         assertEquals(2, ob.size());
         assertTrue(ob.get(0).asc());
         assertFalse(ob.get(1).asc());
@@ -40,7 +45,7 @@ class CosmosQueryEngineOrderByTest {
     @Test
     void fieldSequencePreserved() {
         List<CosmosQueryEngine.OrderByField> ob =
-                engine.parseOrderBy("SELECT * FROM c ORDER BY c.b, c.a, c.z");
+                parseOrderBy("SELECT * FROM c ORDER BY c.b, c.a, c.z");
         assertEquals(List.of("c.b", "c.a", "c.z"),
                 ob.stream().map(CosmosQueryEngine.OrderByField::path).toList());
     }
@@ -48,7 +53,7 @@ class CosmosQueryEngineOrderByTest {
     @Test
     void clauseEndsAtOffset() {
         List<CosmosQueryEngine.OrderByField> ob =
-                engine.parseOrderBy("SELECT * FROM c ORDER BY c.a, c.b OFFSET 5 LIMIT 10");
+                parseOrderBy("SELECT * FROM c ORDER BY c.a, c.b OFFSET 5 LIMIT 10");
         assertEquals(2, ob.size());
         assertEquals("c.b", ob.get(1).path());
     }
@@ -56,7 +61,7 @@ class CosmosQueryEngineOrderByTest {
     @Test
     void lowercaseKeywordsParsed() {
         List<CosmosQueryEngine.OrderByField> ob =
-                engine.parseOrderBy("select * from c order by c.a desc, c.b");
+                parseOrderBy("select * from c order by c.a desc, c.b");
         assertEquals(2, ob.size());
         assertFalse(ob.get(0).asc());
         assertTrue(ob.get(1).asc());
@@ -65,7 +70,7 @@ class CosmosQueryEngineOrderByTest {
     @Test
     void extraWhitespaceAndNewlinesNormalized() {
         List<CosmosQueryEngine.OrderByField> ob =
-                engine.parseOrderBy("SELECT *\n  FROM c\n  ORDER BY   c.a ,\n  c.b   DESC");
+                parseOrderBy("SELECT *\n  FROM c\n  ORDER BY   c.a ,\n  c.b   DESC");
         assertEquals(2, ob.size());
         assertEquals("c.a", ob.get(0).path());
         assertEquals("c.b", ob.get(1).path());
@@ -74,7 +79,7 @@ class CosmosQueryEngineOrderByTest {
 
     @Test
     void whereClauseDoesNotLeakIntoOrderBy() {
-        List<CosmosQueryEngine.OrderByField> ob = engine.parseOrderBy(
+        List<CosmosQueryEngine.OrderByField> ob = parseOrderBy(
                 "SELECT * FROM c WHERE c.category = 'order by trap' ORDER BY c.a, c.b");
         assertEquals(2, ob.size());
         assertEquals("c.a", ob.get(0).path());


### PR DESCRIPTION
Closes #127

## What

- **Custom `indexingPolicy` on container create** — persisted and returned on container read. Policies are normalized the way Azure does it: defaults filled in, `indexingMode` lowercased, composite-index path `order` defaulting to `ascending`. Invalid policies (non-object policy, unknown mode, single-path composite, missing/invalid path, bad order value) are rejected with `400 BadRequest` and leave no state behind.
- **Container replace** — new `PUT /dbs/{db}/colls/{coll}` route so SDKs can update the indexing policy on an existing container. `id` and `partitionKey` are immutable (400 on change attempt), matching Azure; a replace without an `indexingPolicy` resets to the default, dropping composite indexes (Azure full-replace semantics). A failed replace leaves the existing policy untouched.
- **Composite-index ORDER BY enforcement** — an `ORDER BY` over two or more properties (including mixed-direction sorts) now fails with `400 BadRequest` (`"The order by query does not have a corresponding composite index that it can be served from"`, code `SC2104`) unless the container has a composite index matching the clause exactly: same paths, same sequence, same length, with directions matching exactly or all-inverted. Verified against the [Azure composite-index rules](https://learn.microsoft.com/en-us/azure/cosmos-db/index-policy#composite-indexes), including the non-obvious one that a composite `(a, b, c)` does **not** serve `ORDER BY a, b`.

This closes a bug-masking parity gap: `ORDER BY c.conversationId, c.sequence` used to succeed locally against the permissive in-process engine, then return 400 in production when the container lacked the composite index. It now fails locally too.

## Implementation notes

- `CosmosIndexingPolicy` (new) owns policy normalization/validation and the composite-index matching rule; `CosmosHandler` routes create/replace through it and enforces the ORDER BY rule in the query path.
- `CosmosQueryEngine` gained a `prepare()`/`execute(ParsedQuery, docs)` split so the handler validates and executes from a single parse per query; the FROM-alias strip is now a shared `stripAlias()` helper so validation and execution always agree on property paths.
- Drive-by fix: `indexOfKeyword` now skips string literals, so a `WHERE` value containing `'order by'` no longer mis-parses the query (previously it would corrupt clause detection; post-enforcement it would have caused false 400s). Regression-tested at parser and HTTP level.

## Testing

- **Unit** (`CosmosIndexingPolicyTest`, 26): normalization defaults, invalid-shape rejections, and the full ORDER BY matching matrix (exact / inverted / partial / wrong sequence / prefix-of-longer / multi-index / nested + quoted paths / case sensitivity).
- **Parser** (`CosmosQueryEngineOrderByTest`, 8): ORDER BY extraction across casing, whitespace, clause boundaries, and string-literal traps.
- **HTTP** (`CosmosContainerIndexingTest`, 29 `@QuarkusTest`): create/replace lifecycle happy + non-happy paths, enforcement wiring incl. parameterized queries, OFFSET/LIMIT, lowercase SQL, and replace atomicity.
- **SDK compat** (`CosmosCompatibilityTest`, +5): real `azure-cosmos` Java SDK — policy round-trip, replace, single-path composite rejection, ORDER BY 400, and ORDER BY served with sorted results. Ran green against a live TLS-enabled emulator.
- Full unit suite: 372 tests, 0 failures.