### PR TITLE
fix(storage): serialize service properties XML instead of returning toString

### DIFF
--- a/src/main/java/io/floci/az/core/XmlBuilder.java
+++ b/src/main/java/io/floci/az/core/XmlBuilder.java
@@ -108,6 +108,12 @@ public final class XmlBuilder {
         return sb.toString();
     }
 
+    /** Same as {@link #build()}, so accidental string conversion never leaks the object identity. */
+    @Override
+    public String toString() {
+        return build();
+    }
+
     /**
      * Escapes the five XML special characters: {@code & < > " '}.
      * Returns an empty string for null or empty input.

--- a/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
+++ b/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
@@ -187,7 +187,7 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
                 .end("MinuteMetrics")
                 .start("StaticWebsite").elem("Enabled", "false").end("StaticWebsite")
             .end("StorageServiceProperties")
-            .toString();
+            .build();
         return Response.ok(xml, "application/xml").build();
     }
 

--- a/src/main/java/io/floci/az/services/queue/QueueServiceHandler.java
+++ b/src/main/java/io/floci/az/services/queue/QueueServiceHandler.java
@@ -172,7 +172,7 @@ public class QueueServiceHandler implements AzureServiceHandler, Resettable {
                 .end("MinuteMetrics")
                 .selfClose("Cors")
             .end("StorageServiceProperties")
-            .toString();
+            .build();
         return Response.ok(xml, "application/xml").build();
     }
 

--- a/src/test/java/io/floci/az/services/BlobServiceTest.java
+++ b/src/test/java/io/floci/az/services/BlobServiceTest.java
@@ -25,6 +25,17 @@ public class BlobServiceTest {
     }
 
     @Test
+    void getBlobServicePropertiesReturnsXml() {
+        given()
+            .when().get("/{account}?restype=service&comp=properties", ACCOUNT)
+            .then()
+            .statusCode(200)
+            .contentType("application/xml")
+            .body(startsWith("<StorageServiceProperties>"))
+            .body("StorageServiceProperties.Logging.Version", equalTo("1.0"));
+    }
+
+    @Test
     void createAndDeleteContainer() {
         given()
             .when().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER)

--- a/src/test/java/io/floci/az/services/QueueServiceTest.java
+++ b/src/test/java/io/floci/az/services/QueueServiceTest.java
@@ -20,6 +20,17 @@ public class QueueServiceTest {
     }
 
     @Test
+    void getQueueServicePropertiesReturnsXml() {
+        given()
+            .when().get("/{account}?restype=service&comp=properties", ACCOUNT)
+            .then()
+            .statusCode(200)
+            .contentType("application/xml")
+            .body(startsWith("<StorageServiceProperties>"))
+            .body("StorageServiceProperties.Logging.Version", equalTo("1.0"));
+    }
+
+    @Test
     void createAndDeleteQueue() {
         given()
             .when().put("/{account}/{queue}", ACCOUNT, QUEUE)


### PR DESCRIPTION
## Summary

Fixes #131.

`GET /{account}-queue?restype=service&comp=properties` returned the Java object identity string (`io.floci.az.core.XmlBuilder@...`) instead of the serialized `<StorageServiceProperties>` document, because the handler called `toString()` on `XmlBuilder`, which only exposes `build()` and never overrode `Object.toString()`. Azure SDK clients failed with `System.Xml.XmlException: Data at the root level is invalid`.

The Blob service properties endpoint (`getBlobServiceProperties`) had the identical bug and is fixed here too.

## Changes

- `QueueServiceHandler.getQueueServiceProperties` and `BlobServiceHandler.getBlobServiceProperties`: call `.build()` instead of `.toString()`.
- `XmlBuilder`: override `toString()` to delegate to `build()`, so any future accidental string conversion produces the XML rather than the object identity string.
- Regression tests in `QueueServiceTest` and `BlobServiceTest` asserting the endpoints return 200 with a document starting `<StorageServiceProperties>`.

## Testing

Full test suite passes locally (`mvnw test`), including the two new regression tests.