### PR TITLE
fix(email): match the ACS operation contract so the SDKs can complete a send

### DIFF
--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -74,6 +74,10 @@
             <artifactId>azure-messaging-eventgrid</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.azure</groupId>
+            <artifactId>azure-communication-email</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${junit.version}</version>

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/EmailCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/EmailCompatibilityTest.java
@@ -1,0 +1,101 @@
+package io.floci.az.compat;
+
+import com.azure.communication.email.EmailClient;
+import com.azure.communication.email.EmailClientBuilder;
+import com.azure.communication.email.models.EmailAddress;
+import com.azure.communication.email.models.EmailMessage;
+import com.azure.communication.email.models.EmailSendResult;
+import com.azure.communication.email.models.EmailSendStatus;
+import com.azure.core.http.HttpHeaderName;
+import com.azure.core.http.HttpPipelineCallContext;
+import com.azure.core.http.HttpPipelineNextPolicy;
+import com.azure.core.http.HttpResponse;
+import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.util.polling.SyncPoller;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("Communication Services Email Compatibility")
+class EmailCompatibilityTest {
+
+    private static final String SENDER = "DoNotReply@example.com";
+    private static final String RECIPIENT = "dev@example.com";
+
+    private EmailClient client;
+
+    @BeforeAll
+    void setUp() throws Exception {
+        EmulatorConfig.assumeEmulatorRunning();
+        EmulatorConfig.installEmulatorTlsCert();
+        Assumptions.assumeTrue(
+                System.getProperty("javax.net.ssl.trustStore") != null,
+                "requires FLOCI_AZ_TLS_ENABLED=true — the ACS credential only signs https URLs");
+        client = buildClient(null);
+    }
+
+    @Test
+    @DisplayName("beginSend completes through the SDK's long-running-operation poller")
+    void beginSendCompletesThroughTheSdkPoller() {
+        SyncPoller<EmailSendResult, EmailSendResult> poller = client.beginSend(message("SDK poller"));
+        poller.waitForCompletion();
+
+        EmailSendResult result = poller.getFinalResult();
+        assertNotNull(result);
+        assertEquals(EmailSendStatus.SUCCEEDED, result.getStatus());
+        assertNotNull(result.getId());
+        assertNull(result.getError());
+    }
+
+    @Test
+    @DisplayName("a caller-supplied Operation-Id is adopted as the operation id")
+    void callerSuppliedOperationIdIsAdopted() {
+        String operationId = UUID.randomUUID().toString();
+
+        SyncPoller<EmailSendResult, EmailSendResult> poller =
+                buildClient(operationId).beginSend(message("Operation-Id echo"));
+        poller.waitForCompletion();
+
+        assertEquals(operationId, poller.getFinalResult().getId());
+    }
+
+    private EmailClient buildClient(String operationId) {
+        String endpoint = EmulatorConfig.httpBase().replace("http://", "https://");
+        EmailClientBuilder builder = new EmailClientBuilder()
+                .connectionString("endpoint=" + endpoint + "/;accesskey=" + EmulatorConfig.DEV_KEY);
+        if (operationId != null) {
+            builder.addPolicy(new StaticOperationIdPolicy(operationId));
+        }
+        return builder.buildClient();
+    }
+
+    private static EmailMessage message(String subject) {
+        return new EmailMessage()
+                .setSenderAddress(SENDER)
+                .setSubject(subject)
+                .setBodyHtml("<p>floci-az compatibility test</p>")
+                .setToRecipients(List.of(new EmailAddress(RECIPIENT)));
+    }
+
+    private record StaticOperationIdPolicy(String operationId) implements HttpPipelinePolicy {
+
+        private static final HttpHeaderName OPERATION_ID = HttpHeaderName.fromString("Operation-Id");
+
+        @Override
+        public Mono<HttpResponse> process(HttpPipelineCallContext context, HttpPipelineNextPolicy next) {
+            context.getHttpRequest().getHeaders().set(OPERATION_ID, operationId);
+            return next.process();
+        }
+    }
+}

