### PR TITLE
feat(servicebus): subscription rules and topic filters (CorrelationFilter, SqlFilter, $Default)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **servicebus:** subscription rules and topic filters — the `/{topic}/subscriptions/{sub}/rules[/{rule}]` management-plane endpoints (create/get/list/delete, ATOM `RuleDescription` wire format with `CorrelationFilter`/`SqlFilter`/`TrueFilter`/`FalseFilter` and `SqlRuleAction` bodies), Azure's implicit `$Default` TrueFilter rule (auto-created per subscription, replaceable via the delete-then-add SDK flow or a `DefaultRuleDescription` in the subscription create body), and broker-side filter evaluation: rules compile to Artemis SQL92 queue selectors (`CorrelationId`→`JMSCorrelationID`, `Label`/`Subject`→`JMSType`, `SessionId`→`JMSXGroupID`, application properties by name, with typed int/long/double/boolean correlation values), multiple rules OR-combine into a single delivery, no rules delivers nothing, and rule changes update the queue filter in place (`updateQueue`) without dropping routed messages or kicking receivers. Filters on `MessageId`/`To`/`ReplyTo`/`ReplyToSessionId`/`ContentType` are rejected with 400 (no broker-side AMQP mapping); `SqlRuleAction` is stored/echoed but not applied to delivered messages ([#124](https://github.com/floci-io/floci-az/issues/124))
+
+### Fixed
+
+- **servicebus:** ATOM feed responses (queues/topics/subscriptions list) no longer embed an XML prolog inside every `<entry>`, which made the feed malformed XML for strict parsers
+
 ## [0.9.0] - 2026-07-09
 
 ### Added

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/EmulatorConfig.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/EmulatorConfig.java
@@ -502,6 +502,50 @@ public final class EmulatorConfig {
     }
 
     /**
+     * Creates or replaces a subscription rule via the floci-az management API.
+     * {@code ruleDescriptionXml} is the inner {@code <RuleDescription>} element
+     * (with xmlns declarations), as sent by ServiceBusAdministrationClient.
+     */
+    static void ensureServiceBusRule(String topicName, String subName,
+                                      String ruleName, String ruleDescriptionXml) throws Exception {
+        String url = BASE + "/" + ACCOUNT + "-servicebus/" + SERVICEBUS_NAMESPACE
+                + "/topics/" + topicName + "/subscriptions/" + subName + "/rules/" + ruleName;
+        String body = "<entry xmlns=\"http://www.w3.org/2005/Atom\"><content type=\"application/xml\">"
+                + ruleDescriptionXml + "</content></entry>";
+        byte[] bodyBytes = body.getBytes(StandardCharsets.UTF_8);
+        HttpURLConnection conn = (HttpURLConnection) URI.create(url).toURL().openConnection();
+        conn.setRequestMethod("PUT");
+        conn.setDoOutput(true);
+        conn.setConnectTimeout(5_000);
+        conn.setReadTimeout(30_000);
+        conn.setRequestProperty("Content-Type", "application/atom+xml;charset=utf-8");
+        conn.setRequestProperty("Content-Length", String.valueOf(bodyBytes.length));
+        try (OutputStream os = conn.getOutputStream()) {
+            os.write(bodyBytes);
+        }
+        int status = conn.getResponseCode();
+        if (status != 200 && status != 201) {
+            throw new RuntimeException("Failed to create rule '" + ruleName + "' on '"
+                    + topicName + "/" + subName + "', HTTP " + status);
+        }
+    }
+
+    /** Deletes a subscription rule (e.g. the implicit $Default) via the management API. */
+    static void deleteServiceBusRule(String topicName, String subName, String ruleName) throws Exception {
+        String url = BASE + "/" + ACCOUNT + "-servicebus/" + SERVICEBUS_NAMESPACE
+                + "/topics/" + topicName + "/subscriptions/" + subName + "/rules/" + ruleName;
+        HttpURLConnection conn = (HttpURLConnection) URI.create(url).toURL().openConnection();
+        conn.setRequestMethod("DELETE");
+        conn.setConnectTimeout(5_000);
+        conn.setReadTimeout(30_000);
+        int status = conn.getResponseCode();
+        if (status != 200) {
+            throw new RuntimeException("Failed to delete rule '" + ruleName + "' on '"
+                    + topicName + "/" + subName + "', HTTP " + status);
+        }
+    }
+
+    /**
      * Returns a ServiceBusClientBuilder connected to the emulator's AMQPS (TLS) port.
      *
      * The Azure Service Bus SDK 7.17.x always uses TLS when {@code customEndpointAddress}

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/ServiceBusRuleCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/ServiceBusRuleCompatibilityTest.java
@@ -47,17 +47,17 @@ class ServiceBusRuleCompatibilityTest {
         EmulatorConfig.ensureServiceBusTopic(topic);
         EmulatorConfig.ensureServiceBusSubscription(topic, "red-sub");
         EmulatorConfig.ensureServiceBusSubscription(topic, "blue-sub");
-        replaceDefaultRule(topic, "red-sub", correlationRule("only-red", "<Label>red</Label>"));
-        replaceDefaultRule(topic, "blue-sub", correlationRule("only-blue", "<Label>blue</Label>"));
+        replaceDefaultRule(topic, "red-sub", "only-red", correlationRule("only-red", "<Label>red</Label>"));
+        replaceDefaultRule(topic, "blue-sub", "only-blue", correlationRule("only-blue", "<Label>blue</Label>"));
 
         sendWithSubject(topic, "m-red", "red");
         sendWithSubject(topic, "m-blue", "blue");
         sendWithSubject(topic, "m-green", "green");
 
-        List<String> red = drain(topic, "red-sub");
+        List<String> red = drain(topic, "red-sub", 1);
         assertEquals(List.of("m-red"), red, "red-sub must receive exactly the red message");
 
-        List<String> blue = drain(topic, "blue-sub");
+        List<String> blue = drain(topic, "blue-sub", 1);
         assertEquals(List.of("m-blue"), blue, "blue-sub must receive exactly the blue message");
     }
 
@@ -67,7 +67,7 @@ class ServiceBusRuleCompatibilityTest {
         String topic = uniqueName("rules-cid");
         EmulatorConfig.ensureServiceBusTopic(topic);
         EmulatorConfig.ensureServiceBusSubscription(topic, "high-sub");
-        replaceDefaultRule(topic, "high-sub",
+        replaceDefaultRule(topic, "high-sub", "only-high",
                 correlationRule("only-high", "<CorrelationId>high</CorrelationId>"));
 
         try (ServiceBusSenderClient sender = topicSender(topic)) {
@@ -75,7 +75,7 @@ class ServiceBusRuleCompatibilityTest {
             sender.sendMessage(new ServiceBusMessage("m-low").setCorrelationId("low"));
         }
 
-        assertEquals(List.of("m-high"), drain(topic, "high-sub"));
+        assertEquals(List.of("m-high"), drain(topic, "high-sub", 1));
     }
 
     @Test
@@ -84,7 +84,7 @@ class ServiceBusRuleCompatibilityTest {
         String topic = uniqueName("rules-prop");
         EmulatorConfig.ensureServiceBusTopic(topic);
         EmulatorConfig.ensureServiceBusSubscription(topic, "prop-sub");
-        replaceDefaultRule(topic, "prop-sub", correlationRule("only-eu",
+        replaceDefaultRule(topic, "prop-sub", "only-eu", correlationRule("only-eu",
                 "<Properties><KeyValueOfstringanyType><Key>region</Key>"
                         + "<Value i:type=\"d6p1:string\" xmlns:d6p1=\"http://www.w3.org/2001/XMLSchema\">eu</Value>"
                         + "</KeyValueOfstringanyType></Properties>"));
@@ -98,7 +98,7 @@ class ServiceBusRuleCompatibilityTest {
             sender.sendMessage(us);
         }
 
-        assertEquals(List.of("m-eu"), drain(topic, "prop-sub"));
+        assertEquals(List.of("m-eu"), drain(topic, "prop-sub", 1));
     }
 
     @Test
@@ -107,7 +107,7 @@ class ServiceBusRuleCompatibilityTest {
         String topic = uniqueName("rules-sql");
         EmulatorConfig.ensureServiceBusTopic(topic);
         EmulatorConfig.ensureServiceBusSubscription(topic, "sql-sub");
-        replaceDefaultRule(topic, "sql-sub", sqlRule("big-blue",
+        replaceDefaultRule(topic, "sql-sub", "big-blue", sqlRule("big-blue",
                 "color='blue' AND quantity &gt; 5 AND sys.Label='order'"));
 
         try (ServiceBusSenderClient sender = topicSender(topic)) {
@@ -117,7 +117,7 @@ class ServiceBusRuleCompatibilityTest {
             sender.sendMessage(withProps("m-wrong-label", "invoice", "blue", 10));
         }
 
-        assertEquals(List.of("m-match"), drain(topic, "sql-sub"));
+        assertEquals(List.of("m-match"), drain(topic, "sql-sub", 1));
     }
 
     @Test
@@ -130,7 +130,7 @@ class ServiceBusRuleCompatibilityTest {
         sendWithSubject(topic, "m-1", "red");
         sendWithSubject(topic, "m-2", "blue");
 
-        List<String> got = drain(topic, "all-sub");
+        List<String> got = drain(topic, "all-sub", 2);
         assertEquals(List.of("m-1", "m-2"), got, "$Default TrueFilter must accept everything");
     }
 
@@ -144,7 +144,7 @@ class ServiceBusRuleCompatibilityTest {
 
         sendWithSubject(topic, "m-lost", "red");
 
-        assertEquals(List.of(), drain(topic, "empty-sub"),
+        assertEquals(List.of(), drain(topic, "empty-sub", 0),
                 "a subscription without rules must not receive messages");
     }
 
@@ -154,7 +154,7 @@ class ServiceBusRuleCompatibilityTest {
         String topic = uniqueName("rules-or");
         EmulatorConfig.ensureServiceBusTopic(topic);
         EmulatorConfig.ensureServiceBusSubscription(topic, "or-sub");
-        replaceDefaultRule(topic, "or-sub", correlationRule("red", "<Label>red</Label>"));
+        replaceDefaultRule(topic, "or-sub", "red", correlationRule("red", "<Label>red</Label>"));
         EmulatorConfig.ensureServiceBusRule(topic, "or-sub", "blue",
                 correlationRule("blue", "<Label>blue</Label>"));
 
@@ -162,21 +162,16 @@ class ServiceBusRuleCompatibilityTest {
         sendWithSubject(topic, "m-blue", "blue");
         sendWithSubject(topic, "m-green", "green");
 
-        assertEquals(List.of("m-red", "m-blue"), drain(topic, "or-sub"));
+        assertEquals(List.of("m-red", "m-blue"), drain(topic, "or-sub", 2));
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     /** Azure SDK flow: add the new rule first, then delete the implicit $Default. */
-    private static void replaceDefaultRule(String topic, String sub, String ruleXml) throws Exception {
-        String ruleName = ruleNameOf(ruleXml);
+    private static void replaceDefaultRule(String topic, String sub, String ruleName,
+                                            String ruleXml) throws Exception {
         EmulatorConfig.ensureServiceBusRule(topic, sub, ruleName, ruleXml);
         EmulatorConfig.deleteServiceBusRule(topic, sub, "$Default");
-    }
-
-    private static String ruleNameOf(String ruleXml) {
-        int start = ruleXml.indexOf("<Name>") + "<Name>".length();
-        return ruleXml.substring(start, ruleXml.indexOf("</Name>"));
     }
 
     private static String correlationRule(String name, String filterChildren) {
@@ -212,11 +207,11 @@ class ServiceBusRuleCompatibilityTest {
     }
 
     /**
-     * Receives and completes everything currently on the subscription (send order preserved),
-     * waiting {@link #RECV_TIMEOUT} for the first message and {@link #EMPTY_TIMEOUT} to
-     * confirm there is nothing more.
+     * Receives and completes everything on the subscription (send order preserved).
+     * Requests the expected count first so the call returns as soon as those messages
+     * arrive, then makes one short {@link #EMPTY_TIMEOUT} pass to catch misrouted strays.
      */
-    private List<String> drain(String topic, String sub) {
+    private List<String> drain(String topic, String sub, int expectedCount) {
         List<String> bodies = new ArrayList<>();
         try (ServiceBusReceiverClient receiver = EmulatorConfig.serviceBusClientBuilder()
                 .receiver()
@@ -224,21 +219,20 @@ class ServiceBusRuleCompatibilityTest {
                 .subscriptionName(sub)
                 .receiveMode(ServiceBusReceiveMode.PEEK_LOCK)
                 .buildClient()) {
-            Duration timeout = RECV_TIMEOUT;
-            while (true) {
-                List<ServiceBusReceivedMessage> batch = new ArrayList<>();
-                receiver.receiveMessages(10, timeout).forEach(batch::add);
-                if (batch.isEmpty()) {
-                    break;
-                }
-                for (ServiceBusReceivedMessage msg : batch) {
-                    bodies.add(msg.getBody().toString());
-                    receiver.complete(msg);
-                }
-                timeout = EMPTY_TIMEOUT;
+            if (expectedCount > 0) {
+                consume(receiver, expectedCount, RECV_TIMEOUT, bodies);
             }
+            consume(receiver, 10, EMPTY_TIMEOUT, bodies);
         }
         return bodies;
+    }
+
+    private static void consume(ServiceBusReceiverClient receiver, int maxMessages,
+                                 Duration timeout, List<String> bodies) {
+        for (ServiceBusReceivedMessage msg : receiver.receiveMessages(maxMessages, timeout)) {
+            bodies.add(msg.getBody().toString());
+            receiver.complete(msg);
+        }
     }
 
     private static String uniqueName(String prefix) {

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/ServiceBusRuleCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/ServiceBusRuleCompatibilityTest.java
@@ -1,0 +1,247 @@
+package io.floci.az.compat;
+
+import com.azure.messaging.servicebus.ServiceBusMessage;
+import com.azure.messaging.servicebus.ServiceBusReceivedMessage;
+import com.azure.messaging.servicebus.ServiceBusReceiverClient;
+import com.azure.messaging.servicebus.ServiceBusSenderClient;
+import com.azure.messaging.servicebus.models.ServiceBusReceiveMode;
+import org.junit.jupiter.api.*;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Subscription rule / topic filter compatibility tests (CorrelationFilter, SqlFilter,
+ * $Default TrueFilter semantics) against the Artemis sidecar.
+ *
+ * Rules compile to Artemis queue selectors, so these tests verify broker-side
+ * evaluation end to end: send via the Azure SDK, assert which subscriptions the
+ * message lands on. Rule management uses raw HTTP like the other compat tests.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.DisplayName.class)
+@DisplayName("Service Bus Subscription Rules Compatibility")
+class ServiceBusRuleCompatibilityTest {
+
+    private static final Duration RECV_TIMEOUT = Duration.ofSeconds(10);
+    private static final Duration EMPTY_TIMEOUT = Duration.ofSeconds(3);
+
+    private static final String SB_NS = "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect";
+    private static final String XSI_NS = "http://www.w3.org/2001/XMLSchema-instance";
+
+    @BeforeAll
+    void ensureNamespace() throws Exception {
+        EmulatorConfig.ensureServiceBusNamespace();
+        Assumptions.assumeFalse(EmulatorConfig.serviceBusMocked,
+                "Service Bus is in mocked mode — no Artemis broker, AMQP tests skipped");
+    }
+
+    @Test
+    @DisplayName("correlation filter on subject routes only matching messages")
+    void correlationFilterOnSubject() throws Exception {
+        String topic = uniqueName("rules-subj");
+        EmulatorConfig.ensureServiceBusTopic(topic);
+        EmulatorConfig.ensureServiceBusSubscription(topic, "red-sub");
+        EmulatorConfig.ensureServiceBusSubscription(topic, "blue-sub");
+        replaceDefaultRule(topic, "red-sub", correlationRule("only-red", "<Label>red</Label>"));
+        replaceDefaultRule(topic, "blue-sub", correlationRule("only-blue", "<Label>blue</Label>"));
+
+        sendWithSubject(topic, "m-red", "red");
+        sendWithSubject(topic, "m-blue", "blue");
+        sendWithSubject(topic, "m-green", "green");
+
+        List<String> red = drain(topic, "red-sub");
+        assertEquals(List.of("m-red"), red, "red-sub must receive exactly the red message");
+
+        List<String> blue = drain(topic, "blue-sub");
+        assertEquals(List.of("m-blue"), blue, "blue-sub must receive exactly the blue message");
+    }
+
+    @Test
+    @DisplayName("correlation filter on correlation id routes only matching messages")
+    void correlationFilterOnCorrelationId() throws Exception {
+        String topic = uniqueName("rules-cid");
+        EmulatorConfig.ensureServiceBusTopic(topic);
+        EmulatorConfig.ensureServiceBusSubscription(topic, "high-sub");
+        replaceDefaultRule(topic, "high-sub",
+                correlationRule("only-high", "<CorrelationId>high</CorrelationId>"));
+
+        try (ServiceBusSenderClient sender = topicSender(topic)) {
+            sender.sendMessage(new ServiceBusMessage("m-high").setCorrelationId("high"));
+            sender.sendMessage(new ServiceBusMessage("m-low").setCorrelationId("low"));
+        }
+
+        assertEquals(List.of("m-high"), drain(topic, "high-sub"));
+    }
+
+    @Test
+    @DisplayName("correlation filter on application property routes only matching messages")
+    void correlationFilterOnUserProperty() throws Exception {
+        String topic = uniqueName("rules-prop");
+        EmulatorConfig.ensureServiceBusTopic(topic);
+        EmulatorConfig.ensureServiceBusSubscription(topic, "prop-sub");
+        replaceDefaultRule(topic, "prop-sub", correlationRule("only-eu",
+                "<Properties><KeyValueOfstringanyType><Key>region</Key>"
+                        + "<Value i:type=\"d6p1:string\" xmlns:d6p1=\"http://www.w3.org/2001/XMLSchema\">eu</Value>"
+                        + "</KeyValueOfstringanyType></Properties>"));
+
+        try (ServiceBusSenderClient sender = topicSender(topic)) {
+            ServiceBusMessage eu = new ServiceBusMessage("m-eu");
+            eu.getApplicationProperties().put("region", "eu");
+            sender.sendMessage(eu);
+            ServiceBusMessage us = new ServiceBusMessage("m-us");
+            us.getApplicationProperties().put("region", "us");
+            sender.sendMessage(us);
+        }
+
+        assertEquals(List.of("m-eu"), drain(topic, "prop-sub"));
+    }
+
+    @Test
+    @DisplayName("sql filter evaluates user properties and sys.Label")
+    void sqlFilterOnPropertiesAndLabel() throws Exception {
+        String topic = uniqueName("rules-sql");
+        EmulatorConfig.ensureServiceBusTopic(topic);
+        EmulatorConfig.ensureServiceBusSubscription(topic, "sql-sub");
+        replaceDefaultRule(topic, "sql-sub", sqlRule("big-blue",
+                "color='blue' AND quantity &gt; 5 AND sys.Label='order'"));
+
+        try (ServiceBusSenderClient sender = topicSender(topic)) {
+            sender.sendMessage(withProps("m-match", "order", "blue", 10));
+            sender.sendMessage(withProps("m-small", "order", "blue", 3));
+            sender.sendMessage(withProps("m-red", "order", "red", 10));
+            sender.sendMessage(withProps("m-wrong-label", "invoice", "blue", 10));
+        }
+
+        assertEquals(List.of("m-match"), drain(topic, "sql-sub"));
+    }
+
+    @Test
+    @DisplayName("$Default rule accepts every message until replaced")
+    void defaultRuleAcceptsEverything() throws Exception {
+        String topic = uniqueName("rules-def");
+        EmulatorConfig.ensureServiceBusTopic(topic);
+        EmulatorConfig.ensureServiceBusSubscription(topic, "all-sub");
+
+        sendWithSubject(topic, "m-1", "red");
+        sendWithSubject(topic, "m-2", "blue");
+
+        List<String> got = drain(topic, "all-sub");
+        assertEquals(List.of("m-1", "m-2"), got, "$Default TrueFilter must accept everything");
+    }
+
+    @Test
+    @DisplayName("subscription with no rules receives nothing")
+    void noRulesDeliversNothing() throws Exception {
+        String topic = uniqueName("rules-none");
+        EmulatorConfig.ensureServiceBusTopic(topic);
+        EmulatorConfig.ensureServiceBusSubscription(topic, "empty-sub");
+        EmulatorConfig.deleteServiceBusRule(topic, "empty-sub", "$Default");
+
+        sendWithSubject(topic, "m-lost", "red");
+
+        assertEquals(List.of(), drain(topic, "empty-sub"),
+                "a subscription without rules must not receive messages");
+    }
+
+    @Test
+    @DisplayName("multiple rules combine as OR and deliver a single copy")
+    void multipleRulesCombineAsOr() throws Exception {
+        String topic = uniqueName("rules-or");
+        EmulatorConfig.ensureServiceBusTopic(topic);
+        EmulatorConfig.ensureServiceBusSubscription(topic, "or-sub");
+        replaceDefaultRule(topic, "or-sub", correlationRule("red", "<Label>red</Label>"));
+        EmulatorConfig.ensureServiceBusRule(topic, "or-sub", "blue",
+                correlationRule("blue", "<Label>blue</Label>"));
+
+        sendWithSubject(topic, "m-red", "red");
+        sendWithSubject(topic, "m-blue", "blue");
+        sendWithSubject(topic, "m-green", "green");
+
+        assertEquals(List.of("m-red", "m-blue"), drain(topic, "or-sub"));
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /** Azure SDK flow: add the new rule first, then delete the implicit $Default. */
+    private static void replaceDefaultRule(String topic, String sub, String ruleXml) throws Exception {
+        String ruleName = ruleNameOf(ruleXml);
+        EmulatorConfig.ensureServiceBusRule(topic, sub, ruleName, ruleXml);
+        EmulatorConfig.deleteServiceBusRule(topic, sub, "$Default");
+    }
+
+    private static String ruleNameOf(String ruleXml) {
+        int start = ruleXml.indexOf("<Name>") + "<Name>".length();
+        return ruleXml.substring(start, ruleXml.indexOf("</Name>"));
+    }
+
+    private static String correlationRule(String name, String filterChildren) {
+        return "<RuleDescription xmlns:i=\"" + XSI_NS + "\" xmlns=\"" + SB_NS + "\">"
+                + "<Filter i:type=\"CorrelationFilter\">" + filterChildren + "</Filter>"
+                + "<Action i:type=\"EmptyRuleAction\"/>"
+                + "<Name>" + name + "</Name></RuleDescription>";
+    }
+
+    private static String sqlRule(String name, String escapedExpression) {
+        return "<RuleDescription xmlns:i=\"" + XSI_NS + "\" xmlns=\"" + SB_NS + "\">"
+                + "<Filter i:type=\"SqlFilter\"><SqlExpression>" + escapedExpression + "</SqlExpression>"
+                + "<CompatibilityLevel>20</CompatibilityLevel></Filter>"
+                + "<Action i:type=\"EmptyRuleAction\"/>"
+                + "<Name>" + name + "</Name></RuleDescription>";
+    }
+
+    private static ServiceBusMessage withProps(String body, String subject, String color, int quantity) {
+        ServiceBusMessage msg = new ServiceBusMessage(body).setSubject(subject);
+        msg.getApplicationProperties().put("color", color);
+        msg.getApplicationProperties().put("quantity", quantity);
+        return msg;
+    }
+
+    private void sendWithSubject(String topic, String body, String subject) {
+        try (ServiceBusSenderClient sender = topicSender(topic)) {
+            sender.sendMessage(new ServiceBusMessage(body).setSubject(subject));
+        }
+    }
+
+    private ServiceBusSenderClient topicSender(String topic) {
+        return EmulatorConfig.serviceBusClientBuilder().sender().topicName(topic).buildClient();
+    }
+
+    /**
+     * Receives and completes everything currently on the subscription (send order preserved),
+     * waiting {@link #RECV_TIMEOUT} for the first message and {@link #EMPTY_TIMEOUT} to
+     * confirm there is nothing more.
+     */
+    private List<String> drain(String topic, String sub) {
+        List<String> bodies = new ArrayList<>();
+        try (ServiceBusReceiverClient receiver = EmulatorConfig.serviceBusClientBuilder()
+                .receiver()
+                .topicName(topic)
+                .subscriptionName(sub)
+                .receiveMode(ServiceBusReceiveMode.PEEK_LOCK)
+                .buildClient()) {
+            Duration timeout = RECV_TIMEOUT;
+            while (true) {
+                List<ServiceBusReceivedMessage> batch = new ArrayList<>();
+                receiver.receiveMessages(10, timeout).forEach(batch::add);
+                if (batch.isEmpty()) {
+                    break;
+                }
+                for (ServiceBusReceivedMessage msg : batch) {
+                    bodies.add(msg.getBody().toString());
+                    receiver.complete(msg);
+                }
+                timeout = EMPTY_TIMEOUT;
+            }
+        }
+        return bodies;
+    }
+
+    private static String uniqueName(String prefix) {
+        return prefix + "-" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+    }
+}

--- a/docs/services/service-bus.md
+++ b/docs/services/service-bus.md
@@ -28,6 +28,44 @@ Entity CRUD is served over HTTP at `/{account}-servicebus/`:
 | `PUT` / `DELETE` | `/{account}-servicebus/{topic}` | Create / delete a topic |
 | `GET` | `/{account}-servicebus/{topic}/subscriptions` | List subscriptions |
 | `PUT` / `GET` / `DELETE` | `/{account}-servicebus/{topic}/subscriptions/{sub}` | Manage a subscription |
+| `GET` | `/{account}-servicebus/{topic}/subscriptions/{sub}/rules` | List subscription rules |
+| `PUT` / `GET` / `DELETE` | `/{account}-servicebus/{topic}/subscriptions/{sub}/rules/{rule}` | Manage a subscription rule |
+
+## Subscription rules and filters
+
+Subscriptions filter which topic messages they receive through named **rules**, matching Azure
+semantics:
+
+- Every new subscription starts with the implicit **`$Default`** rule (a `TrueFilter` that accepts
+  everything). The usual SDK flow — add your real rule, then delete `$Default` — works as on Azure,
+  as does passing a `DefaultRuleDescription` in the subscription create body
+  (`CreateSubscriptionAsync(subscriptionOptions, ruleOptions)`).
+- **`CorrelationFilter`** — exact-match (case-sensitive) AND-combination over `CorrelationId`,
+  `Label`/`Subject`, `SessionId`, and application properties.
+- **`SqlFilter`** — SQL92 expressions over application properties and `sys.CorrelationId`,
+  `sys.Label`, `sys.Subject`, `sys.SessionId` (including `LIKE`, `IN`, `BETWEEN`, `IS NULL`,
+  `EXISTS(prop)`, arithmetic and boolean operators).
+- **`TrueFilter`** / **`FalseFilter`** — accept-all / accept-none.
+- Multiple rules combine as a logical **OR** and deliver a **single** copy of a matching message.
+  A subscription whose rules have all been deleted receives nothing.
+
+Filters compile to [Artemis queue selectors](https://activemq.apache.org/components/artemis/documentation/latest/filter-expressions.html),
+so evaluation happens inside the broker at routing time — messages that don't match a
+subscription's rules are never routed to it (no delivery-count inflation, no spurious
+dead-lettering).
+
+**Emulator deviations from Azure:**
+
+- Filters on `MessageId`, `To`, `ReplyTo`, `ReplyToSessionId`, or `ContentType` (and their `sys.*`
+  forms) are **rejected with HTTP 400** — these AMQP fields have no broker-side selector mapping.
+- **Rule actions** (`SqlRuleAction`) are stored and echoed back by the management API but are
+  **not applied** to delivered messages, and rules with actions do not produce extra message
+  copies.
+- Property names in filters are case-sensitive and must be valid selector identifiers
+  (letters, digits, `_`, `$`). Correlation-filter values typed `int`/`long`/`double`/`boolean`
+  etc. compare with their declared type; other non-string types compare as strings.
+- Rule changes update the subscription's filter in place (messages already routed to the
+  subscription stay, receivers stay attached) and, as on Azure, apply to future messages only.
 
 ## Connection String
 

--- a/src/main/java/io/floci/az/core/XmlParser.java
+++ b/src/main/java/io/floci/az/core/XmlParser.java
@@ -32,11 +32,20 @@ public final class XmlParser {
     private XmlParser() {}
 
     /**
+     * Creates a stream reader with this class's hardened settings (namespace-aware,
+     * external entities and DTDs disabled) — for callers whose parsing needs go beyond
+     * the extraction helpers here (e.g. reading attributes).
+     */
+    public static XMLStreamReader newStreamReader(String xml) throws XMLStreamException {
+        return FACTORY.createXMLStreamReader(new StringReader(xml));
+    }
+
+    /**
      * Reads the text content of the current element if it is a leaf (contains only text).
      * If the element contains nested child elements, the subtree is skipped and {@code null} is returned.
      * After this returns, the reader is positioned on the END_ELEMENT of the element that was open.
      */
-    private static String readLeafText(XMLStreamReader r) throws XMLStreamException {
+    public static String readLeafText(XMLStreamReader r) throws XMLStreamException {
         StringBuilder sb = new StringBuilder();
         while (r.hasNext()) {
             int event = r.next();

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
@@ -43,6 +43,10 @@ import java.util.Optional;
  *   GET    /{account}-servicebus/{topicName}/subscriptions/{sub}       — get subscription
  *   PUT    /{account}-servicebus/{topicName}/subscriptions/{sub}       — create subscription
  *   DELETE /{account}-servicebus/{topicName}/subscriptions/{sub}       — delete subscription
+ *   GET    /{account}-servicebus/{topicName}/subscriptions/{sub}/rules         — list rules
+ *   GET    /{account}-servicebus/{topicName}/subscriptions/{sub}/rules/{rule}  — get rule
+ *   PUT    /{account}-servicebus/{topicName}/subscriptions/{sub}/rules/{rule}  — create/update rule
+ *   DELETE /{account}-servicebus/{topicName}/subscriptions/{sub}/rules/{rule}  — delete rule
  * </pre>
  *
  * <p><b>Custom paths</b> (with explicit namespace, for programmatic setup):
@@ -61,6 +65,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
     private static final Logger LOG = Logger.getLogger(ServiceBusHandler.class);
 
     private static final String ATOM_XML_CONTENT_TYPE = "application/atom+xml;charset=utf-8";
+    private static final String XML_PROLOG = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
     private static final String DEFAULT_NAMESPACE = "default";
     /** Main Service Bus namespace for entity descriptions. */
     private static final String SB_NS = "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect";
@@ -245,13 +250,13 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         Optional<StoredObject> qObj = store.get(qKey);
         if (qObj.isPresent()) {
             ServiceBusModels.QueueEntity q = fromBytes(qObj.get().data(), ServiceBusModels.QueueEntity.class);
-            return Response.ok(queueEntryXml(ns, q)).type(ATOM_XML_CONTENT_TYPE).build();
+            return atomEntry(200, queueEntryXml(ns, q));
         }
         String tKey = topicKey(account, ns, entityName);
         Optional<StoredObject> tObj = store.get(tKey);
         if (tObj.isPresent()) {
             ServiceBusModels.TopicEntity t = fromBytes(tObj.get().data(), ServiceBusModels.TopicEntity.class);
-            return Response.ok(topicEntryXml(ns, t)).type(ATOM_XML_CONTENT_TYPE).build();
+            return atomEntry(200, topicEntryXml(ns, t));
         }
         return notFoundAtom(entityName + " not found");
     }
@@ -292,7 +297,21 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         if (subRest.isEmpty()) {
             return handleListSubscriptions(account, ns, topicName);
         }
-        return handleSubscriptionCrud(req, account, ns, topicName, subRest);
+        int slash = subRest.indexOf('/');
+        if (slash < 0) {
+            return handleSubscriptionCrud(req, account, ns, topicName, subRest);
+        }
+        // {subName}/rules[/{ruleName}]
+        String subName = subRest.substring(0, slash);
+        String tail = subRest.substring(slash + 1);
+        if ("rules".equals(tail)) {
+            return handleListRules(account, ns, topicName, subName);
+        }
+        if (tail.startsWith("rules/")) {
+            String ruleName = tail.substring("rules/".length());
+            return handleRuleCrud(req, account, ns, topicName, subName, ruleName);
+        }
+        return notFoundAtom("Path not found: " + topicName + "/subscriptions/" + subRest);
     }
 
     // ── Namespace management ──────────────────────────────────────────────────
@@ -410,8 +429,20 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                 return handleListSubscriptions(account, namespace, topicName);
             }
             if (sub.startsWith("subscriptions/")) {
-                String subName = sub.substring("subscriptions/".length());
-                return handleSubscriptionCrud(req, account, namespace, topicName, subName);
+                String subRest = sub.substring("subscriptions/".length());
+                int subSlash = subRest.indexOf('/');
+                if (subSlash < 0) {
+                    return handleSubscriptionCrud(req, account, namespace, topicName, subRest);
+                }
+                String subName = subRest.substring(0, subSlash);
+                String tail = subRest.substring(subSlash + 1);
+                if ("rules".equals(tail)) {
+                    return handleListRules(account, namespace, topicName, subName);
+                }
+                if (tail.startsWith("rules/")) {
+                    return handleRuleCrud(req, account, namespace, topicName, subName,
+                            tail.substring("rules/".length()));
+                }
             }
         }
         return notFound("Path not found: " + entityPath);
@@ -447,7 +478,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         return store.get(key)
                 .map(obj -> {
                     ServiceBusModels.QueueEntity q = fromBytes(obj.data(), ServiceBusModels.QueueEntity.class);
-                    return Response.ok(queueEntryXml(namespace, q)).type(ATOM_XML_CONTENT_TYPE).build();
+                    return atomEntry(200, queueEntryXml(namespace, q));
                 })
                 .orElseGet(() -> notFoundAtom("Queue not found: " + queueName));
     }
@@ -458,7 +489,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         if (store.get(key).isPresent()) {
             ServiceBusModels.QueueEntity existing =
                     fromBytes(store.get(key).get().data(), ServiceBusModels.QueueEntity.class);
-            return Response.ok(queueEntryXml(namespace, existing)).type(ATOM_XML_CONTENT_TYPE).build();
+            return atomEntry(200, queueEntryXml(namespace, existing));
         }
 
         if (namespaceManager.getNamespace(namespace).isEmpty()) {
@@ -475,8 +506,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
             LOG.warnf(e, "Failed to provision queue '%s' in Artemis for namespace '%s'", queueName, namespace);
         }
 
-        return Response.status(201).entity(queueEntryXml(namespace, queue))
-                .type(ATOM_XML_CONTENT_TYPE).build();
+        return atomEntry(201, queueEntryXml(namespace, queue));
     }
 
     private Response handleDeleteQueue(String account, String namespace, String queueName) {
@@ -519,7 +549,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         return store.get(key)
                 .map(obj -> {
                     ServiceBusModels.TopicEntity t = fromBytes(obj.data(), ServiceBusModels.TopicEntity.class);
-                    return Response.ok(topicEntryXml(namespace, t)).type(ATOM_XML_CONTENT_TYPE).build();
+                    return atomEntry(200, topicEntryXml(namespace, t));
                 })
                 .orElseGet(() -> notFoundAtom("Topic not found: " + topicName));
     }
@@ -529,7 +559,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         if (store.get(key).isPresent()) {
             ServiceBusModels.TopicEntity existing =
                     fromBytes(store.get(key).get().data(), ServiceBusModels.TopicEntity.class);
-            return Response.ok(topicEntryXml(namespace, existing)).type(ATOM_XML_CONTENT_TYPE).build();
+            return atomEntry(200, topicEntryXml(namespace, existing));
         }
 
         if (namespaceManager.getNamespace(namespace).isEmpty()) {
@@ -544,8 +574,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
             LOG.warnf(e, "Failed to provision topic '%s' in Artemis for namespace '%s'", topicName, namespace);
         }
 
-        return Response.status(201).entity(topicEntryXml(namespace, topic))
-                .type(ATOM_XML_CONTENT_TYPE).build();
+        return atomEntry(201, topicEntryXml(namespace, topic));
     }
 
     private Response handleDeleteTopic(String account, String namespace, String topicName) {
@@ -570,7 +599,9 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
 
     private Response handleListSubscriptions(String account, String namespace, String topicName) {
         String prefix = subPrefix(account, namespace, topicName);
-        List<ServiceBusModels.SubscriptionEntity> subs = store.scan(k -> k.startsWith(prefix))
+        // Rule entries live under {subPrefix}{sub}/rules/… — only direct children are subscriptions
+        List<ServiceBusModels.SubscriptionEntity> subs = store.scan(
+                        k -> k.startsWith(prefix) && k.indexOf('/', prefix.length()) < 0)
                 .stream()
                 .map(obj -> fromBytes(obj.data(), ServiceBusModels.SubscriptionEntity.class))
                 .filter(s -> s != null)
@@ -586,7 +617,8 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
             case "PUT", "POST"  -> {
                 String body = readBody(req);
                 boolean requiresSession = body.contains("<RequiresSession>true</RequiresSession>");
-                yield handleCreateSubscription(account, namespace, topicName, subName, requiresSession);
+                yield handleCreateSubscription(account, namespace, topicName, subName,
+                        requiresSession, body);
             }
             case "DELETE"       -> handleDeleteSubscription(account, namespace, topicName, subName);
             default             -> Response.status(405).build();
@@ -600,15 +632,14 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                 .map(obj -> {
                     ServiceBusModels.SubscriptionEntity s =
                             fromBytes(obj.data(), ServiceBusModels.SubscriptionEntity.class);
-                    return Response.ok(subscriptionEntryXml(namespace, s))
-                            .type(ATOM_XML_CONTENT_TYPE).build();
+                    return atomEntry(200, subscriptionEntryXml(namespace, s));
                 })
                 .orElseGet(() -> notFoundAtom("Subscription not found: " + subName));
     }
 
     private Response handleCreateSubscription(String account, String namespace,
                                                 String topicName, String subName,
-                                                boolean requiresSession) {
+                                                boolean requiresSession, String body) {
         if (store.get(topicKey(account, namespace, topicName)).isEmpty()) {
             return notFoundAtom("Topic not found: " + topicName);
         }
@@ -617,24 +648,37 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         if (store.get(key).isPresent()) {
             ServiceBusModels.SubscriptionEntity existing =
                     fromBytes(store.get(key).get().data(), ServiceBusModels.SubscriptionEntity.class);
-            return Response.ok(subscriptionEntryXml(namespace, existing))
-                    .type(ATOM_XML_CONTENT_TYPE).build();
+            return atomEntry(200, subscriptionEntryXml(namespace, existing));
+        }
+
+        // A subscription starts with its initial rule: an explicit <DefaultRuleDescription>
+        // from the create body, or Azure's implicit $Default TrueFilter (accept everything).
+        ServiceBusModels.RuleEntity initialRule =
+                ServiceBusRuleXml.parseDefaultRule(topicName, subName, body)
+                        .orElseGet(() -> ServiceBusModels.RuleEntity.trueFilter(topicName, subName, "$Default"));
+        String selector;
+        try {
+            selector = ServiceBusRuleSelector.forRules(List.of(initialRule));
+        } catch (IllegalArgumentException e) {
+            return badRequestAtom(e.getMessage());
         }
 
         EmulatorConfig.ServiceBusConfig sb = config.services().serviceBus();
         ServiceBusModels.SubscriptionEntity sub = ServiceBusModels.SubscriptionEntity.defaults(
                 topicName, subName, sb.maxDeliveryCount(), sb.lockDurationSeconds(), requiresSession);
         store.put(key, toStoredObject(key, sub));
+        String ruleStoreKey = ruleKey(account, namespace, topicName, subName, initialRule.name());
+        store.put(ruleStoreKey, toStoredObject(ruleStoreKey, initialRule));
+        warnOnActionIgnored(initialRule);
 
         try {
-            namespaceManager.jolokiaCreateSubscription(namespace, topicName, subName);
+            namespaceManager.jolokiaCreateSubscription(namespace, topicName, subName, selector);
         } catch (Exception e) {
             LOG.warnf(e, "Failed to provision subscription '%s/%s' in Artemis for namespace '%s'",
                     topicName, subName, namespace);
         }
 
-        return Response.status(201).entity(subscriptionEntryXml(namespace, sub))
-                .type(ATOM_XML_CONTENT_TYPE).build();
+        return atomEntry(201, subscriptionEntryXml(namespace, sub));
     }
 
     private Response handleDeleteSubscription(String account, String namespace,
@@ -643,6 +687,8 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         if (store.get(key).isEmpty()) {
             return notFoundAtom("Subscription not found: " + subName);
         }
+        String rulePrefix = rulePrefix(account, namespace, topicName, subName);
+        store.scan(k -> k.startsWith(rulePrefix)).forEach(obj -> store.delete(obj.key()));
         store.delete(key);
         try {
             namespaceManager.jolokiaDeleteSubscription(namespace, topicName, subName);
@@ -652,13 +698,118 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         return Response.ok().build();
     }
 
+    // ── Rule CRUD ─────────────────────────────────────────────────────────────
+
+    private Response handleListRules(String account, String namespace,
+                                      String topicName, String subName) {
+        if (store.get(subKey(account, namespace, topicName, subName)).isEmpty()) {
+            return notFoundAtom("Subscription not found: " + subName);
+        }
+        List<ServiceBusModels.RuleEntity> rules = loadRules(account, namespace, topicName, subName);
+        return Response.ok(ruleFeedXml(namespace, topicName, subName, rules))
+                .type(ATOM_XML_CONTENT_TYPE).build();
+    }
+
+    private Response handleRuleCrud(AzureRequest req, String account, String namespace,
+                                     String topicName, String subName, String ruleName) {
+        if (store.get(subKey(account, namespace, topicName, subName)).isEmpty()) {
+            return notFoundAtom("Subscription not found: " + subName);
+        }
+        return switch (req.method()) {
+            case "GET"          -> handleGetRule(account, namespace, topicName, subName, ruleName);
+            case "PUT", "POST"  -> handlePutRule(req, account, namespace, topicName, subName, ruleName);
+            case "DELETE"       -> handleDeleteRule(account, namespace, topicName, subName, ruleName);
+            default             -> Response.status(405).build();
+        };
+    }
+
+    private Response handleGetRule(String account, String namespace,
+                                    String topicName, String subName, String ruleName) {
+        String key = ruleKey(account, namespace, topicName, subName, ruleName);
+        return store.get(key)
+                .map(obj -> {
+                    ServiceBusModels.RuleEntity rule =
+                            fromBytes(obj.data(), ServiceBusModels.RuleEntity.class);
+                    return atomEntry(200, ruleEntryXml(namespace, rule));
+                })
+                .orElseGet(() -> notFoundAtom("Rule not found: " + ruleName));
+    }
+
+    /** Creates or updates a rule, then re-applies the compiled selector to the Artemis queue. */
+    private Response handlePutRule(AzureRequest req, String account, String namespace,
+                                    String topicName, String subName, String ruleName) {
+        ServiceBusModels.RuleEntity rule =
+                ServiceBusRuleXml.parseRule(topicName, subName, ruleName, readBody(req));
+        try {
+            ServiceBusRuleSelector.forRule(rule);
+        } catch (IllegalArgumentException e) {
+            return badRequestAtom(e.getMessage());
+        }
+
+        String key = ruleKey(account, namespace, topicName, subName, ruleName);
+        boolean existed = store.get(key).isPresent();
+        store.put(key, toStoredObject(key, rule));
+        warnOnActionIgnored(rule);
+        applySubscriptionFilter(account, namespace, topicName, subName);
+
+        return atomEntry(existed ? 200 : 201, ruleEntryXml(namespace, rule));
+    }
+
+    private Response handleDeleteRule(String account, String namespace,
+                                       String topicName, String subName, String ruleName) {
+        String key = ruleKey(account, namespace, topicName, subName, ruleName);
+        if (store.get(key).isEmpty()) {
+            return notFoundAtom("Rule not found: " + ruleName);
+        }
+        store.delete(key);
+        applySubscriptionFilter(account, namespace, topicName, subName);
+        return Response.ok().build();
+    }
+
+    private List<ServiceBusModels.RuleEntity> loadRules(String account, String namespace,
+                                                         String topicName, String subName) {
+        String prefix = rulePrefix(account, namespace, topicName, subName);
+        return store.scan(k -> k.startsWith(prefix))
+                .stream()
+                .map(obj -> fromBytes(obj.data(), ServiceBusModels.RuleEntity.class))
+                .filter(r -> r != null)
+                .toList();
+    }
+
+    /** Recompiles the subscription's rules and re-creates its Artemis queue with the new selector. */
+    private void applySubscriptionFilter(String account, String namespace,
+                                          String topicName, String subName) {
+        String selector;
+        try {
+            selector = ServiceBusRuleSelector.forRules(loadRules(account, namespace, topicName, subName));
+        } catch (IllegalArgumentException e) {
+            LOG.warnf("Cannot compile rules of subscription '%s/%s' to an Artemis filter: %s",
+                    topicName, subName, e.getMessage());
+            return;
+        }
+        try {
+            namespaceManager.jolokiaUpdateSubscriptionFilter(namespace, topicName, subName, selector);
+        } catch (Exception e) {
+            LOG.warnf(e, "Failed to update filter of subscription '%s/%s' in Artemis for namespace '%s'",
+                    topicName, subName, namespace);
+        }
+    }
+
+    private static void warnOnActionIgnored(ServiceBusModels.RuleEntity rule) {
+        if (rule.actionSqlExpression() != null && !rule.actionSqlExpression().isBlank()) {
+            LOG.warnf("Rule '%s' on subscription '%s/%s' declares a SqlRuleAction (\"%s\"); "
+                            + "the emulator stores it but does not apply actions to delivered messages",
+                    rule.name(), rule.topicName(), rule.subscriptionName(), rule.actionSqlExpression());
+        }
+    }
+
     // ── ATOM XML serialization ────────────────────────────────────────────────
 
+    /** Entry XML carries no {@code <?xml?>} prolog so it can be embedded in feeds; responses prepend it. */
     private String queueEntryXml(String namespace, ServiceBusModels.QueueEntity q) {
         String created = ISO8601.format(q.createdAt());
         String updated = ISO8601.format(q.updatedAt());
-        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-                + "<entry xmlns=\"http://www.w3.org/2005/Atom\">"
+        return "<entry xmlns=\"http://www.w3.org/2005/Atom\">"
                 + "<id>https://localhost/" + namespace + "/queues/" + xmlEsc(q.name()) + "</id>"
                 + "<title type=\"text\">" + xmlEsc(q.name()) + "</title>"
                 + "<published>" + created + "</published>"
@@ -705,8 +856,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
     private String topicEntryXml(String namespace, ServiceBusModels.TopicEntity t) {
         String created = ISO8601.format(t.createdAt());
         String updated = ISO8601.format(t.updatedAt());
-        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-                + "<entry xmlns=\"http://www.w3.org/2005/Atom\">"
+        return "<entry xmlns=\"http://www.w3.org/2005/Atom\">"
                 + "<id>https://localhost/" + xmlEsc(namespace) + "/topics/" + xmlEsc(t.name()) + "</id>"
                 + "<title type=\"text\">" + xmlEsc(t.name()) + "</title>"
                 + "<published>" + created + "</published>"
@@ -749,8 +899,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         String created = ISO8601.format(s.createdAt());
         String updated = ISO8601.format(s.updatedAt());
         String lockDuration = isoDuration(s.lockDurationSeconds());
-        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-                + "<entry xmlns=\"http://www.w3.org/2005/Atom\">"
+        return "<entry xmlns=\"http://www.w3.org/2005/Atom\">"
                 + "<id>https://localhost/" + xmlEsc(namespace) + "/topics/" + xmlEsc(s.topicName())
                 + "/subscriptions/" + xmlEsc(s.name()) + "</id>"
                 + "<title type=\"text\">" + xmlEsc(s.name()) + "</title>"
@@ -795,6 +944,39 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         return sb.toString();
     }
 
+    private String ruleEntryXml(String namespace, ServiceBusModels.RuleEntity rule) {
+        String created = ISO8601.format(rule.createdAt());
+        return "<entry xmlns=\"http://www.w3.org/2005/Atom\">"
+                + "<id>https://localhost/" + xmlEsc(namespace) + "/topics/" + xmlEsc(rule.topicName())
+                + "/subscriptions/" + xmlEsc(rule.subscriptionName())
+                + "/rules/" + xmlEsc(rule.name()) + "</id>"
+                + "<title type=\"text\">" + xmlEsc(rule.name()) + "</title>"
+                + "<published>" + created + "</published>"
+                + "<updated>" + created + "</updated>"
+                + "<content type=\"application/xml\">"
+                + ServiceBusRuleXml.ruleDescriptionXml(rule, SB_NS)
+                + "</content>"
+                + "</entry>";
+    }
+
+    private String ruleFeedXml(String namespace, String topicName, String subName,
+                                List<ServiceBusModels.RuleEntity> rules) {
+        String now = ISO8601.format(Instant.now());
+        StringBuilder sb = new StringBuilder();
+        sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
+          .append("<feed xmlns=\"http://www.w3.org/2005/Atom\">")
+          .append("<title type=\"text\">Rules</title>")
+          .append("<id>https://localhost/").append(xmlEsc(namespace)).append("/topics/")
+          .append(xmlEsc(topicName)).append("/subscriptions/").append(xmlEsc(subName))
+          .append("/rules</id>")
+          .append("<updated>").append(now).append("</updated>");
+        for (ServiceBusModels.RuleEntity rule : rules) {
+            sb.append(ruleEntryXml(namespace, rule));
+        }
+        sb.append("</feed>");
+        return sb.toString();
+    }
+
     /**
      * Returns a {@code <MessageCountDetails>} element using the spec-mandated 2011/06 namespace.
      * All counts are zero because message state lives entirely in Artemis.
@@ -833,6 +1015,15 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
 
     private static String subKey(String account, String namespace, String topicName, String subName) {
         return subPrefix(account, namespace, topicName) + subName;
+    }
+
+    private static String rulePrefix(String account, String namespace, String topicName, String subName) {
+        return subKey(account, namespace, topicName, subName) + "/rules/";
+    }
+
+    private static String ruleKey(String account, String namespace, String topicName,
+                                   String subName, String ruleName) {
+        return rulePrefix(account, namespace, topicName, subName) + ruleName;
     }
 
     // ── Utility helpers ───────────────────────────────────────────────────────
@@ -947,6 +1138,19 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         return Response.status(Response.Status.NOT_FOUND)
                 .entity("{\"error\":\"" + message + "\"}")
                 .type("application/json").build();
+    }
+
+    /** Wraps a prolog-free {@code <entry>} into a standalone ATOM response. */
+    private static Response atomEntry(int status, String entryXml) {
+        return Response.status(status).entity(XML_PROLOG + entryXml)
+                .type(ATOM_XML_CONTENT_TYPE).build();
+    }
+
+    private static Response badRequestAtom(String message) {
+        return Response.status(Response.Status.BAD_REQUEST)
+                .entity("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                        + "<Error><Code>400</Code><Detail>" + xmlEsc(message) + "</Detail></Error>")
+                .type(ATOM_XML_CONTENT_TYPE).build();
     }
 
     private static Response notFoundAtom(String message) {

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
@@ -71,8 +70,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
     private static final String SB_NS = "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect";
     /** Separate namespace used by MessageCountDetails child elements (per spec). */
     private static final String SB_COUNT_NS = "http://schemas.microsoft.com/netservices/2011/06/servicebus";
-    private static final DateTimeFormatter ISO8601 =
-            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'").withZone(ZoneOffset.UTC);
+    private static final DateTimeFormatter ISO8601 = ServiceBusModels.ISO8601;
 
     private static final ObjectMapper MAPPER = new ObjectMapper()
             .registerModule(new JavaTimeModule())
@@ -182,8 +180,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         Optional<String> activeNs = resolveActiveNamespace();
         String now = ISO8601.format(Instant.now());
         String nsName = activeNs.orElse(account);
-        String xml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-                + "<entry xmlns=\"http://www.w3.org/2005/Atom\">"
+        String xml = "<entry xmlns=\"http://www.w3.org/2005/Atom\">"
                 + "<id>https://localhost/$namespaceinfo</id>"
                 + "<title type=\"text\">" + nsName + "</title>"
                 + "<updated>" + now + "</updated>"
@@ -197,7 +194,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                 + "</NamespaceInfo>"
                 + "</content>"
                 + "</entry>";
-        return Response.ok(xml).type(ATOM_XML_CONTENT_TYPE).build();
+        return atomEntry(200, xml);
     }
 
     // ── Spec: list resources (queues or topics) ───────────────────────────────
@@ -218,7 +215,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
 
     private Response emptyFeed(String entityType) {
         String now = ISO8601.format(Instant.now());
-        return Response.ok("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+        return Response.ok(XML_PROLOG
                 + "<feed xmlns=\"http://www.w3.org/2005/Atom\">"
                 + "<title type=\"text\">" + entityType + "</title>"
                 + "<updated>" + now + "</updated>"
@@ -297,23 +294,34 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         if (subRest.isEmpty()) {
             return handleListSubscriptions(account, ns, topicName);
         }
+        Response response = handleSubscriptionSubPath(req, account, ns, topicName, subRest);
+        return response != null ? response
+                : notFoundAtom("Path not found: " + topicName + "/subscriptions/" + subRest);
+    }
+
+    /**
+     * Routes {@code {subName}[/rules[/{ruleName}]]} for both the spec and legacy paths.
+     * Returns {@code null} when the tail is not a recognised subscription sub-path,
+     * letting each caller keep its own not-found response format.
+     */
+    private Response handleSubscriptionSubPath(AzureRequest req, String account, String namespace,
+                                                String topicName, String subRest) {
         int slash = subRest.indexOf('/');
         if (slash < 0) {
-            return handleSubscriptionCrud(req, account, ns, topicName, subRest);
+            return handleSubscriptionCrud(req, account, namespace, topicName, subRest);
         }
-        // {subName}/rules[/{ruleName}]
         String subName = subRest.substring(0, slash);
         String tail = subRest.substring(slash + 1);
         if ("rules".equals(tail)) {
             return "GET".equals(req.method())
-                    ? handleListRules(account, ns, topicName, subName)
+                    ? handleListRules(account, namespace, topicName, subName)
                     : Response.status(405).build();
         }
         if (tail.startsWith("rules/")) {
-            String ruleName = tail.substring("rules/".length());
-            return handleRuleCrud(req, account, ns, topicName, subName, ruleName);
+            return handleRuleCrud(req, account, namespace, topicName, subName,
+                    tail.substring("rules/".length()));
         }
-        return notFoundAtom("Path not found: " + topicName + "/subscriptions/" + subRest);
+        return null;
     }
 
     // ── Namespace management ──────────────────────────────────────────────────
@@ -432,20 +440,9 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
             }
             if (sub.startsWith("subscriptions/")) {
                 String subRest = sub.substring("subscriptions/".length());
-                int subSlash = subRest.indexOf('/');
-                if (subSlash < 0) {
-                    return handleSubscriptionCrud(req, account, namespace, topicName, subRest);
-                }
-                String subName = subRest.substring(0, subSlash);
-                String tail = subRest.substring(subSlash + 1);
-                if ("rules".equals(tail)) {
-                    return "GET".equals(req.method())
-                            ? handleListRules(account, namespace, topicName, subName)
-                            : Response.status(405).build();
-                }
-                if (tail.startsWith("rules/")) {
-                    return handleRuleCrud(req, account, namespace, topicName, subName,
-                            tail.substring("rules/".length()));
+                Response response = handleSubscriptionSubPath(req, account, namespace, topicName, subRest);
+                if (response != null) {
+                    return response;
                 }
             }
         }
@@ -455,8 +452,8 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
     // ── Queue CRUD ────────────────────────────────────────────────────────────
 
     private Response handleListQueues(String account, String namespace) {
-        String prefix = queuePrefix(account, namespace);
-        List<ServiceBusModels.QueueEntity> queues = store.scan(k -> k.startsWith(prefix))
+        List<ServiceBusModels.QueueEntity> queues =
+                scanDirectChildren(queuePrefix(account, namespace))
                 .stream()
                 .map(obj -> fromBytes(obj.data(), ServiceBusModels.QueueEntity.class))
                 .filter(q -> q != null)
@@ -530,8 +527,8 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
     // ── Topic CRUD ────────────────────────────────────────────────────────────
 
     private Response handleListTopics(String account, String namespace) {
-        String prefix = topicPrefix(account, namespace);
-        List<ServiceBusModels.TopicEntity> topics = store.scan(k -> k.startsWith(prefix))
+        List<ServiceBusModels.TopicEntity> topics =
+                scanDirectChildren(topicPrefix(account, namespace))
                 .stream()
                 .map(obj -> fromBytes(obj.data(), ServiceBusModels.TopicEntity.class))
                 .filter(t -> t != null)
@@ -602,10 +599,8 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
     // ── Subscription CRUD ─────────────────────────────────────────────────────
 
     private Response handleListSubscriptions(String account, String namespace, String topicName) {
-        String prefix = subPrefix(account, namespace, topicName);
-        // Rule entries live under {subPrefix}{sub}/rules/… — only direct children are subscriptions
-        List<ServiceBusModels.SubscriptionEntity> subs = store.scan(
-                        k -> k.startsWith(prefix) && k.indexOf('/', prefix.length()) < 0)
+        List<ServiceBusModels.SubscriptionEntity> subs =
+                scanDirectChildren(subPrefix(account, namespace, topicName))
                 .stream()
                 .map(obj -> fromBytes(obj.data(), ServiceBusModels.SubscriptionEntity.class))
                 .filter(s -> s != null)
@@ -662,7 +657,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                         .orElseGet(() -> ServiceBusModels.RuleEntity.trueFilter(topicName, subName, "$Default"));
         String selector;
         try {
-            selector = ServiceBusRuleSelector.forRules(List.of(initialRule));
+            selector = ServiceBusRuleSelector.forRule(initialRule);
         } catch (IllegalArgumentException e) {
             return badRequestAtom(e.getMessage());
         }
@@ -845,7 +840,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
     private String queueFeedXml(String namespace, List<ServiceBusModels.QueueEntity> queues) {
         String now = ISO8601.format(Instant.now());
         StringBuilder sb = new StringBuilder();
-        sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
+        sb.append(XML_PROLOG)
           .append("<feed xmlns=\"http://www.w3.org/2005/Atom\">")
           .append("<title type=\"text\">Queues</title>")
           .append("<id>https://localhost/").append(xmlEsc(namespace)).append("/$Resources/queues</id>")
@@ -887,7 +882,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
     private String topicFeedXml(String namespace, List<ServiceBusModels.TopicEntity> topics) {
         String now = ISO8601.format(Instant.now());
         StringBuilder sb = new StringBuilder();
-        sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
+        sb.append(XML_PROLOG)
           .append("<feed xmlns=\"http://www.w3.org/2005/Atom\">")
           .append("<title type=\"text\">Topics</title>")
           .append("<id>https://localhost/").append(xmlEsc(namespace)).append("/$Resources/topics</id>")
@@ -935,7 +930,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                                         List<ServiceBusModels.SubscriptionEntity> subs) {
         String now = ISO8601.format(Instant.now());
         StringBuilder sb = new StringBuilder();
-        sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
+        sb.append(XML_PROLOG)
           .append("<feed xmlns=\"http://www.w3.org/2005/Atom\">")
           .append("<title type=\"text\">Subscriptions</title>")
           .append("<id>https://localhost/").append(xmlEsc(namespace)).append("/topics/")
@@ -967,7 +962,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                                 List<ServiceBusModels.RuleEntity> rules) {
         String now = ISO8601.format(Instant.now());
         StringBuilder sb = new StringBuilder();
-        sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
+        sb.append(XML_PROLOG)
           .append("<feed xmlns=\"http://www.w3.org/2005/Atom\">")
           .append("<title type=\"text\">Rules</title>")
           .append("<id>https://localhost/").append(xmlEsc(namespace)).append("/topics/")
@@ -1019,6 +1014,15 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
 
     private static String subKey(String account, String namespace, String topicName, String subName) {
         return subPrefix(account, namespace, topicName) + subName;
+    }
+
+    /**
+     * Storage keys are hierarchical: entities directly under a prefix are that prefix's
+     * children; deeper paths (e.g. {@code {sub}/rules/{rule}} under a subscription prefix)
+     * belong to sub-entities and are excluded from listings.
+     */
+    private List<StoredObject> scanDirectChildren(String prefix) {
+        return store.scan(k -> k.startsWith(prefix) && k.indexOf('/', prefix.length()) < 0);
     }
 
     private static String rulePrefix(String account, String namespace, String topicName, String subName) {
@@ -1150,18 +1154,19 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                 .type(ATOM_XML_CONTENT_TYPE).build();
     }
 
-    private static Response badRequestAtom(String message) {
-        return Response.status(Response.Status.BAD_REQUEST)
-                .entity("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-                        + "<Error><Code>400</Code><Detail>" + xmlEsc(message) + "</Detail></Error>")
+    private static Response errorAtom(int status, String message) {
+        return Response.status(status)
+                .entity(XML_PROLOG
+                        + "<Error><Code>" + status + "</Code><Detail>" + xmlEsc(message) + "</Detail></Error>")
                 .type(ATOM_XML_CONTENT_TYPE).build();
     }
 
+    private static Response badRequestAtom(String message) {
+        return errorAtom(400, message);
+    }
+
     private static Response notFoundAtom(String message) {
-        return Response.status(Response.Status.NOT_FOUND)
-                .entity("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-                        + "<Error><Code>404</Code><Detail>" + xmlEsc(message) + "</Detail></Error>")
-                .type(ATOM_XML_CONTENT_TYPE).build();
+        return errorAtom(404, message);
     }
 
     /** Wipes all Service Bus data — used by {@code POST /_admin/reset}. */

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
@@ -305,7 +305,9 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         String subName = subRest.substring(0, slash);
         String tail = subRest.substring(slash + 1);
         if ("rules".equals(tail)) {
-            return handleListRules(account, ns, topicName, subName);
+            return "GET".equals(req.method())
+                    ? handleListRules(account, ns, topicName, subName)
+                    : Response.status(405).build();
         }
         if (tail.startsWith("rules/")) {
             String ruleName = tail.substring("rules/".length());
@@ -437,7 +439,9 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                 String subName = subRest.substring(0, subSlash);
                 String tail = subRest.substring(subSlash + 1);
                 if ("rules".equals(tail)) {
-                    return handleListRules(account, namespace, topicName, subName);
+                    return "GET".equals(req.method())
+                            ? handleListRules(account, namespace, topicName, subName)
+                            : Response.status(405).build();
                 }
                 if (tail.startsWith("rules/")) {
                     return handleRuleCrud(req, account, namespace, topicName, subName,

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusModels.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusModels.java
@@ -3,9 +3,15 @@ package io.floci.az.services.servicebus;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 
 public final class ServiceBusModels {
+
+    /** Service Bus wire timestamp format, shared by all ATOM serialization in this package. */
+    static final DateTimeFormatter ISO8601 =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'").withZone(ZoneOffset.UTC);
 
     private ServiceBusModels() {}
 

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusModels.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusModels.java
@@ -3,6 +3,7 @@ package io.floci.az.services.servicebus;
 import io.quarkus.runtime.annotations.RegisterForReflection;
 
 import java.time.Instant;
+import java.util.Map;
 
 public final class ServiceBusModels {
 
@@ -36,6 +37,48 @@ public final class ServiceBusModels {
         static TopicEntity defaults(String name) {
             Instant now = Instant.now();
             return new TopicEntity(name, 1024, now, now);
+        }
+    }
+
+    /**
+     * A subscription rule: a named filter (plus optional SQL action) attached to a subscription.
+     * {@code filterType} is one of the Azure filter type names:
+     * {@code TrueFilter}, {@code FalseFilter}, {@code SqlFilter}, {@code CorrelationFilter}.
+     * The correlation* fields and {@code correlationProperties} are only populated for
+     * {@code CorrelationFilter}; {@code sqlExpression} only for {@code SqlFilter}.
+     * {@code correlationPropertyTypes} carries the XML Schema type of each correlation
+     * property value (e.g. {@code int}, {@code boolean}); properties without an entry
+     * are strings.
+     */
+    @RegisterForReflection
+    public record RuleEntity(
+            String topicName,
+            String subscriptionName,
+            String name,
+            String filterType,
+            String sqlExpression,
+            String correlationId,
+            String messageId,
+            String to,
+            String replyTo,
+            String label,
+            String sessionId,
+            String replyToSessionId,
+            String contentType,
+            Map<String, String> correlationProperties,
+            Map<String, String> correlationPropertyTypes,
+            String actionSqlExpression,
+            Instant createdAt) {
+
+        public RuleEntity {
+            correlationProperties = correlationProperties == null ? Map.of() : correlationProperties;
+            correlationPropertyTypes = correlationPropertyTypes == null ? Map.of() : correlationPropertyTypes;
+        }
+
+        public static RuleEntity trueFilter(String topicName, String subscriptionName, String name) {
+            return new RuleEntity(topicName, subscriptionName, name, "TrueFilter",
+                    null, null, null, null, null, null, null, null, null,
+                    Map.of(), Map.of(), null, Instant.now());
         }
     }
 

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -374,7 +374,7 @@ public class ServiceBusNamespaceManager {
             if (i > 0) sb.append(",");
             Object v = values[i];
             if (v instanceof String s) {
-                sb.append("\"").append(s.replace("\\", "\\\\").replace("\"", "\\\"")).append("\"");
+                sb.append(jsonString(s));
             } else {
                 sb.append(v);
             }

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -365,7 +365,28 @@ public class ServiceBusNamespaceManager {
     }
 
     private static String jsonString(String value) {
-        return "\"" + value.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
+        StringBuilder sb = new StringBuilder(value.length() + 2);
+        sb.append('"');
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '\\' -> sb.append("\\\\");
+                case '"' -> sb.append("\\\"");
+                case '\n' -> sb.append("\\n");
+                case '\r' -> sb.append("\\r");
+                case '\t' -> sb.append("\\t");
+                case '\f' -> sb.append("\\f");
+                case '\b' -> sb.append("\\b");
+                default -> {
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+                }
+            }
+        }
+        return sb.append('"').toString();
     }
 
     private static String jsonArr(Object... values) {

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -227,14 +227,38 @@ public class ServiceBusNamespaceManager {
     /**
      * Provisions a durable MULTICAST queue (subscription) bound to the topic address.
      * The queue name follows the Azure convention: {@code {topicName}/Subscriptions/{subName}}.
+     *
+     * @param filter Artemis core filter (SQL92 selector) applied to the queue — the compiled
+     *               form of the subscription's rules; empty string matches everything
      */
-    public void jolokiaCreateSubscription(String namespaceName, String topicName, String subName) {
+    public void jolokiaCreateSubscription(String namespaceName, String topicName, String subName,
+                                           String filter) {
         String queueName = topicName + "/Subscriptions/" + subName;
         withJolokia(namespaceName, (http, baseUrl, auth, mbean) -> {
             // address=topicName (MULTICAST), queue name=topicName/Subscriptions/subName
             jolokiaExec(http, baseUrl, auth, mbean,
                     "createQueue(java.lang.String,java.lang.String,java.lang.String,java.lang.String,boolean,int,boolean,boolean)",
-                    jsonArr(topicName, "MULTICAST", queueName, "", true, -1, false, false));
+                    jsonArr(topicName, "MULTICAST", queueName, filter, true, -1, false, false));
+        });
+    }
+
+    /**
+     * Replaces the filter of an existing subscription queue in place via
+     * {@code ActiveMQServerControl.updateQueue(String queueConfiguration)}. The broker applies
+     * the new filter to future routing only ({@code Queue.setFilter}), matching Azure's
+     * rule-change semantics: messages already routed to the subscription stay, attached
+     * receivers stay connected.
+     */
+    public void jolokiaUpdateSubscriptionFilter(String namespaceName, String topicName, String subName,
+                                                 String filter) {
+        String queueName = topicName + "/Subscriptions/" + subName;
+        // QueueConfiguration JSON uses kebab-case keys ("filter-string", not "filterString")
+        String queueConfigJson = "{\"name\":" + jsonString(queueName)
+                + ",\"filter-string\":" + jsonString(filter) + "}";
+        withJolokia(namespaceName, (http, baseUrl, auth, mbean) -> {
+            jolokiaExec(http, baseUrl, auth, mbean,
+                    "updateQueue(java.lang.String)",
+                    jsonArr(queueConfigJson));
         });
     }
 
@@ -338,6 +362,10 @@ public class ServiceBusNamespaceManager {
         } catch (Exception e) {
             LOG.debugv("Jolokia call failed ({0}): {1}", operation.split("\\(")[0], e.getMessage());
         }
+    }
+
+    private static String jsonString(String value) {
+        return "\"" + value.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
     }
 
     private static String jsonArr(Object... values) {

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusRuleSelector.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusRuleSelector.java
@@ -218,8 +218,7 @@ final class ServiceBusRuleSelector {
      * {@code EXISTS} consumes its parenthesised argument as well.
      */
     private static int appendIdentifier(StringBuilder out, String expression, String token, int resume) {
-        String lower = token.toLowerCase(Locale.ROOT);
-        switch (lower) {
+        switch (token.toLowerCase(Locale.ROOT)) {
             case "and", "or", "not", "like", "in", "is", "null", "between", "escape", "true", "false" -> {
                 out.append(token);
                 return resume;
@@ -229,16 +228,20 @@ final class ServiceBusRuleSelector {
             }
             default -> { }
         }
+        out.append(mapProperty(token));
+        return resume;
+    }
+
+    /** Resolves a {@code sys.}/{@code user.}/bare property token to its selector identifier. */
+    private static String mapProperty(String token) {
+        String lower = token.toLowerCase(Locale.ROOT);
         if (lower.startsWith("sys.")) {
-            out.append(mapSystemProperty(token.substring(4)));
-            return resume;
+            return mapSystemProperty(token.substring(4));
         }
         if (lower.startsWith("user.")) {
-            out.append(userProperty(token.substring(5)));
-            return resume;
+            return userProperty(token.substring(5));
         }
-        out.append(userProperty(token));
-        return resume;
+        return userProperty(token);
     }
 
     private static String mapSystemProperty(String name) {
@@ -264,16 +267,7 @@ final class ServiceBusRuleSelector {
             throw new IllegalArgumentException("Unterminated EXISTS(...) in filter: " + expression);
         }
         String rawName = expression.substring(i + 1, close).trim();
-        String lower = rawName.toLowerCase(Locale.ROOT);
-        String mapped;
-        if (lower.startsWith("sys.")) {
-            mapped = mapSystemProperty(rawName.substring(4));
-        } else if (lower.startsWith("user.")) {
-            mapped = userProperty(rawName.substring(5));
-        } else {
-            mapped = userProperty(rawName);
-        }
-        out.append("(").append(mapped).append(" IS NOT NULL)");
+        out.append("(").append(mapProperty(rawName)).append(" IS NOT NULL)");
         return close + 1;
     }
 }

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusRuleSelector.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusRuleSelector.java
@@ -1,0 +1,279 @@
+package io.floci.az.services.servicebus;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * Compiles a subscription's rule set into an ActiveMQ Artemis core filter (SQL92 selector)
+ * applied to the subscription's MULTICAST queue, so filter evaluation happens inside the
+ * broker at routing time.
+ *
+ * <p>Azure system properties map to the identifiers Artemis resolves on AMQP messages
+ * ({@code AMQPMessage.getObjectProperty}):
+ * <ul>
+ *   <li>{@code CorrelationId} / {@code sys.CorrelationId} → {@code JMSCorrelationID} (AMQP correlation-id)</li>
+ *   <li>{@code Label} / {@code sys.Label} / {@code sys.Subject} → {@code JMSType} (AMQP subject)</li>
+ *   <li>{@code SessionId} / {@code sys.SessionId} → {@code JMSXGroupID} (AMQP group-id)</li>
+ *   <li>user properties → AMQP application properties, referenced by name</li>
+ * </ul>
+ * System properties without a broker-side identifier (MessageId, To, ReplyTo,
+ * ReplyToSessionId, ContentType) are rejected with {@link IllegalArgumentException}
+ * so misrouting fails loudly at rule creation instead of silently at delivery.
+ */
+final class ServiceBusRuleSelector {
+
+    /** Selector that never matches — used when a subscription has no (effective) rules. */
+    static final String MATCH_NONE = "1=0";
+    /** Empty Artemis filter — the queue receives every message routed to the address. */
+    static final String MATCH_ALL = "";
+
+    private static final Pattern IDENTIFIER = Pattern.compile("[A-Za-z_$][A-Za-z0-9_$]*");
+
+    private ServiceBusRuleSelector() {}
+
+    /**
+     * Compiles the full rule set of one subscription. Rules combine as a logical OR
+     * (Azure semantics for rules without actions). No rules → match nothing.
+     */
+    static String forRules(List<ServiceBusModels.RuleEntity> rules) {
+        List<String> parts = new ArrayList<>();
+        for (ServiceBusModels.RuleEntity rule : rules) {
+            String selector = forRule(rule);
+            if (MATCH_ALL.equals(selector)) {
+                return MATCH_ALL;
+            }
+            if (!MATCH_NONE.equals(selector)) {
+                parts.add(selector);
+            }
+        }
+        if (parts.isEmpty()) {
+            return MATCH_NONE;
+        }
+        if (parts.size() == 1) {
+            return parts.get(0);
+        }
+        return "(" + String.join(") OR (", parts) + ")";
+    }
+
+    /** Compiles a single rule's filter to a selector fragment. */
+    static String forRule(ServiceBusModels.RuleEntity rule) {
+        return switch (rule.filterType()) {
+            case "TrueFilter" -> MATCH_ALL;
+            case "FalseFilter" -> MATCH_NONE;
+            case "SqlFilter" -> translateSql(rule.sqlExpression());
+            case "CorrelationFilter" -> compileCorrelation(rule);
+            default -> throw new IllegalArgumentException("Unknown filter type: " + rule.filterType());
+        };
+    }
+
+    private static String compileCorrelation(ServiceBusModels.RuleEntity rule) {
+        rejectUnsupported("MessageId", rule.messageId());
+        rejectUnsupported("To", rule.to());
+        rejectUnsupported("ReplyTo", rule.replyTo());
+        rejectUnsupported("ReplyToSessionId", rule.replyToSessionId());
+        rejectUnsupported("ContentType", rule.contentType());
+
+        List<String> conditions = new ArrayList<>();
+        if (rule.correlationId() != null) {
+            conditions.add("JMSCorrelationID = " + stringLiteral(rule.correlationId()));
+        }
+        if (rule.label() != null) {
+            conditions.add("JMSType = " + stringLiteral(rule.label()));
+        }
+        if (rule.sessionId() != null) {
+            conditions.add("JMSXGroupID = " + stringLiteral(rule.sessionId()));
+        }
+        for (Map.Entry<String, String> e : rule.correlationProperties().entrySet()) {
+            String valueType = rule.correlationPropertyTypes().get(e.getKey());
+            conditions.add(userProperty(e.getKey()) + " = " + typedLiteral(e.getValue(), valueType));
+        }
+        if (conditions.isEmpty()) {
+            throw new IllegalArgumentException("CorrelationFilter must set at least one property");
+        }
+        return String.join(" AND ", conditions);
+    }
+
+    private static void rejectUnsupported(String field, String value) {
+        if (value != null) {
+            throw new IllegalArgumentException("CorrelationFilter on " + field
+                    + " is not supported by the emulator (no broker-side AMQP mapping); "
+                    + "filter on CorrelationId, Label, SessionId or application properties instead");
+        }
+    }
+
+    private static String userProperty(String name) {
+        if (!IDENTIFIER.matcher(name).matches()) {
+            throw new IllegalArgumentException("Property name '" + name
+                    + "' cannot be used in a filter: it is not a valid selector identifier");
+        }
+        return name;
+    }
+
+    private static String stringLiteral(String value) {
+        return "'" + value.replace("'", "''") + "'";
+    }
+
+    private static final Pattern INTEGER_LITERAL = Pattern.compile("[+-]?\\d+");
+    private static final Pattern DECIMAL_LITERAL = Pattern.compile("[+-]?\\d*\\.?\\d+([eE][+-]?\\d+)?");
+
+    /**
+     * Emits a correlation-property value as a selector literal matching its declared
+     * XML Schema type, so numeric and boolean application properties compare with
+     * the correct selector type (JMS selectors never match across types).
+     */
+    private static String typedLiteral(String value, String xmlSchemaType) {
+        if (xmlSchemaType == null) {
+            return stringLiteral(value);
+        }
+        String trimmed = value.trim();
+        switch (xmlSchemaType.toLowerCase(Locale.ROOT)) {
+            case "int", "long", "short", "byte",
+                 "integer", "unsignedint", "unsignedlong", "unsignedshort", "unsignedbyte" -> {
+                if (INTEGER_LITERAL.matcher(trimmed).matches()) {
+                    return trimmed;
+                }
+            }
+            case "double", "float", "decimal" -> {
+                if (DECIMAL_LITERAL.matcher(trimmed).matches()) {
+                    return trimmed;
+                }
+            }
+            case "boolean" -> {
+                if ("true".equalsIgnoreCase(trimmed) || "false".equalsIgnoreCase(trimmed)) {
+                    return trimmed.toUpperCase(Locale.ROOT);
+                }
+            }
+            default -> { }
+        }
+        return stringLiteral(value);
+    }
+
+    // ── SqlFilter translation ─────────────────────────────────────────────────
+
+    /**
+     * Translates an Azure SQL filter expression to Artemis selector syntax:
+     * {@code sys.*} identifiers are mapped to broker identifiers, {@code user.} prefixes
+     * and {@code [bracketed]} delimiters are stripped, and {@code EXISTS(p)} becomes
+     * {@code (p IS NOT NULL)}. String literals pass through untouched.
+     */
+    static String translateSql(String expression) {
+        if (expression == null || expression.isBlank()) {
+            throw new IllegalArgumentException("SqlFilter requires a SqlExpression");
+        }
+        StringBuilder out = new StringBuilder(expression.length());
+        int i = 0;
+        int n = expression.length();
+        while (i < n) {
+            char c = expression.charAt(i);
+            if (c == '\'') {
+                int end = endOfStringLiteral(expression, i);
+                out.append(expression, i, end);
+                i = end;
+            } else if (c == '[') {
+                int close = expression.indexOf(']', i);
+                if (close < 0) {
+                    throw new IllegalArgumentException("Unterminated [delimited] identifier in filter: " + expression);
+                }
+                i = appendIdentifier(out, expression, expression.substring(i + 1, close), close + 1);
+            } else if (Character.isLetter(c) || c == '_' || c == '$') {
+                int end = i;
+                while (end < n && (Character.isLetterOrDigit(expression.charAt(end))
+                        || expression.charAt(end) == '_' || expression.charAt(end) == '$'
+                        || expression.charAt(end) == '.')) {
+                    end++;
+                }
+                i = appendIdentifier(out, expression, expression.substring(i, end), end);
+            } else if (c == '%') {
+                throw new IllegalArgumentException(
+                        "The modulo operator (%) is not supported in emulator SQL filters");
+            } else {
+                out.append(c);
+                i++;
+            }
+        }
+        return out.toString();
+    }
+
+    /** Returns the index just past the closing quote, honouring {@code ''} escapes. */
+    private static int endOfStringLiteral(String s, int start) {
+        int i = start + 1;
+        while (i < s.length()) {
+            if (s.charAt(i) == '\'') {
+                if (i + 1 < s.length() && s.charAt(i + 1) == '\'') {
+                    i += 2;
+                    continue;
+                }
+                return i + 1;
+            }
+            i++;
+        }
+        throw new IllegalArgumentException("Unterminated string literal in filter: " + s);
+    }
+
+    /**
+     * Emits the translated form of one identifier/keyword token and returns the resume index.
+     * {@code EXISTS} consumes its parenthesised argument as well.
+     */
+    private static int appendIdentifier(StringBuilder out, String expression, String token, int resume) {
+        String lower = token.toLowerCase(Locale.ROOT);
+        switch (lower) {
+            case "and", "or", "not", "like", "in", "is", "null", "between", "escape", "true", "false" -> {
+                out.append(token);
+                return resume;
+            }
+            case "exists" -> {
+                return appendExists(out, expression, resume);
+            }
+            default -> { }
+        }
+        if (lower.startsWith("sys.")) {
+            out.append(mapSystemProperty(token.substring(4)));
+            return resume;
+        }
+        if (lower.startsWith("user.")) {
+            out.append(userProperty(token.substring(5)));
+            return resume;
+        }
+        out.append(userProperty(token));
+        return resume;
+    }
+
+    private static String mapSystemProperty(String name) {
+        return switch (name.toLowerCase(Locale.ROOT)) {
+            case "correlationid" -> "JMSCorrelationID";
+            case "label", "subject" -> "JMSType";
+            case "sessionid" -> "JMSXGroupID";
+            default -> throw new IllegalArgumentException("System property 'sys." + name
+                    + "' is not supported by the emulator (no broker-side AMQP mapping); "
+                    + "supported: sys.CorrelationId, sys.Label, sys.Subject, sys.SessionId");
+        };
+    }
+
+    /** Rewrites {@code EXISTS ( ident )} to {@code (ident IS NOT NULL)}. */
+    private static int appendExists(StringBuilder out, String expression, int i) {
+        int n = expression.length();
+        while (i < n && Character.isWhitespace(expression.charAt(i))) i++;
+        if (i >= n || expression.charAt(i) != '(') {
+            throw new IllegalArgumentException("EXISTS must be followed by (property): " + expression);
+        }
+        int close = expression.indexOf(')', i);
+        if (close < 0) {
+            throw new IllegalArgumentException("Unterminated EXISTS(...) in filter: " + expression);
+        }
+        String rawName = expression.substring(i + 1, close).trim();
+        String lower = rawName.toLowerCase(Locale.ROOT);
+        String mapped;
+        if (lower.startsWith("sys.")) {
+            mapped = mapSystemProperty(rawName.substring(4));
+        } else if (lower.startsWith("user.")) {
+            mapped = userProperty(rawName.substring(5));
+        } else {
+            mapped = userProperty(rawName);
+        }
+        out.append("(").append(mapped).append(" IS NOT NULL)");
+        return close + 1;
+    }
+}

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusRuleSelector.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusRuleSelector.java
@@ -267,6 +267,9 @@ final class ServiceBusRuleSelector {
             throw new IllegalArgumentException("Unterminated EXISTS(...) in filter: " + expression);
         }
         String rawName = expression.substring(i + 1, close).trim();
+        if (rawName.startsWith("[") && rawName.endsWith("]") && rawName.length() >= 2) {
+            rawName = rawName.substring(1, rawName.length() - 1);
+        }
         out.append("(").append(mapProperty(rawName)).append(" IS NOT NULL)");
         return close + 1;
     }

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusRuleXml.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusRuleXml.java
@@ -1,14 +1,11 @@
 package io.floci.az.services.servicebus;
 
 import io.floci.az.core.XmlBuilder;
+import io.floci.az.core.XmlParser;
 
-import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamReader;
-import java.io.StringReader;
 import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -26,17 +23,6 @@ import java.util.Optional;
 final class ServiceBusRuleXml {
 
     private static final String XSI_NS = "http://www.w3.org/2001/XMLSchema-instance";
-    private static final DateTimeFormatter ISO8601 =
-            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'").withZone(ZoneOffset.UTC);
-
-    private static final XMLInputFactory FACTORY;
-
-    static {
-        FACTORY = XMLInputFactory.newInstance();
-        FACTORY.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, true);
-        FACTORY.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
-        FACTORY.setProperty(XMLInputFactory.SUPPORT_DTD, false);
-    }
 
     private ServiceBusRuleXml() {}
 
@@ -48,12 +34,6 @@ final class ServiceBusRuleXml {
     static ServiceBusModels.RuleEntity parseRule(String topicName, String subscriptionName,
                                                   String ruleName, String xml) {
         return parse(topicName, subscriptionName, ruleName, xml, "RuleDescription")
-                .map(r -> new ServiceBusModels.RuleEntity(
-                        r.topicName(), r.subscriptionName(), ruleName, r.filterType(),
-                        r.sqlExpression(), r.correlationId(), r.messageId(), r.to(), r.replyTo(),
-                        r.label(), r.sessionId(), r.replyToSessionId(), r.contentType(),
-                        r.correlationProperties(), r.correlationPropertyTypes(),
-                        r.actionSqlExpression(), r.createdAt()))
                 .orElseGet(() -> ServiceBusModels.RuleEntity.trueFilter(topicName, subscriptionName, ruleName));
     }
 
@@ -64,17 +44,21 @@ final class ServiceBusRuleXml {
      */
     static Optional<ServiceBusModels.RuleEntity> parseDefaultRule(String topicName,
                                                                    String subscriptionName, String xml) {
-        return parse(topicName, subscriptionName, "$Default", xml, "DefaultRuleDescription");
+        return parse(topicName, subscriptionName, null, xml, "DefaultRuleDescription");
     }
 
+    /**
+     * @param forcedName authoritative rule name (path segment); when {@code null} the body's
+     *                   {@code <Name>} wins, falling back to {@code $Default}
+     */
     private static Optional<ServiceBusModels.RuleEntity> parse(String topicName, String subscriptionName,
-                                                                String fallbackName, String xml,
+                                                                String forcedName, String xml,
                                                                 String containerElement) {
         if (xml == null || xml.isEmpty()) {
             return Optional.empty();
         }
         try {
-            XMLStreamReader r = FACTORY.createXMLStreamReader(new StringReader(xml));
+            XMLStreamReader r = XmlParser.newStreamReader(xml);
             boolean sawContainer = false;
             boolean inContainer = false;
             boolean inFilter = false;
@@ -104,7 +88,6 @@ final class ServiceBusRuleXml {
                         actionType = typeAttribute(r);
                     } else if (inFilter && "Properties".equals(local)) {
                         inProperties = true;
-                        pendingKey = null;
                     } else if (inProperties && "Key".equals(local)) {
                         pendingKey = r.getElementText();
                     } else if (inProperties && "Value".equals(local)) {
@@ -119,7 +102,7 @@ final class ServiceBusRuleXml {
                     } else if (inProperties) {
                         // KeyValueOfstringanyType wrapper — descend without consuming
                     } else if (inFilter) {
-                        String text = readLeafText(r);
+                        String text = XmlParser.readLeafText(r);
                         if (text != null) {
                             fields.put(local, text);
                         }
@@ -148,9 +131,11 @@ final class ServiceBusRuleXml {
             }
             String resolvedType = resolveFilterType(filterType, fields, properties);
             String action = "SqlRuleAction".equals(actionType) ? actionSql : null;
+            String resolvedName = forcedName != null ? forcedName
+                    : (name != null && !name.isBlank() ? name : "$Default");
             return Optional.of(new ServiceBusModels.RuleEntity(
                     topicName, subscriptionName,
-                    name != null && !name.isBlank() ? name : fallbackName,
+                    resolvedName,
                     resolvedType,
                     "SqlFilter".equals(resolvedType) ? fields.get("SqlExpression") : null,
                     fields.get("CorrelationId"),
@@ -168,32 +153,6 @@ final class ServiceBusRuleXml {
         } catch (Exception e) {
             return Optional.empty();
         }
-    }
-
-    /**
-     * Reads the text of the currently open element if it is a leaf; skips the subtree
-     * and returns {@code null} when it contains child elements. On return the reader
-     * is positioned on the element's END_ELEMENT.
-     */
-    private static String readLeafText(XMLStreamReader r) throws javax.xml.stream.XMLStreamException {
-        StringBuilder sb = new StringBuilder();
-        while (r.hasNext()) {
-            int event = r.next();
-            if (event == XMLStreamConstants.CHARACTERS || event == XMLStreamConstants.CDATA) {
-                sb.append(r.getText());
-            } else if (event == XMLStreamConstants.START_ELEMENT) {
-                int depth = 2;
-                while (r.hasNext()) {
-                    int e = r.next();
-                    if (e == XMLStreamConstants.START_ELEMENT) depth++;
-                    else if (e == XMLStreamConstants.END_ELEMENT && --depth == 0) break;
-                }
-                return null;
-            } else if (event == XMLStreamConstants.END_ELEMENT) {
-                break;
-            }
-        }
-        return sb.toString();
     }
 
     /** Extracts the local part of the xsi:type attribute (e.g. {@code d2p1:SqlFilter} → {@code SqlFilter}). */
@@ -239,7 +198,7 @@ final class ServiceBusRuleXml {
                         "xmlns", sbNamespace);
         appendFilter(xb, rule);
         appendAction(xb, rule);
-        xb.elem("CreatedAt", ISO8601.format(rule.createdAt()))
+        xb.elem("CreatedAt", ServiceBusModels.ISO8601.format(rule.createdAt()))
           .elem("Name", rule.name());
         return xb.end("RuleDescription").build();
     }

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusRuleXml.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusRuleXml.java
@@ -1,0 +1,302 @@
+package io.floci.az.services.servicebus;
+
+import io.floci.az.core.XmlBuilder;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamReader;
+import java.io.StringReader;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Parses and serialises Service Bus {@code <RuleDescription>} payloads
+ * (rule create/update bodies and the optional {@code <DefaultRuleDescription>}
+ * embedded in a subscription create body).
+ *
+ * <p>Filter subtypes are identified by the {@code i:type} (xsi:type) attribute on
+ * {@code <Filter>}/{@code <Action>}, exactly as emitted by the Azure SDKs:
+ * {@code TrueFilter}, {@code FalseFilter}, {@code SqlFilter}, {@code CorrelationFilter},
+ * {@code EmptyRuleAction}, {@code SqlRuleAction}.
+ */
+final class ServiceBusRuleXml {
+
+    private static final String XSI_NS = "http://www.w3.org/2001/XMLSchema-instance";
+    private static final DateTimeFormatter ISO8601 =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'").withZone(ZoneOffset.UTC);
+
+    private static final XMLInputFactory FACTORY;
+
+    static {
+        FACTORY = XMLInputFactory.newInstance();
+        FACTORY.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, true);
+        FACTORY.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+        FACTORY.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+    }
+
+    private ServiceBusRuleXml() {}
+
+    /**
+     * Parses a rule create/update body ({@code <entry>} wrapping a {@code <RuleDescription>}).
+     * The rule name from the request path is authoritative; a body without a
+     * {@code <Filter>} yields a TrueFilter rule (Azure's default).
+     */
+    static ServiceBusModels.RuleEntity parseRule(String topicName, String subscriptionName,
+                                                  String ruleName, String xml) {
+        return parse(topicName, subscriptionName, ruleName, xml, "RuleDescription")
+                .map(r -> new ServiceBusModels.RuleEntity(
+                        r.topicName(), r.subscriptionName(), ruleName, r.filterType(),
+                        r.sqlExpression(), r.correlationId(), r.messageId(), r.to(), r.replyTo(),
+                        r.label(), r.sessionId(), r.replyToSessionId(), r.contentType(),
+                        r.correlationProperties(), r.correlationPropertyTypes(),
+                        r.actionSqlExpression(), r.createdAt()))
+                .orElseGet(() -> ServiceBusModels.RuleEntity.trueFilter(topicName, subscriptionName, ruleName));
+    }
+
+    /**
+     * Parses the optional {@code <DefaultRuleDescription>} of a subscription create body.
+     * When present it replaces the implicit $Default TrueFilter rule; the rule keeps the
+     * name given in the body, falling back to {@code $Default}.
+     */
+    static Optional<ServiceBusModels.RuleEntity> parseDefaultRule(String topicName,
+                                                                   String subscriptionName, String xml) {
+        return parse(topicName, subscriptionName, "$Default", xml, "DefaultRuleDescription");
+    }
+
+    private static Optional<ServiceBusModels.RuleEntity> parse(String topicName, String subscriptionName,
+                                                                String fallbackName, String xml,
+                                                                String containerElement) {
+        if (xml == null || xml.isEmpty()) {
+            return Optional.empty();
+        }
+        try {
+            XMLStreamReader r = FACTORY.createXMLStreamReader(new StringReader(xml));
+            boolean sawContainer = false;
+            boolean inContainer = false;
+            boolean inFilter = false;
+            boolean inAction = false;
+            boolean inProperties = false;
+            String filterType = null;
+            String actionType = null;
+            String name = null;
+            String pendingKey = null;
+            Map<String, String> fields = new LinkedHashMap<>();
+            Map<String, String> properties = new LinkedHashMap<>();
+            Map<String, String> propertyTypes = new LinkedHashMap<>();
+            String actionSql = null;
+
+            while (r.hasNext()) {
+                int event = r.next();
+                if (event == XMLStreamConstants.START_ELEMENT) {
+                    String local = r.getLocalName();
+                    if (containerElement.equals(local)) {
+                        sawContainer = true;
+                        inContainer = true;
+                    } else if (inContainer && "Filter".equals(local)) {
+                        inFilter = true;
+                        filterType = typeAttribute(r);
+                    } else if (inContainer && "Action".equals(local)) {
+                        inAction = true;
+                        actionType = typeAttribute(r);
+                    } else if (inFilter && "Properties".equals(local)) {
+                        inProperties = true;
+                        pendingKey = null;
+                    } else if (inProperties && "Key".equals(local)) {
+                        pendingKey = r.getElementText();
+                    } else if (inProperties && "Value".equals(local)) {
+                        if (pendingKey != null) {
+                            String valueType = typeAttribute(r);
+                            if (valueType != null && !"string".equalsIgnoreCase(valueType)) {
+                                propertyTypes.put(pendingKey, valueType);
+                            }
+                            properties.put(pendingKey, r.getElementText());
+                            pendingKey = null;
+                        }
+                    } else if (inProperties) {
+                        // KeyValueOfstringanyType wrapper — descend without consuming
+                    } else if (inFilter) {
+                        String text = readLeafText(r);
+                        if (text != null) {
+                            fields.put(local, text);
+                        }
+                    } else if (inAction && "SqlExpression".equals(local)) {
+                        actionSql = r.getElementText();
+                    } else if (inContainer && "Name".equals(local)) {
+                        name = r.getElementText();
+                    }
+                } else if (event == XMLStreamConstants.END_ELEMENT) {
+                    String local = r.getLocalName();
+                    if (containerElement.equals(local)) {
+                        inContainer = false;
+                    } else if ("Filter".equals(local)) {
+                        inFilter = false;
+                    } else if ("Action".equals(local)) {
+                        inAction = false;
+                    } else if ("Properties".equals(local)) {
+                        inProperties = false;
+                    }
+                }
+            }
+            r.close();
+
+            if (!sawContainer) {
+                return Optional.empty();
+            }
+            String resolvedType = resolveFilterType(filterType, fields, properties);
+            String action = "SqlRuleAction".equals(actionType) ? actionSql : null;
+            return Optional.of(new ServiceBusModels.RuleEntity(
+                    topicName, subscriptionName,
+                    name != null && !name.isBlank() ? name : fallbackName,
+                    resolvedType,
+                    "SqlFilter".equals(resolvedType) ? fields.get("SqlExpression") : null,
+                    fields.get("CorrelationId"),
+                    fields.get("MessageId"),
+                    fields.get("To"),
+                    fields.get("ReplyTo"),
+                    fields.get("Label"),
+                    fields.get("SessionId"),
+                    fields.get("ReplyToSessionId"),
+                    fields.get("ContentType"),
+                    Map.copyOf(properties),
+                    Map.copyOf(propertyTypes),
+                    action,
+                    Instant.now()));
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Reads the text of the currently open element if it is a leaf; skips the subtree
+     * and returns {@code null} when it contains child elements. On return the reader
+     * is positioned on the element's END_ELEMENT.
+     */
+    private static String readLeafText(XMLStreamReader r) throws javax.xml.stream.XMLStreamException {
+        StringBuilder sb = new StringBuilder();
+        while (r.hasNext()) {
+            int event = r.next();
+            if (event == XMLStreamConstants.CHARACTERS || event == XMLStreamConstants.CDATA) {
+                sb.append(r.getText());
+            } else if (event == XMLStreamConstants.START_ELEMENT) {
+                int depth = 2;
+                while (r.hasNext()) {
+                    int e = r.next();
+                    if (e == XMLStreamConstants.START_ELEMENT) depth++;
+                    else if (e == XMLStreamConstants.END_ELEMENT && --depth == 0) break;
+                }
+                return null;
+            } else if (event == XMLStreamConstants.END_ELEMENT) {
+                break;
+            }
+        }
+        return sb.toString();
+    }
+
+    /** Extracts the local part of the xsi:type attribute (e.g. {@code d2p1:SqlFilter} → {@code SqlFilter}). */
+    private static String typeAttribute(XMLStreamReader r) {
+        String value = r.getAttributeValue(XSI_NS, "type");
+        if (value == null) {
+            value = r.getAttributeValue(null, "type");
+        }
+        if (value == null) {
+            return null;
+        }
+        int colon = value.indexOf(':');
+        return colon < 0 ? value : value.substring(colon + 1);
+    }
+
+    /** Falls back to structural detection when the xsi:type attribute is missing. */
+    private static String resolveFilterType(String declaredType, Map<String, String> fields,
+                                             Map<String, String> properties) {
+        if (declaredType != null && !declaredType.isBlank()) {
+            return declaredType;
+        }
+        if (!properties.isEmpty()
+                || fields.containsKey("CorrelationId") || fields.containsKey("Label")
+                || fields.containsKey("MessageId") || fields.containsKey("To")
+                || fields.containsKey("ReplyTo") || fields.containsKey("SessionId")
+                || fields.containsKey("ReplyToSessionId") || fields.containsKey("ContentType")) {
+            return "CorrelationFilter";
+        }
+        if (fields.containsKey("SqlExpression")) {
+            return "SqlFilter";
+        }
+        return "TrueFilter";
+    }
+
+    /**
+     * Builds the {@code <RuleDescription>} content element for ATOM responses.
+     * Element order follows the Service Bus XSD: Filter, Action, CreatedAt, Name.
+     */
+    static String ruleDescriptionXml(ServiceBusModels.RuleEntity rule, String sbNamespace) {
+        XmlBuilder xb = new XmlBuilder()
+                .startAttr("RuleDescription",
+                        "xmlns:i", XSI_NS,
+                        "xmlns", sbNamespace);
+        appendFilter(xb, rule);
+        appendAction(xb, rule);
+        xb.elem("CreatedAt", ISO8601.format(rule.createdAt()))
+          .elem("Name", rule.name());
+        return xb.end("RuleDescription").build();
+    }
+
+    private static void appendFilter(XmlBuilder xb, ServiceBusModels.RuleEntity rule) {
+        switch (rule.filterType()) {
+            case "CorrelationFilter" -> {
+                xb.startAttr("Filter", "i:type", "CorrelationFilter")
+                  .elem("CorrelationId", rule.correlationId())
+                  .elem("MessageId", rule.messageId())
+                  .elem("To", rule.to())
+                  .elem("ReplyTo", rule.replyTo())
+                  .elem("Label", rule.label())
+                  .elem("SessionId", rule.sessionId())
+                  .elem("ReplyToSessionId", rule.replyToSessionId())
+                  .elem("ContentType", rule.contentType());
+                if (!rule.correlationProperties().isEmpty()) {
+                    xb.start("Properties");
+                    for (Map.Entry<String, String> e : rule.correlationProperties().entrySet()) {
+                        String valueType = rule.correlationPropertyTypes()
+                                .getOrDefault(e.getKey(), "string");
+                        xb.start("KeyValueOfstringanyType")
+                          .elem("Key", e.getKey())
+                          .startAttr("Value",
+                                  "xmlns:d6p1", "http://www.w3.org/2001/XMLSchema",
+                                  "i:type", "d6p1:" + valueType)
+                          .raw(XmlBuilder.escape(e.getValue()))
+                          .end("Value")
+                          .end("KeyValueOfstringanyType");
+                    }
+                    xb.end("Properties");
+                }
+                xb.end("Filter");
+            }
+            case "SqlFilter" -> xb.startAttr("Filter", "i:type", "SqlFilter")
+                    .elem("SqlExpression", rule.sqlExpression())
+                    .elem("CompatibilityLevel", "20")
+                    .end("Filter");
+            case "FalseFilter" -> xb.startAttr("Filter", "i:type", "FalseFilter")
+                    .elem("SqlExpression", "1=0")
+                    .elem("CompatibilityLevel", "20")
+                    .end("Filter");
+            default -> xb.startAttr("Filter", "i:type", "TrueFilter")
+                    .elem("SqlExpression", "1=1")
+                    .elem("CompatibilityLevel", "20")
+                    .end("Filter");
+        }
+    }
+
+    private static void appendAction(XmlBuilder xb, ServiceBusModels.RuleEntity rule) {
+        if (rule.actionSqlExpression() == null || rule.actionSqlExpression().isBlank()) {
+            xb.selfClose("Action", "i:type", "EmptyRuleAction");
+        } else {
+            xb.startAttr("Action", "i:type", "SqlRuleAction")
+              .elem("SqlExpression", rule.actionSqlExpression())
+              .elem("CompatibilityLevel", "20")
+              .end("Action");
+        }
+    }
+}

--- a/src/test/java/io/floci/az/services/ServiceBusRulesTest.java
+++ b/src/test/java/io/floci/az/services/ServiceBusRulesTest.java
@@ -193,4 +193,228 @@ public class ServiceBusRulesTest {
                 .when().put(rulesPath("rules-topic-404", "nosub") + "/r")
                 .then().statusCode(404);
     }
+
+    @Test
+    void rulesOnMissingTopicReturn404() {
+        given().when().get(rulesPath("no-such-topic", "nosub")).then().statusCode(404);
+        given().body(correlationRuleBody("r", "x"))
+                .when().put(rulesPath("no-such-topic", "nosub") + "/r")
+                .then().statusCode(404);
+        given().when().delete(rulesPath("no-such-topic", "nosub") + "/r").then().statusCode(404);
+    }
+
+    @Test
+    void nonGetOnRulesCollectionReturns405() {
+        createTopicAndSubscription("rules-topic-405", "sub1");
+        given().when().delete(rulesPath("rules-topic-405", "sub1")).then().statusCode(405);
+        given().body(correlationRuleBody("r", "x"))
+                .when().put(rulesPath("rules-topic-405", "sub1"))
+                .then().statusCode(405);
+    }
+
+    @Test
+    void invalidSqlFiltersAreRejectedWith400() {
+        createTopicAndSubscription("rules-topic-badsql", "sub1");
+        String rules = rulesPath("rules-topic-badsql", "sub1");
+
+        // unterminated string literal
+        given().body(sqlRuleBody("bad1", "color = 'unterminated"))
+                .when().put(rules + "/bad1").then().statusCode(400);
+        // unsupported system property
+        given().body(sqlRuleBody("bad2", "sys.MessageId = 'x'"))
+                .when().put(rules + "/bad2").then().statusCode(400);
+        // unsupported modulo operator
+        given().body(sqlRuleBody("bad3", "quantity % 2 = 0"))
+                .when().put(rules + "/bad3").then().statusCode(400);
+
+        // failed creates must not leave partial rules behind
+        given().when().get(rules)
+                .then().statusCode(200)
+                .body(not(containsString("bad1")))
+                .body(not(containsString("bad2")))
+                .body(not(containsString("bad3")));
+    }
+
+    @Test
+    void emptyCorrelationFilterIsRejectedWith400() {
+        createTopicAndSubscription("rules-topic-emptycorr", "sub1");
+        String body = "<entry xmlns=\"http://www.w3.org/2005/Atom\"><content type=\"application/xml\">"
+                + "<RuleDescription xmlns:i=\"" + XSI_NS + "\" xmlns=\"" + SB_NS + "\">"
+                + "<Filter i:type=\"CorrelationFilter\"></Filter>"
+                + "<Name>empty</Name></RuleDescription></content></entry>";
+        given().body(body)
+                .when().put(rulesPath("rules-topic-emptycorr", "sub1") + "/empty")
+                .then().statusCode(400)
+                .body(containsString("at least one property"));
+    }
+
+    @Test
+    void sqlRuleActionIsStoredAndEchoed() {
+        createTopicAndSubscription("rules-topic-action", "sub1");
+        String body = "<entry xmlns=\"http://www.w3.org/2005/Atom\"><content type=\"application/xml\">"
+                + "<RuleDescription xmlns:i=\"" + XSI_NS + "\" xmlns=\"" + SB_NS + "\">"
+                + "<Filter i:type=\"SqlFilter\"><SqlExpression>color='red'</SqlExpression></Filter>"
+                + "<Action i:type=\"SqlRuleAction\"><SqlExpression>SET quantity = 1</SqlExpression></Action>"
+                + "<Name>with-action</Name></RuleDescription></content></entry>";
+        String rules = rulesPath("rules-topic-action", "sub1");
+
+        given().body(body).when().put(rules + "/with-action")
+                .then().statusCode(201)
+                .body(containsString("i:type=\"SqlRuleAction\""));
+
+        given().when().get(rules + "/with-action")
+                .then().statusCode(200)
+                .body(containsString("SET quantity = 1"));
+    }
+
+    @Test
+    void falseFilterRuleIsAccepted() {
+        createTopicAndSubscription("rules-topic-false", "sub1");
+        String body = "<entry xmlns=\"http://www.w3.org/2005/Atom\"><content type=\"application/xml\">"
+                + "<RuleDescription xmlns:i=\"" + XSI_NS + "\" xmlns=\"" + SB_NS + "\">"
+                + "<Filter i:type=\"FalseFilter\"><SqlExpression>1=0</SqlExpression></Filter>"
+                + "<Name>none</Name></RuleDescription></content></entry>";
+        given().body(body)
+                .when().put(rulesPath("rules-topic-false", "sub1") + "/none")
+                .then().statusCode(201)
+                .body(containsString("i:type=\"FalseFilter\""));
+    }
+
+    @Test
+    void subscriptionCreateWithUnsupportedDefaultRuleIsRejected() {
+        given().body(TOPIC_BODY).when().put(BASE + "/rules-topic-baddrd").then().statusCode(201);
+
+        String subBody = "<entry xmlns=\"http://www.w3.org/2005/Atom\"><content type=\"application/xml\">"
+                + "<SubscriptionDescription xmlns:i=\"" + XSI_NS + "\" xmlns=\"" + SB_NS + "\">"
+                + "<DefaultRuleDescription>"
+                + "<Filter i:type=\"CorrelationFilter\"><MessageId>m1</MessageId></Filter>"
+                + "<Name>bad</Name></DefaultRuleDescription>"
+                + "</SubscriptionDescription></content></entry>";
+
+        given().body(subBody)
+                .when().put(BASE + "/rules-topic-baddrd/subscriptions/sub1")
+                .then().statusCode(400);
+
+        // the subscription must not have been half-created
+        given().when().get(BASE + "/rules-topic-baddrd/subscriptions/sub1")
+                .then().statusCode(404);
+    }
+
+    @Test
+    void recreatingExistingSubscriptionKeepsItsRules() {
+        createTopicAndSubscription("rules-topic-recreate", "sub1");
+        String rules = rulesPath("rules-topic-recreate", "sub1");
+        given().body(correlationRuleBody("keep-me", "red"))
+                .when().put(rules + "/keep-me").then().statusCode(201);
+        given().when().delete(rules + "/$Default").then().statusCode(200);
+
+        // idempotent re-create returns the existing subscription and leaves rules alone
+        given().when().put(BASE + "/rules-topic-recreate/subscriptions/sub1")
+                .then().statusCode(200);
+        given().when().get(rules)
+                .then().statusCode(200)
+                .body(containsString("keep-me"))
+                .body(not(containsString("$Default")));
+    }
+
+    @Test
+    void updatingRuleCanChangeFilterType() {
+        createTopicAndSubscription("rules-topic-retype", "sub1");
+        String rules = rulesPath("rules-topic-retype", "sub1");
+
+        given().body(correlationRuleBody("morph", "red"))
+                .when().put(rules + "/morph").then().statusCode(201);
+        given().body(sqlRuleBody("morph", "color='blue'"))
+                .when().put(rules + "/morph")
+                .then().statusCode(200)
+                .body(containsString("i:type=\"SqlFilter\""));
+
+        given().when().get(rules + "/morph")
+                .then().statusCode(200)
+                .body(containsString("i:type=\"SqlFilter\""))
+                .body(not(containsString("CorrelationFilter")));
+    }
+
+    @Test
+    void deletingTopicCascadesRules() {
+        createTopicAndSubscription("rules-topic-tcascade", "sub1");
+        given().body(correlationRuleBody("r1", "red"))
+                .when().put(rulesPath("rules-topic-tcascade", "sub1") + "/r1")
+                .then().statusCode(201);
+
+        given().when().delete(BASE + "/rules-topic-tcascade").then().statusCode(200);
+
+        // recreating the same topic + subscription starts fresh with only $Default
+        createTopicAndSubscription("rules-topic-tcascade", "sub1");
+        given().when().get(rulesPath("rules-topic-tcascade", "sub1"))
+                .then().statusCode(200)
+                .body(containsString("$Default"))
+                .body(not(containsString("<Name>r1</Name>")));
+    }
+
+    @Test
+    void deletingRuleTwiceReturns404() {
+        createTopicAndSubscription("rules-topic-del2", "sub1");
+        String rule = rulesPath("rules-topic-del2", "sub1") + "/$Default";
+        given().when().delete(rule).then().statusCode(200);
+        given().when().delete(rule).then().statusCode(404);
+    }
+
+    @Test
+    void legacyNamespacePathSupportsRuleCrud() {
+        String legacyBase = BASE + "/default/topics/rules-topic-legacy";
+        given().when().put(legacyBase).then().statusCode(201);
+        given().when().put(legacyBase + "/subscriptions/sub1").then().statusCode(201);
+
+        given().body(correlationRuleBody("legacy-rule", "red"))
+                .when().put(legacyBase + "/subscriptions/sub1/rules/legacy-rule")
+                .then().statusCode(201)
+                .body(containsString("<Name>legacy-rule</Name>"));
+
+        given().when().get(legacyBase + "/subscriptions/sub1/rules")
+                .then().statusCode(200)
+                .body(containsString("legacy-rule"))
+                .body(containsString("$Default"));
+
+        given().when().delete(legacyBase + "/subscriptions/sub1/rules/legacy-rule")
+                .then().statusCode(200);
+        given().when().get(legacyBase + "/subscriptions/sub1/rules/legacy-rule")
+                .then().statusCode(404);
+    }
+
+    @Test
+    void feedsContainExactlyOneXmlProlog() {
+        createTopicAndSubscription("rules-topic-prolog", "sub1");
+        given().body(correlationRuleBody("r1", "red"))
+                .when().put(rulesPath("rules-topic-prolog", "sub1") + "/r1")
+                .then().statusCode(201);
+
+        for (String path : new String[]{
+                rulesPath("rules-topic-prolog", "sub1"),
+                BASE + "/rules-topic-prolog/subscriptions"}) {
+            String feed = given().when().get(path)
+                    .then().statusCode(200).extract().asString();
+            long prologs = feed.split("<\\?xml", -1).length - 1;
+            org.junit.jupiter.api.Assertions.assertEquals(1, prologs,
+                    "feed at " + path + " must contain exactly one XML prolog");
+        }
+    }
+
+    @Test
+    void unparseableRuleBodyDegradesToTrueFilter() {
+        // lenient like the rest of the management plane: garbage bodies fall back
+        // to Azure's default TrueFilter instead of failing the create
+        createTopicAndSubscription("rules-topic-garbage", "sub1");
+        given().body("this is not xml <at all")
+                .when().put(rulesPath("rules-topic-garbage", "sub1") + "/lenient")
+                .then().statusCode(201)
+                .body(containsString("i:type=\"TrueFilter\""));
+    }
+
+    private static String sqlRuleBody(String ruleName, String escapedExpression) {
+        return "<entry xmlns=\"http://www.w3.org/2005/Atom\"><content type=\"application/xml\">"
+                + "<RuleDescription xmlns:i=\"" + XSI_NS + "\" xmlns=\"" + SB_NS + "\">"
+                + "<Filter i:type=\"SqlFilter\"><SqlExpression>" + escapedExpression + "</SqlExpression></Filter>"
+                + "<Name>" + ruleName + "</Name></RuleDescription></content></entry>";
+    }
 }

--- a/src/test/java/io/floci/az/services/ServiceBusRulesTest.java
+++ b/src/test/java/io/floci/az/services/ServiceBusRulesTest.java
@@ -1,0 +1,196 @@
+package io.floci.az.services;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * Rule CRUD over the spec-compatible management paths. Runs against the mocked
+ * Service Bus namespace (no broker), which exercises the full ATOM protocol.
+ */
+@QuarkusTest
+public class ServiceBusRulesTest {
+
+    private static final String BASE = "/devstoreaccount1-servicebus";
+    private static final String SB_NS = "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect";
+    private static final String XSI_NS = "http://www.w3.org/2001/XMLSchema-instance";
+
+    private static final String TOPIC_BODY =
+            "<entry xmlns=\"http://www.w3.org/2005/Atom\"><content type=\"application/xml\">"
+                    + "<TopicDescription xmlns=\"" + SB_NS + "\"/></content></entry>";
+
+    private static void createTopicAndSubscription(String topic, String sub) {
+        given().body(TOPIC_BODY).when().put(BASE + "/" + topic).then().statusCode(201);
+        given().when().put(BASE + "/" + topic + "/subscriptions/" + sub).then().statusCode(201);
+    }
+
+    private static String rulesPath(String topic, String sub) {
+        return BASE + "/" + topic + "/subscriptions/" + sub + "/rules";
+    }
+
+    private static String correlationRuleBody(String ruleName, String label) {
+        return "<entry xmlns=\"http://www.w3.org/2005/Atom\"><content type=\"application/xml\">"
+                + "<RuleDescription xmlns:i=\"" + XSI_NS + "\" xmlns=\"" + SB_NS + "\">"
+                + "<Filter i:type=\"CorrelationFilter\"><Label>" + label + "</Label></Filter>"
+                + "<Action i:type=\"EmptyRuleAction\"/>"
+                + "<Name>" + ruleName + "</Name>"
+                + "</RuleDescription></content></entry>";
+    }
+
+    @Test
+    void subscriptionStartsWithDefaultTrueFilterRule() {
+        createTopicAndSubscription("rules-topic-default", "sub1");
+
+        given().when().get(rulesPath("rules-topic-default", "sub1"))
+                .then()
+                .statusCode(200)
+                .contentType("application/atom+xml")
+                .body(containsString("<title type=\"text\">$Default</title>"))
+                .body(containsString("i:type=\"TrueFilter\""));
+
+        given().when().get(rulesPath("rules-topic-default", "sub1") + "/$Default")
+                .then()
+                .statusCode(200)
+                .body(containsString("<Name>$Default</Name>"));
+    }
+
+    @Test
+    void correlationRuleCrudAndDefaultReplacement() {
+        createTopicAndSubscription("rules-topic-crud", "sub1");
+        String rules = rulesPath("rules-topic-crud", "sub1");
+
+        // Azure SDK flow: add the real rule, then delete $Default
+        given().body(correlationRuleBody("only-red", "red"))
+                .when().put(rules + "/only-red")
+                .then()
+                .statusCode(201)
+                .contentType("application/atom+xml")
+                .body(containsString("i:type=\"CorrelationFilter\""))
+                .body(containsString("<Label>red</Label>"))
+                .body(containsString("<Name>only-red</Name>"));
+
+        given().when().delete(rules + "/$Default").then().statusCode(200);
+
+        given().when().get(rules)
+                .then()
+                .statusCode(200)
+                .body(containsString("only-red"))
+                .body(not(containsString("$Default")));
+
+        // update in place (PUT to existing name) returns 200
+        given().body(correlationRuleBody("only-red", "blue"))
+                .when().put(rules + "/only-red")
+                .then()
+                .statusCode(200)
+                .body(containsString("<Label>blue</Label>"));
+
+        given().when().delete(rules + "/only-red").then().statusCode(200);
+        given().when().get(rules + "/only-red").then().statusCode(404);
+    }
+
+    @Test
+    void sqlRuleIsAcceptedAndReturned() {
+        createTopicAndSubscription("rules-topic-sql", "sub1");
+        String body = "<entry xmlns=\"http://www.w3.org/2005/Atom\"><content type=\"application/xml\">"
+                + "<RuleDescription xmlns:i=\"" + XSI_NS + "\" xmlns=\"" + SB_NS + "\">"
+                + "<Filter i:type=\"SqlFilter\"><SqlExpression>color='blue' AND sys.Label='x'</SqlExpression></Filter>"
+                + "<Name>sql1</Name></RuleDescription></content></entry>";
+
+        given().body(body)
+                .when().put(rulesPath("rules-topic-sql", "sub1") + "/sql1")
+                .then()
+                .statusCode(201)
+                .body(containsString("i:type=\"SqlFilter\""))
+                .body(containsString("color=&apos;blue&apos;"));
+    }
+
+    @Test
+    void unsupportedCorrelationFieldIsRejected() {
+        createTopicAndSubscription("rules-topic-reject", "sub1");
+        String body = "<entry xmlns=\"http://www.w3.org/2005/Atom\"><content type=\"application/xml\">"
+                + "<RuleDescription xmlns:i=\"" + XSI_NS + "\" xmlns=\"" + SB_NS + "\">"
+                + "<Filter i:type=\"CorrelationFilter\"><MessageId>m1</MessageId></Filter>"
+                + "<Name>bad</Name></RuleDescription></content></entry>";
+
+        given().body(body)
+                .when().put(rulesPath("rules-topic-reject", "sub1") + "/bad")
+                .then()
+                .statusCode(400)
+                .body(containsString("not supported"));
+    }
+
+    @Test
+    void subscriptionCreateHonoursDefaultRuleDescription() {
+        given().body(TOPIC_BODY).when().put(BASE + "/rules-topic-drd").then().statusCode(201);
+
+        String subBody = "<entry xmlns=\"http://www.w3.org/2005/Atom\"><content type=\"application/xml\">"
+                + "<SubscriptionDescription xmlns:i=\"" + XSI_NS + "\" xmlns=\"" + SB_NS + "\">"
+                + "<DefaultRuleDescription>"
+                + "<Filter i:type=\"CorrelationFilter\"><Label>order.created</Label></Filter>"
+                + "<Name>initial</Name>"
+                + "</DefaultRuleDescription>"
+                + "</SubscriptionDescription></content></entry>";
+
+        given().body(subBody)
+                .when().put(BASE + "/rules-topic-drd/subscriptions/sub1")
+                .then().statusCode(201);
+
+        given().when().get(rulesPath("rules-topic-drd", "sub1"))
+                .then()
+                .statusCode(200)
+                .body(containsString("<Name>initial</Name>"))
+                .body(containsString("<Label>order.created</Label>"))
+                .body(not(containsString("$Default")));
+    }
+
+    @Test
+    void ruleEntriesDoNotLeakIntoSubscriptionList() {
+        createTopicAndSubscription("rules-topic-list", "sub1");
+        given().body(correlationRuleBody("r1", "red"))
+                .when().put(rulesPath("rules-topic-list", "sub1") + "/r1")
+                .then().statusCode(201);
+
+        Response resp = given()
+                .when().get(BASE + "/rules-topic-list/subscriptions")
+                .then()
+                .statusCode(200)
+                .body(not(containsString("RuleDescription")))
+                .extract().response();
+        long entries = resp.asString().split("<entry", -1).length - 1;
+        org.junit.jupiter.api.Assertions.assertEquals(1, entries,
+                "subscription feed must contain exactly the one subscription");
+    }
+
+    @Test
+    void deletingSubscriptionRemovesItsRules() {
+        createTopicAndSubscription("rules-topic-cascade", "sub1");
+        given().body(correlationRuleBody("r1", "red"))
+                .when().put(rulesPath("rules-topic-cascade", "sub1") + "/r1")
+                .then().statusCode(201);
+
+        given().when().delete(BASE + "/rules-topic-cascade/subscriptions/sub1")
+                .then().statusCode(200);
+
+        // re-creating the subscription must start fresh with only $Default
+        given().when().put(BASE + "/rules-topic-cascade/subscriptions/sub1")
+                .then().statusCode(201);
+        given().when().get(rulesPath("rules-topic-cascade", "sub1"))
+                .then()
+                .statusCode(200)
+                .body(containsString("$Default"))
+                .body(not(containsString("<Name>r1</Name>")));
+    }
+
+    @Test
+    void rulesOnMissingSubscriptionReturn404() {
+        given().body(TOPIC_BODY).when().put(BASE + "/rules-topic-404").then().statusCode(201);
+        given().when().get(rulesPath("rules-topic-404", "nosub")).then().statusCode(404);
+        given().body(correlationRuleBody("r", "x"))
+                .when().put(rulesPath("rules-topic-404", "nosub") + "/r")
+                .then().statusCode(404);
+    }
+}

--- a/src/test/java/io/floci/az/services/ServiceBusRulesTest.java
+++ b/src/test/java/io/floci/az/services/ServiceBusRulesTest.java
@@ -19,9 +19,7 @@ public class ServiceBusRulesTest {
     private static final String SB_NS = "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect";
     private static final String XSI_NS = "http://www.w3.org/2001/XMLSchema-instance";
 
-    private static final String TOPIC_BODY =
-            "<entry xmlns=\"http://www.w3.org/2005/Atom\"><content type=\"application/xml\">"
-                    + "<TopicDescription xmlns=\"" + SB_NS + "\"/></content></entry>";
+    private static final String TOPIC_BODY = entry("<TopicDescription xmlns=\"" + SB_NS + "\"/>");
 
     private static void createTopicAndSubscription(String topic, String sub) {
         given().body(TOPIC_BODY).when().put(BASE + "/" + topic).then().statusCode(201);
@@ -32,13 +30,29 @@ public class ServiceBusRulesTest {
         return BASE + "/" + topic + "/subscriptions/" + sub + "/rules";
     }
 
-    private static String correlationRuleBody(String ruleName, String label) {
+    private static String entry(String inner) {
         return "<entry xmlns=\"http://www.w3.org/2005/Atom\"><content type=\"application/xml\">"
-                + "<RuleDescription xmlns:i=\"" + XSI_NS + "\" xmlns=\"" + SB_NS + "\">"
-                + "<Filter i:type=\"CorrelationFilter\"><Label>" + label + "</Label></Filter>"
-                + "<Action i:type=\"EmptyRuleAction\"/>"
-                + "<Name>" + ruleName + "</Name>"
-                + "</RuleDescription></content></entry>";
+                + inner + "</content></entry>";
+    }
+
+    private static String ruleBody(String ruleName, String filterXml, String actionXml) {
+        return entry("<RuleDescription xmlns:i=\"" + XSI_NS + "\" xmlns=\"" + SB_NS + "\">"
+                + filterXml
+                + (actionXml == null ? "" : actionXml)
+                + "<Name>" + ruleName + "</Name></RuleDescription>");
+    }
+
+    private static String correlationRuleBody(String ruleName, String label) {
+        return ruleBody(ruleName,
+                "<Filter i:type=\"CorrelationFilter\"><Label>" + label + "</Label></Filter>",
+                "<Action i:type=\"EmptyRuleAction\"/>");
+    }
+
+    private static String sqlRuleBody(String ruleName, String escapedExpression) {
+        return ruleBody(ruleName,
+                "<Filter i:type=\"SqlFilter\"><SqlExpression>" + escapedExpression
+                        + "</SqlExpression></Filter>",
+                null);
     }
 
     @Test
@@ -95,12 +109,7 @@ public class ServiceBusRulesTest {
     @Test
     void sqlRuleIsAcceptedAndReturned() {
         createTopicAndSubscription("rules-topic-sql", "sub1");
-        String body = "<entry xmlns=\"http://www.w3.org/2005/Atom\"><content type=\"application/xml\">"
-                + "<RuleDescription xmlns:i=\"" + XSI_NS + "\" xmlns=\"" + SB_NS + "\">"
-                + "<Filter i:type=\"SqlFilter\"><SqlExpression>color='blue' AND sys.Label='x'</SqlExpression></Filter>"
-                + "<Name>sql1</Name></RuleDescription></content></entry>";
-
-        given().body(body)
+        given().body(sqlRuleBody("sql1", "color='blue' AND sys.Label='x'"))
                 .when().put(rulesPath("rules-topic-sql", "sub1") + "/sql1")
                 .then()
                 .statusCode(201)
@@ -111,10 +120,8 @@ public class ServiceBusRulesTest {
     @Test
     void unsupportedCorrelationFieldIsRejected() {
         createTopicAndSubscription("rules-topic-reject", "sub1");
-        String body = "<entry xmlns=\"http://www.w3.org/2005/Atom\"><content type=\"application/xml\">"
-                + "<RuleDescription xmlns:i=\"" + XSI_NS + "\" xmlns=\"" + SB_NS + "\">"
-                + "<Filter i:type=\"CorrelationFilter\"><MessageId>m1</MessageId></Filter>"
-                + "<Name>bad</Name></RuleDescription></content></entry>";
+        String body = ruleBody("bad",
+                "<Filter i:type=\"CorrelationFilter\"><MessageId>m1</MessageId></Filter>", null);
 
         given().body(body)
                 .when().put(rulesPath("rules-topic-reject", "sub1") + "/bad")
@@ -127,13 +134,12 @@ public class ServiceBusRulesTest {
     void subscriptionCreateHonoursDefaultRuleDescription() {
         given().body(TOPIC_BODY).when().put(BASE + "/rules-topic-drd").then().statusCode(201);
 
-        String subBody = "<entry xmlns=\"http://www.w3.org/2005/Atom\"><content type=\"application/xml\">"
-                + "<SubscriptionDescription xmlns:i=\"" + XSI_NS + "\" xmlns=\"" + SB_NS + "\">"
+        String subBody = entry("<SubscriptionDescription xmlns:i=\"" + XSI_NS + "\" xmlns=\"" + SB_NS + "\">"
                 + "<DefaultRuleDescription>"
                 + "<Filter i:type=\"CorrelationFilter\"><Label>order.created</Label></Filter>"
                 + "<Name>initial</Name>"
                 + "</DefaultRuleDescription>"
-                + "</SubscriptionDescription></content></entry>";
+                + "</SubscriptionDescription>");
 
         given().body(subBody)
                 .when().put(BASE + "/rules-topic-drd/subscriptions/sub1")
@@ -238,10 +244,7 @@ public class ServiceBusRulesTest {
     @Test
     void emptyCorrelationFilterIsRejectedWith400() {
         createTopicAndSubscription("rules-topic-emptycorr", "sub1");
-        String body = "<entry xmlns=\"http://www.w3.org/2005/Atom\"><content type=\"application/xml\">"
-                + "<RuleDescription xmlns:i=\"" + XSI_NS + "\" xmlns=\"" + SB_NS + "\">"
-                + "<Filter i:type=\"CorrelationFilter\"></Filter>"
-                + "<Name>empty</Name></RuleDescription></content></entry>";
+        String body = ruleBody("empty", "<Filter i:type=\"CorrelationFilter\"></Filter>", null);
         given().body(body)
                 .when().put(rulesPath("rules-topic-emptycorr", "sub1") + "/empty")
                 .then().statusCode(400)
@@ -251,11 +254,9 @@ public class ServiceBusRulesTest {
     @Test
     void sqlRuleActionIsStoredAndEchoed() {
         createTopicAndSubscription("rules-topic-action", "sub1");
-        String body = "<entry xmlns=\"http://www.w3.org/2005/Atom\"><content type=\"application/xml\">"
-                + "<RuleDescription xmlns:i=\"" + XSI_NS + "\" xmlns=\"" + SB_NS + "\">"
-                + "<Filter i:type=\"SqlFilter\"><SqlExpression>color='red'</SqlExpression></Filter>"
-                + "<Action i:type=\"SqlRuleAction\"><SqlExpression>SET quantity = 1</SqlExpression></Action>"
-                + "<Name>with-action</Name></RuleDescription></content></entry>";
+        String body = ruleBody("with-action",
+                "<Filter i:type=\"SqlFilter\"><SqlExpression>color='red'</SqlExpression></Filter>",
+                "<Action i:type=\"SqlRuleAction\"><SqlExpression>SET quantity = 1</SqlExpression></Action>");
         String rules = rulesPath("rules-topic-action", "sub1");
 
         given().body(body).when().put(rules + "/with-action")
@@ -270,10 +271,8 @@ public class ServiceBusRulesTest {
     @Test
     void falseFilterRuleIsAccepted() {
         createTopicAndSubscription("rules-topic-false", "sub1");
-        String body = "<entry xmlns=\"http://www.w3.org/2005/Atom\"><content type=\"application/xml\">"
-                + "<RuleDescription xmlns:i=\"" + XSI_NS + "\" xmlns=\"" + SB_NS + "\">"
-                + "<Filter i:type=\"FalseFilter\"><SqlExpression>1=0</SqlExpression></Filter>"
-                + "<Name>none</Name></RuleDescription></content></entry>";
+        String body = ruleBody("none",
+                "<Filter i:type=\"FalseFilter\"><SqlExpression>1=0</SqlExpression></Filter>", null);
         given().body(body)
                 .when().put(rulesPath("rules-topic-false", "sub1") + "/none")
                 .then().statusCode(201)
@@ -284,12 +283,11 @@ public class ServiceBusRulesTest {
     void subscriptionCreateWithUnsupportedDefaultRuleIsRejected() {
         given().body(TOPIC_BODY).when().put(BASE + "/rules-topic-baddrd").then().statusCode(201);
 
-        String subBody = "<entry xmlns=\"http://www.w3.org/2005/Atom\"><content type=\"application/xml\">"
-                + "<SubscriptionDescription xmlns:i=\"" + XSI_NS + "\" xmlns=\"" + SB_NS + "\">"
+        String subBody = entry("<SubscriptionDescription xmlns:i=\"" + XSI_NS + "\" xmlns=\"" + SB_NS + "\">"
                 + "<DefaultRuleDescription>"
                 + "<Filter i:type=\"CorrelationFilter\"><MessageId>m1</MessageId></Filter>"
                 + "<Name>bad</Name></DefaultRuleDescription>"
-                + "</SubscriptionDescription></content></entry>";
+                + "</SubscriptionDescription>");
 
         given().body(subBody)
                 .when().put(BASE + "/rules-topic-baddrd/subscriptions/sub1")
@@ -409,12 +407,5 @@ public class ServiceBusRulesTest {
                 .when().put(rulesPath("rules-topic-garbage", "sub1") + "/lenient")
                 .then().statusCode(201)
                 .body(containsString("i:type=\"TrueFilter\""));
-    }
-
-    private static String sqlRuleBody(String ruleName, String escapedExpression) {
-        return "<entry xmlns=\"http://www.w3.org/2005/Atom\"><content type=\"application/xml\">"
-                + "<RuleDescription xmlns:i=\"" + XSI_NS + "\" xmlns=\"" + SB_NS + "\">"
-                + "<Filter i:type=\"SqlFilter\"><SqlExpression>" + escapedExpression + "</SqlExpression></Filter>"
-                + "<Name>" + ruleName + "</Name></RuleDescription></content></entry>";
     }
 }

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusRuleSelectorTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusRuleSelectorTest.java
@@ -203,6 +203,14 @@ class ServiceBusRuleSelectorTest {
     }
 
     @Test
+    void existsStripsBracketDelimiters() {
+        assertEquals("(color IS NOT NULL)",
+                ServiceBusRuleSelector.forRule(sql("EXISTS([color])")));
+        assertEquals("(JMSType IS NOT NULL)",
+                ServiceBusRuleSelector.forRule(sql("EXISTS( [sys.Label] )")));
+    }
+
+    @Test
     void unknownFilterTypeIsRejected() {
         assertThrows(IllegalArgumentException.class,
                 () -> ServiceBusRuleSelector.forRule(ofType("BogusFilter")));

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusRuleSelectorTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusRuleSelectorTest.java
@@ -1,0 +1,198 @@
+package io.floci.az.services.servicebus;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ServiceBusRuleSelectorTest {
+
+    private static ServiceBusModels.RuleEntity correlation(String correlationId, String label,
+                                                            String sessionId, Map<String, String> props) {
+        return new ServiceBusModels.RuleEntity("t", "s", "r", "CorrelationFilter",
+                null, correlationId, null, null, null, label, sessionId, null, null,
+                props, Map.of(), null, Instant.EPOCH);
+    }
+
+    private static ServiceBusModels.RuleEntity sql(String expression) {
+        return new ServiceBusModels.RuleEntity("t", "s", "r", "SqlFilter",
+                expression, null, null, null, null, null, null, null, null,
+                Map.of(), Map.of(), null, Instant.EPOCH);
+    }
+
+    private static ServiceBusModels.RuleEntity ofType(String filterType) {
+        return new ServiceBusModels.RuleEntity("t", "s", "r", filterType,
+                null, null, null, null, null, null, null, null, null,
+                Map.of(), Map.of(), null, Instant.EPOCH);
+    }
+
+    // ── CorrelationFilter ─────────────────────────────────────────────────────
+
+    @Test
+    void correlationFilterMapsSystemProperties() {
+        String selector = ServiceBusRuleSelector.forRule(
+                correlation("corr-1", "order.created", "sess-9", Map.of()));
+        assertEquals("JMSCorrelationID = 'corr-1' AND JMSType = 'order.created' AND JMSXGroupID = 'sess-9'",
+                selector);
+    }
+
+    @Test
+    void correlationFilterOnLabelOnly() {
+        assertEquals("JMSType = 'red'",
+                ServiceBusRuleSelector.forRule(correlation(null, "red", null, Map.of())));
+    }
+
+    @Test
+    void correlationFilterUserPropertiesAndQuoteEscaping() {
+        String selector = ServiceBusRuleSelector.forRule(
+                correlation(null, "it's", null, Map.of("color", "blue")));
+        assertEquals("JMSType = 'it''s' AND color = 'blue'", selector);
+    }
+
+    @Test
+    void correlationFilterEmitsTypedLiterals() {
+        ServiceBusModels.RuleEntity rule = new ServiceBusModels.RuleEntity(
+                "t", "s", "r", "CorrelationFilter", null, null, null, null, null,
+                null, null, null, null,
+                Map.of("quantity", "10"),
+                Map.of("quantity", "int"),
+                null, Instant.EPOCH);
+        assertEquals("quantity = 10", ServiceBusRuleSelector.forRule(rule));
+
+        ServiceBusModels.RuleEntity boolRule = new ServiceBusModels.RuleEntity(
+                "t", "s", "r", "CorrelationFilter", null, null, null, null, null,
+                null, null, null, null,
+                Map.of("urgent", "true"),
+                Map.of("urgent", "boolean"),
+                null, Instant.EPOCH);
+        assertEquals("urgent = TRUE", ServiceBusRuleSelector.forRule(boolRule));
+
+        // a declared numeric type with a non-numeric value falls back to a string literal
+        ServiceBusModels.RuleEntity badInt = new ServiceBusModels.RuleEntity(
+                "t", "s", "r", "CorrelationFilter", null, null, null, null, null,
+                null, null, null, null,
+                Map.of("quantity", "ten"),
+                Map.of("quantity", "int"),
+                null, Instant.EPOCH);
+        assertEquals("quantity = 'ten'", ServiceBusRuleSelector.forRule(badInt));
+    }
+
+    @Test
+    void correlationFilterRejectsUnsupportedSystemProperties() {
+        ServiceBusModels.RuleEntity withMessageId = new ServiceBusModels.RuleEntity(
+                "t", "s", "r", "CorrelationFilter", null, null, "msg-1", null, null,
+                null, null, null, null, Map.of(), Map.of(), null, Instant.EPOCH);
+        assertThrows(IllegalArgumentException.class,
+                () -> ServiceBusRuleSelector.forRule(withMessageId));
+    }
+
+    @Test
+    void correlationFilterRejectsInvalidPropertyNames() {
+        assertThrows(IllegalArgumentException.class, () -> ServiceBusRuleSelector.forRule(
+                correlation(null, null, null, Map.of("bad-name", "x"))));
+    }
+
+    @Test
+    void emptyCorrelationFilterIsRejected() {
+        assertThrows(IllegalArgumentException.class, () -> ServiceBusRuleSelector.forRule(
+                correlation(null, null, null, Map.of())));
+    }
+
+    // ── SqlFilter translation ─────────────────────────────────────────────────
+
+    @Test
+    void sqlFilterPassesUserPropertiesThrough() {
+        assertEquals("color = 'blue' AND quantity = 10",
+                ServiceBusRuleSelector.forRule(sql("color = 'blue' AND quantity = 10")));
+    }
+
+    @Test
+    void sqlFilterMapsSysAndUserPrefixes() {
+        assertEquals("JMSType = 'red' OR color = 'red'",
+                ServiceBusRuleSelector.forRule(sql("sys.Label = 'red' OR user.color = 'red'")));
+        assertEquals("JMSCorrelationID = 'x'",
+                ServiceBusRuleSelector.forRule(sql("sys.CorrelationId = 'x'")));
+        assertEquals("JMSType = 'y'",
+                ServiceBusRuleSelector.forRule(sql("sys.Subject = 'y'")));
+        assertEquals("JMSXGroupID = 'z'",
+                ServiceBusRuleSelector.forRule(sql("sys.SessionId = 'z'")));
+    }
+
+    @Test
+    void sqlFilterKeywordsAreNotTreatedAsProperties() {
+        assertEquals("color IS NOT NULL AND quantity BETWEEN 1 AND 10 AND color LIKE 'b%'",
+                ServiceBusRuleSelector.forRule(
+                        sql("color IS NOT NULL AND quantity BETWEEN 1 AND 10 AND color LIKE 'b%'")));
+    }
+
+    @Test
+    void sqlFilterRewritesExists() {
+        assertEquals("(color IS NOT NULL)",
+                ServiceBusRuleSelector.forRule(sql("EXISTS(color)")));
+        assertEquals("NOT (JMSType IS NOT NULL)",
+                ServiceBusRuleSelector.forRule(sql("NOT EXISTS ( sys.Label )")));
+    }
+
+    @Test
+    void sqlFilterLeavesStringLiteralsUntouched() {
+        assertEquals("color = 'sys.Label AND EXISTS(x)'",
+                ServiceBusRuleSelector.forRule(sql("color = 'sys.Label AND EXISTS(x)'")));
+        assertEquals("note = 'it''s ok'",
+                ServiceBusRuleSelector.forRule(sql("note = 'it''s ok'")));
+    }
+
+    @Test
+    void sqlFilterStripsBracketDelimiters() {
+        assertEquals("color = 'blue'",
+                ServiceBusRuleSelector.forRule(sql("[color] = 'blue'")));
+    }
+
+    @Test
+    void sqlFilterRejectsUnsupportedConstructs() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ServiceBusRuleSelector.forRule(sql("sys.MessageId = 'x'")));
+        assertThrows(IllegalArgumentException.class,
+                () -> ServiceBusRuleSelector.forRule(sql("quantity % 2 = 0")));
+        assertThrows(IllegalArgumentException.class,
+                () -> ServiceBusRuleSelector.forRule(sql("color = 'unterminated")));
+        assertThrows(IllegalArgumentException.class,
+                () -> ServiceBusRuleSelector.forRule(sql("")));
+    }
+
+    // ── Rule-set combination ──────────────────────────────────────────────────
+
+    @Test
+    void noRulesMatchesNothing() {
+        assertEquals(ServiceBusRuleSelector.MATCH_NONE, ServiceBusRuleSelector.forRules(List.of()));
+    }
+
+    @Test
+    void trueFilterMatchesEverything() {
+        assertEquals(ServiceBusRuleSelector.MATCH_ALL,
+                ServiceBusRuleSelector.forRules(List.of(ofType("TrueFilter"))));
+        assertEquals(ServiceBusRuleSelector.MATCH_ALL,
+                ServiceBusRuleSelector.forRules(List.of(sql("a = 1"), ofType("TrueFilter"))));
+    }
+
+    @Test
+    void multipleRulesCombineWithOr() {
+        assertEquals("(JMSType = 'a') OR (color = 'b')",
+                ServiceBusRuleSelector.forRules(List.of(
+                        correlation(null, "a", null, Map.of()),
+                        sql("color = 'b'"))));
+    }
+
+    @Test
+    void falseFiltersAreDropped() {
+        assertEquals("JMSType = 'a'",
+                ServiceBusRuleSelector.forRules(List.of(
+                        ofType("FalseFilter"),
+                        correlation(null, "a", null, Map.of()))));
+        assertEquals(ServiceBusRuleSelector.MATCH_NONE,
+                ServiceBusRuleSelector.forRules(List.of(ofType("FalseFilter"))));
+    }
+}

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusRuleSelectorTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusRuleSelectorTest.java
@@ -163,6 +163,77 @@ class ServiceBusRuleSelectorTest {
                 () -> ServiceBusRuleSelector.forRule(sql("")));
     }
 
+    @Test
+    void sqlFilterSupportsInBetweenAndParentheses() {
+        assertEquals("color IN ('red', 'blue') OR (quantity + 5) * 2 <= 30",
+                ServiceBusRuleSelector.forRule(sql("color IN ('red', 'blue') OR (quantity + 5) * 2 <= 30")));
+        assertEquals("note NOT LIKE 'a%'",
+                ServiceBusRuleSelector.forRule(sql("note NOT LIKE 'a%'")));
+    }
+
+    @Test
+    void sqlFilterPrefixesAreCaseInsensitiveAndKeywordCasePreserved() {
+        assertEquals("JMSType = 'x'", ServiceBusRuleSelector.forRule(sql("SYS.LABEL = 'x'")));
+        assertEquals("Color = 'y'", ServiceBusRuleSelector.forRule(sql("USER.Color = 'y'")));
+        assertEquals("a = 1 and b = 2", ServiceBusRuleSelector.forRule(sql("a = 1 and b = 2")));
+    }
+
+    @Test
+    void sqlFilterAllowsUnderscoreAndDollarIdentifiers() {
+        assertEquals("_private = 1 AND $dollar = 2",
+                ServiceBusRuleSelector.forRule(sql("_private = 1 AND $dollar = 2")));
+    }
+
+    @Test
+    void sqlFilterMapsBracketedSystemProperty() {
+        assertEquals("JMSType = 'blue'",
+                ServiceBusRuleSelector.forRule(sql("[sys.Label] = 'blue'")));
+    }
+
+    @Test
+    void sqlFilterRejectsBadBracketedIdentifiers() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ServiceBusRuleSelector.forRule(sql("[bad-name] = 1")));
+        assertThrows(IllegalArgumentException.class,
+                () -> ServiceBusRuleSelector.forRule(sql("[unterminated = 1")));
+    }
+
+    @Test
+    void existsVariants() {
+        assertEquals("(color IS NOT NULL)",
+                ServiceBusRuleSelector.forRule(sql("EXISTS(user.color)")));
+        assertEquals("(JMSXGroupID IS NOT NULL)",
+                ServiceBusRuleSelector.forRule(sql("EXISTS ( sys.SessionId )")));
+        assertThrows(IllegalArgumentException.class,
+                () -> ServiceBusRuleSelector.forRule(sql("EXISTS(sys.MessageId)")));
+        assertThrows(IllegalArgumentException.class,
+                () -> ServiceBusRuleSelector.forRule(sql("EXISTS color")));
+        assertThrows(IllegalArgumentException.class,
+                () -> ServiceBusRuleSelector.forRule(sql("EXISTS(color")));
+    }
+
+    @Test
+    void unknownFilterTypeIsRejected() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ServiceBusRuleSelector.forRule(ofType("BogusFilter")));
+    }
+
+    @Test
+    void typedLiteralsForDecimalAndInvalidBoolean() {
+        ServiceBusModels.RuleEntity priceRule = new ServiceBusModels.RuleEntity(
+                "t", "s", "r", "CorrelationFilter", null, null, null, null, null,
+                null, null, null, null,
+                Map.of("price", "2.5"), Map.of("price", "double"), null, Instant.EPOCH);
+        assertEquals("price = 2.5", ServiceBusRuleSelector.forRule(priceRule));
+
+        // a declared boolean that isn't true/false falls back to a string literal
+        ServiceBusModels.RuleEntity badBool = new ServiceBusModels.RuleEntity(
+                "t", "s", "r", "CorrelationFilter", null, null, null, null, null,
+                null, null, null, null,
+                Map.of("urgent", "yes"), Map.of("urgent", "boolean"), null, Instant.EPOCH);
+        assertEquals("urgent = 'yes'", ServiceBusRuleSelector.forRule(badBool));
+    }
+
     // ── Rule-set combination ──────────────────────────────────────────────────
 
     @Test

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusRuleSelectorTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusRuleSelectorTest.java
@@ -30,6 +30,13 @@ class ServiceBusRuleSelectorTest {
                 Map.of(), Map.of(), null, Instant.EPOCH);
     }
 
+    private static ServiceBusModels.RuleEntity correlationTyped(Map<String, String> props,
+                                                                 Map<String, String> types) {
+        return new ServiceBusModels.RuleEntity("t", "s", "r", "CorrelationFilter",
+                null, null, null, null, null, null, null, null, null,
+                props, types, null, Instant.EPOCH);
+    }
+
     // ── CorrelationFilter ─────────────────────────────────────────────────────
 
     @Test
@@ -55,30 +62,13 @@ class ServiceBusRuleSelectorTest {
 
     @Test
     void correlationFilterEmitsTypedLiterals() {
-        ServiceBusModels.RuleEntity rule = new ServiceBusModels.RuleEntity(
-                "t", "s", "r", "CorrelationFilter", null, null, null, null, null,
-                null, null, null, null,
-                Map.of("quantity", "10"),
-                Map.of("quantity", "int"),
-                null, Instant.EPOCH);
-        assertEquals("quantity = 10", ServiceBusRuleSelector.forRule(rule));
-
-        ServiceBusModels.RuleEntity boolRule = new ServiceBusModels.RuleEntity(
-                "t", "s", "r", "CorrelationFilter", null, null, null, null, null,
-                null, null, null, null,
-                Map.of("urgent", "true"),
-                Map.of("urgent", "boolean"),
-                null, Instant.EPOCH);
-        assertEquals("urgent = TRUE", ServiceBusRuleSelector.forRule(boolRule));
-
+        assertEquals("quantity = 10", ServiceBusRuleSelector.forRule(
+                correlationTyped(Map.of("quantity", "10"), Map.of("quantity", "int"))));
+        assertEquals("urgent = TRUE", ServiceBusRuleSelector.forRule(
+                correlationTyped(Map.of("urgent", "true"), Map.of("urgent", "boolean"))));
         // a declared numeric type with a non-numeric value falls back to a string literal
-        ServiceBusModels.RuleEntity badInt = new ServiceBusModels.RuleEntity(
-                "t", "s", "r", "CorrelationFilter", null, null, null, null, null,
-                null, null, null, null,
-                Map.of("quantity", "ten"),
-                Map.of("quantity", "int"),
-                null, Instant.EPOCH);
-        assertEquals("quantity = 'ten'", ServiceBusRuleSelector.forRule(badInt));
+        assertEquals("quantity = 'ten'", ServiceBusRuleSelector.forRule(
+                correlationTyped(Map.of("quantity", "ten"), Map.of("quantity", "int"))));
     }
 
     @Test
@@ -220,18 +210,11 @@ class ServiceBusRuleSelectorTest {
 
     @Test
     void typedLiteralsForDecimalAndInvalidBoolean() {
-        ServiceBusModels.RuleEntity priceRule = new ServiceBusModels.RuleEntity(
-                "t", "s", "r", "CorrelationFilter", null, null, null, null, null,
-                null, null, null, null,
-                Map.of("price", "2.5"), Map.of("price", "double"), null, Instant.EPOCH);
-        assertEquals("price = 2.5", ServiceBusRuleSelector.forRule(priceRule));
-
+        assertEquals("price = 2.5", ServiceBusRuleSelector.forRule(
+                correlationTyped(Map.of("price", "2.5"), Map.of("price", "double"))));
         // a declared boolean that isn't true/false falls back to a string literal
-        ServiceBusModels.RuleEntity badBool = new ServiceBusModels.RuleEntity(
-                "t", "s", "r", "CorrelationFilter", null, null, null, null, null,
-                null, null, null, null,
-                Map.of("urgent", "yes"), Map.of("urgent", "boolean"), null, Instant.EPOCH);
-        assertEquals("urgent = 'yes'", ServiceBusRuleSelector.forRule(badBool));
+        assertEquals("urgent = 'yes'", ServiceBusRuleSelector.forRule(
+                correlationTyped(Map.of("urgent", "yes"), Map.of("urgent", "boolean"))));
     }
 
     // ── Rule-set combination ──────────────────────────────────────────────────

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusRuleXmlTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusRuleXmlTest.java
@@ -131,6 +131,122 @@ class ServiceBusRuleXmlTest {
     }
 
     @Test
+    void missingTypeAttributeFallsBackToStructuralDetection() {
+        String sqlBody = "<RuleDescription xmlns=\"" + SB_NS + "\">"
+                + "<Filter><SqlExpression>a = 1</SqlExpression></Filter>"
+                + "<Name>r</Name></RuleDescription>";
+        assertEquals("SqlFilter", ServiceBusRuleXml.parseRule("t", "s", "r", sqlBody).filterType());
+
+        String corrBody = "<RuleDescription xmlns=\"" + SB_NS + "\">"
+                + "<Filter><Label>red</Label></Filter>"
+                + "<Name>r</Name></RuleDescription>";
+        assertEquals("CorrelationFilter", ServiceBusRuleXml.parseRule("t", "s", "r", corrBody).filterType());
+
+        String emptyFilter = "<RuleDescription xmlns=\"" + SB_NS + "\">"
+                + "<Filter/><Name>r</Name></RuleDescription>";
+        assertEquals("TrueFilter", ServiceBusRuleXml.parseRule("t", "s", "r", emptyFilter).filterType());
+    }
+
+    @Test
+    void namespacePrefixedTypeAttributeIsStripped() {
+        String body = "<RuleDescription xmlns:i=\"" + XSI_NS + "\" xmlns=\"" + SB_NS + "\">"
+                + "<Filter i:type=\"d2p1:SqlFilter\"><SqlExpression>a = 1</SqlExpression></Filter>"
+                + "<Name>r</Name></RuleDescription>";
+        ServiceBusModels.RuleEntity rule = ServiceBusRuleXml.parseRule("t", "s", "r", body);
+        assertEquals("SqlFilter", rule.filterType());
+        assertEquals("a = 1", rule.sqlExpression());
+    }
+
+    @Test
+    void multipleCorrelationPropertiesAreAllParsed() {
+        String body = "<RuleDescription xmlns:i=\"" + XSI_NS + "\" xmlns=\"" + SB_NS + "\">"
+                + "<Filter i:type=\"CorrelationFilter\"><Properties>"
+                + "<KeyValueOfstringanyType><Key>b</Key><Value>2</Value></KeyValueOfstringanyType>"
+                + "<KeyValueOfstringanyType><Key>a</Key><Value>1</Value></KeyValueOfstringanyType>"
+                + "</Properties></Filter><Name>r</Name></RuleDescription>";
+        ServiceBusModels.RuleEntity rule = ServiceBusRuleXml.parseRule("t", "s", "r", body);
+        assertEquals(Map.of("b", "2", "a", "1"), rule.correlationProperties());
+    }
+
+    @Test
+    void specialCharactersSurviveBuildParseRoundTrip() {
+        String nasty = "a<b&'c\"";
+        ServiceBusModels.RuleEntity rule = new ServiceBusModels.RuleEntity(
+                "t", "s", "r", "CorrelationFilter",
+                null, null, null, null, null, nasty, null, null, null,
+                Map.of("k", nasty), Map.of(), null, Instant.EPOCH);
+        ServiceBusModels.RuleEntity reparsed = ServiceBusRuleXml.parseRule(
+                "t", "s", "r", ServiceBusRuleXml.ruleDescriptionXml(rule, SB_NS));
+        assertEquals(nasty, reparsed.label());
+        assertEquals(nasty, reparsed.correlationProperties().get("k"));
+    }
+
+    @Test
+    void malformedXmlFallsBackSafely() {
+        // rule body: unparseable input degrades to Azure's default TrueFilter
+        assertEquals("TrueFilter",
+                ServiceBusRuleXml.parseRule("t", "s", "r", "<Filter i:type=").filterType());
+        // subscription body: unparseable input means "no DefaultRuleDescription"
+        assertTrue(ServiceBusRuleXml.parseDefaultRule("t", "s", "not xml at all").isEmpty());
+    }
+
+    @Test
+    void unknownNestedElementInsideFilterIsSkipped() {
+        String body = "<RuleDescription xmlns:i=\"" + XSI_NS + "\" xmlns=\"" + SB_NS + "\">"
+                + "<Filter i:type=\"SqlFilter\">"
+                + "<SqlExpression>a = 1</SqlExpression>"
+                + "<Parameters><KeyValueOfstringanyType><Key>x</Key><Value>1</Value></KeyValueOfstringanyType></Parameters>"
+                + "</Filter><Name>r</Name></RuleDescription>";
+        ServiceBusModels.RuleEntity rule = ServiceBusRuleXml.parseRule("t", "s", "r", body);
+        assertEquals("SqlFilter", rule.filterType());
+        assertEquals("a = 1", rule.sqlExpression());
+    }
+
+    @Test
+    void emptyPropertiesElementYieldsNoProperties() {
+        String body = "<RuleDescription xmlns:i=\"" + XSI_NS + "\" xmlns=\"" + SB_NS + "\">"
+                + "<Filter i:type=\"CorrelationFilter\"><CorrelationId>c</CorrelationId><Properties/></Filter>"
+                + "<Name>r</Name></RuleDescription>";
+        ServiceBusModels.RuleEntity rule = ServiceBusRuleXml.parseRule("t", "s", "r", body);
+        assertEquals("c", rule.correlationId());
+        assertTrue(rule.correlationProperties().isEmpty());
+    }
+
+    @Test
+    void defaultRuleWithoutNameIsNamedDefault() {
+        String body = "<SubscriptionDescription xmlns:i=\"" + XSI_NS + "\" xmlns=\"" + SB_NS + "\">"
+                + "<DefaultRuleDescription><Filter i:type=\"TrueFilter\"/></DefaultRuleDescription>"
+                + "</SubscriptionDescription>";
+        Optional<ServiceBusModels.RuleEntity> rule = ServiceBusRuleXml.parseDefaultRule("t", "s", body);
+        assertTrue(rule.isPresent());
+        assertEquals("$Default", rule.get().name());
+        assertEquals("TrueFilter", rule.get().filterType());
+    }
+
+    @Test
+    void falseFilterXmlUsesCanonicalExpression() {
+        ServiceBusModels.RuleEntity rule = new ServiceBusModels.RuleEntity(
+                "t", "s", "r", "FalseFilter", null, null, null, null, null,
+                null, null, null, null, Map.of(), Map.of(), null, Instant.EPOCH);
+        String xml = ServiceBusRuleXml.ruleDescriptionXml(rule, SB_NS);
+        assertTrue(xml.contains("i:type=\"FalseFilter\""));
+        assertTrue(xml.contains("<SqlExpression>1=0</SqlExpression>"));
+    }
+
+    @Test
+    void sqlRuleActionRoundTrips() {
+        ServiceBusModels.RuleEntity rule = new ServiceBusModels.RuleEntity(
+                "t", "s", "r", "SqlFilter", "a = 1", null, null, null, null,
+                null, null, null, null, Map.of(), Map.of(), "SET quantity = 1", Instant.EPOCH);
+        String xml = ServiceBusRuleXml.ruleDescriptionXml(rule, SB_NS);
+        assertTrue(xml.contains("i:type=\"SqlRuleAction\""));
+
+        ServiceBusModels.RuleEntity reparsed = ServiceBusRuleXml.parseRule("t", "s", "r", xml);
+        assertEquals("a = 1", reparsed.sqlExpression());
+        assertEquals("SET quantity = 1", reparsed.actionSqlExpression());
+    }
+
+    @Test
     void trueFilterXmlUsesCanonicalExpression() {
         ServiceBusModels.RuleEntity rule = ServiceBusModels.RuleEntity.trueFilter("t", "s", "$Default");
         String xml = ServiceBusRuleXml.ruleDescriptionXml(rule, SB_NS);

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusRuleXmlTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusRuleXmlTest.java
@@ -1,0 +1,141 @@
+package io.floci.az.services.servicebus;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ServiceBusRuleXmlTest {
+
+    private static final String SB_NS = "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect";
+    private static final String XSI_NS = "http://www.w3.org/2001/XMLSchema-instance";
+
+    @Test
+    void parsesCorrelationFilterRule() {
+        String body = "<entry xmlns=\"http://www.w3.org/2005/Atom\"><content type=\"application/xml\">"
+                + "<RuleDescription xmlns:i=\"" + XSI_NS + "\" xmlns=\"" + SB_NS + "\">"
+                + "<Filter i:type=\"CorrelationFilter\">"
+                + "<CorrelationId>high</CorrelationId>"
+                + "<Label>red</Label>"
+                + "<Properties><KeyValueOfstringanyType><Key>prop1</Key>"
+                + "<Value i:type=\"d6p1:string\" xmlns:d6p1=\"http://www.w3.org/2001/XMLSchema\">abc</Value>"
+                + "</KeyValueOfstringanyType></Properties>"
+                + "</Filter>"
+                + "<Action i:type=\"EmptyRuleAction\"/>"
+                + "<Name>my-rule</Name>"
+                + "</RuleDescription></content></entry>";
+
+        ServiceBusModels.RuleEntity rule = ServiceBusRuleXml.parseRule("t", "s", "my-rule", body);
+        assertEquals("CorrelationFilter", rule.filterType());
+        assertEquals("high", rule.correlationId());
+        assertEquals("red", rule.label());
+        assertEquals(Map.of("prop1", "abc"), rule.correlationProperties());
+        assertEquals("my-rule", rule.name());
+    }
+
+    @Test
+    void parsesSqlFilterRuleWithAction() {
+        String body = "<entry xmlns=\"http://www.w3.org/2005/Atom\"><content type=\"application/xml\">"
+                + "<RuleDescription xmlns:i=\"" + XSI_NS + "\" xmlns=\"" + SB_NS + "\">"
+                + "<Filter i:type=\"SqlFilter\">"
+                + "<SqlExpression>color='blue' AND quantity=10</SqlExpression>"
+                + "<CompatibilityLevel>20</CompatibilityLevel>"
+                + "</Filter>"
+                + "<Action i:type=\"SqlRuleAction\"><SqlExpression>SET quantity = quantity/2</SqlExpression></Action>"
+                + "<Name>sql-rule</Name>"
+                + "</RuleDescription></content></entry>";
+
+        ServiceBusModels.RuleEntity rule = ServiceBusRuleXml.parseRule("t", "s", "sql-rule", body);
+        assertEquals("SqlFilter", rule.filterType());
+        assertEquals("color='blue' AND quantity=10", rule.sqlExpression());
+        assertEquals("SET quantity = quantity/2", rule.actionSqlExpression());
+    }
+
+    @Test
+    void ruleNameFromPathWinsOverBody() {
+        String body = "<RuleDescription xmlns:i=\"" + XSI_NS + "\" xmlns=\"" + SB_NS + "\">"
+                + "<Filter i:type=\"TrueFilter\"><SqlExpression>1=1</SqlExpression></Filter>"
+                + "<Name>body-name</Name></RuleDescription>";
+        assertEquals("path-name", ServiceBusRuleXml.parseRule("t", "s", "path-name", body).name());
+    }
+
+    @Test
+    void emptyBodyDefaultsToTrueFilter() {
+        ServiceBusModels.RuleEntity rule = ServiceBusRuleXml.parseRule("t", "s", "r", "");
+        assertEquals("TrueFilter", rule.filterType());
+    }
+
+    @Test
+    void parsesDefaultRuleDescriptionFromSubscriptionBody() {
+        String body = "<entry xmlns=\"http://www.w3.org/2005/Atom\"><content type=\"application/xml\">"
+                + "<SubscriptionDescription xmlns:i=\"" + XSI_NS + "\" xmlns=\"" + SB_NS + "\">"
+                + "<LockDuration>PT1M</LockDuration>"
+                + "<DefaultRuleDescription>"
+                + "<Filter i:type=\"CorrelationFilter\"><Label>order.created</Label></Filter>"
+                + "<Name>my-default</Name>"
+                + "</DefaultRuleDescription>"
+                + "</SubscriptionDescription></content></entry>";
+
+        Optional<ServiceBusModels.RuleEntity> rule = ServiceBusRuleXml.parseDefaultRule("t", "s", body);
+        assertTrue(rule.isPresent());
+        assertEquals("CorrelationFilter", rule.get().filterType());
+        assertEquals("order.created", rule.get().label());
+        assertEquals("my-default", rule.get().name());
+    }
+
+    @Test
+    void subscriptionBodyWithoutDefaultRuleYieldsEmpty() {
+        String body = "<SubscriptionDescription xmlns=\"" + SB_NS + "\">"
+                + "<RequiresSession>true</RequiresSession></SubscriptionDescription>";
+        assertTrue(ServiceBusRuleXml.parseDefaultRule("t", "s", body).isEmpty());
+    }
+
+    @Test
+    void roundTripsCorrelationFilterXml() {
+        ServiceBusModels.RuleEntity rule = new ServiceBusModels.RuleEntity(
+                "topic", "sub", "r1", "CorrelationFilter",
+                null, "cid", null, null, null, "lbl", "sid", null, null,
+                Map.of("k", "v"), Map.of(), null, Instant.EPOCH);
+        String xml = ServiceBusRuleXml.ruleDescriptionXml(rule, SB_NS);
+
+        ServiceBusModels.RuleEntity reparsed = ServiceBusRuleXml.parseRule("topic", "sub", "r1", xml);
+        assertEquals("CorrelationFilter", reparsed.filterType());
+        assertEquals("cid", reparsed.correlationId());
+        assertEquals("lbl", reparsed.label());
+        assertEquals("sid", reparsed.sessionId());
+        assertEquals(Map.of("k", "v"), reparsed.correlationProperties());
+
+        assertTrue(xml.contains("i:type=\"CorrelationFilter\""));
+        assertTrue(xml.contains("<Name>r1</Name>"));
+    }
+
+    @Test
+    void typedCorrelationPropertyValuesRoundTrip() {
+        String body = "<RuleDescription xmlns:i=\"" + XSI_NS + "\" xmlns=\"" + SB_NS + "\">"
+                + "<Filter i:type=\"CorrelationFilter\">"
+                + "<Properties><KeyValueOfstringanyType><Key>quantity</Key>"
+                + "<Value i:type=\"d6p1:int\" xmlns:d6p1=\"http://www.w3.org/2001/XMLSchema\">10</Value>"
+                + "</KeyValueOfstringanyType></Properties>"
+                + "</Filter><Name>typed</Name></RuleDescription>";
+
+        ServiceBusModels.RuleEntity rule = ServiceBusRuleXml.parseRule("t", "s", "typed", body);
+        assertEquals(Map.of("quantity", "10"), rule.correlationProperties());
+        assertEquals(Map.of("quantity", "int"), rule.correlationPropertyTypes());
+
+        String xml = ServiceBusRuleXml.ruleDescriptionXml(rule, SB_NS);
+        assertTrue(xml.contains("i:type=\"d6p1:int\""));
+    }
+
+    @Test
+    void trueFilterXmlUsesCanonicalExpression() {
+        ServiceBusModels.RuleEntity rule = ServiceBusModels.RuleEntity.trueFilter("t", "s", "$Default");
+        String xml = ServiceBusRuleXml.ruleDescriptionXml(rule, SB_NS);
+        assertTrue(xml.contains("i:type=\"TrueFilter\""));
+        assertTrue(xml.contains("<SqlExpression>1=1</SqlExpression>"));
+        assertTrue(xml.contains("i:type=\"EmptyRuleAction\""));
+    }
+}


### PR DESCRIPTION
Closes #124

## What

Subscription rules / topic filters for Service Bus: the `/{topic}/subscriptions/{sub}/rules[/{rule}]` management-plane endpoints, Azure's implicit `$Default` TrueFilter rule, and broker-side filter evaluation (CorrelationFilter, SqlFilter, TrueFilter, FalseFilter) by compiling rules to Artemis SQL92 queue selectors.

## Management plane

- `PUT` / `GET` / `DELETE` `/{topic}/subscriptions/{sub}/rules/{rule}` and `GET .../rules` (ATOM `RuleDescription` wire format), on both the spec paths used by `ServiceBusAdministrationClient` and the legacy `/{ns}/topics/...` paths.
- Every new subscription gets the implicit `$Default` TrueFilter rule. Both standard SDK flows work: add-rule-then-delete-`$Default`, and `DefaultRuleDescription` embedded in the subscription create body (`CreateSubscriptionAsync(subscriptionOptions, ruleOptions)` — the flow the issue's Aspire topology uses).
- Rule PUT upserts (201 create / 200 replace); cascade deletes on subscription and topic removal.

## Data plane

Filters compile to Artemis core filters on the subscription's MULTICAST queue, so evaluation happens **inside the broker at routing time** — non-matching messages are never routed to the subscription: no wrong-consumer deliveries, no delivery-count inflation, no spurious dead-lettering (the exact failure modes described in #124).

Identifier mapping (verified against Artemis `AMQPMessage.getObjectProperty`):

| Azure | Artemis selector |
|---|---|
| `CorrelationId` / `sys.CorrelationId` | `JMSCorrelationID` (AMQP correlation-id) |
| `Label` / `Subject` / `sys.Label` / `sys.Subject` | `JMSType` (AMQP subject) |
| `SessionId` / `sys.SessionId` | `JMSXGroupID` (AMQP group-id) |
| application properties | referenced by name |

- SqlFilter translation strips `user.`/`[bracket]` forms and rewrites `EXISTS(p)` → `(p IS NOT NULL)`; `LIKE`, `IN`, `BETWEEN`, `IS NULL`, arithmetic and boolean operators pass through.
- Correlation property values typed `int`/`long`/`double`/`boolean` compare with their declared type (JMS selectors never match across types).
- Multiple rules OR-combine into a single delivery; a subscription with no rules receives nothing (`1=0`), matching Azure.
- Rule changes update the queue filter **in place** via `ActiveMQServerControl.updateQueue` — routed messages and attached receivers survive; changes apply to future messages only, as on Azure.

## Documented deviations

- Filters on `MessageId`, `To`, `ReplyTo`, `ReplyToSessionId`, `ContentType` are rejected with HTTP 400 — these AMQP fields have no broker-side selector identifier, so rejecting loudly beats silently misrouting. (Fixable later via a small Artemis broker-plugin that copies them into filterable properties.)
- `SqlRuleAction` is stored and echoed by the management API but not applied to delivered messages (no per-subscription transformer without a divert-based re-architecture).

Both are documented in `docs/services/service-bus.md`.

## Also fixed

- Service Bus ATOM feed responses embedded a full `<?xml?>` prolog inside every `<entry>`, making list responses malformed XML for strict parsers. Entry builders are now prolog-free; responses prepend it once.

## Testing

- **67 new unit tests** across selector compilation (26), RuleDescription XML codec (19), and REST rule CRUD (22) — happy paths plus non-happy: 400s leave no partial state, 404s, 405 on non-GET rules collection, malformed-body fallbacks, cascade behavior, prolog regression. Full suite: 376 green.
- **End-to-end against a real Artemis sidecar** with real SDK traffic — 7 scenarios verified (Label routing, typed int property, SQL filter with `sys.Label` + numeric comparison, OR rules single-copy, no-rules-delivers-nothing, SessionId routing, `$Default` accepts-all), and compiled selectors inspected on the broker via Jolokia.
- `ServiceBusRuleCompatibilityTest` added to the Java SDK compat suite (same skip-when-mocked behavior as the existing Service Bus AMQP tests).

## Pre-existing issue found (not addressed here)

In real-broker mode, **every** Service Bus Java SDK send currently fails with `"Size of the payload exceeded maximum message size: 0 kb"`: azure-core-amqp leaves its link size at 0 when the broker's ATTACH carries no `max-message-size`, and Artemis never advertises one (verified on 2.42.0 and 2.44.0 — no config knob exists). CI never sees this because `mocked: true` skips all AMQP compat tests. Worth its own issue; e2e verification for this PR used a different SDK stack to sidestep it.
