### PR TITLE
feat(network): synthesize LB, NSG, and application gateway shapes for azurerm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Network**: realistic property synthesis for `Microsoft.Network` load balancers
+  (top-level `sku` round-trip, frontend/rule/pool ARM IDs), network security groups
+  (rule IDs, the six real-Azure `defaultSecurityRules`, standalone `securityRules`
+  child endpoint), and application gateways (child sub-resource IDs,
+  `operationalState`), plus the `backendAddressPools` child endpoint — enabling
+  `azurerm_lb*`, `azurerm_network_security_*`, and `azurerm_application_gateway`
+  Terraform/OpenTofu flows.
 - **servicebus:** subscription rules and topic filters — the `/{topic}/subscriptions/{sub}/rules[/{rule}]` management-plane endpoints (create/get/list/delete, ATOM `RuleDescription` wire format with `CorrelationFilter`/`SqlFilter`/`TrueFilter`/`FalseFilter` and `SqlRuleAction` bodies), Azure's implicit `$Default` TrueFilter rule (auto-created per subscription, replaceable via the delete-then-add SDK flow or a `DefaultRuleDescription` in the subscription create body), and broker-side filter evaluation: rules compile to Artemis SQL92 queue selectors (`CorrelationId`→`JMSCorrelationID`, `Label`/`Subject`→`JMSType`, `SessionId`→`JMSXGroupID`, application properties by name, with typed int/long/double/boolean correlation values), multiple rules OR-combine into a single delivery, no rules delivers nothing, and rule changes update the queue filter in place (`updateQueue`) without dropping routed messages or kicking receivers. Filters on `MessageId`/`To`/`ReplyTo`/`ReplyToSessionId`/`ContentType` are rejected with 400 (no broker-side AMQP mapping); `SqlRuleAction` is stored/echoed but not applied to delivered messages ([#124](https://github.com/floci-io/floci-az/issues/124))
 
 ### Fixed

