### PR TITLE
feat(cosmos): container DefaultTimeToLive (TTL) with per-document overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **cosmos:** container `DefaultTimeToLive` (TTL) support. `defaultTtl` is accepted and validated on container create and replace (`PUT /dbs/{db}/colls/{coll}`), echoed on container reads, and enforced with Azure's semantics measured from `_ts`: absent = TTL off (per-item `ttl` inert), `-1` = TTL on with no default expiry, `n` = expire after `n` seconds, with per-document `ttl` overrides (`-1` opts out). Expired documents immediately vanish from point reads, lists, queries, and transactional batches, no longer block re-creating the same id, and are purged lazily when encountered — mirroring Azure's contract that expired items leave query results at once while background deletion timing is unspecified ([#126](https://github.com/floci-io/floci-az/issues/126))
+
 ## [0.10.0] - 2026-07-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- **cosmos:** container `DefaultTimeToLive` (TTL) support. `defaultTtl` is accepted and validated on container create and replace (`PUT /dbs/{db}/colls/{coll}`), echoed on container reads, and enforced with Azure's semantics measured from `_ts`: absent = TTL off (per-item `ttl` inert), `-1` = TTL on with no default expiry, `n` = expire after `n` seconds, with per-document `ttl` overrides (`-1` opts out). Expired documents immediately vanish from point reads, lists, queries, and transactional batches, no longer block re-creating the same id, and are purged lazily when encountered — mirroring Azure's contract that expired items leave query results at once while background deletion timing is unspecified ([#126](https://github.com/floci-io/floci-az/issues/126))
-
 ## [0.10.0] - 2026-07-31
 
 ### Added

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/CosmosCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/CosmosCompatibilityTest.java
@@ -427,4 +427,52 @@ class CosmosCompatibilityTest {
 
         db.delete();
     }
+
+    // --- Time to live ---
+
+    @Test
+    @DisplayName("container TTL: defaultTtl round-trips, expired items disappear, ttl=-1 opts out")
+    void containerTtl() throws InterruptedException {
+        String id = dbId();
+        client.createDatabase(id);
+        CosmosDatabase db = client.getDatabase(id);
+
+        CosmosContainerProperties props = new CosmosContainerProperties("events", "/category");
+        props.setDefaultTimeToLiveInSeconds(2);
+        db.createContainer(props);
+        CosmosContainer container = db.getContainer("events");
+
+        assertEquals(Integer.valueOf(2),
+            container.read().getProperties().getDefaultTimeToLiveInSeconds());
+
+        container.createItem(doc("short-lived", "logs"), new PartitionKey("logs"),
+                new CosmosItemRequestOptions());
+        container.createItem(doc("keeper", "logs", "ttl", -1), new PartitionKey("logs"),
+                new CosmosItemRequestOptions());
+
+        // the item using the container default expires within the TTL window
+        long deadline = System.currentTimeMillis() + 10_000;
+        while (true) {
+            try {
+                container.readItem("short-lived", new PartitionKey("logs"), Map.class);
+                if (System.currentTimeMillis() > deadline) fail("item did not expire within 10s");
+                Thread.sleep(250);
+            } catch (CosmosException e) {
+                assertEquals(404, e.getStatusCode());
+                break;
+            }
+        }
+
+        // the ttl=-1 item outlives the container default
+        assertEquals("keeper",
+            container.readItem("keeper", new PartitionKey("logs"), Map.class).getItem().get("id"));
+
+        // replacing the container without a TTL switches it off
+        CosmosContainerProperties replace = container.read().getProperties();
+        replace.setDefaultTimeToLiveInSeconds(null);
+        container.replace(replace);
+        assertNull(container.read().getProperties().getDefaultTimeToLiveInSeconds());
+
+        db.delete();
+    }
 }

--- a/docs/services/cosmos.md
+++ b/docs/services/cosmos.md
@@ -7,6 +7,7 @@ Compatible with the `azure-cosmos` SDK (Java, Python, JavaScript, .NET).
 - **Databases** — create, get, list, delete (cascade-deletes all containers and documents)
 - **Containers** — create, replace, get, list, delete; configurable partition key path; custom indexing policies with composite indexes (persisted on create/replace and returned on read)
 - **Documents** — create, get, replace, delete, list; upsert via `x-ms-documentdb-is-upsert` header
+- **Time to live (TTL)** — container `defaultTtl` (set on create or replace) with per-document `ttl` overrides; expired documents disappear from reads, lists, queries, and batches
 - **Queries** — in-process SQL engine with full Cosmos DB SQL dialect support:
   - `SELECT *`, `SELECT c.field1, c.field2`, `SELECT VALUE c.field`, `SELECT TOP n`
   - `WHERE` with `=`, `!=`, `<>`, `>`, `>=`, `<`, `<=`, `IN`, `BETWEEN`, `NOT`, `AND`, `OR`
@@ -92,7 +93,7 @@ Default endpoint: `http://localhost:4577/devstoreaccount1-cosmos`
 | `POST` | `/dbs/{dbId}/colls` | Create a container |
 | `GET` | `/dbs/{dbId}/colls` | List containers |
 | `GET` | `/dbs/{dbId}/colls/{collId}` | Get a container |
-| `PUT` | `/dbs/{dbId}/colls/{collId}` | Replace a container (e.g. update the indexing policy) |
+| `PUT` | `/dbs/{dbId}/colls/{collId}` | Replace container properties (e.g. the indexing policy or `defaultTtl`; id and partition key are immutable) |
 | `DELETE` | `/dbs/{dbId}/colls/{collId}` | Delete a container (cascades to documents) |
 
 #### Indexing policies
@@ -275,6 +276,40 @@ curl -X POST .../docs \
   -H "x-ms-documentdb-is-upsert: True" \
   -d '{"id": "laptop-1", "category": "electronics", "price": 999}'
 ```
+
+## Time to live (TTL)
+
+Containers accept Azure's `defaultTtl` property on create and replace (`-1`, or a positive
+number of seconds up to `2147483647`; `0` is rejected with `400`, matching Azure). Documents
+may override it with their own `ttl` property. Expiry follows the
+[Azure TTL semantics](https://learn.microsoft.com/en-us/azure/cosmos-db/time-to-live), measured
+from the document's last modification (`_ts`):
+
+| Container `defaultTtl` | Document `ttl` | Result |
+|---|---|---|
+| absent | anything | TTL disabled — nothing expires |
+| `-1` | absent or `-1` | never expires |
+| `-1` | `m` | expires `m` seconds after `_ts` |
+| `n` | absent | expires `n` seconds after `_ts` |
+| `n` | `-1` | never expires |
+| `n` | `m` | expires `m` seconds after `_ts` |
+
+```bash
+# Create a container whose documents expire after one hour
+curl -X POST http://localhost:4577/devstoreaccount1-cosmos/dbs/mydb/colls \
+  -H "Content-Type: application/json" \
+  -d '{"id": "audit", "partitionKey": {"paths": ["/tenant"], "kind": "Hash"}, "defaultTtl": 3600}'
+
+# Switch TTL off again (omit defaultTtl on replace)
+curl -X PUT http://localhost:4577/devstoreaccount1-cosmos/dbs/mydb/colls/audit \
+  -H "Content-Type: application/json" \
+  -d '{"id": "audit"}'
+```
+
+Expired documents vanish from point reads, lists, queries, and transactional batches
+immediately (and no longer block re-creating the same id). Physical deletion is lazy — an
+expired document is purged when a read next encounters it — mirroring Azure's contract that
+expired items leave query results at once while background deletion timing is unspecified.
 
 ## Storage Mode
 

--- a/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
@@ -301,8 +301,10 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         if (store.get(key).isPresent()) return errorResponse(409, "Conflict", "Container '" + id + "' already exists.");
 
         Map<String, Object> indexingPolicy;
+        Integer defaultTtl;
         try {
             indexingPolicy = CosmosIndexingPolicy.normalize(body.get("indexingPolicy"));
+            defaultTtl     = CosmosTtl.normalizeDefaultTtl(body.get("defaultTtl"));
         } catch (IllegalArgumentException e) {
             return errorResponse(400, "BadRequest", e.getMessage());
         }
@@ -325,6 +327,7 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         coll.put("_ts",            now.getEpochSecond());
         coll.put("partitionKey",   pk);
         coll.put("indexingPolicy", indexingPolicy);
+        if (defaultTtl != null) coll.put("defaultTtl", defaultTtl);
         coll.put("_docs",          "docs/");
         coll.put("_sprocs",        "sprocs/");
         coll.put("_triggers",      "triggers/");
@@ -345,10 +348,11 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
     /**
      * PUT /dbs/{db}/colls/{coll} — replace container properties.
      *
-     * <p>Azure only allows mutable settings such as the indexing policy to
-     * change on replace; the id and partition key are immutable.  SDKs use
-     * this to update the indexing policy of an existing container (e.g. to
-     * add composite indexes).</p>
+     * <p>Azure only allows mutable settings to change on replace; the id and
+     * partition key are immutable.  SDKs use this to update the indexing
+     * policy of an existing container (e.g. to add composite indexes), and to
+     * change {@code defaultTtl} — enable TTL, adjust it, or (by omitting the
+     * property) switch it off.</p>
      */
     private Response replaceContainer(AzureRequest req, String dbId, String collId) {
         String key = collKey(req.accountName(), dbId, collId);
@@ -372,8 +376,10 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         }
 
         Map<String, Object> indexingPolicy;
+        Integer defaultTtl;
         try {
             indexingPolicy = CosmosIndexingPolicy.normalize(body.get("indexingPolicy"));
+            defaultTtl     = CosmosTtl.normalizeDefaultTtl(body.get("defaultTtl"));
         } catch (IllegalArgumentException e) {
             return errorResponse(400, "BadRequest", e.getMessage());
         }
@@ -381,6 +387,8 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         Instant now  = Instant.now();
         String  etag = newEtag();
         coll.put("indexingPolicy", indexingPolicy);
+        if (defaultTtl != null) coll.put("defaultTtl", defaultTtl);
+        else                    coll.remove("defaultTtl");   // absent on replace switches TTL off
         coll.put("_etag", quoted(etag));
         coll.put("_ts",   now.getEpochSecond());
 
@@ -516,10 +524,10 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
     // -----------------------------------------------------------------------
 
     private Response listDocuments(AzureRequest req, String dbId, String collId) {
-        if (store.get(collKey(req.accountName(), dbId, collId)).isEmpty()) return notFound(collId);
-        String prefix = req.accountName() + K_DOC + dbId + "|" + collId + "|";
-        List<Map<String, Object>> items = store.scan(k -> k.startsWith(prefix))
-                .stream().map(this::parseData).collect(Collectors.toList());
+        Optional<StoredObject> collFound = store.get(collKey(req.accountName(), dbId, collId));
+        if (collFound.isEmpty()) return notFound(collId);
+        List<Map<String, Object>> items =
+                liveDocuments(req.accountName(), dbId, collId, containerDefaultTtl(collFound));
         return listResponse("Documents", items, collRid(req.accountName(), dbId, collId));
     }
 
@@ -538,7 +546,7 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         String pkEnc  = encodeKey(pk);
         String docKey = docKey(req.accountName(), dbId, collId, pkEnc, id);
 
-        if (!upsert && store.get(docKey).isPresent())
+        if (!upsert && liveDoc(store.get(docKey), collMeta.get("defaultTtl")).isPresent())
             return errorResponse(409, "Conflict", "Document with id '" + id + "' already exists.");
 
         Instant now  = Instant.now();
@@ -574,11 +582,12 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         String pkEnc  = encodeKey(pk);
         String docKey = docKey(req.accountName(), dbId, collId, pkEnc, docId);
 
-        if (store.get(docKey).isEmpty()) return notFound(docId);
+        Optional<StoredObject> existing = liveDoc(store.get(docKey), collMeta.get("defaultTtl"));
+        if (existing.isEmpty()) return notFound(docId);
 
         Instant now  = Instant.now();
         String  etag = newEtag();
-        Map<String, Object> old = parseData(store.get(docKey).get());
+        Map<String, Object> old = parseData(existing.get());
 
         body.put("_rid",         old.getOrDefault("_rid", newRid(12)));
         body.put("_self",        "dbs/" + dbId + "/colls/" + collId + "/docs/" + docId);
@@ -752,6 +761,7 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
 
         String pk    = extractPartitionKeyValue(req);
         String pkEnc = encodeKey(pk);
+        Object defaultTtl = containerDefaultTtl(collFound);
 
         List<Map<String, Object>> operations;
         try {
@@ -769,11 +779,11 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
                     ? (Map<String, Object>) m : null;
 
             results.add(switch (opType) {
-                case "Create"  -> batchCreate(req.accountName(), dbId, collId, pk, pkEnc, body, false);
-                case "Upsert"  -> batchCreate(req.accountName(), dbId, collId, pk, pkEnc, body, true);
-                case "Read"    -> batchRead(req.accountName(), dbId, collId, pkEnc, docId);
-                case "Replace" -> batchReplace(req.accountName(), dbId, collId, pkEnc, docId, body);
-                case "Delete"  -> batchDelete(req.accountName(), dbId, collId, pkEnc, docId);
+                case "Create"  -> batchCreate(req.accountName(), dbId, collId, pk, pkEnc, body, false, defaultTtl);
+                case "Upsert"  -> batchCreate(req.accountName(), dbId, collId, pk, pkEnc, body, true, defaultTtl);
+                case "Read"    -> batchRead(req.accountName(), dbId, collId, pkEnc, docId, defaultTtl);
+                case "Replace" -> batchReplace(req.accountName(), dbId, collId, pkEnc, docId, body, defaultTtl);
+                case "Delete"  -> batchDelete(req.accountName(), dbId, collId, pkEnc, docId, defaultTtl);
                 default        -> batchResultError(400);
             });
         }
@@ -792,7 +802,7 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
 
     @SuppressWarnings("unchecked")
     private Map<String, Object> batchCreate(String account, String dbId, String collId,
-            String pk, String pkEnc, Map<String, Object> body, boolean upsert) {
+            String pk, String pkEnc, Map<String, Object> body, boolean upsert, Object defaultTtl) {
         if (body == null) return batchResultError(400);
 
         body = new LinkedHashMap<>(body);
@@ -800,7 +810,7 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         body.put("id", id);
 
         String key     = docKey(account, dbId, collId, pkEnc, id);
-        boolean existed = store.get(key).isPresent();
+        boolean existed = liveDoc(store.get(key), defaultTtl).isPresent();
         if (!upsert && existed) return batchResultError(409);
 
         Instant now  = Instant.now();
@@ -818,16 +828,16 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
     }
 
     private Map<String, Object> batchRead(String account, String dbId, String collId,
-            String pkEnc, String docId) {
+            String pkEnc, String docId, Object defaultTtl) {
         if (docId == null) return batchResultError(400);
 
         String key = docKey(account, dbId, collId, pkEnc, docId);
-        Optional<StoredObject> found = store.get(key);
+        Optional<StoredObject> found = liveDoc(store.get(key), defaultTtl);
         if (found.isEmpty()) {
             // Fallback scan for cases where PK is unknown/encoded differently
             String prefix = account + K_DOC + dbId + "|" + collId + "|";
-            found = store.scan(k -> k.startsWith(prefix) && k.endsWith("|" + docId))
-                    .stream().findFirst();
+            found = liveDoc(store.scan(k -> k.startsWith(prefix) && k.endsWith("|" + docId))
+                    .stream().findFirst(), defaultTtl);
         }
         if (found.isEmpty()) return batchResultError(404);
 
@@ -837,11 +847,11 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
 
     @SuppressWarnings("unchecked")
     private Map<String, Object> batchReplace(String account, String dbId, String collId,
-            String pkEnc, String docId, Map<String, Object> body) {
+            String pkEnc, String docId, Map<String, Object> body, Object defaultTtl) {
         if (docId == null || body == null) return batchResultError(400);
 
         String key = docKey(account, dbId, collId, pkEnc, docId);
-        Optional<StoredObject> found = store.get(key);
+        Optional<StoredObject> found = liveDoc(store.get(key), defaultTtl);
         if (found.isEmpty()) return batchResultError(404);
 
         body = new LinkedHashMap<>(body);
@@ -862,15 +872,15 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
     }
 
     private Map<String, Object> batchDelete(String account, String dbId, String collId,
-            String pkEnc, String docId) {
+            String pkEnc, String docId, Object defaultTtl) {
         if (docId == null) return batchResultError(400);
 
         String key = docKey(account, dbId, collId, pkEnc, docId);
-        Optional<StoredObject> found = store.get(key);
+        Optional<StoredObject> found = liveDoc(store.get(key), defaultTtl);
         if (found.isEmpty()) {
             String prefix = account + K_DOC + dbId + "|" + collId + "|";
-            found = store.scan(k -> k.startsWith(prefix) && k.endsWith("|" + docId))
-                    .stream().findFirst();
+            found = liveDoc(store.scan(k -> k.startsWith(prefix) && k.endsWith("|" + docId))
+                    .stream().findFirst(), defaultTtl);
         }
         if (found.isEmpty()) return batchResultError(404);
 
@@ -924,9 +934,8 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
                     + "that it can be served from.\"}]}");
         }
 
-        String prefix = req.accountName() + K_DOC + dbId + "|" + collId + "|";
-        List<Map<String, Object>> allDocs = store.scan(k -> k.startsWith(prefix))
-                .stream().map(this::parseData).collect(Collectors.toList());
+        List<Map<String, Object>> allDocs =
+                liveDocuments(req.accountName(), dbId, collId, containerDefaultTtl(collFound));
 
         CosmosQueryEngine.QueryResult result = queryEngine.execute(parsed, allDocs);
 
@@ -1010,19 +1019,53 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
     // -----------------------------------------------------------------------
 
     private StoredObject findDoc(AzureRequest req, String dbId, String collId, String docId) {
-        // Fast path: construct exact key using partition key from header
         Optional<StoredObject> collFound = store.get(collKey(req.accountName(), dbId, collId));
+        Object defaultTtl = containerDefaultTtl(collFound);
+        // Fast path: construct exact key using partition key from header
         if (collFound.isPresent()) {
             String pk    = extractPartitionKeyValue(req);
             String pkEnc = encodeKey(pk);
             String exact = docKey(req.accountName(), dbId, collId, pkEnc, docId);
-            Optional<StoredObject> found = store.get(exact);
+            Optional<StoredObject> found = liveDoc(store.get(exact), defaultTtl);
             if (found.isPresent()) return found.get();
         }
         // Fallback: scan (handles missing PK header or cross-partition reads)
         String prefix = req.accountName() + K_DOC + dbId + "|" + collId + "|";
-        return store.scan(k -> k.startsWith(prefix) && k.endsWith("|" + docId))
-                .stream().findFirst().orElse(null);
+        return liveDoc(store.scan(k -> k.startsWith(prefix) && k.endsWith("|" + docId))
+                .stream().findFirst(), defaultTtl).orElse(null);
+    }
+
+    // -----------------------------------------------------------------------
+    // TTL enforcement (lazy: expired docs vanish from reads and are purged)
+    // -----------------------------------------------------------------------
+
+    /** The container's stored {@code defaultTtl} value, or {@code null} when TTL is off. */
+    private Object containerDefaultTtl(Optional<StoredObject> collFound) {
+        return collFound.map(o -> parseData(o).get("defaultTtl")).orElse(null);
+    }
+
+    /** Returns the doc when present and not expired; an expired doc is purged and treated as absent. */
+    private Optional<StoredObject> liveDoc(Optional<StoredObject> found, Object defaultTtl) {
+        if (found.isPresent()
+                && CosmosTtl.isExpired(parseData(found.get()), defaultTtl, Instant.now().getEpochSecond())) {
+            store.delete(found.get().key());
+            return Optional.empty();
+        }
+        return found;
+    }
+
+    /** All non-expired docs of a container; expired docs encountered by the scan are purged. */
+    private List<Map<String, Object>> liveDocuments(String account, String dbId, String collId,
+            Object defaultTtl) {
+        String prefix = account + K_DOC + dbId + "|" + collId + "|";
+        long now = Instant.now().getEpochSecond();
+        List<Map<String, Object>> live = new ArrayList<>();
+        for (StoredObject obj : store.scan(k -> k.startsWith(prefix))) {
+            Map<String, Object> doc = parseData(obj);
+            if (CosmosTtl.isExpired(doc, defaultTtl, now)) store.delete(obj.key());
+            else live.add(doc);
+        }
+        return live;
     }
 
     // -----------------------------------------------------------------------

--- a/src/main/java/io/floci/az/services/cosmos/CosmosTtl.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosTtl.java
@@ -1,0 +1,81 @@
+package io.floci.az.services.cosmos;
+
+import java.util.Map;
+
+/**
+ * Pure TTL (time-to-live) decision logic for the Cosmos DB emulator.
+ *
+ * <p>Azure semantics
+ * (<a href="https://learn.microsoft.com/en-us/azure/cosmos-db/time-to-live">docs</a>):</p>
+ * <ul>
+ *   <li>Container {@code defaultTtl} absent (or null) — TTL is disabled; no item
+ *       expires, even when the item carries its own {@code ttl} property.</li>
+ *   <li>Container {@code defaultTtl = -1} — TTL is enabled but items do not expire
+ *       by default; only items with a positive {@code ttl} of their own expire.</li>
+ *   <li>Container {@code defaultTtl = n > 0} — items expire {@code n} seconds after
+ *       their last modification ({@code _ts}) unless overridden per item.</li>
+ *   <li>Item {@code ttl = m > 0} — the item expires {@code m} seconds after
+ *       {@code _ts}; {@code ttl = -1} — the item never expires.</li>
+ * </ul>
+ */
+final class CosmosTtl {
+
+    /** Azure's maximum TTL: 2147483647 seconds (~68 years). */
+    private static final long MAX_TTL = Integer.MAX_VALUE;
+
+    private CosmosTtl() {}
+
+    /**
+     * Validates the {@code defaultTtl} property of a container create/replace body.
+     *
+     * @return the normalised value, or {@code null} when the property is absent
+     *         (TTL disabled)
+     * @throws IllegalArgumentException when the value is not {@code -1} or a
+     *         positive integer up to 2147483647
+     */
+    static Integer normalizeDefaultTtl(Object raw) {
+        if (raw == null) return null;
+        Long value = asIntegral(raw);
+        if (value == null || (value != -1 && (value < 1 || value > MAX_TTL))) {
+            throw new IllegalArgumentException(
+                    "The value '" + raw + "' specified for 'defaultTtl' is invalid. "
+                    + "It must be a nonzero positive integer up to 2147483647, "
+                    + "or -1 so that items do not expire by default.");
+        }
+        return value.intValue();
+    }
+
+    /**
+     * Decides whether a document is expired at {@code nowEpochSecond}.
+     *
+     * <p>{@code defaultTtlRaw} is the container's stored {@code defaultTtl} value
+     * (may be {@code null}). An item {@code ttl} that is a whole number overrides
+     * the container default: a positive value expires the item that many seconds
+     * after {@code _ts}, while {@code -1} (and, defensively, any other value
+     * {@code <= 0}) means the item never expires. A malformed item {@code ttl}
+     * (non-numeric or fractional) is treated as absent, so the container default
+     * applies — Azure would have rejected such a document at write time.</p>
+     */
+    static boolean isExpired(Map<String, Object> doc, Object defaultTtlRaw, long nowEpochSecond) {
+        Long defaultTtl = asIntegral(defaultTtlRaw);
+        if (defaultTtl == null) return false;          // TTL disabled on the container
+
+        Long itemTtl   = asIntegral(doc.get("ttl"));
+        long effective = itemTtl != null ? itemTtl : defaultTtl;
+        if (effective <= 0) return false;              // -1 — never expires
+
+        Long ts = asIntegral(doc.get("_ts"));
+        if (ts == null) return false;
+        return nowEpochSecond >= ts + effective;
+    }
+
+    /** Returns the value as a whole number, or {@code null} when absent, non-numeric, or fractional. */
+    private static Long asIntegral(Object value) {
+        if (value instanceof Integer || value instanceof Long) return ((Number) value).longValue();
+        if (value instanceof Number n) {
+            double d = n.doubleValue();
+            return d == Math.floor(d) && !Double.isInfinite(d) ? (long) d : null;
+        }
+        return null;
+    }
+}

--- a/src/test/java/io/floci/az/services/cosmos/CosmosContainerTtlTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosContainerTtlTest.java
@@ -1,0 +1,215 @@
+package io.floci.az.services.cosmos;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * HTTP-level tests for issue #126: container {@code defaultTtl} on
+ * create/replace, per-document {@code ttl} overrides, and expired documents
+ * disappearing from reads, lists, queries, and batches.
+ *
+ * <p>The TTL decision matrix itself is unit-tested in {@link CosmosTtlTest}
+ * with an explicit clock; only {@link #expiredDocumentsVanishEndToEnd()} waits
+ * for real time to pass, proving the wiring end to end.</p>
+ */
+@QuarkusTest
+public class CosmosContainerTtlTest {
+
+    private static final String ACCT = "ttlacct";
+    private static final String BASE = "/" + ACCT + "-cosmos";
+    private static final String DB   = "ttldb";
+
+    @BeforeEach
+    void reset() {
+        given().when().post("/_admin/reset").then().statusCode(204);
+        given().contentType("application/json").body("{\"id\":\"" + DB + "\"}")
+                .when().post(BASE + "/dbs").then().statusCode(201);
+    }
+
+    private io.restassured.response.Response createContainer(String id, String defaultTtlJson) {
+        String body = "{\"id\":\"" + id + "\","
+                + "\"partitionKey\":{\"paths\":[\"/category\"],\"kind\":\"Hash\"}"
+                + (defaultTtlJson == null ? "" : ",\"defaultTtl\":" + defaultTtlJson)
+                + "}";
+        return given().contentType("application/json").body(body)
+                .when().post(BASE + "/dbs/" + DB + "/colls");
+    }
+
+    private io.restassured.response.Response replaceContainer(String id, String defaultTtlJson) {
+        String body = "{\"id\":\"" + id + "\","
+                + "\"partitionKey\":{\"paths\":[\"/category\"],\"kind\":\"Hash\"}"
+                + (defaultTtlJson == null ? "" : ",\"defaultTtl\":" + defaultTtlJson)
+                + "}";
+        return given().contentType("application/json").body(body)
+                .when().put(BASE + "/dbs/" + DB + "/colls/" + id);
+    }
+
+    private void insertDoc(String coll, String docJson) {
+        given().contentType("application/json")
+                .header("x-ms-documentdb-partitionkey", "[\"x\"]")
+                .body(docJson)
+                .when().post(BASE + "/dbs/" + DB + "/colls/" + coll + "/docs")
+                .then().statusCode(201);
+    }
+
+    private int getDocStatus(String coll, String docId) {
+        return given().when().get(BASE + "/dbs/" + DB + "/colls/" + coll + "/docs/" + docId)
+                .statusCode();
+    }
+
+    // ------------------------------------------------------------------ create
+
+    @Test
+    void createContainerPersistsDefaultTtl() {
+        createContainer("events", "3600").then().statusCode(201).body("defaultTtl", is(3600));
+
+        given().when().get(BASE + "/dbs/" + DB + "/colls/events")
+                .then().statusCode(200).body("defaultTtl", is(3600));
+
+        given().when().get(BASE + "/dbs/" + DB + "/colls")
+                .then().statusCode(200)
+                .body("DocumentCollections[0].defaultTtl", is(3600));
+    }
+
+    @Test
+    void createContainerPersistsMinusOne() {
+        createContainer("events", "-1").then().statusCode(201).body("defaultTtl", is(-1));
+    }
+
+    @Test
+    void createContainerWithoutTtlOmitsProperty() {
+        createContainer("events", null).then().statusCode(201).body("defaultTtl", nullValue());
+
+        given().when().get(BASE + "/dbs/" + DB + "/colls/events")
+                .then().statusCode(200).body("defaultTtl", nullValue());
+    }
+
+    @Test
+    void createContainerRejectsInvalidDefaultTtl() {
+        for (String bad : new String[] {"0", "-2", "1.5", "\"3600\"", "2147483648"}) {
+            createContainer("events", bad).then().statusCode(400)
+                    .body("message", containsString("defaultTtl"));
+        }
+        // none of the rejected creates may have left a container behind
+        given().when().get(BASE + "/dbs/" + DB + "/colls/events").then().statusCode(404);
+    }
+
+    // ------------------------------------------------------------------ replace
+
+    @Test
+    void replaceContainerEnablesAndAdjustsTtl() {
+        createContainer("events", null).then().statusCode(201);
+
+        replaceContainer("events", "60").then().statusCode(200).body("defaultTtl", is(60));
+        given().when().get(BASE + "/dbs/" + DB + "/colls/events")
+                .then().statusCode(200).body("defaultTtl", is(60));
+
+        replaceContainer("events", "-1").then().statusCode(200).body("defaultTtl", is(-1));
+    }
+
+    @Test
+    void replaceContainerOmittingTtlDisablesIt() {
+        createContainer("events", "3600").then().statusCode(201);
+
+        replaceContainer("events", null).then().statusCode(200).body("defaultTtl", nullValue());
+        given().when().get(BASE + "/dbs/" + DB + "/colls/events")
+                .then().statusCode(200).body("defaultTtl", nullValue());
+    }
+
+    @Test
+    void replaceContainerRejectsInvalidTtlAndKeepsStoredValue() {
+        createContainer("events", "3600").then().statusCode(201);
+
+        replaceContainer("events", "0").then().statusCode(400)
+                .body("message", containsString("defaultTtl"));
+        given().when().get(BASE + "/dbs/" + DB + "/colls/events")
+                .then().statusCode(200).body("defaultTtl", is(3600));
+    }
+
+    @Test
+    void replaceContainerRejectsIdMismatch() {
+        createContainer("events", null).then().statusCode(201);
+
+        given().contentType("application/json").body("{\"id\":\"other\",\"defaultTtl\":60}")
+                .when().put(BASE + "/dbs/" + DB + "/colls/events")
+                .then().statusCode(400).body("message", containsString("id"));
+    }
+
+    @Test
+    void replaceContainerRejectsPartitionKeyChange() {
+        createContainer("events", null).then().statusCode(201);
+
+        given().contentType("application/json")
+                .body("{\"id\":\"events\",\"partitionKey\":{\"paths\":[\"/other\"],\"kind\":\"Hash\"}}")
+                .when().put(BASE + "/dbs/" + DB + "/colls/events")
+                .then().statusCode(400).body("message", containsString("partition key"));
+    }
+
+    @Test
+    void replaceMissingContainerIs404() {
+        replaceContainer("ghost", "60").then().statusCode(404);
+    }
+
+    // ------------------------------------------------------------------ expiry
+
+    /**
+     * End-to-end expiry: container "events" has {@code defaultTtl = 2}; doc "a"
+     * uses the default, doc "b" opts out with {@code ttl = -1}.  Container
+     * "keep" has TTL off, so its doc "c" ({@code ttl = 1}) must never expire.
+     */
+    @Test
+    void expiredDocumentsVanishEndToEnd() throws InterruptedException {
+        createContainer("events", "2").then().statusCode(201);
+        createContainer("keep", null).then().statusCode(201);
+
+        insertDoc("events", "{\"id\":\"a\",\"category\":\"x\"}");
+        insertDoc("events", "{\"id\":\"b\",\"category\":\"x\",\"ttl\":-1}");
+        insertDoc("keep",   "{\"id\":\"c\",\"category\":\"x\",\"ttl\":1}");
+
+        // wait (up to 8s) for "a" to expire
+        long deadline = System.currentTimeMillis() + 8_000;
+        while (getDocStatus("events", "a") != 404) {
+            if (System.currentTimeMillis() > deadline) fail("doc 'a' did not expire within 8s");
+            Thread.sleep(200);
+        }
+
+        // "b" (ttl -1) and "c" (TTL off on container) are still readable
+        given().when().get(BASE + "/dbs/" + DB + "/colls/events/docs/b").then().statusCode(200);
+        given().when().get(BASE + "/dbs/" + DB + "/colls/keep/docs/c").then().statusCode(200);
+
+        // list and query exclude the expired doc
+        given().when().get(BASE + "/dbs/" + DB + "/colls/events/docs")
+                .then().statusCode(200)
+                .body("_count", is(1))
+                .body("Documents[0].id", is("b"));
+
+        given().contentType("application/query+json")
+                .header("x-ms-documentdb-isquery", "True")
+                .body("{\"query\":\"SELECT * FROM c\",\"parameters\":[]}")
+                .when().post(BASE + "/dbs/" + DB + "/colls/events/docs")
+                .then().statusCode(200)
+                .body("_count", is(1))
+                .body("Documents[0].id", is("b"));
+
+        // transactional batch sees the expired doc as gone too
+        given().contentType("application/json")
+                .header("x-ms-cosmos-is-batch-request", "true")
+                .header("x-ms-documentdb-partitionkey", "[\"x\"]")
+                .body("[{\"operationType\":\"Read\",\"id\":\"a\"},{\"operationType\":\"Read\",\"id\":\"b\"}]")
+                .when().post(BASE + "/dbs/" + DB + "/colls/events/docs")
+                .then().statusCode(200)
+                .body("statusCode", contains(404, 200));
+
+        // an expired doc no longer blocks re-creating the same id
+        insertDoc("events", "{\"id\":\"a\",\"category\":\"x\"}");
+        given().when().get(BASE + "/dbs/" + DB + "/colls/events/docs/a").then().statusCode(200);
+    }
+}

--- a/src/test/java/io/floci/az/services/cosmos/CosmosTtlTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosTtlTest.java
@@ -1,0 +1,114 @@
+package io.floci.az.services.cosmos;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link CosmosTtl} — the Azure TTL semantics matrix from
+ * https://learn.microsoft.com/en-us/azure/cosmos-db/time-to-live, evaluated
+ * with an explicit clock so no test needs to sleep.
+ */
+class CosmosTtlTest {
+
+    private static final long TS  = 1_000_000L;
+
+    private static Map<String, Object> doc(Object ttl) {
+        Map<String, Object> d = new HashMap<>();
+        d.put("id",  "doc1");
+        d.put("_ts", TS);
+        if (ttl != null) d.put("ttl", ttl);
+        return d;
+    }
+
+    // --- Example 1: container TTL absent — TTL disabled ---
+
+    @Test
+    void nothingExpiresWhenContainerTtlAbsent() {
+        long farFuture = TS + 1_000_000;
+        assertFalse(CosmosTtl.isExpired(doc(null), null, farFuture), "no item ttl");
+        assertFalse(CosmosTtl.isExpired(doc(-1),   null, farFuture), "item ttl -1");
+        assertFalse(CosmosTtl.isExpired(doc(2000), null, farFuture), "item ttl 2000 is inert when TTL is off");
+    }
+
+    // --- Example 2: container TTL -1 — enabled, no default expiry ---
+
+    @Test
+    void containerMinusOneExpiresOnlyItemsWithPositiveTtl() {
+        long afterItemTtl = TS + 2001;
+        assertFalse(CosmosTtl.isExpired(doc(null), -1, afterItemTtl), "no item ttl — never expires");
+        assertFalse(CosmosTtl.isExpired(doc(-1),   -1, afterItemTtl), "item ttl -1 — never expires");
+        assertTrue(CosmosTtl.isExpired(doc(2000),  -1, afterItemTtl), "item ttl 2000 — expires");
+        assertFalse(CosmosTtl.isExpired(doc(2000), -1, TS + 1999),   "item ttl 2000 — not yet expired");
+    }
+
+    // --- Example 3: container TTL n — default expiry, item override ---
+
+    @Test
+    void containerDefaultAppliesUnlessItemOverrides() {
+        int defaultTtl = 1000;
+        assertTrue(CosmosTtl.isExpired(doc(null), defaultTtl, TS + 1000), "default applies");
+        assertFalse(CosmosTtl.isExpired(doc(null), defaultTtl, TS + 999), "default not yet reached");
+        assertFalse(CosmosTtl.isExpired(doc(-1),   defaultTtl, TS + 999_999), "item -1 overrides to never");
+        assertTrue(CosmosTtl.isExpired(doc(2000),  defaultTtl, TS + 2000), "item 2000 overrides default");
+        assertFalse(CosmosTtl.isExpired(doc(2000), defaultTtl, TS + 1500), "longer override outlives default");
+    }
+
+    @Test
+    void expiryBoundaryIsAtTsPlusTtl() {
+        assertFalse(CosmosTtl.isExpired(doc(null), 60, TS + 59));
+        assertTrue(CosmosTtl.isExpired(doc(null),  60, TS + 60));
+    }
+
+    // --- Defensive handling of odd stored values ---
+
+    @Test
+    void malformedItemTtlFallsBackToContainerDefault() {
+        assertTrue(CosmosTtl.isExpired(doc("60"), 10, TS + 10), "string ttl ignored — default applies");
+        assertTrue(CosmosTtl.isExpired(doc(1.5),  10, TS + 10), "fractional ttl ignored — default applies");
+    }
+
+    @Test
+    void nonPositiveItemTtlMeansNeverExpires() {
+        assertFalse(CosmosTtl.isExpired(doc(0),  10, TS + 999_999));
+        assertFalse(CosmosTtl.isExpired(doc(-5), 10, TS + 999_999));
+    }
+
+    @Test
+    void missingTsNeverExpires() {
+        Map<String, Object> noTs = new HashMap<>(Map.of("id", "doc1"));
+        assertFalse(CosmosTtl.isExpired(noTs, 10, Long.MAX_VALUE));
+    }
+
+    @Test
+    void longValuesFromJsonAreAccepted() {
+        Map<String, Object> d = doc(2000L);       // Jackson may parse numbers as Long
+        d.put("_ts", (int) TS);                   // ... or Integer
+        assertTrue(CosmosTtl.isExpired(d, -1L, TS + 2000));
+    }
+
+    // --- normalizeDefaultTtl ---
+
+    @Test
+    void normalizeAcceptsAbsentMinusOneAndPositive() {
+        assertNull(CosmosTtl.normalizeDefaultTtl(null));
+        assertEquals(-1,   CosmosTtl.normalizeDefaultTtl(-1));
+        assertEquals(1,    CosmosTtl.normalizeDefaultTtl(1));
+        assertEquals(3600, CosmosTtl.normalizeDefaultTtl(3600));
+        assertEquals(Integer.MAX_VALUE, CosmosTtl.normalizeDefaultTtl(2147483647L));
+        assertEquals(60,   CosmosTtl.normalizeDefaultTtl(60.0), "whole-number double is accepted");
+    }
+
+    @Test
+    void normalizeRejectsInvalidValues() {
+        assertThrows(IllegalArgumentException.class, () -> CosmosTtl.normalizeDefaultTtl(0));
+        assertThrows(IllegalArgumentException.class, () -> CosmosTtl.normalizeDefaultTtl(-2));
+        assertThrows(IllegalArgumentException.class, () -> CosmosTtl.normalizeDefaultTtl(2147483648L));
+        assertThrows(IllegalArgumentException.class, () -> CosmosTtl.normalizeDefaultTtl(1.5));
+        assertThrows(IllegalArgumentException.class, () -> CosmosTtl.normalizeDefaultTtl("3600"));
+        assertThrows(IllegalArgumentException.class, () -> CosmosTtl.normalizeDefaultTtl(Map.of()));
+    }
+}


### PR DESCRIPTION
## Summary

Implements container `DefaultTimeToLive` for the Cosmos DB SQL API emulator (closes #126).

- `defaultTtl` is accepted and validated on container create (`-1` or a positive integer up to `2147483647`; `0` and malformed values are rejected with `400`, matching Azure) and echoed on container reads and lists.
- Adds the container replace route (`PUT /dbs/{db}/colls/{coll}`) so SDK `replaceContainer` flows can enable, adjust, or (by omitting the property) switch off TTL. The id and partition key are immutable, as on Azure.
- Documents may override the container default with their own `ttl` property (`-1` opts out, positive values shorten or lengthen expiry).
- Expiry follows the [documented semantics](https://learn.microsoft.com/en-us/azure/cosmos-db/time-to-live), measured from `_ts`: with `defaultTtl` absent nothing expires (per-item `ttl` is inert); `-1` enables TTL with no default; `n` expires items `n` seconds after last modification.

As suggested in the issue, enforcement is read-time filtering plus lazy purge: expired documents immediately vanish from point reads, lists, queries, and transactional batches, no longer block re-creating the same id, and are physically deleted when a read next encounters them. This mirrors Azure's contract that expired items leave query results at once while background deletion timing is unspecified.

## Implementation notes

- The decision matrix lives in a small pure class, `CosmosTtl`, evaluated against an explicit clock; the handler passes `Instant.now()` at its call sites. Validation and expiry rules are therefore unit-testable without sleeping.
- `CosmosHandler` gains two helpers (`liveDoc`, `liveDocuments`) used by every document read path, so the batch, query, list, and point-read routes share one enforcement point.
- Write paths already refresh `_ts` on create/replace/patch/upsert, so the TTL clock resets on modification, matching Azure.

## Validation

- `CosmosTtlTest`: the full container/item TTL matrix from the Azure docs, plus validation edge cases (`0`, negatives, fractionals, strings, `2147483648`), with a fixed clock.
- `CosmosContainerTtlTest` (`@QuarkusTest`): the HTTP contract for create/replace (round-trip, disable, invalid values, id/partition-key guards) and one end-to-end expiry test covering reads, lists, queries, batches, and id reuse.
- `CosmosCompatibilityTest#containerTtl`: the real `azure-cosmos` Java SDK against a live emulator run with TLS: `setDefaultTimeToLiveInSeconds` round-trips through create/read/replace, an item using the default expires, and a `ttl = -1` item survives. Verified locally (all 10 tests in the class pass); it will also run in the compat matrix here.
- Full main-module suite: 330 tests, 0 failures.

## Note on #129

This PR and #129 both add a `PUT /dbs/{db}/colls/{coll}` route; the `replaceContainer` here deliberately mirrors the id and partition-key guards from that PR so the merge conflict is mechanical whichever lands second. Happy to rebase this one if #129 goes in first.