--- a/docs/services/email.md
+++ b/docs/services/email.md
@@ -14,9 +14,12 @@ mailbox for your tests. No real email is ever delivered.
 
 - **Send email** — `POST /emails:send` accepts the full ACS payload (`senderAddress`, `content`
   with `subject`/`plainText`/`html`, `recipients` `to`/`cc`/`bcc`, `attachments`, `replyTo`,
-  `headers`) and returns `202 Accepted` with an `Operation-Location` header for polling
+  `headers`) and returns `202 Accepted` with `Operation-Location` and `Retry-After` headers for
+  polling. A caller-supplied **`Operation-Id`** request header is adopted as the operation id; without
+  one the emulator generates a UUID, matching ACS
 - **Operation status** — `GET /emails/operations/{operationId}` reports the long-running operation
-  status; the emulator completes immediately, so it returns `Succeeded` with a `resourceLocation`
+  status as `{"id":…,"status":…,"error":null}`, the same shape ACS returns. The emulator completes
+  immediately, so the status is `Succeeded`
 - **Inspection mailbox** — `GET /emailMessages` lists every captured message, `GET
   /emailMessages/{operationId}` returns one in full (including the original request body), and
   `DELETE /emailMessages` clears the mailbox
@@ -119,7 +122,8 @@ floci-az:
 - **No delivery.** Messages are captured in-memory only; nothing is sent over SMTP and no external
   recipient receives anything. The mailbox is not persisted and is cleared on restart.
 - **Operations always succeed immediately.** There is no `Running`→`Succeeded` transition delay and
-  no failure simulation.
+  no failure simulation. `Retry-After: 3` is still returned on the `202` to match ACS, but the first
+  poll already reports `Succeeded`.
 - **Auth is permissive.** The connection-string access key and `Authorization` header are accepted
   but not validated (dev mode), matching the rest of the emulator.
 - **ARM resources are state-only.** `communicationServices`/`emailServices`/`domains` return

