### PR TITLE
chore(ci): welcome first-time contributors on their first issue or PR

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -1,0 +1,47 @@
+name: Welcome First-Time Contributors
+
+on:
+  issues:
+    types: [opened]
+  # pull_request_target so the token has write access on fork PRs, which is where
+  # first-time contributions come from. This workflow never checks out or executes
+  # PR code — it only posts a comment — so the elevated context is not exposed.
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  welcome:
+    name: Greet on first issue or PR
+    runs-on: ubuntu-latest
+
+    steps:
+      # Block scalars below are literal (|), not folded (>): folding joins Markdown
+      # bullets onto one line. One paragraph per line, because GitHub renders a
+      # single newline in a comment as a hard line break.
+      - uses: actions/first-interaction@v3.1.0
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+
+          issue_message: |
+            👋 Thanks for opening your first issue in floci-az!
+
+            A maintainer will triage this and add the right service label. If you included a minimal reproduction and the floci-az version, that is everything we need — no action required from you right now.
+
+            Come say hi in [Slack](https://join.slack.com/t/floci/shared_invite/zt-3tjn02s3q-A00kEjJ1cZxsg_imTfy6Cw) if you want to talk it through with maintainers and other contributors. Questions about Azure behaviour, design tradeoffs, and rough proposals are all welcome there.
+
+          pr_message: |
+            🎉 Thanks for your first pull request to floci-az!
+
+            **Your CI checks need a maintainer to approve them before they run.** That is GitHub's standard gate on first-time contributors, not a problem with your PR — so if the checks look like they are doing nothing, that is why. Once a maintainer approves, CI and the compatibility suite start automatically. Nothing is needed from you in the meantime.
+
+            While you wait, a couple of things that make review faster:
+
+            - Link the issue this fixes with `Closes #N` in the description
+            - Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(blob): ...`, `fix(keyvault): ...`)
+            - Behaviour changes come with a test — see [CONTRIBUTING.md](https://github.com/floci-io/floci-az/blob/main/CONTRIBUTING.md)
+
+            Come join us in [Slack](https://join.slack.com/t/floci/shared_invite/zt-3tjn02s3q-A00kEjJ1cZxsg_imTfy6Cw) — it is the fastest way to reach maintainers if you get stuck, or want feedback on an approach before investing more time in it.


### PR DESCRIPTION
## Summary

Adds a `welcome.yml` workflow that greets first-time contributors: first issues get a triage-expectations note, first PRs get an explanation of the maintainer-approval gate on CI (the most common first-timer confusion), the Conventional Commits/testing conventions, and a Slack invite. Uses `pull_request_target` so the token can comment on fork PRs; the job never checks out or executes PR code.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## Azure Compatibility

n/a — CI workflow only; no emulator behavior touched.

## Checklist

- [x] `./mvnw test` passes locally (unaffected)
- [ ] New or updated integration test added — none needed: comment-only GitHub workflow, verifiable only on a real first interaction
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)