--- a/compatibility-tests/compat-opentofu/main.tf
+++ b/compatibility-tests/compat-opentofu/main.tf
@@ -220,3 +220,161 @@ resource "azurerm_container_registry" "acr" {
 output "acr_login_server" {
   value = azurerm_container_registry.acr.login_server
 }
+
+# ── Network type synthesis: NSG / Load Balancer / Application Gateway ────────
+
+resource "azurerm_network_security_group" "nsg" {
+  name                = "floci-test-nsg"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  security_rule {
+    name                       = "allow-https"
+    priority                   = 100
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+}
+
+resource "azurerm_network_security_rule" "ssh" {
+  name                        = "allow-ssh"
+  priority                    = 200
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "22"
+  source_address_prefix       = "10.0.0.0/8"
+  destination_address_prefix  = "*"
+  resource_group_name         = azurerm_resource_group.rg.name
+  network_security_group_name = azurerm_network_security_group.nsg.name
+}
+
+resource "azurerm_public_ip" "lb_pip" {
+  name                = "floci-test-lb-pip"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_lb" "lb" {
+  name                = "floci-test-lb"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  sku                 = "Standard"
+
+  frontend_ip_configuration {
+    name                 = "frontend"
+    public_ip_address_id = azurerm_public_ip.lb_pip.id
+  }
+}
+
+resource "azurerm_lb_backend_address_pool" "pool" {
+  name            = "floci-test-lb-pool"
+  loadbalancer_id = azurerm_lb.lb.id
+}
+
+resource "azurerm_lb_probe" "probe" {
+  name            = "floci-test-lb-probe"
+  loadbalancer_id = azurerm_lb.lb.id
+  port            = 8080
+}
+
+resource "azurerm_lb_rule" "rule" {
+  name                           = "floci-test-lb-rule"
+  loadbalancer_id                = azurerm_lb.lb.id
+  protocol                       = "Tcp"
+  frontend_port                  = 80
+  backend_port                   = 8080
+  frontend_ip_configuration_name = "frontend"
+  backend_address_pool_ids       = [azurerm_lb_backend_address_pool.pool.id]
+  probe_id                       = azurerm_lb_probe.probe.id
+}
+
+resource "azurerm_subnet" "agw_subnet" {
+  name                 = "floci-test-agw-subnet"
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = ["10.0.3.0/24"]
+}
+
+resource "azurerm_public_ip" "agw_pip" {
+  name                = "floci-test-agw-pip"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_application_gateway" "agw" {
+  name                = "floci-test-agw"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  sku {
+    name     = "Standard_v2"
+    tier     = "Standard_v2"
+    capacity = 1
+  }
+
+  gateway_ip_configuration {
+    name      = "gwip"
+    subnet_id = azurerm_subnet.agw_subnet.id
+  }
+
+  frontend_port {
+    name = "port80"
+    port = 80
+  }
+
+  frontend_ip_configuration {
+    name                 = "feip"
+    public_ip_address_id = azurerm_public_ip.agw_pip.id
+  }
+
+  backend_address_pool {
+    name = "bepool"
+  }
+
+  backend_http_settings {
+    name                  = "behttp"
+    cookie_based_affinity = "Disabled"
+    port                  = 8080
+    protocol              = "Http"
+    request_timeout       = 30
+  }
+
+  http_listener {
+    name                           = "listener"
+    frontend_ip_configuration_name = "feip"
+    frontend_port_name             = "port80"
+    protocol                       = "Http"
+  }
+
+  request_routing_rule {
+    name                       = "rule1"
+    priority                   = 100
+    rule_type                  = "Basic"
+    http_listener_name         = "listener"
+    backend_address_pool_name  = "bepool"
+    backend_http_settings_name = "behttp"
+  }
+}
+
+output "lb_id" {
+  value = azurerm_lb.lb.id
+}
+
+output "nsg_id" {
+  value = azurerm_network_security_group.nsg.id
+}
+
+output "application_gateway_id" {
+  value = azurerm_application_gateway.agw.id
+}

--- a/compatibility-tests/compat-opentofu/test/opentofu.bats
+++ b/compatibility-tests/compat-opentofu/test/opentofu.bats
@@ -173,3 +173,33 @@ setup() {
     assert_output --partial "networkInterfaces"
     assert_output --partial "Succeeded"
 }
+
+@test "OpenTofu: NSG created with inline rule, child rule, and default rules" {
+    run arm_get "subscriptions/${SUB_ID}/resourceGroups/${RG_NAME}/providers/Microsoft.Network/networkSecurityGroups/${NSG_NAME}"
+    assert_success
+    assert_output --partial "Microsoft.Network/networkSecurityGroups"
+    assert_output --partial "allow-https"
+    assert_output --partial "${NSG_RULE_NAME}"
+    assert_output --partial "DenyAllInBound"
+    assert_output --partial "Succeeded"
+}
+
+@test "OpenTofu: load balancer echoes sku and frontend with backend pool" {
+    run arm_get "subscriptions/${SUB_ID}/resourceGroups/${RG_NAME}/providers/Microsoft.Network/loadBalancers/${LB_NAME}"
+    assert_success
+    assert_output --partial "Microsoft.Network/loadBalancers"
+    assert_output --partial "Standard"
+    assert_output --partial "frontendIPConfigurations"
+    assert_output --partial "${LB_POOL_NAME}"
+    assert_output --partial "Succeeded"
+}
+
+@test "OpenTofu: application gateway created with listeners and routing rules" {
+    run arm_get "subscriptions/${SUB_ID}/resourceGroups/${RG_NAME}/providers/Microsoft.Network/applicationGateways/${AGW_NAME}"
+    assert_success
+    assert_output --partial "Microsoft.Network/applicationGateways"
+    assert_output --partial "httpListeners"
+    assert_output --partial "requestRoutingRules"
+    assert_output --partial "Running"
+    assert_output --partial "Succeeded"
+}

--- a/compatibility-tests/compat-opentofu/test/test_helper/common-setup.bash
+++ b/compatibility-tests/compat-opentofu/test/test_helper/common-setup.bash
@@ -35,6 +35,11 @@ export PG_DB_NAME="floci-test-db"
 export PDZ_NAME="privatelink.blob.core.windows.net"
 export PDZ_LINK_NAME="floci-test-pdzvnl"
 export PE_NAME="floci-test-pe"
+export NSG_NAME="floci-test-nsg"
+export NSG_RULE_NAME="allow-ssh"
+export LB_NAME="floci-test-lb"
+export LB_POOL_NAME="floci-test-lb-pool"
+export AGW_NAME="floci-test-agw"
 export SUB_ID="${TF_VAR_subscription_id}"
 
 arm_get() {

--- a/compatibility-tests/compat-terraform/main.tf
+++ b/compatibility-tests/compat-terraform/main.tf
@@ -186,3 +186,161 @@ resource "azurerm_container_registry" "acr" {
 output "acr_login_server" {
   value = azurerm_container_registry.acr.login_server
 }
+
+# ── Network type synthesis: NSG / Load Balancer / Application Gateway ────────
+
+resource "azurerm_network_security_group" "nsg" {
+  name                = "floci-test-nsg"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  security_rule {
+    name                       = "allow-https"
+    priority                   = 100
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "443"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+}
+
+resource "azurerm_network_security_rule" "ssh" {
+  name                        = "allow-ssh"
+  priority                    = 200
+  direction                   = "Inbound"
+  access                      = "Allow"
+  protocol                    = "Tcp"
+  source_port_range           = "*"
+  destination_port_range      = "22"
+  source_address_prefix       = "10.0.0.0/8"
+  destination_address_prefix  = "*"
+  resource_group_name         = azurerm_resource_group.rg.name
+  network_security_group_name = azurerm_network_security_group.nsg.name
+}
+
+resource "azurerm_public_ip" "lb_pip" {
+  name                = "floci-test-lb-pip"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_lb" "lb" {
+  name                = "floci-test-lb"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  sku                 = "Standard"
+
+  frontend_ip_configuration {
+    name                 = "frontend"
+    public_ip_address_id = azurerm_public_ip.lb_pip.id
+  }
+}
+
+resource "azurerm_lb_backend_address_pool" "pool" {
+  name            = "floci-test-lb-pool"
+  loadbalancer_id = azurerm_lb.lb.id
+}
+
+resource "azurerm_lb_probe" "probe" {
+  name            = "floci-test-lb-probe"
+  loadbalancer_id = azurerm_lb.lb.id
+  port            = 8080
+}
+
+resource "azurerm_lb_rule" "rule" {
+  name                           = "floci-test-lb-rule"
+  loadbalancer_id                = azurerm_lb.lb.id
+  protocol                       = "Tcp"
+  frontend_port                  = 80
+  backend_port                   = 8080
+  frontend_ip_configuration_name = "frontend"
+  backend_address_pool_ids       = [azurerm_lb_backend_address_pool.pool.id]
+  probe_id                       = azurerm_lb_probe.probe.id
+}
+
+resource "azurerm_subnet" "agw_subnet" {
+  name                 = "floci-test-agw-subnet"
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = ["10.0.3.0/24"]
+}
+
+resource "azurerm_public_ip" "agw_pip" {
+  name                = "floci-test-agw-pip"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+}
+
+resource "azurerm_application_gateway" "agw" {
+  name                = "floci-test-agw"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  sku {
+    name     = "Standard_v2"
+    tier     = "Standard_v2"
+    capacity = 1
+  }
+
+  gateway_ip_configuration {
+    name      = "gwip"
+    subnet_id = azurerm_subnet.agw_subnet.id
+  }
+
+  frontend_port {
+    name = "port80"
+    port = 80
+  }
+
+  frontend_ip_configuration {
+    name                 = "feip"
+    public_ip_address_id = azurerm_public_ip.agw_pip.id
+  }
+
+  backend_address_pool {
+    name = "bepool"
+  }
+
+  backend_http_settings {
+    name                  = "behttp"
+    cookie_based_affinity = "Disabled"
+    port                  = 8080
+    protocol              = "Http"
+    request_timeout       = 30
+  }
+
+  http_listener {
+    name                           = "listener"
+    frontend_ip_configuration_name = "feip"
+    frontend_port_name             = "port80"
+    protocol                       = "Http"
+  }
+
+  request_routing_rule {
+    name                       = "rule1"
+    priority                   = 100
+    rule_type                  = "Basic"
+    http_listener_name         = "listener"
+    backend_address_pool_name  = "bepool"
+    backend_http_settings_name = "behttp"
+  }
+}
+
+output "lb_id" {
+  value = azurerm_lb.lb.id
+}
+
+output "nsg_id" {
+  value = azurerm_network_security_group.nsg.id
+}
+
+output "application_gateway_id" {
+  value = azurerm_application_gateway.agw.id
+}

--- a/compatibility-tests/compat-terraform/test/terraform.bats
+++ b/compatibility-tests/compat-terraform/test/terraform.bats
@@ -159,3 +159,33 @@ setup() {
     assert_output --partial "networkInterfaces"
     assert_output --partial "Succeeded"
 }
+
+@test "Terraform: NSG created with inline rule, child rule, and default rules" {
+    run arm_get "subscriptions/${SUB_ID}/resourceGroups/${RG_NAME}/providers/Microsoft.Network/networkSecurityGroups/${NSG_NAME}"
+    assert_success
+    assert_output --partial "Microsoft.Network/networkSecurityGroups"
+    assert_output --partial "allow-https"
+    assert_output --partial "${NSG_RULE_NAME}"
+    assert_output --partial "DenyAllInBound"
+    assert_output --partial "Succeeded"
+}
+
+@test "Terraform: load balancer echoes sku and frontend with backend pool" {
+    run arm_get "subscriptions/${SUB_ID}/resourceGroups/${RG_NAME}/providers/Microsoft.Network/loadBalancers/${LB_NAME}"
+    assert_success
+    assert_output --partial "Microsoft.Network/loadBalancers"
+    assert_output --partial "Standard"
+    assert_output --partial "frontendIPConfigurations"
+    assert_output --partial "${LB_POOL_NAME}"
+    assert_output --partial "Succeeded"
+}
+
+@test "Terraform: application gateway created with listeners and routing rules" {
+    run arm_get "subscriptions/${SUB_ID}/resourceGroups/${RG_NAME}/providers/Microsoft.Network/applicationGateways/${AGW_NAME}"
+    assert_success
+    assert_output --partial "Microsoft.Network/applicationGateways"
+    assert_output --partial "httpListeners"
+    assert_output --partial "requestRoutingRules"
+    assert_output --partial "Running"
+    assert_output --partial "Succeeded"
+}

--- a/compatibility-tests/compat-terraform/test/test_helper/common-setup.bash
+++ b/compatibility-tests/compat-terraform/test/test_helper/common-setup.bash
@@ -33,6 +33,11 @@ export ACR_NAME="flocitestacr"
 export PDZ_NAME="privatelink.blob.core.windows.net"
 export PDZ_LINK_NAME="floci-test-pdzvnl"
 export PE_NAME="floci-test-pe"
+export NSG_NAME="floci-test-nsg"
+export NSG_RULE_NAME="allow-ssh"
+export LB_NAME="floci-test-lb"
+export LB_POOL_NAME="floci-test-lb-pool"
+export AGW_NAME="floci-test-agw"
 export SUB_ID="${TF_VAR_subscription_id}"
 
 arm_get() {

--- a/docs/services/network.md
+++ b/docs/services/network.md
@@ -12,12 +12,14 @@ Compatible with ARM-speaking clients, Terraform's AzureRM provider, and OpenTofu
 - **Subnets** — CreateOrUpdate, Get, Delete, and List under a virtual network
 - **Network interfaces** — CreateOrUpdate, Get, Delete, and List by resource group
 - **Public IP addresses** — CreateOrUpdate, Get, Delete, and List by resource group
-- **Network security groups** — CreateOrUpdate, Get, Delete, and List by resource group
+- **Network security groups** — CreateOrUpdate, Get, Delete, and List by resource group; inline and standalone `securityRules` (child endpoint) with synthesized rule IDs, plus the six real-Azure `defaultSecurityRules`
+- **Load balancers** — CreateOrUpdate, Get, Delete, and List; top-level `sku` round-trips, frontend IP configurations get synthesized IDs and private IPs, and `backendAddressPools` are manageable through the dedicated child endpoint (`azurerm_lb_backend_address_pool`)
+- **Application gateways** — CreateOrUpdate, Get, Delete, and List; child sub-resources (listeners, ports, pools, routing rules, …) echo with well-formed ARM IDs (synthesized when absent) and the gateway reports `operationalState = "Running"`
 - **Private DNS zones** — CreateOrUpdate, Get, Delete, and List, with record sets (A, AAAA, CNAME, MX, PTR, SOA, SRV, TXT); a default SOA record set is seeded on creation, record/link counts are tracked, and ETag (`If-Match` / `If-None-Match`) concurrency is enforced
 - **Private DNS virtual network links** — CreateOrUpdate, Get, Delete, and List under a private DNS zone; links report `virtualNetworkLinkState = "Completed"`
 - **Private endpoints** — CreateOrUpdate, Get, Delete, and List; `privateLinkServiceConnections` are auto-approved, a backing network interface with a synthesized private IP is created, and nested `privateDnsZoneGroups` are supported
 - **Private link services** — CreateOrUpdate, Get, Delete, and List, with a synthesized `alias`
-- **Terraform/OpenTofu compatibility** — supports the Network resources needed by `azurerm_linux_virtual_machine`, `azurerm_private_dns_zone`, `azurerm_private_dns_zone_virtual_network_link`, and `azurerm_private_endpoint`
+- **Terraform/OpenTofu compatibility** — supports the Network resources needed by `azurerm_linux_virtual_machine`, `azurerm_private_dns_zone`, `azurerm_private_dns_zone_virtual_network_link`, `azurerm_private_endpoint`, `azurerm_network_security_group` / `azurerm_network_security_rule`, `azurerm_lb` (+ backend pool, probe, rule), and `azurerm_application_gateway`
 - **Resource group listing** — Network resources appear in ARM resource group resource listings
 
 Created resources return `properties.provisioningState = "Succeeded"`. NICs synthesize a dynamic private IP (`10.0.0.4`) when no private IP is supplied, and public IP resources synthesize a dynamic public IP (`20.0.0.4`) when no address is supplied. Creating a private endpoint likewise synthesizes a backing network interface with a `10.0.0.4` private IP.
@@ -118,8 +120,8 @@ floci-az:
 ## Scope And Limitations
 
 - No real L2/L3 networking, routing, peering, DNS, packet forwarding, or service endpoints
-- No NSG rule enforcement; NSG resources are stored as ARM state only
-- No route table, NAT gateway, load balancer, or application gateway behavior
+- No NSG rule enforcement; NSG resources (including default rules) are stored as ARM state only
+- No route table or NAT gateway behavior; load balancers and application gateways are ARM-state synthesis only — no traffic is balanced or routed
 - Private endpoints and private DNS zones are ARM-state only — a backing NIC with a synthesized `10.0.0.4` is created and connections are auto-approved, but there is no real private-link traffic, name registration, or DNS resolution against the private zone records
 - No real IP address management; default private and public IPs are synthesized for SDK and provider compatibility
 - Deletes are state-only; deleting a VNet also removes its child subnets from the in-memory store

--- a/src/main/java/io/floci/az/services/network/NetworkService.java
+++ b/src/main/java/io/floci/az/services/network/NetworkService.java
@@ -49,6 +49,23 @@ public class NetworkService {
             return Response.ok(Map.of("value", listSubnets(sub, rg, vnetName))).build();
         }
 
+        // Child resources whose canonical home is an array on the parent. Azure models LB
+        // backend pools and NSG security rules this way, and azurerm manages them through
+        // these dedicated child endpoints — routing them into the generic CRUD would store
+        // a mis-typed sibling the parent read-back never sees.
+        if (tail.matches("loadBalancers/[^/?]+/backendAddressPools([/?].*)?")) {
+            return handleParentArrayChild(request, method, sub, rg, tail,
+                    "loadBalancers", "backendAddressPools", false);
+        }
+        if (tail.matches("networkSecurityGroups/[^/?]+/securityRules([/?].*)?")) {
+            return handleParentArrayChild(request, method, sub, rg, tail,
+                    "networkSecurityGroups", "securityRules", false);
+        }
+        if (tail.matches("networkSecurityGroups/[^/?]+/defaultSecurityRules([/?].*)?")) {
+            return handleParentArrayChild(request, method, sub, rg, tail,
+                    "networkSecurityGroups", "defaultSecurityRules", true);
+        }
+
         String resourceType = resourceType(tail);
         String name = resourceName(tail);
         String key = key(sub, rg, tail);
@@ -98,15 +115,16 @@ public class NetworkService {
     private Response createOrUpdateResource(AzureRequest request, String sub, String rg, String tail,
                                             String resourceType, String name, String key) {
         Map<String, Object> body = parseBody(request);
+        String id = "/subscriptions/" + sub + "/resourceGroups/" + rg
+                + "/providers/Microsoft.Network/" + tail;
         Map<String, Object> properties = new LinkedHashMap<>(cast(body.get("properties")));
-        synthesizeProperties(resourceType, name, properties);
+        synthesizeProperties(resourceType, name, id, properties);
         properties.put("provisioningState", "Succeeded");
 
         Map<String, Object> resource = new LinkedHashMap<>();
         resource.put("_sub", sub);
         resource.put("_rg", rg);
-        resource.put("id", "/subscriptions/" + sub + "/resourceGroups/" + rg
-                + "/providers/Microsoft.Network/" + tail);
+        resource.put("id", id);
         resource.put("name", name);
         resource.put("type", resourceType);
         String location = bodyString(body, "location", null);
@@ -115,6 +133,15 @@ public class NetworkService {
         }
         if (body.get("tags") instanceof Map<?, ?> tags && !tags.isEmpty()) {
             resource.put("tags", tags);
+        }
+        // ARM envelope fields that live beside properties and must round-trip verbatim —
+        // azurerm reads them from the response model, not from its own state (e.g.
+        // azurerm_lb sets sku/sku_tier from model.Sku and diffs forever if it vanishes).
+        for (String envelope : List.of("sku", "zones", "identity")) {
+            Object value = body.get(envelope);
+            if (value != null) {
+                resource.put(envelope, value);
+            }
         }
         resource.put("properties", properties);
         resources.put(key, resource);
@@ -129,9 +156,116 @@ public class NetworkService {
         }
     }
 
+    /**
+     * CRUD for child resources stored as an array on the parent (LB backendAddressPools,
+     * NSG securityRules/defaultSecurityRules). The parent's array is the single source of
+     * truth: a child PUT upserts into it, so the parent read-back and the child endpoint
+     * never diverge, and cascade delete is inherent. {@code readOnly} models Azure's
+     * defaultSecurityRules, which exist only as a synthesized read surface.
+     */
     @SuppressWarnings("unchecked")
-    private static void synthesizeProperties(String resourceType, String name, Map<String, Object> properties) {
+    private Response handleParentArrayChild(AzureRequest request, String method, String sub, String rg,
+                                            String tail, String parentSegment, String childSegment,
+                                            boolean readOnly) {
+        String[] parts = tail.split("[/?]");
+        String parentName = parts[1];
+        String childName = parts.length > 3 && !parts[3].isEmpty() ? parts[3] : null;
+
+        Map<String, Object> parent = resources.get(key(sub, rg, parentSegment + "/" + parentName));
+        if (parent == null) {
+            return notFound(parentSegment + "/" + parentName);
+        }
+        Map<String, Object> parentProps = cast(parent.get("properties"));
+        List<Object> entries = parentProps.get(childSegment) instanceof List<?> l
+                ? new ArrayList<>((List<Object>) l)
+                : new ArrayList<>();
+
+        if (childName == null) {
+            return "GET".equals(method)
+                    ? Response.ok(Map.of("value", entries)).build()
+                    : Response.status(405).build();
+        }
+
+        switch (method) {
+            case "GET" -> {
+                for (Object item : entries) {
+                    Map<String, Object> entry = cast(item);
+                    if (childName.equals(entry.get("name"))) {
+                        return Response.ok(entry).build();
+                    }
+                }
+                return notFound(tail);
+            }
+            case "PUT" -> {
+                if (readOnly) {
+                    return Response.status(405).build();
+                }
+                Map<String, Object> body = parseBody(request);
+                Map<String, Object> entryProps = new LinkedHashMap<>(cast(body.get("properties")));
+                entryProps.put("provisioningState", "Succeeded");
+                Map<String, Object> entry = new LinkedHashMap<>();
+                entry.put("name", childName);
+                entry.put("id", parent.get("id") + "/" + childSegment + "/" + childName);
+                entry.put("properties", entryProps);
+                entries.removeIf(item -> childName.equals(cast(item).get("name")));
+                entries.add(entry);
+                parentProps.put(childSegment, entries);
+                return Response.ok(entry).build();
+            }
+            case "DELETE" -> {
+                if (readOnly) {
+                    return Response.status(405).build();
+                }
+                entries.removeIf(item -> childName.equals(cast(item).get("name")));
+                parentProps.put(childSegment, entries);
+                return Response.ok().build();
+            }
+            default -> {
+                return Response.status(405).build();
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void synthesizeProperties(String resourceType, String name, String id,
+                                             Map<String, Object> properties) {
         switch (resourceType) {
+            case "Microsoft.Network/loadBalancers" -> {
+                // azurerm's flatteners scan every frontend for id + private IP fields, and
+                // lb_rule/probe/nat_rule child resources read-modify-write these arrays on
+                // the parent, so entries must echo with well-formed ARM ids. Every collection
+                // must EXIST even when empty — real Azure always returns them, and azurerm v3
+                // child resources deref the collection unguarded (probe_resource panics on a
+                // missing probes array).
+                stampChildArray(properties, "frontendIPConfigurations", id, entryProps -> {
+                    entryProps.putIfAbsent("privateIPAllocationMethod", "Dynamic");
+                    entryProps.putIfAbsent("privateIPAddress", "10.0.0.6");
+                });
+                properties.putIfAbsent("frontendIPConfigurations", new ArrayList<>());
+                for (String segment : List.of("backendAddressPools", "loadBalancingRules",
+                        "probes", "inboundNatRules", "inboundNatPools", "outboundRules")) {
+                    stampChildArray(properties, segment, id, entryProps -> { });
+                    properties.putIfAbsent(segment, new ArrayList<>());
+                }
+            }
+            case "Microsoft.Network/networkSecurityGroups" -> {
+                stampChildArray(properties, "securityRules", id, entryProps -> { });
+                properties.putIfAbsent("securityRules", new ArrayList<>());
+                properties.putIfAbsent("defaultSecurityRules", defaultSecurityRules(id));
+            }
+            case "Microsoft.Network/applicationGateways" -> {
+                // azurerm builds child sub-resource ids itself and sends them in the PUT, so
+                // echo is usually enough — but its flatteners parse every id and fail the
+                // apply on a malformed one, so ids synthesized here must use the exact
+                // {agwId}/{segment}/{name} form.
+                for (String segment : List.of("gatewayIPConfigurations", "frontendIPConfigurations",
+                        "frontendPorts", "httpListeners", "backendAddressPools",
+                        "backendHttpSettingsCollection", "requestRoutingRules", "probes",
+                        "sslCertificates", "urlPathMaps", "redirectConfigurations")) {
+                    stampChildArray(properties, segment, id, entryProps -> { });
+                }
+                properties.putIfAbsent("operationalState", "Running");
+            }
             case "Microsoft.Network/privateLinkServices" -> {
                 properties.putIfAbsent("alias",
                         name + "." + java.util.UUID.randomUUID() + ".azure.privatelinkservice");
@@ -165,6 +299,78 @@ public class NetworkService {
             }
             default -> { }
         }
+    }
+
+    /**
+     * Stamps each entry of an inline child array with its ARM id
+     * ({@code {parentId}/{segment}/{name}}), a Succeeded provisioningState, and
+     * segment-specific property defaults. Existing ids are kept — azurerm sends
+     * self-built ids for Application Gateway children and they must echo untouched.
+     */
+    @SuppressWarnings("unchecked")
+    private static void stampChildArray(Map<String, Object> properties, String segment, String parentId,
+                                        java.util.function.Consumer<Map<String, Object>> defaults) {
+        if (!(properties.get(segment) instanceof List<?> items) || items.isEmpty()) {
+            return;
+        }
+        List<Object> stamped = new ArrayList<>(items.size());
+        int index = 0;
+        for (Object item : items) {
+            index++;
+            Map<String, Object> entry = new LinkedHashMap<>(cast(item));
+            String name = bodyString(entry, "name", segment + index);
+            entry.put("name", name);
+            entry.putIfAbsent("id", parentId + "/" + segment + "/" + name);
+            Map<String, Object> entryProps = new LinkedHashMap<>(cast(entry.get("properties")));
+            defaults.accept(entryProps);
+            entryProps.put("provisioningState", "Succeeded");
+            entry.put("properties", entryProps);
+            stamped.add(entry);
+        }
+        properties.put(segment, stamped);
+    }
+
+    /**
+     * The six default rules every real NSG carries, from the Network 2025-01-01 spec's
+     * NetworkSecurityGroupGet example. Terraform never reads them; az and the SDKs do.
+     */
+    private static List<Object> defaultSecurityRules(String nsgId) {
+        record Rule(String name, String description, String sourceAddressPrefix,
+                    String destinationAddressPrefix, String access, int priority, String direction) { }
+        List<Rule> rules = List.of(
+                new Rule("AllowVnetInBound", "Allow inbound traffic from all VMs in VNET",
+                        "VirtualNetwork", "VirtualNetwork", "Allow", 65000, "Inbound"),
+                new Rule("AllowAzureLoadBalancerInBound", "Allow inbound traffic from azure load balancer",
+                        "AzureLoadBalancer", "*", "Allow", 65001, "Inbound"),
+                new Rule("DenyAllInBound", "Deny all inbound traffic",
+                        "*", "*", "Deny", 65500, "Inbound"),
+                new Rule("AllowVnetOutBound", "Allow outbound traffic from all VMs to all VMs in VNET",
+                        "VirtualNetwork", "VirtualNetwork", "Allow", 65000, "Outbound"),
+                new Rule("AllowInternetOutBound", "Allow outbound traffic from all VMs to Internet",
+                        "*", "Internet", "Allow", 65001, "Outbound"),
+                new Rule("DenyAllOutBound", "Deny all outbound traffic",
+                        "*", "*", "Deny", 65500, "Outbound"));
+
+        List<Object> result = new ArrayList<>(rules.size());
+        for (Rule rule : rules) {
+            Map<String, Object> props = new LinkedHashMap<>();
+            props.put("description", rule.description());
+            props.put("protocol", "*");
+            props.put("sourcePortRange", "*");
+            props.put("destinationPortRange", "*");
+            props.put("sourceAddressPrefix", rule.sourceAddressPrefix());
+            props.put("destinationAddressPrefix", rule.destinationAddressPrefix());
+            props.put("access", rule.access());
+            props.put("priority", rule.priority());
+            props.put("direction", rule.direction());
+            props.put("provisioningState", "Succeeded");
+            Map<String, Object> entry = new LinkedHashMap<>();
+            entry.put("name", rule.name());
+            entry.put("id", nsgId + "/defaultSecurityRules/" + rule.name());
+            entry.put("properties", props);
+            result.add(entry);
+        }
+        return result;
     }
 
     private static String resourceType(String tail) {
@@ -1043,7 +1249,7 @@ public class NetworkService {
             nicKey = key(sub, rg, "networkInterfaces/" + nicName);
             nicId = "/subscriptions/" + sub + "/resourceGroups/" + rg + "/providers/Microsoft.Network/networkInterfaces/" + nicName;
             Map<String, Object> nicProps = new LinkedHashMap<>();
-            synthesizeProperties("Microsoft.Network/networkInterfaces", nicName, nicProps);
+            synthesizeProperties("Microsoft.Network/networkInterfaces", nicName, nicId, nicProps);
             nicProps.put("provisioningState", "Succeeded");
             Map<String, Object> nic = new LinkedHashMap<>();
             nic.put("_sub", sub);

--- a/src/test/java/io/floci/az/services/network/NetworkHandlerTest.java
+++ b/src/test/java/io/floci/az/services/network/NetworkHandlerTest.java
@@ -568,4 +568,182 @@ class NetworkHandlerTest {
                 .then().statusCode(200)
                 .body("value", hasSize(0));
     }
+
+    @Test
+    void loadBalancerEchoesSkuAndSynthesizesFrontendIds() {
+        String lbBody = """
+                {
+                  "location": "eastus",
+                  "sku": {"name": "Standard", "tier": "Regional"},
+                  "properties": {
+                    "frontendIPConfigurations": [
+                      {"name": "internal", "properties": {"subnet": {"id": "/subscriptions/test-sub-net/resourceGroups/test-rg-net/providers/Microsoft.Network/virtualNetworks/vnet1/subnets/sub1"}}}
+                    ],
+                    "loadBalancingRules": [
+                      {"name": "rule1", "properties": {"protocol": "Tcp", "frontendPort": 80, "backendPort": 8080}}
+                    ]
+                  }
+                }
+                """;
+
+        String lbId = BASE.replace("/subscriptions", "/subscriptions") + "/loadBalancers/lb1";
+        given().contentType("application/json").body(lbBody)
+                .when().put(BASE + "/loadBalancers/lb1" + API)
+                .then().statusCode(200)
+                .body("sku.name", equalTo("Standard"))
+                .body("sku.tier", equalTo("Regional"))
+                .body("properties.frontendIPConfigurations[0].id",
+                        equalTo(lbId + "/frontendIPConfigurations/internal"))
+                .body("properties.frontendIPConfigurations[0].properties.privateIPAllocationMethod",
+                        equalTo("Dynamic"))
+                .body("properties.frontendIPConfigurations[0].properties.provisioningState",
+                        equalTo("Succeeded"))
+                .body("properties.loadBalancingRules[0].id", equalTo(lbId + "/loadBalancingRules/rule1"))
+                .body("properties.provisioningState", equalTo("Succeeded"));
+
+        given().when().get(BASE + "/loadBalancers/lb1" + API)
+                .then().statusCode(200)
+                .body("sku.name", equalTo("Standard"));
+    }
+
+    @Test
+    void loadBalancerBackendAddressPoolChildEndpointSyncsWithParent() {
+        given().contentType("application/json")
+                .body("{\"location\": \"eastus\", \"sku\": {\"name\": \"Standard\"}, \"properties\": {}}")
+                .when().put(BASE + "/loadBalancers/lb1" + API)
+                .then().statusCode(200);
+
+        given().contentType("application/json").body("{\"properties\": {}}")
+                .when().put(BASE + "/loadBalancers/lb1/backendAddressPools/pool1" + API)
+                .then().statusCode(200)
+                .body("name", equalTo("pool1"))
+                .body("id", equalTo(BASE + "/loadBalancers/lb1/backendAddressPools/pool1"))
+                .body("properties.provisioningState", equalTo("Succeeded"));
+
+        given().when().get(BASE + "/loadBalancers/lb1/backendAddressPools/pool1" + API)
+                .then().statusCode(200)
+                .body("name", equalTo("pool1"));
+
+        given().when().get(BASE + "/loadBalancers/lb1/backendAddressPools" + API)
+                .then().statusCode(200)
+                .body("value", hasSize(1));
+
+        given().when().get(BASE + "/loadBalancers/lb1" + API)
+                .then().statusCode(200)
+                .body("properties.backendAddressPools[0].name", equalTo("pool1"));
+
+        given().when().delete(BASE + "/loadBalancers/lb1/backendAddressPools/pool1" + API)
+                .then().statusCode(200);
+
+        given().when().get(BASE + "/loadBalancers/lb1/backendAddressPools/pool1" + API)
+                .then().statusCode(404);
+
+        given().when().get(BASE + "/loadBalancers/lb1" + API)
+                .then().statusCode(200)
+                .body("properties.backendAddressPools", hasSize(0));
+    }
+
+    @Test
+    void networkSecurityGroupSynthesizesRuleIdsAndDefaultRules() {
+        String nsgBody = """
+                {
+                  "location": "eastus",
+                  "properties": {
+                    "securityRules": [
+                      {"name": "allow-https", "properties": {
+                        "protocol": "Tcp", "sourcePortRange": "*", "destinationPortRange": "443",
+                        "sourceAddressPrefix": "*", "destinationAddressPrefix": "*",
+                        "access": "Allow", "priority": 100, "direction": "Inbound"}}
+                    ]
+                  }
+                }
+                """;
+
+        given().contentType("application/json").body(nsgBody)
+                .when().put(BASE + "/networkSecurityGroups/nsg1" + API)
+                .then().statusCode(200)
+                .body("properties.securityRules[0].id",
+                        equalTo(BASE + "/networkSecurityGroups/nsg1/securityRules/allow-https"))
+                .body("properties.securityRules[0].properties.provisioningState", equalTo("Succeeded"))
+                .body("properties.defaultSecurityRules", hasSize(6))
+                .body("properties.defaultSecurityRules[0].name", equalTo("AllowVnetInBound"))
+                .body("properties.defaultSecurityRules[0].id",
+                        equalTo(BASE + "/networkSecurityGroups/nsg1/defaultSecurityRules/AllowVnetInBound"))
+                .body("properties.defaultSecurityRules[2].properties.access", equalTo("Deny"))
+                .body("properties.defaultSecurityRules[2].properties.priority", equalTo(65500));
+
+        given().when().get(BASE + "/networkSecurityGroups/nsg1/defaultSecurityRules" + API)
+                .then().statusCode(200)
+                .body("value", hasSize(6));
+
+        given().when().get(BASE + "/networkSecurityGroups/nsg1/defaultSecurityRules/DenyAllInBound" + API)
+                .then().statusCode(200)
+                .body("properties.direction", equalTo("Inbound"));
+    }
+
+    @Test
+    void networkSecurityRuleChildEndpointSyncsWithParent() {
+        given().contentType("application/json").body("{\"location\": \"eastus\", \"properties\": {}}")
+                .when().put(BASE + "/networkSecurityGroups/nsg1" + API)
+                .then().statusCode(200);
+
+        String ruleBody = """
+                {"properties": {
+                  "protocol": "Tcp", "sourcePortRange": "*", "destinationPortRange": "22",
+                  "sourceAddressPrefix": "10.0.0.0/8", "destinationAddressPrefix": "*",
+                  "access": "Allow", "priority": 200, "direction": "Inbound"}}
+                """;
+
+        given().contentType("application/json").body(ruleBody)
+                .when().put(BASE + "/networkSecurityGroups/nsg1/securityRules/allow-ssh" + API)
+                .then().statusCode(200)
+                .body("name", equalTo("allow-ssh"))
+                .body("id", equalTo(BASE + "/networkSecurityGroups/nsg1/securityRules/allow-ssh"))
+                .body("properties.priority", equalTo(200));
+
+        given().when().get(BASE + "/networkSecurityGroups/nsg1" + API)
+                .then().statusCode(200)
+                .body("properties.securityRules[0].name", equalTo("allow-ssh"));
+
+        given().when().delete(BASE + "/networkSecurityGroups/nsg1/securityRules/allow-ssh" + API)
+                .then().statusCode(200);
+
+        given().when().get(BASE + "/networkSecurityGroups/nsg1/securityRules/allow-ssh" + API)
+                .then().statusCode(404);
+    }
+
+    @Test
+    void applicationGatewayEchoesChildIdsAndSynthesizesAbsentOnes() {
+        String agwId = BASE + "/applicationGateways/agw1";
+        String agwBody = """
+                {
+                  "location": "eastus",
+                  "properties": {
+                    "sku": {"name": "Standard_v2", "tier": "Standard_v2", "capacity": 1},
+                    "frontendPorts": [
+                      {"name": "port80", "properties": {"port": 80}}
+                    ],
+                    "httpListeners": [
+                      {"name": "listener1",
+                       "id": "%s/httpListeners/listener1",
+                       "properties": {
+                         "frontendIPConfiguration": {"id": "%s/frontendIPConfigurations/feip"},
+                         "frontendPort": {"id": "%s/frontendPorts/port80"},
+                         "protocol": "Http"}}
+                    ]
+                  }
+                }
+                """.formatted(agwId, agwId, agwId);
+
+        given().contentType("application/json").body(agwBody)
+                .when().put(BASE + "/applicationGateways/agw1" + API)
+                .then().statusCode(200)
+                .body("properties.sku.name", equalTo("Standard_v2"))
+                .body("properties.frontendPorts[0].id", equalTo(agwId + "/frontendPorts/port80"))
+                .body("properties.httpListeners[0].id", equalTo(agwId + "/httpListeners/listener1"))
+                .body("properties.httpListeners[0].properties.frontendPort.id",
+                        equalTo(agwId + "/frontendPorts/port80"))
+                .body("properties.operationalState", equalTo("Running"))
+                .body("properties.provisioningState", equalTo("Succeeded"));
+    }
 }


### PR DESCRIPTION
## Summary

Realistic property synthesis for `Microsoft.Network` load balancers, network security groups, and application gateways, so `azurerm_lb*`, `azurerm_network_security_*`, and `azurerm_application_gateway` apply and read back cleanly (services.md roadmap item 1).

- **Load balancers**: top-level `sku` round-trips (azurerm reads it from the response model), frontend configurations get ARM ids + private-IP defaults, and **every child collection is always present, empty included** — matching real Azure, and required because azurerm v3 child resources (probe/rule) deref the arrays unguarded during read-modify-write.
- **Child endpoints** for LB `backendAddressPools` and NSG `securityRules` (the routes azurerm actually manages them through), with the parent array as the single source of truth; also fixes those paths being stored as mis-typed siblings.
- **NSGs**: rule ids + the six real-Azure `defaultSecurityRules` (spec example fixture).
- **Application gateways**: child sub-resources echo with well-formed ARM ids (synthesized only when absent — azurerm's flatteners parse every id and fail the apply on malformed ones), `operationalState: Running`.
- ARM envelope fields (`sku`/`zones`/`identity`) now round-trip for all Microsoft.Network types.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

Grounded in the api-versions azurerm pins: LB `network/2023-09-01`, NSG + AGW `network/2025-01-01` (provider checkout e6c4fe66; read functions in `lb_resource.go`, `network_security_group_resource.go`, `application_gateway_resource.go`), plus the REST spec's `LoadBalancerGet`/`NetworkSecurityGroupGet` examples. Verified end to end against azurerm v3.117.1 via the Terraform suite (a missing `probes` array crashes the provider — reproduced, then fixed by always-present collections).

## Checklist

- [x] `./mvnw test` passes locally (474 tests, 5 new NetworkHandlerTest cases)
- [x] New or updated integration test added — NSG/LB/AGW resources + spot checks added to BOTH the Terraform (18/18) and OpenTofu (20/20) suites
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)