### PR TITLE
fix(servicebus): stop the CBS responder from exhausting file descriptors

### DIFF
--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusCbsResponder.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusCbsResponder.java
@@ -34,6 +34,7 @@ public class ServiceBusCbsResponder {
     private static final Logger LOG = Logger.getLogger(ServiceBusCbsResponder.class);
     private static final String CBS_ADDRESS = "$cbs";
     private static final String CBS_INTERCEPT_ADDRESS = "$cbs-intercept";
+    private static final long RECONNECT_BACKOFF_MS = 2_000;
 
     private final String host;
     private final int port;
@@ -67,22 +68,42 @@ public class ServiceBusCbsResponder {
 
     private void run() {
         while (running) {
+            Reactor reactor = null;
             try {
-                Reactor reactor = Proton.reactor(new CbsHandler());
+                reactor = Proton.reactor(new CbsHandler());
                 currentReactor = reactor;
                 reactor.run();
             } catch (Exception e) {
                 if (running) {
                     LOG.debugv("CBS responder reconnecting ({0}:{1}): {2}", host, port, e.getMessage());
-                    try {
-                        Thread.sleep(2_000);
-                    } catch (InterruptedException ie) {
-                        Thread.currentThread().interrupt();
-                        return;
-                    }
                 }
             } finally {
                 currentReactor = null;
+                if (reactor != null) {
+                    try {
+                        reactor.free();
+                    } catch (Exception e) {
+                        LOG.debugv("CBS responder failed to free reactor ({0}:{1}): {2}",
+                                host, port, e.getMessage());
+                    }
+                }
+            }
+
+            // Back off between reactor lifecycles.
+            //
+            // This MUST sit outside the catch. The reactor also returns *normally* when the broker
+            // is unreachable or the connection closes -- no exception is thrown -- so a backoff
+            // that only runs on the exception path never fires in the common case. The loop then
+            // re-creates a Reactor (and its selector + wakeup pipe, i.e. fresh file descriptors)
+            // as fast as the CPU allows, exhausting the process FD limit within a second and
+            // taking down every unrelated socket in the JVM with it.
+            if (running) {
+                try {
+                    Thread.sleep(RECONNECT_BACKOFF_MS);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
             }
         }
     }

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusContainerManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusContainerManager.java
@@ -11,9 +11,12 @@ import org.jboss.logging.Logger;
 /**
  * Lifecycle manager for Service Bus sidecar containers.
  *
- * When {@code mocked = false} (default), the default namespace starts automatically on boot.
- * Additional namespaces can be started on-demand via PUT /{account}-servicebus/namespaces/{ns}.
- * All running namespaces are stopped on application shutdown.
+ * When {@code mocked = false} (the default), a namespace starts on its first entity-management
+ * call -- not on boot. Namespaces can also be started explicitly via
+ * PUT /{account}-servicebus/namespaces/{ns}. All running namespaces are stopped on shutdown.
+ *
+ * <p>When {@code mocked = true}, no container is started and the namespace is management-plane
+ * state only: there is no AMQP data plane.
  */
 @ApplicationScoped
 public class ServiceBusContainerManager {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -120,6 +120,10 @@ floci-az:
       enabled: true
     event-hub:
       enabled: true
+      # Deliberately mocked: the Artemis sidecar starts fine, but the AMQP data plane does not yet
+      # work with the Azure SDKs (EventHubCompatibilityTest: 6/6 fail with "Connection reset").
+      # Do NOT flip this to false until that is fixed -- the compat suite self-skips on this flag,
+      # so flipping it turns a silent skip into 6 hard failures. See local/full-parity.md (C1).
       mocked: true
       default-namespace: emulatorNs1
       entities: "eh1:4"
@@ -146,6 +150,11 @@ floci-az:
       default-port: 0        # 0 = OS picks a free port per server (recommended)
     service-bus:
       enabled: true
+      # Deliberately mocked: the Artemis sidecar starts fine, but every SDK send fails with
+      # "payload exceeded maximum message size: 0 kb" -- Artemis attaches the link with
+      # max-message-size=0 ("no limit" per AMQP 1.0) and azure-core-amqp reads it literally
+      # (ReactorSender.getLinkSize). The maxMessageSize=... on the acceptor below is NOT a real
+      # Artemis parameter and is silently ignored. See local/full-parity.md (C1) before flipping.
       mocked: true
       amqp-port: 5673
       amqp-tls-port: 5674


### PR DESCRIPTION
## Summary

`ServiceBusCbsResponder.run()` placed its 2-second reconnect backoff inside the catch block, but Proton's `reactor.run()` returns **normally** (no exception) when the broker is unreachable or the connection closes — the common case. The backoff never fired: the loop re-created a Reactor (fresh selector + wakeup pipe) as fast as the CPU allowed, exhausting the JVM's file descriptors in under a second and taking every unrelated socket down with it. In practice this surfaced as dozens of bogus unrelated test errors (`NoClassDefFound`, "failed to load application.yml") all masking a single "Too many open files".

The backoff now applies on every loop iteration and each Reactor is freed before the next attempt. Also documents in `application.yml` why service-bus and event-hub stay mocked by default.

This closes infra finding 2 of the three documented Service Bus compat-infra issues (the host-mode fd storm).

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

n/a — internal responder lifecycle fix; no wire-shape changes.

## Checklist

- [x] `./mvnw test` passes locally (469 tests)
- [ ] New or updated integration test added — the failure mode needs a live unreachable broker plus fd-limit observation; reproduced and verified manually (fd count stable vs 1,600+/6s before). No deterministic unit harness for it yet.
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)