### PR TITLE
fix(storage): return service properties XML

### DIFF
--- a/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
+++ b/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
@@ -187,7 +187,7 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
                 .end("MinuteMetrics")
                 .start("StaticWebsite").elem("Enabled", "false").end("StaticWebsite")
             .end("StorageServiceProperties")
-            .toString();
+            .build();
         return Response.ok(xml, "application/xml").build();
     }
 

--- a/src/main/java/io/floci/az/services/queue/QueueServiceHandler.java
+++ b/src/main/java/io/floci/az/services/queue/QueueServiceHandler.java
@@ -172,7 +172,7 @@ public class QueueServiceHandler implements AzureServiceHandler, Resettable {
                 .end("MinuteMetrics")
                 .selfClose("Cors")
             .end("StorageServiceProperties")
-            .toString();
+            .build();
         return Response.ok(xml, "application/xml").build();
     }
 

--- a/src/main/java/io/floci/az/services/table/TableServiceHandler.java
+++ b/src/main/java/io/floci/az/services/table/TableServiceHandler.java
@@ -8,6 +8,7 @@ import io.floci.az.core.AzureServiceHandler;
 import io.floci.az.core.ServiceRoutes;
 import io.floci.az.core.Resettable;
 import io.floci.az.core.StoredObject;
+import io.floci.az.core.XmlBuilder;
 import io.floci.az.core.storage.StorageBackend;
 import io.floci.az.core.storage.StorageFactory;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -79,6 +80,7 @@ public class TableServiceHandler implements AzureServiceHandler, Resettable {
     public Response handle(AzureRequest request) {
         String path = request.resourcePath();
         String method = request.method();
+        Map<String, String> query = request.queryParams();
 
         LOGGER.infof("TableService handling: %s %s", method, path);
 
@@ -93,7 +95,15 @@ public class TableServiceHandler implements AzureServiceHandler, Resettable {
         }
 
         Response response;
-        if (path.startsWith("Tables")) {
+        if ((path.isEmpty() || path.equals("/"))
+                && "service".equals(query.get("restype"))
+                && "properties".equals(query.get("comp"))) {
+            if ("GET".equalsIgnoreCase(method) || "HEAD".equalsIgnoreCase(method)) {
+                response = getTableServiceProperties();
+            } else {
+                response = Response.ok().build();
+            }
+        } else if (path.startsWith("Tables")) {
             if ("GET".equalsIgnoreCase(method)) {
                 response = listTables(request);
             } else if ("POST".equalsIgnoreCase(method)) {
@@ -137,6 +147,32 @@ public class TableServiceHandler implements AzureServiceHandler, Resettable {
                 .header("x-ms-version", request.headers().getHeaderString("x-ms-version"))
                 .header("DataServiceVersion", "3.0;")
                 .build();
+    }
+
+    private Response getTableServiceProperties() {
+        String xml = new XmlBuilder()
+            .start("StorageServiceProperties")
+                .start("Logging")
+                    .elem("Version", "1.0")
+                    .elem("Delete", "false")
+                    .elem("Read", "false")
+                    .elem("Write", "false")
+                    .start("RetentionPolicy").elem("Enabled", "false").end("RetentionPolicy")
+                .end("Logging")
+                .start("HourMetrics")
+                    .elem("Version", "1.0")
+                    .elem("Enabled", "false")
+                    .start("RetentionPolicy").elem("Enabled", "false").end("RetentionPolicy")
+                .end("HourMetrics")
+                .start("MinuteMetrics")
+                    .elem("Version", "1.0")
+                    .elem("Enabled", "false")
+                    .start("RetentionPolicy").elem("Enabled", "false").end("RetentionPolicy")
+                .end("MinuteMetrics")
+                .selfClose("Cors")
+            .end("StorageServiceProperties")
+            .build();
+        return Response.ok(xml, "application/xml").build();
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/java/io/floci/az/services/BlobServiceTest.java
+++ b/src/test/java/io/floci/az/services/BlobServiceTest.java
@@ -45,6 +45,18 @@ public class BlobServiceTest {
     }
 
     @Test
+    void getBlobServicePropertiesReturnsXml() {
+        given()
+            .when().get("/{account}?restype=service&comp=properties", ACCOUNT)
+            .then()
+            .statusCode(200)
+            .contentType(containsString("xml"))
+            .body(containsString("<StorageServiceProperties>"))
+            .body(containsString("<StaticWebsite>"))
+            .body(not(containsString("XmlBuilder@")));
+    }
+
+    @Test
     void putAndGetBlob() {
         given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
 

--- a/src/test/java/io/floci/az/services/QueueServiceTest.java
+++ b/src/test/java/io/floci/az/services/QueueServiceTest.java
@@ -31,6 +31,18 @@ public class QueueServiceTest {
     }
 
     @Test
+    void getQueueServicePropertiesReturnsXml() {
+        given()
+            .when().get("/{account}?restype=service&comp=properties", ACCOUNT)
+            .then()
+            .statusCode(200)
+            .contentType(containsString("xml"))
+            .body(containsString("<StorageServiceProperties>"))
+            .body(containsString("<Logging>"))
+            .body(not(containsString("XmlBuilder@")));
+    }
+
+    @Test
     void createExistingQueuePreservesMetadata() {
         given()
             .header("x-ms-meta-owner", "sdk")

--- a/src/test/java/io/floci/az/services/TableServiceTest.java
+++ b/src/test/java/io/floci/az/services/TableServiceTest.java
@@ -1,0 +1,32 @@
+package io.floci.az.services;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+@QuarkusTest
+public class TableServiceTest {
+
+    private static final String ACCOUNT = "devstoreaccount1-table";
+
+    @BeforeEach
+    void reset() {
+        given().post("/_admin/reset").then().statusCode(204);
+    }
+
+    @Test
+    void getTableServicePropertiesReturnsXml() {
+        given()
+            .when().get("/{account}?restype=service&comp=properties", ACCOUNT)
+            .then()
+            .statusCode(200)
+            .contentType(containsString("xml"))
+            .body(containsString("<StorageServiceProperties>"))
+            .body(containsString("<Logging>"))
+            .body(not(containsString("\"value\"")));
+    }
+}


### PR DESCRIPTION
## Summary

- Return real `StorageServiceProperties` XML for Blob and Queue storage instead of the `XmlBuilder@...` object identity string.
- Route Table storage account-root `?restype=service&comp=properties` requests to an Azure-compatible XML response.
- Add regression tests for Blob, Queue, and Table service-properties responses.

Closes #131
Closes #132

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

Azure Storage clients expect `StorageServiceProperties` XML for account-root `restype=service&comp=properties` requests. Blob and Queue previously returned the builder object's identity string, while Table returned list-table JSON. This change returns the expected XML response shape for all three storage services.

## Checklist

- [x] `./mvnw test` passes locally on JDK 25
- [x] New or updated automated tests added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)