### PR TITLE
fix(storage): serve service-properties XML for table, queue, and blob

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/BlobCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/BlobCompatibilityTest.java
@@ -10,6 +10,7 @@ import com.azure.storage.blob.models.BlobItem;
 import com.azure.storage.blob.models.BlobProperties;
 import com.azure.storage.blob.models.BlobRange;
 import com.azure.storage.blob.models.BlobRequestConditions;
+import com.azure.storage.blob.models.BlobServiceProperties;
 import com.azure.storage.blob.models.BlobStorageException;
 import com.azure.storage.blob.models.BlockListType;
 import com.azure.storage.blob.models.LeaseStateType;
@@ -407,5 +408,16 @@ class BlobCompatibilityTest {
         assertEquals(412, ex.getStatusCode());
 
         client.deleteBlobContainer(name);
+    }
+
+    @Test
+    @DisplayName("service properties: getProperties returns StorageServiceProperties XML")
+    void getServiceProperties() {
+        BlobServiceProperties props = client.getProperties();
+
+        assertNotNull(props);
+        assertNotNull(props.getLogging());
+        assertNotNull(props.getHourMetrics());
+        assertNotNull(props.getMinuteMetrics());
     }
 }

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/QueueCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/QueueCompatibilityTest.java
@@ -6,6 +6,7 @@ import com.azure.storage.queue.QueueServiceClientBuilder;
 import com.azure.storage.queue.models.PeekedMessageItem;
 import com.azure.storage.queue.models.QueueItem;
 import com.azure.storage.queue.models.QueueMessageItem;
+import com.azure.storage.queue.models.QueueServiceProperties;
 import com.azure.storage.queue.models.QueueStorageException;
 import com.azure.storage.queue.models.QueuesSegmentOptions;
 import com.azure.storage.queue.models.UpdateMessageResult;
@@ -218,5 +219,16 @@ class QueueCompatibilityTest {
         QueueStorageException ex = assertThrows(QueueStorageException.class,
             () -> queue.receiveMessages(1).stream().toList());
         assertEquals(404, ex.getStatusCode());
+    }
+
+    @Test
+    @DisplayName("service properties: getProperties returns StorageServiceProperties XML")
+    void getServiceProperties() {
+        QueueServiceProperties props = client.getProperties();
+
+        assertNotNull(props);
+        assertNotNull(props.getAnalyticsLogging());
+        assertNotNull(props.getHourMetrics());
+        assertNotNull(props.getMinuteMetrics());
     }
 }

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/TableCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/TableCompatibilityTest.java
@@ -7,6 +7,7 @@ import com.azure.data.tables.models.ListEntitiesOptions;
 import com.azure.data.tables.models.TableEntity;
 import com.azure.data.tables.models.TableEntityUpdateMode;
 import com.azure.data.tables.models.TableServiceException;
+import com.azure.data.tables.models.TableServiceProperties;
 import com.azure.data.tables.models.TableTransactionAction;
 import com.azure.data.tables.models.TableTransactionActionType;
 import org.junit.jupiter.api.*;
@@ -279,5 +280,16 @@ class TableCompatibilityTest {
         assertEquals(404, ex.getResponse().getStatusCode());
 
         client.deleteTable(name);
+    }
+
+    @Test
+    @DisplayName("service properties: getProperties returns StorageServiceProperties XML")
+    void getServiceProperties() {
+        TableServiceProperties props = client.getProperties();
+
+        assertNotNull(props);
+        assertNotNull(props.getLogging());
+        assertNotNull(props.getHourMetrics());
+        assertNotNull(props.getMinuteMetrics());
     }
 }

--- a/docs/services/table.md
+++ b/docs/services/table.md
@@ -20,6 +20,8 @@ authentication.
   (`x-ms-continuation-Next*` headers)
 - **Optimistic concurrency** — `ETag` / `If-Match` on update and delete; a stale ETag is rejected
 - **Batch transactions** — `$batch` multipart change sets are applied atomically
+- **Service properties** — `restype=service&comp=properties` returns a static
+  `<StorageServiceProperties>` document (logging and metrics disabled); Set is accepted as a no-op
 
 ## Endpoint
 

