### PR TITLE
chore(test): merge duplicate service-properties test methods from #133/#144

### DIFF
--- a/src/test/java/io/floci/az/services/BlobServiceTest.java
+++ b/src/test/java/io/floci/az/services/BlobServiceTest.java
@@ -36,7 +36,9 @@ public class BlobServiceTest {
             .statusCode(200)
             .contentType("application/xml")
             .body(startsWith("<StorageServiceProperties>"))
-            .body("StorageServiceProperties.Logging.Version", equalTo("1.0"));
+            .body("StorageServiceProperties.Logging.Version", equalTo("1.0"))
+            .body(containsString("<StaticWebsite>"))
+            .body(not(containsString("XmlBuilder@")));
     }
 
     @Test
@@ -57,18 +59,6 @@ public class BlobServiceTest {
         given()
             .when().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER)
             .then().statusCode(409);
-    }
-
-    @Test
-    void getBlobServicePropertiesReturnsXml() {
-        given()
-            .when().get("/{account}?restype=service&comp=properties", ACCOUNT)
-            .then()
-            .statusCode(200)
-            .contentType(containsString("xml"))
-            .body(containsString("<StorageServiceProperties>"))
-            .body(containsString("<StaticWebsite>"))
-            .body(not(containsString("XmlBuilder@")));
     }
 
     @Test

--- a/src/test/java/io/floci/az/services/QueueServiceTest.java
+++ b/src/test/java/io/floci/az/services/QueueServiceTest.java
@@ -27,7 +27,9 @@ public class QueueServiceTest {
             .statusCode(200)
             .contentType("application/xml")
             .body(startsWith("<StorageServiceProperties>"))
-            .body("StorageServiceProperties.Logging.Version", equalTo("1.0"));
+            .body("StorageServiceProperties.Logging.Version", equalTo("1.0"))
+            .body(containsString("<Logging>"))
+            .body(not(containsString("XmlBuilder@")));
     }
 
     @Test
@@ -39,18 +41,6 @@ public class QueueServiceTest {
         given()
             .when().delete("/{account}/{queue}", ACCOUNT, QUEUE)
             .then().statusCode(204);
-    }
-
-    @Test
-    void getQueueServicePropertiesReturnsXml() {
-        given()
-            .when().get("/{account}?restype=service&comp=properties", ACCOUNT)
-            .then()
-            .statusCode(200)
-            .contentType(containsString("xml"))
-            .body(containsString("<StorageServiceProperties>"))
-            .body(containsString("<Logging>"))
-            .body(not(containsString("XmlBuilder@")));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Main's test compilation is broken since `aa3e378`: #133 and #144 each added `getBlobServicePropertiesReturnsXml` / `getQueueServicePropertiesReturnsXml`, and the merges were textually clean but left duplicate method definitions. Each pair is now a single method carrying **both** copies' assertions: the XML structure checks from #144 (`Logging.Version`) plus the `<StaticWebsite>`/`<Logging>` presence and the `XmlBuilder@` toString-regression guard from #133. `TableServiceTest` had only one copy and is untouched.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## Azure Compatibility

n/a — test-only dedupe; no emulator behavior changes.

## Checklist

- [x] `./mvnw test` passes locally (469 tests)
- [ ] New or updated integration test added — n/a, this deduplicates existing tests without losing any assertion
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)