--- a/src/main/java/io/floci/az/config/EmulatorConfig.java
+++ b/src/main/java/io/floci/az/config/EmulatorConfig.java
@@ -36,7 +36,7 @@ public interface EmulatorConfig {
      * {@code tls().enabled()} is true — the TlsProxyServer serves HTTPS on the same port.
      */
     default String baseUrlHttps() {
-        return baseUrl().replaceFirst("^http://", "https://");
+        return effectiveBaseUrl().replaceFirst("^http://", "https://");
     }
 
     TlsConfig tls();

--- a/src/main/java/io/floci/az/services/email/EmailHandler.java
+++ b/src/main/java/io/floci/az/services/email/EmailHandler.java
@@ -19,6 +19,7 @@ import io.floci.az.core.arm.ArmJson;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
+import org.apache.commons.lang3.StringUtils;
 import org.jboss.logging.Logger;
 
 import java.time.Instant;
@@ -60,6 +61,9 @@ public class EmailHandler implements AzureServiceHandler, Resettable {
             .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
     private static final String PROVIDER_COMMUNICATION = "/providers/Microsoft.Communication/";
+
+    private static final String OPERATION_ID_HEADER = "Operation-Id";
+    private static final String RETRY_AFTER_SECONDS = "3";
 
     // In-memory stores — no persistence needed for email capture
     private final StorageBackend<String, StoredObject> emailStorage = new InMemoryStorage<>();
@@ -143,7 +147,7 @@ public class EmailHandler implements AzureServiceHandler, Resettable {
         try {
             EmailSendRequest sendRequest = MAPPER.readValue(req.bodyStream(), EmailSendRequest.class);
 
-            String operationId = UUID.randomUUID().toString();
+            String operationId = clientOperationId(req);
             String messageId   = UUID.randomUUID().toString();
 
             CapturedEmail captured = new CapturedEmail();
@@ -163,17 +167,17 @@ public class EmailHandler implements AzureServiceHandler, Resettable {
                     sendRequest.getContent() != null ? sendRequest.getContent().getSubject() : "(none)");
 
             // ACS returns 202 Accepted with Operation-Location header for polling
-            String baseUrl = config.effectiveBaseUrl();
+            String baseUrl = req.secure() ? config.baseUrlHttps() : config.effectiveBaseUrl();
             String operationLocation = baseUrl + "/emails/operations/" + operationId
                     + "?api-version=" + req.queryParams().getOrDefault("api-version", "2023-03-31");
 
+            EmailSendResultResponse result = new EmailSendResultResponse(operationId, "Running");
+
             return Response.status(202)
                     .header("Operation-Location", operationLocation)
+                    .header("Retry-After", RETRY_AFTER_SECONDS)
                     .header("x-ms-request-id", UUID.randomUUID().toString())
-                    .entity(Map.of(
-                            "id", operationId,
-                            "status", "Running",
-                            "error", Map.of()))
+                    .entity(result)
                     .type("application/json")
                     .build();
 
@@ -193,15 +197,10 @@ public class EmailHandler implements AzureServiceHandler, Resettable {
 
         try {
             CapturedEmail captured = MAPPER.readValue(found.get().data(), CapturedEmail.class);
-
-            Map<String, Object> result = new LinkedHashMap<>();
-            result.put("id", captured.getOperationId());
-            result.put("status", captured.getStatus());
-            if ("Succeeded".equals(captured.getStatus())) {
-                result.put("resourceLocation", captured.getMessageId());
-            }
-            result.put("error", Map.of());
-
+            EmailSendResultResponse result = new EmailSendResultResponse(
+                    captured.getOperationId(),
+                    captured.getStatus()
+            );
             return Response.ok(result).type("application/json").build();
         } catch (Exception e) {
             return serverError("Failed to read operation status: " + e.getMessage());
@@ -404,6 +403,16 @@ public class EmailHandler implements AzureServiceHandler, Resettable {
         };
     }
 
+    private record EmailSendResultResponse(
+            String id,
+            String status,
+            Object error
+    ) {
+        EmailSendResultResponse(String id, String status) {
+            this(id, status, null);
+        }
+    }
+
     // ── Path parsing helpers ─────────────────────────────────────────────────
 
     private static String extractCommunicationPath(String fullPath) {
@@ -437,6 +446,15 @@ public class EmailHandler implements AzureServiceHandler, Resettable {
                     ? fullPath.indexOf('?') : fullPath.length());
         }
         return "/subscriptions/default/providers/Microsoft.Communication/" + resourceType + "/" + name;
+    }
+
+    // ── Header parsing helpers ───────────────────────────────────────────────
+
+    private String clientOperationId(AzureRequest req) {
+        return Optional.ofNullable(req.headers())
+                .map(h -> h.getHeaderString(OPERATION_ID_HEADER))
+                .filter(StringUtils::isNotBlank)
+                .orElseGet(() -> UUID.randomUUID().toString());
     }
 
     // ── Body parsing helpers ─────────────────────────────────────────────────

--- a/src/main/java/io/floci/az/services/email/EmailHandler.java
+++ b/src/main/java/io/floci/az/services/email/EmailHandler.java
@@ -1,6 +1,5 @@
 package io.floci.az.services.email;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -14,12 +13,12 @@ import io.floci.az.core.storage.InMemoryStorage;
 import io.floci.az.core.storage.StorageBackend;
 import io.floci.az.services.email.EmailModels.CapturedEmail;
 import io.floci.az.services.email.EmailModels.EmailSendRequest;
+import io.floci.az.services.email.EmailModels.EmailSendResult;
 import io.floci.az.core.arm.ArmErrors;
 import io.floci.az.core.arm.ArmJson;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
-import org.apache.commons.lang3.StringUtils;
 import org.jboss.logging.Logger;
 
 import java.time.Instant;
@@ -171,7 +170,7 @@ public class EmailHandler implements AzureServiceHandler, Resettable {
             String operationLocation = baseUrl + "/emails/operations/" + operationId
                     + "?api-version=" + req.queryParams().getOrDefault("api-version", "2023-03-31");
 
-            EmailSendResultResponse result = new EmailSendResultResponse(operationId, "Running");
+            EmailSendResult result = new EmailSendResult(operationId, "Running");
 
             return Response.status(202)
                     .header("Operation-Location", operationLocation)
@@ -197,7 +196,7 @@ public class EmailHandler implements AzureServiceHandler, Resettable {
 
         try {
             CapturedEmail captured = MAPPER.readValue(found.get().data(), CapturedEmail.class);
-            EmailSendResultResponse result = new EmailSendResultResponse(
+            EmailSendResult result = new EmailSendResult(
                     captured.getOperationId(),
                     captured.getStatus()
             );
@@ -403,16 +402,6 @@ public class EmailHandler implements AzureServiceHandler, Resettable {
         };
     }
 
-    private record EmailSendResultResponse(
-            String id,
-            String status,
-            Object error
-    ) {
-        EmailSendResultResponse(String id, String status) {
-            this(id, status, null);
-        }
-    }
-
     // ── Path parsing helpers ─────────────────────────────────────────────────
 
     private static String extractCommunicationPath(String fullPath) {
@@ -453,7 +442,7 @@ public class EmailHandler implements AzureServiceHandler, Resettable {
     private String clientOperationId(AzureRequest req) {
         return Optional.ofNullable(req.headers())
                 .map(h -> h.getHeaderString(OPERATION_ID_HEADER))
-                .filter(StringUtils::isNotBlank)
+                .filter(id -> !id.isBlank())
                 .orElseGet(() -> UUID.randomUUID().toString());
     }
 

--- a/src/main/java/io/floci/az/services/email/EmailModels.java
+++ b/src/main/java/io/floci/az/services/email/EmailModels.java
@@ -167,4 +167,16 @@ public final class EmailModels {
         public EmailSendRequest getRequest() { return request; }
         public void setRequest(EmailSendRequest request) { this.request = request; }
     }
+
+    @RegisterForReflection
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record EmailSendResult(
+            String id,
+            String status,
+            Object error
+    ) {
+        EmailSendResult(String id, String status) {
+            this(id, status, null);
+        }
+    }
 }

--- a/src/test/java/io/floci/az/services/email/EmailHandlerTest.java
+++ b/src/test/java/io/floci/az/services/email/EmailHandlerTest.java
@@ -1,0 +1,166 @@
+package io.floci.az.services.email;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
+
+/**
+ * Data-plane tests for {@link EmailHandler}.
+ *
+ * <p>The response shapes asserted here were taken from a live ACS resource, identical on
+ * {@code 2023-03-31}, {@code 2024-07-01-preview} and {@code 2025-09-01}:
+ *
+ * <pre>
+ *   POST /emails:send            → 202  {"id":…,"status":"Running","error":null}   + Operation-Location, Retry-After
+ *   GET  /emails/operations/{id} → 200  {"id":…,"status":"Succeeded","error":null}
+ * </pre>
+ *
+ * <p>Shape matters as much as status: the SDK models are code-generated with required fields, so an extra
+ * or wrongly-typed property breaks clients that a status-code assertion would call healthy.
+ */
+@QuarkusTest
+@DisplayName("EmailHandler — ACS Email data plane")
+class EmailHandlerTest {
+
+    private static final String API = "?api-version=2023-03-31";
+
+    private static final String SEND_BODY = """
+            {
+              "senderAddress": "DoNotReply@example.com",
+              "content": {"subject": "Hello", "html": "<p>Hi from floci-az</p>"},
+              "recipients": {"to": [{"address": "dev@example.com"}]}
+            }""";
+
+    @BeforeEach
+    void reset() {
+        given().post("/_admin/reset").then().statusCode(204);
+    }
+
+    @Test
+    @DisplayName("send returns 202 with Operation-Location, Retry-After, and error:null")
+    void sendReturnsAcsAcceptedShape() {
+        given().contentType("application/json")
+                .body(SEND_BODY)
+                .when()
+                .post("/emails:send" + API)
+                .then()
+                .statusCode(202)
+                .header("Operation-Location", notNullValue())
+                .header("Retry-After", notNullValue())
+                .contentType(startsWith("application/json"))
+                .body("id", notNullValue())
+                .body("status", equalTo("Running"))
+                .body("$", hasKey("error"))
+                .body("error", nullValue());
+    }
+
+    @Test
+    @DisplayName("Operation-Location is followable and carries the caller's scheme")
+    void operationLocationIsFollowable() {
+        given().contentType("application/json")
+                .body(SEND_BODY)
+                .when()
+                .post("/emails:send" + API)
+                .then()
+                .statusCode(202)
+                .header("Operation-Location", startsWith("http://"))
+                .header("Operation-Location", containsString("/emails/operations/"))
+                .header("Operation-Location", containsString("api-version=2023-03-31"));
+    }
+
+    @Test
+    @DisplayName("operation status is {id, status, error} with no resourceLocation")
+    void operationStatusMatchesAcsContract() {
+        String operationId = sendAndExtractId();
+
+        given().when()
+                .get("/emails/operations/" + operationId + API)
+                .then()
+                .statusCode(200)
+                .body("id", equalTo(operationId))
+                .body("status", equalTo("Succeeded"))
+                .body("$", hasKey("error"))
+                .body("error", nullValue())
+                .body("$", not(hasKey("resourceLocation")));
+    }
+
+    @Test
+    @DisplayName("a caller-supplied Operation-Id becomes the operation id")
+    void clientSuppliedOperationIdIsAdopted() {
+        String supplied = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
+
+        given().contentType("application/json")
+                .header("Operation-Id", supplied)
+                .body(SEND_BODY)
+                .when()
+                .post("/emails:send" + API)
+                .then()
+                .statusCode(202)
+                .body("id", equalTo(supplied))
+                .header("Operation-Location", containsString(supplied));
+
+        given().when()
+                .get("/emails/operations/" + supplied + API)
+                .then()
+                .statusCode(200)
+                .body("id", equalTo(supplied))
+                .body("status", equalTo("Succeeded"));
+    }
+
+    @Test
+    @DisplayName("without Operation-Id the service generates one")
+    void operationIdIsGeneratedWhenAbsent() {
+        String first = sendAndExtractId();
+        String second = sendAndExtractId();
+
+        given().when().get("/emails/operations/" + first + API).then().statusCode(200);
+        given().when().get("/emails/operations/" + second + API).then().statusCode(200);
+        Assertions.assertNotEquals(first, second);
+    }
+
+    @Test
+    @DisplayName("an unknown operation id is a 404")
+    void unknownOperationIsNotFound() {
+        given().when()
+                .get("/emails/operations/00000000-0000-0000-0000-000000000000" + API)
+                .then()
+                .statusCode(404);
+    }
+
+    @Test
+    @DisplayName("the captured message keeps the original request payload")
+    void capturedMessageRetainsRequest() {
+        String operationId = sendAndExtractId();
+
+        given().when()
+                .get("/emailMessages/" + operationId)
+                .then()
+                .statusCode(200)
+                .body("operationId", equalTo(operationId))
+                .body("request.senderAddress", equalTo("DoNotReply@example.com"))
+                .body("request.content.subject", equalTo("Hello"))
+                .body("request.recipients.to[0].address", equalTo("dev@example.com"));
+    }
+
+    private String sendAndExtractId() {
+        return given().contentType("application/json")
+                .body(SEND_BODY)
+                .when()
+                .post("/emails:send" + API)
+                .then()
+                .statusCode(202)
+                .extract()
+                .path("id");
+    }
+}


### PR DESCRIPTION
Fixes #147.

The `azure-communication-email` **Java** SDK could not complete a `beginSend`. Four deviations, all in the
two data-plane responses:

| | Was | ACS sends | Effect |
|---|---|---|---|
| 1 | `"error": {}` | `"error": null` | generated `ErrorDetail` requires `code`+`message` → `Missing required properties: code, message` |
| 2 | `"resourceLocation": "<uuid>"` | *(no such field)* | generic LRO field, so `OperationResourcePollingStrategy` GETs `{endpoint}/<uuid>` → `501` in Storage's XML shape → JSON parse failure |
| 3 | `Operation-Id` ignored | caller's id adopted | callers can't reconcile a send whose response they never saw |
| 4 | `Operation-Location` on `base-url`'s scheme | follows the request | an HTTPS client gets an `http://` poll URL its HMAC credential won't sign |

Plus `Retry-After: 3` on the `202`, as ACS does.

1 and 2 each break every send on their own, and neither surfaces as an `ErrorResponseException` — both
arrive as parse failures — so a caller with retry logic sees a send retry forever without ever failing. 2 is
masked by 1, and 4 by both, so they only appear one at a time.

### Where the expected shapes came from

Per `AGENTS.md` ("Do not invent protocol behavior… test against a real Azure endpoint"), signed curl against
a live ACS resource — identical on `2023-03-31` (this emulator's own default), `2024-07-01-preview` and
`2025-09-01`, so none of it is an api-version difference:

```console
# POST /emails:send  →  202, Retry-After: 3, Operation-Id echoed back
{"id":"440521b4-fa3e-4f6e-afdd-19cf47a5582e","status":"Running","error":null}

# GET /emails/operations/440521b4-...  →  200
{"id":"440521b4-fa3e-4f6e-afdd-19cf47a5582e","status":"Succeeded","error":null}
```

### Notes

- `Map.of` rejects null values, which is presumably why `Map.of()` stood in for "no error" — the `202` now
  builds a `LinkedHashMap`.
- Bug 4 uses `EmulatorConfig.baseUrlHttps()`, which already existed for this and had no callers.
  `RequestUrls.resolveBaseUrl` looks like the natural fit but isn't usable: ACS's
  `HmacAuthenticationPolicy` overwrites `Host` with `url.getHost()`, dropping the port, so a
  Host-derived URL sends the poller to `:443`. `TlsProxyServer` serves both schemes on one port, so only
  the scheme needs to vary.
- ARM, the mailbox and routing are untouched.

### Tests

The service had no test, and no `compatibility-tests/` suite covered it — which is why this shipped.

- **`EmailHandlerTest`** — `@QuarkusTest` + RestAssured, 7 cases over the response shapes.
- **`EmailCompatibilityTest`** — real SDK through `beginSend` → `waitForCompletion` → `getFinalResult`,
  which catches 1, 2 and 4 in one assertion, plus `Operation-Id` adoption. Needs
  `FLOCI_AZ_TLS_ENABLED=true` (already set by `docker-compose.yml` and the `Makefile` compat target) since
  the ACS credential only signs `https`; skips itself otherwise.

|  | `EmailHandlerTest` | `EmailCompatibilityTest` |
|---|---|---|
| before | 3 of 7 fail, one per bug | 2/2 error: `Missing required properties: code, message` |
| after | 7/7 | 2/2 |

Full suite: **316 tests, 0 failures**. The compat suite was run against a `Dockerfile.jvm-package` image
built from this branch, and against published `0.9.0` to confirm it fails there.

### Out of scope

APIM, Event Grid, Functions, Monitor and VM also build absolute URLs from `config.effectiveBaseUrl()` and
carry the same scheme assumption. Left alone: those advertise endpoints for a later, separate call, whereas
`Operation-Location` is followed immediately by the same client in the same operation. Happy to generalise
it into a shared helper in a follow-up if you'd prefer that to a per-handler fix.