--- a/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
+++ b/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
@@ -114,8 +114,10 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
             } else if ("service".equals(query.get("restype")) && "properties".equals(query.get("comp"))) {
                 if ("GET".equalsIgnoreCase(method) || "HEAD".equalsIgnoreCase(method)) {
                     response = getBlobServiceProperties();
-                } else {
+                } else if ("PUT".equalsIgnoreCase(method)) {
                     response = Response.accepted().build();
+                } else {
+                    response = notImplemented();
                 }
             } else {
                 response = notImplemented();

--- a/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
+++ b/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
@@ -115,7 +115,7 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
                 if ("GET".equalsIgnoreCase(method) || "HEAD".equalsIgnoreCase(method)) {
                     response = getBlobServiceProperties();
                 } else {
-                    response = Response.ok().build();
+                    response = Response.accepted().build();
                 }
             } else {
                 response = notImplemented();

--- a/src/main/java/io/floci/az/services/queue/QueueServiceHandler.java
+++ b/src/main/java/io/floci/az/services/queue/QueueServiceHandler.java
@@ -94,7 +94,7 @@ public class QueueServiceHandler implements AzureServiceHandler, Resettable {
                 if ("GET".equalsIgnoreCase(method) || "HEAD".equalsIgnoreCase(method)) {
                     response = getQueueServiceProperties();
                 } else {
-                    response = Response.ok().build();
+                    response = Response.accepted().build();
                 }
             } else {
                 response = new AzureErrorResponse("NotImplemented", "The requested operation is not implemented.")

--- a/src/main/java/io/floci/az/services/queue/QueueServiceHandler.java
+++ b/src/main/java/io/floci/az/services/queue/QueueServiceHandler.java
@@ -93,8 +93,12 @@ public class QueueServiceHandler implements AzureServiceHandler, Resettable {
             } else if ("service".equals(query.get("restype")) && "properties".equals(query.get("comp"))) {
                 if ("GET".equalsIgnoreCase(method) || "HEAD".equalsIgnoreCase(method)) {
                     response = getQueueServiceProperties();
-                } else {
+                } else if ("PUT".equalsIgnoreCase(method)) {
                     response = Response.accepted().build();
+                } else {
+                    response = new AzureErrorResponse(
+                            "NotImplemented", "The requested operation is not implemented.")
+                            .toXmlResponse(501);
                 }
             } else {
                 response = new AzureErrorResponse("NotImplemented", "The requested operation is not implemented.")

--- a/src/main/java/io/floci/az/services/table/TableServiceHandler.java
+++ b/src/main/java/io/floci/az/services/table/TableServiceHandler.java
@@ -101,7 +101,7 @@ public class TableServiceHandler implements AzureServiceHandler, Resettable {
             if ("GET".equalsIgnoreCase(method) || "HEAD".equalsIgnoreCase(method)) {
                 response = getTableServiceProperties();
             } else {
-                response = Response.ok().build();
+                response = Response.accepted().build();
             }
         } else if (path.startsWith("Tables")) {
             if ("GET".equalsIgnoreCase(method)) {

--- a/src/main/java/io/floci/az/services/table/TableServiceHandler.java
+++ b/src/main/java/io/floci/az/services/table/TableServiceHandler.java
@@ -100,8 +100,12 @@ public class TableServiceHandler implements AzureServiceHandler, Resettable {
                 && "properties".equals(query.get("comp"))) {
             if ("GET".equalsIgnoreCase(method) || "HEAD".equalsIgnoreCase(method)) {
                 response = getTableServiceProperties();
-            } else {
+            } else if ("PUT".equalsIgnoreCase(method)) {
                 response = Response.accepted().build();
+            } else {
+                response = new AzureErrorResponse(
+                        "NotImplemented", "The requested operation is not implemented.")
+                        .toXmlResponse(501);
             }
         } else if (path.startsWith("Tables")) {
             if ("GET".equalsIgnoreCase(method)) {

--- a/src/test/java/io/floci/az/services/BlobServiceTest.java
+++ b/src/test/java/io/floci/az/services/BlobServiceTest.java
@@ -42,6 +42,16 @@ public class BlobServiceTest {
     }
 
     @Test
+    void setBlobServicePropertiesReturns202() {
+        given()
+            .contentType("application/xml")
+            .body("<StorageServiceProperties><Logging><Version>1.0</Version></Logging></StorageServiceProperties>")
+            .when().put("/{account}?restype=service&comp=properties", ACCOUNT)
+            .then()
+            .statusCode(202);
+    }
+
+    @Test
     void createAndDeleteContainer() {
         given()
             .when().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER)

--- a/src/test/java/io/floci/az/services/BlobServiceTest.java
+++ b/src/test/java/io/floci/az/services/BlobServiceTest.java
@@ -52,6 +52,14 @@ public class BlobServiceTest {
     }
 
     @Test
+    void postBlobServicePropertiesIsNotImplemented() {
+        given()
+            .when().post("/{account}?restype=service&comp=properties", ACCOUNT)
+            .then()
+            .statusCode(501);
+    }
+
+    @Test
     void createAndDeleteContainer() {
         given()
             .when().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER)

--- a/src/test/java/io/floci/az/services/QueueServiceTest.java
+++ b/src/test/java/io/floci/az/services/QueueServiceTest.java
@@ -33,6 +33,16 @@ public class QueueServiceTest {
     }
 
     @Test
+    void setQueueServicePropertiesReturns202() {
+        given()
+            .contentType("application/xml")
+            .body("<StorageServiceProperties><Logging><Version>1.0</Version></Logging></StorageServiceProperties>")
+            .when().put("/{account}?restype=service&comp=properties", ACCOUNT)
+            .then()
+            .statusCode(202);
+    }
+
+    @Test
     void createAndDeleteQueue() {
         given()
             .when().put("/{account}/{queue}", ACCOUNT, QUEUE)

--- a/src/test/java/io/floci/az/services/QueueServiceTest.java
+++ b/src/test/java/io/floci/az/services/QueueServiceTest.java
@@ -43,6 +43,14 @@ public class QueueServiceTest {
     }
 
     @Test
+    void postQueueServicePropertiesIsNotImplemented() {
+        given()
+            .when().post("/{account}?restype=service&comp=properties", ACCOUNT)
+            .then()
+            .statusCode(501);
+    }
+
+    @Test
     void createAndDeleteQueue() {
         given()
             .when().put("/{account}/{queue}", ACCOUNT, QUEUE)

--- a/src/test/java/io/floci/az/services/TableServiceTest.java
+++ b/src/test/java/io/floci/az/services/TableServiceTest.java
@@ -45,6 +45,14 @@ public class TableServiceTest {
     }
 
     @Test
+    void postTableServicePropertiesIsNotImplemented() {
+        given()
+            .when().post("/{account}?restype=service&comp=properties", ACCOUNT)
+            .then()
+            .statusCode(501);
+    }
+
+    @Test
     void listTablesStillReturnsJson() {
         given()
             .contentType("application/json")

--- a/src/test/java/io/floci/az/services/TableServiceTest.java
+++ b/src/test/java/io/floci/az/services/TableServiceTest.java
@@ -6,7 +6,9 @@ import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
 
 @QuarkusTest
 public class TableServiceTest {
@@ -27,6 +29,34 @@ public class TableServiceTest {
             .contentType(containsString("xml"))
             .body(containsString("<StorageServiceProperties>"))
             .body(containsString("<Logging>"))
+            .body(containsString("<HourMetrics>"))
+            .body(containsString("<MinuteMetrics>"))
             .body(not(containsString("\"value\"")));
+    }
+
+    @Test
+    void setTableServicePropertiesIsAccepted() {
+        given()
+            .contentType("application/xml")
+            .body("<StorageServiceProperties><Logging><Version>1.0</Version></Logging></StorageServiceProperties>")
+            .when().put("/{account}?restype=service&comp=properties", ACCOUNT)
+            .then()
+            .statusCode(202);
+    }
+
+    @Test
+    void listTablesStillReturnsJson() {
+        given()
+            .contentType("application/json")
+            .body("{\"TableName\":\"mytable\"}")
+            .when().post("/{account}/Tables", ACCOUNT)
+            .then().statusCode(201);
+
+        given()
+            .when().get("/{account}/Tables", ACCOUNT)
+            .then()
+            .statusCode(200)
+            .header("Content-Type", startsWith("application/json"))
+            .body("value.TableName", hasItem("mytable"));
     }
 }


### PR DESCRIPTION
## Summary

Fixes #132 and #131 in the Storage service-properties API family.

- Route Table Storage `restype=service&comp=properties` before table/entity routing.
- Return Azure-compatible service-properties XML for Blob, Queue, and Table GET/HEAD requests.
- Return `202 Accepted` for PUT and `501 NotImplemented` for unsupported write methods.
- Add RestAssured regressions and Java SDK `getProperties()` compatibility coverage.
- Document Table service-properties support.

## Validation

- Full unit suite: 449 tests passed.
- Java compatibility suite compiles and the new SDK coverage runs in the compatibility matrix.
- Current PR checks pass.

Closes #131
Closes #132