### PR TITLE
fix(postgres): answer 202 with Location so azurerm 3.x and 4.x both apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- **postgres:** mutating operations on Flexible Servers (and their databases, firewall rules and configurations) now answer `202 Accepted` with a `Location` header pointing at the resource, instead of `200`/`201`. ARM models these as long-running operations and the provider's accepted status codes narrowed between majors: azurerm 3.x accepts 200/201/202 on PUT, but **4.x accepts only 202**, so every `azurerm_postgresql_flexible_server*` apply failed against the emulator with `unexpected status 201 (201 Created)`. 202 is the only value both majors accept. Because the work is already complete when we answer, the `Location` header points back at the resource itself and the SDK's poller finishes on its first poll. `DELETE` is unchanged at 204, which both majors already accept ([#135](https://github.com/floci-io/floci-az/pull/135))
-
 ## [0.10.0] - 2026-07-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **postgres:** mutating operations on Flexible Servers (and their databases, firewall rules and configurations) now answer `202 Accepted` with a `Location` header pointing at the resource, instead of `200`/`201`. ARM models these as long-running operations and the provider's accepted status codes narrowed between majors: azurerm 3.x accepts 200/201/202 on PUT, but **4.x accepts only 202**, so every `azurerm_postgresql_flexible_server*` apply failed against the emulator with `unexpected status 201 (201 Created)`. 202 is the only value both majors accept. Because the work is already complete when we answer, the `Location` header points back at the resource itself and the SDK's poller finishes on its first poll. `DELETE` is unchanged at 204, which both majors already accept ([#135](https://github.com/floci-io/floci-az/pull/135))
+
 ## [0.10.0] - 2026-07-31
 
 ### Added

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/PostgresCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/PostgresCompatibilityTest.java
@@ -84,8 +84,10 @@ class PostgresCompatibilityTest {
         HttpResponse<String> resp = send("PUT",
             ARM_BASE + "/flexibleServers/" + SERVER + API, serverBody, Duration.ofMinutes(5));
 
-        assertTrue(resp.statusCode() == 200 || resp.statusCode() == 201,
-            "PUT server failed (" + resp.statusCode() + "): " + resp.body());
+        // 202 + Location: the ARM long-running-operation shape both azurerm 3.x and 4.x accept.
+        assertEquals(202, resp.statusCode(), "PUT server failed: " + resp.body());
+        assertTrue(resp.headers().firstValue("Location").isPresent(),
+            "PUT server must carry a Location header for the SDK poller to follow");
 
         HttpResponse<String> connectResp = send("GET",
             BASE + "/devstoreaccount1-postgres/flexibleServers/" + SERVER + "/connect", null);
@@ -155,15 +157,14 @@ class PostgresCompatibilityTest {
 
     @Test
     @Order(30)
-    @DisplayName("PUT database registers it and returns 200/201")
+    @DisplayName("PUT database registers it and returns 202")
     void createDatabase() throws Exception {
         String dbBody = "{\"properties\":{\"charset\":\"UTF8\",\"collation\":\"en_US.utf8\"}}";
 
         HttpResponse<String> resp = send("PUT",
             ARM_BASE + "/flexibleServers/" + SERVER + "/databases/" + DB + API,
             dbBody, Duration.ofSeconds(60));
-        assertTrue(resp.statusCode() == 200 || resp.statusCode() == 201,
-            "PUT database failed (" + resp.statusCode() + "): " + resp.body());
+        assertEquals(202, resp.statusCode(), "PUT database failed: " + resp.body());
         assertTrue(resp.body().contains("\"name\":\"" + DB + "\""), "db name in response");
     }
 
@@ -258,8 +259,7 @@ class PostgresCompatibilityTest {
         String ruleUrl = ARM_BASE + "/flexibleServers/" + SERVER + "/firewallRules/" + ruleName + API;
 
         HttpResponse<String> putResp = send("PUT", ruleUrl, ruleBody);
-        assertTrue(putResp.statusCode() == 200 || putResp.statusCode() == 201,
-            "PUT firewall rule: " + putResp.body());
+        assertEquals(202, putResp.statusCode(), "PUT firewall rule: " + putResp.body());
 
         HttpResponse<String> getResp = send("GET", ruleUrl, null);
         assertEquals(200, getResp.statusCode());
@@ -285,7 +285,7 @@ class PostgresCompatibilityTest {
 
         HttpResponse<String> putResp = send("PUT", cfgUrl,
             "{\"properties\":{\"value\":\"200\",\"source\":\"user-override\"}}");
-        assertEquals(200, putResp.statusCode(), "PUT configuration: " + putResp.body());
+        assertEquals(202, putResp.statusCode(), "PUT configuration: " + putResp.body());
 
         HttpResponse<String> getResp = send("GET", cfgUrl, null);
         assertEquals(200, getResp.statusCode());

--- a/src/main/java/io/floci/az/services/postgres/PostgresHandler.java
+++ b/src/main/java/io/floci/az/services/postgres/PostgresHandler.java
@@ -44,9 +44,30 @@ import java.util.concurrent.ConcurrentHashMap;
  *   <li>Convenience: {@code /connect} — returns all connection string formats</li>
  * </ul>
  *
- * <p>Responses are synchronous (mirroring {@code SqlHandler}); the container is started
- * during the PUT and the server is reported {@code provisioningState=Succeeded} immediately,
- * which the azurerm long-running-operation poller accepts as a terminal result.
+ * <p>Server create is fully synchronous: the container is started during the PUT and the
+ * response body reports {@code provisioningState=Succeeded} / {@code state=Ready}.</p>
+ *
+ * <h2>Why mutating operations answer 202</h2>
+ *
+ * <p>Every mutating operation (PUT and PATCH on servers, databases, firewall rules and
+ * configurations) returns <b>HTTP 202</b> with a {@code Location} header pointing at the
+ * resource's own URL. ARM models these as long-running operations, and the provider's
+ * expected status codes differ by major version:</p>
+ *
+ * <table border="1">
+ *   <caption>go-azure-sdk expected status codes</caption>
+ *   <tr><th>Operation</th><th>azurerm 3.x</th><th>azurerm 4.x</th></tr>
+ *   <tr><td>PUT (create/update)</td><td>200, 201, 202</td><td>202 only</td></tr>
+ *   <tr><td>PATCH (update)</td><td>200, 202</td><td>202 only</td></tr>
+ *   <tr><td>DELETE</td><td>200, 202, 204</td><td>202, 204</td></tr>
+ * </table>
+ *
+ * <p>202 is therefore the only value both majors accept; a 200 or 201 fails 4.x with
+ * {@code unexpected status}. Because the work is already finished when we answer, the
+ * {@code Location} header points back at the resource itself: the SDK's poller then reads
+ * the terminal {@code provisioningState} (or, for the metadata-only children that carry no
+ * such field, treats its absence as completion) and finishes on the first poll. DELETE keeps
+ * returning 204, which both majors already accept.</p>
  */
 @ApplicationScoped
 public class PostgresHandler implements AzureServiceHandler, Resettable {
@@ -135,6 +156,34 @@ public class PostgresHandler implements AzureServiceHandler, Resettable {
             .build();
     }
 
+    // ── ARM long-running-operation responses ──────────────────────────────────
+
+    /**
+     * Builds the absolute URL of an ARM resource for the {@code Location} header,
+     * preserving the caller's {@code api-version} so the polled URL matches the one
+     * the client just wrote to.
+     */
+    private String resourceLocation(AzureRequest request, String armId) {
+        String host = request.headers().getHeaderString("Host");
+        if (host == null || host.isBlank()) host = "localhost:" + config.port();
+        String scheme = request.headers().getHeaderString("X-Forwarded-Proto");
+        if (scheme == null || scheme.isBlank()) scheme = request.secure() ? "https" : "http";
+        String apiVersion = request.queryParams().get("api-version");
+        return scheme + "://" + host + armId
+            + (apiVersion == null || apiVersion.isBlank() ? "" : "?api-version=" + apiVersion);
+    }
+
+    /**
+     * Completed mutating operation: 202 plus a self-referencing {@code Location}, the only
+     * shape both azurerm majors accept (see class javadoc).
+     */
+    private Response accepted(AzureRequest request, String armId, Object body) {
+        return Response.status(202)
+            .header("Location", resourceLocation(request, armId))
+            .entity(body)
+            .build();
+    }
+
     // ── checkNameAvailability ─────────────────────────────────────────────────
 
     private Response handleCheckNameAvailability(AzureRequest request) {
@@ -204,7 +253,7 @@ public class PostgresHandler implements AzureServiceHandler, Resettable {
 
                 if (config.services().postgres().mocked()) {
                     // Control-plane only: no container, data plane unavailable. Reports Ready.
-                    return Response.status(201).entity(serverResponse(entry)).build();
+                    return accepted(request, entry.armId(), serverResponse(entry));
                 }
 
                 try {
@@ -225,7 +274,7 @@ public class PostgresHandler implements AzureServiceHandler, Resettable {
                         .entity(Map.of("error", "ContainerStartFailed", "message", String.valueOf(e.getMessage())))
                         .build();
                 }
-                return Response.status(201).entity(serverResponse(entry)).build();
+                return accepted(request, entry.armId(), serverResponse(entry));
             }
 
             // Update existing server metadata in place — do NOT restart the container.
@@ -246,7 +295,7 @@ public class PostgresHandler implements AzureServiceHandler, Resettable {
                 existing.databases(), existing.firewallRules(), existing.configurations(),
                 existing.createdAt());
             state.putServer(updated);
-            return Response.status(200).entity(serverResponse(updated)).build();
+            return accepted(request, updated.armId(), serverResponse(updated));
 
         } catch (Exception e) {
             LOG.errorf(e, "Error creating PostgreSQL server %s", serverName);
@@ -302,17 +351,14 @@ public class PostgresHandler implements AzureServiceHandler, Resettable {
             String charset   = props.path("charset").asText("");
             String collation = props.path("collation").asText("");
 
-            boolean isNew = !state.databaseExists(serverName, dbName);
-
             // The emulator tracks the database in state only. Actual CREATE DATABASE is the
             // application's responsibility (psql, Flyway, Liquibase, etc.) via the /connect URL.
             PostgresState.DatabaseEntry db = PostgresState.DatabaseEntry.create(
                 dbName, serverName, charset, collation);
             state.putDatabase(serverName, db);
 
-            return Response.status(isNew ? 201 : 200)
-                .entity(databaseResponse(db, serverOpt.get()))
-                .build();
+            Map<String, Object> resp = databaseResponse(db, serverOpt.get());
+            return accepted(request, String.valueOf(resp.get("id")), resp);
         } catch (Exception e) {
             LOG.errorf(e, "Error creating database %s on server %s", dbName, serverName);
             return Response.status(500).entity(Map.of("error", String.valueOf(e.getMessage()))).build();
@@ -374,11 +420,10 @@ public class PostgresHandler implements AzureServiceHandler, Resettable {
             String end     = props.path("endIpAddress").asText();
             if (start.isBlank() || end.isBlank())
                 return badRequest("startIpAddress and endIpAddress are required");
-            boolean isNew = !state.getFirewallRule(serverName, ruleName).isPresent();
             PostgresState.FirewallRule rule = new PostgresState.FirewallRule(ruleName, start, end);
             state.putFirewallRule(serverName, rule);
-            return Response.status(isNew ? 201 : 200)
-                .entity(firewallRuleResponse(rule, serverName)).build();
+            Map<String, Object> resp = firewallRuleResponse(rule, serverName);
+            return accepted(request, String.valueOf(resp.get("id")), resp);
         } catch (Exception e) {
             return badRequest("Invalid firewall rule body: " + e.getMessage());
         }
@@ -408,7 +453,8 @@ public class PostgresHandler implements AzureServiceHandler, Resettable {
                     JsonNode body = readBody(request.bodyStream());
                     String value  = body.path("properties").path("value").asText("");
                     state.putConfiguration(serverName, cfgName, value);
-                    yield Response.status(200).entity(configurationResponse(serverName, cfgName, value)).build();
+                    Map<String, Object> resp = configurationResponse(serverName, cfgName, value);
+                    yield accepted(request, String.valueOf(resp.get("id")), resp);
                 } catch (Exception e) {
                     yield badRequest("Invalid configuration body: " + e.getMessage());
                 }

--- a/src/test/java/io/floci/az/services/postgres/PostgresDockerTest.java
+++ b/src/test/java/io/floci/az/services/postgres/PostgresDockerTest.java
@@ -75,13 +75,16 @@ class PostgresDockerTest {
 
     @Test
     @Order(1)
-    @DisplayName("PUT server starts a container and returns 201 with provisioningState=Succeeded + localPort")
+    @DisplayName("PUT server starts a container and returns 202 with provisioningState=Succeeded + localPort")
     void createServer() {
         given().post("/_admin/reset").then().statusCode(204);
 
+        // 202 + Location: the create shape both azurerm 3.x and 4.x accept, answered only once
+        // the container is actually up, so the client's first poll already sees Succeeded.
         localPort = given().contentType("application/json").body(CREATE_BODY)
             .when().put(PG_PATH + API)
-            .then().statusCode(201)
+            .then().statusCode(202)
+            .header("Location", containsString(NAME))
             .body("name", equalTo(NAME))
             .body("properties.provisioningState", equalTo("Succeeded"))
             .body("properties.state", equalTo("Ready"))

--- a/src/test/java/io/floci/az/services/postgres/PostgresHandlerMockedTest.java
+++ b/src/test/java/io/floci/az/services/postgres/PostgresHandlerMockedTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Map;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 /**
@@ -54,15 +55,16 @@ class PostgresHandlerMockedTest {
     private void createServer(String name) {
         given().contentType("application/json").body(SERVER_BODY)
             .when().put(BASE + "/flexibleServers/" + name + API)
-            .then().statusCode(201);
+            .then().statusCode(202);
     }
 
     @Test
-    @DisplayName("PUT server returns 201 with state=Ready, provisioningState=Succeeded and no localPort")
+    @DisplayName("PUT server returns 202 with state=Ready, provisioningState=Succeeded and no localPort")
     void putServerReady() {
+        // 202 is the only create status both azurerm 3.x and 4.x accept (see PostgresHandler javadoc).
         given().contentType("application/json").body(SERVER_BODY)
             .when().put(BASE + "/flexibleServers/pgserver" + API)
-            .then().statusCode(201)
+            .then().statusCode(202)
             .body("name", equalTo("pgserver"))
             .body("type", equalTo("Microsoft.DBforPostgreSQL/flexibleServers"))
             .body("sku.name", equalTo("Standard_B1ms"))
@@ -74,6 +76,56 @@ class PostgresHandlerMockedTest {
             .body("properties.storage.storageSizeGB", equalTo(32))
             .body("properties.fullyQualifiedDomainName", notNullValue())
             .body("properties", not(hasKey("localPort")));
+    }
+
+    @Test
+    @DisplayName("PUT existing server is idempotent update and still returns 202")
+    void putServerIdempotentUpdate() {
+        createServer("idempotent");
+        given().contentType("application/json").body(SERVER_BODY)
+            .when().put(BASE + "/flexibleServers/idempotent" + API)
+            .then().statusCode(202)
+            .body("name", equalTo("idempotent"))
+            .body("properties.provisioningState", equalTo("Succeeded"));
+    }
+
+    @Test
+    @DisplayName("mutating responses carry a Location header the client can poll to completion")
+    void acceptedResponsesArePollable() {
+        // The go-azure-sdk poller follows Location and finishes once the resource reports a
+        // terminal provisioningState — this replays that exact two-step exchange.
+        String location = given().contentType("application/json").body(SERVER_BODY)
+            .when().put(BASE + "/flexibleServers/pollme" + API)
+            .then().statusCode(202)
+            .header("Location", notNullValue())
+            .extract().header("Location");
+
+        assertThat(location, containsString("/flexibleServers/pollme"));
+        assertThat(location, containsString("api-version="));
+
+        given().when().get(location)
+            .then().statusCode(200)
+            .body("properties.provisioningState", equalTo("Succeeded"));
+    }
+
+    @Test
+    @DisplayName("child resources answer 202 with a pollable Location too")
+    void childResourcesAreAccepted() {
+        createServer("children");
+
+        String dbLocation = given().contentType("application/json")
+            .body("{\"properties\":{\"charset\":\"UTF8\",\"collation\":\"en_US.utf8\"}}")
+            .when().put(BASE + "/flexibleServers/children/databases/appdb" + API)
+            .then().statusCode(202)
+            .extract().header("Location");
+        given().when().get(dbLocation).then().statusCode(200).body("name", equalTo("appdb"));
+
+        String fwLocation = given().contentType("application/json")
+            .body("{\"properties\":{\"startIpAddress\":\"0.0.0.0\",\"endIpAddress\":\"255.255.255.255\"}}")
+            .when().put(BASE + "/flexibleServers/children/firewallRules/AllowAll" + API)
+            .then().statusCode(202)
+            .extract().header("Location");
+        given().when().get(fwLocation).then().statusCode(200).body("name", equalTo("AllowAll"));
     }
 
     @Test
@@ -97,7 +149,7 @@ class PostgresHandlerMockedTest {
         given().contentType("application/json")
             .body("{\"sku\":{\"name\":\"Standard_B2s\",\"tier\":\"Burstable\"}}")
             .when().patch(BASE + "/flexibleServers/patchme" + API)
-            .then().statusCode(200)
+            .then().statusCode(202)
             .body("sku.name", equalTo("Standard_B2s"))
             .body("properties.administratorLogin", equalTo("psqladmin"));
     }
@@ -110,7 +162,7 @@ class PostgresHandlerMockedTest {
         given().contentType("application/json")
             .body("{\"properties\":{\"charset\":\"UTF8\",\"collation\":\"en_US.utf8\"}}")
             .when().put(BASE + "/flexibleServers/dbhost/databases/appdb" + API)
-            .then().statusCode(201)
+            .then().statusCode(202)
             .body("name", equalTo("appdb"))
             .body("properties.charset", equalTo("UTF8"));
 
@@ -136,7 +188,7 @@ class PostgresHandlerMockedTest {
         given().contentType("application/json")
             .body("{\"properties\":{\"startIpAddress\":\"0.0.0.0\",\"endIpAddress\":\"255.255.255.255\"}}")
             .when().put(BASE + "/flexibleServers/fwhost/firewallRules/AllowAll" + API)
-            .then().statusCode(201)
+            .then().statusCode(202)
             .body("properties.startIpAddress", equalTo("0.0.0.0"));
 
         given().when().get(BASE + "/flexibleServers/fwhost/firewallRules" + API)
@@ -155,7 +207,7 @@ class PostgresHandlerMockedTest {
         given().contentType("application/json")
             .body("{\"properties\":{\"value\":\"200\",\"source\":\"user-override\"}}")
             .when().put(BASE + "/flexibleServers/cfghost/configurations/max_connections" + API)
-            .then().statusCode(200)
+            .then().statusCode(202)
             .body("name", equalTo("max_connections"))
             .body("properties.value", equalTo("200"));
 


### PR DESCRIPTION
## Summary

Revised per review: **202 is the only status both provider majors accept**, and the fix has to cover the child resources too, not just the server.

Every mutating operation on Flexible Servers (and their databases, firewall rules and configurations) now returns `202 Accepted` with a `Location` header pointing at the resource. `DELETE` is unchanged at `204`.

## Why 202, and why the child resources

I checked the vendored `go-azure-sdk` in both provider majors:

| Operation | azurerm 3.x accepts | azurerm 4.x accepts |
|---|---|---|
| `PUT` (create/update) | 200, 201, 202 | **202 only** |
| `PATCH` (update) | 200, 202 | **202 only** |
| `DELETE` | 200, 202, 204 | 202, 204 |

Two things follow. **202 is the only value in the intersection**, which is why the previous revision of this PR (200) traded one incompatibility for another, exactly as you said. And the same narrowing applies to `databases`, `firewallRules` and `configurations`, so the original scope was insufficient: fixing only the server would have moved the failure to the very next resource in the config.

This also explains why CI never caught it. `compat-opentofu/provider.tf` pins `~> 3.0`, and 3.x accepts the 201 that main returns.

Because the emulator has already finished the work when it answers, the `Location` header points back at the resource itself. The SDK's poller then reads the terminal `provisioningState` from a GET of that URL and completes on its first poll. The metadata-only children carry no `provisioningState`, which the poller explicitly treats as completion, so they need no body changes.

## On the version question

You asked which provider version reproduced the original 201 error, and I have to admit that session didn't record it, so I can't answer honestly for the original report. Everything in this revision is pinned and reproducible: **azurerm 4.81.0** for the failing case, and the suite's own `~> 3.0` constraint for the regression check.

## Validation

Run against a real emulator container (`floci-az:test` on the compat network, TLS on, real Postgres sidecar), driving the actual provider rather than asserting status codes in isolation:

- **Before, azurerm 4.81.0, unpatched `main`:** fails exactly as reported.
  ```
  Error: creating Flexible Server (...): performing CreateOrUpdate:
  unexpected status 201 (201 Created) with response: {... "provisioningState":"Succeeded" ...}
  ```
- **After, azurerm 4.81.0:** `Apply complete! Resources: 4 added, 0 changed, 0 destroyed.` A follow-up `plan` reports no differences (no perpetual diff), and `destroy` removes all four.
- **Regression check, the repo's OpenTofu suite at `~> 3.0`:** 20/20 green, including the postgres server and database cases.
- **Unit and HTTP suites:** 570 tests, 0 failures, with the Docker-backed `PostgresDockerTest` actually executing against a real container. `PostgresHandlerMockedTest` gains two tests that replay the poller's exchange: PUT returns 202 with a `Location`, and a GET of that URL reports `Succeeded`.

## Note on scope

`SqlHandler` returns 201 on create and looks to have the identical problem for 4.x users. I've left it out of this PR to keep the change reviewable, and I'm happy to raise it separately or fold it in, whichever you prefer.

The 202 shape also makes a genuinely asynchronous create possible later (answer immediately with `provisioningState: Creating` and let the poller wait), which would address the cold-start complaint in #138. That felt like a separate change, so this PR keeps create synchronous.
