### PR TITLE
fix(blob): stop routing unimplemented comp operations to putBlob

### DIFF
--- a/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
+++ b/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
@@ -117,17 +117,24 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
                     response = Response.ok().build();
                 }
             } else {
-                response = new AzureErrorResponse("NotImplemented", "The requested operation is not implemented.")
-                        .toXmlResponse(501);
+                response = notImplemented();
             }
         } else {
             String[] parts = path.split("/", 2);
             String containerName = parts[0];
             String blobName = parts.length > 1 ? parts[1] : "";
 
+            String comp = query.get("comp");
+
             if (blobName.isEmpty()) {
-                if ("GET".equalsIgnoreCase(method) && "list".equals(query.get("comp"))) {
+                if ("GET".equalsIgnoreCase(method) && "list".equals(comp)) {
                     response = listBlobs(request, containerName);
+                } else if (comp != null) {
+                    // Container ops are multiplexed onto the same URL by `comp` (metadata, acl,
+                    // lease, ...). None are implemented. This branch must stay ABOVE the
+                    // restype=container ones: they ignore `comp`, so SetContainerMetadata would
+                    // otherwise land in createContainer and answer 409.
+                    response = notImplemented();
                 } else if ("PUT".equalsIgnoreCase(method) && "container".equals(query.get("restype"))) {
                     response = createContainer(request, containerName);
                 } else if ("DELETE".equalsIgnoreCase(method) && "container".equals(query.get("restype"))) {
@@ -135,11 +142,9 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
                 } else if (("GET".equalsIgnoreCase(method) || "HEAD".equalsIgnoreCase(method)) && "container".equals(query.get("restype"))) {
                     response = getContainer(request, containerName, "HEAD".equalsIgnoreCase(method));
                 } else {
-                    response = new AzureErrorResponse("NotImplemented", "The requested operation is not implemented.")
-                            .toXmlResponse(501);
+                    response = notImplemented();
                 }
             } else {
-                String comp = query.get("comp");
                 if ("PUT".equalsIgnoreCase(method) && "metadata".equals(comp)) {
                     response = setBlobMetadata(request, containerName, blobName);
                 } else if (("GET".equalsIgnoreCase(method) || "HEAD".equalsIgnoreCase(method))
@@ -152,15 +157,14 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
                 } else if (("GET".equalsIgnoreCase(method) || "HEAD".equalsIgnoreCase(method))
                         && "blocklist".equals(comp)) {
                     response = getBlockList(request, containerName, blobName);
-                } else if ("PUT".equalsIgnoreCase(method)) {
+                } else if ("PUT".equalsIgnoreCase(method) && isPutBlob(request, comp)) {
                     response = putBlob(request, containerName, blobName);
                 } else if ("GET".equalsIgnoreCase(method) || "HEAD".equalsIgnoreCase(method)) {
                     response = getBlob(request, containerName, blobName, "HEAD".equalsIgnoreCase(method));
                 } else if ("DELETE".equalsIgnoreCase(method)) {
                     response = deleteBlob(request, containerName, blobName);
                 } else {
-                    response = new AzureErrorResponse("NotImplemented", "The requested operation is not implemented.")
-                            .toXmlResponse(501);
+                    response = notImplemented();
                 }
             }
         }
@@ -180,6 +184,27 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
                     .toXmlResponse(Response.Status.FORBIDDEN.getStatusCode());
         }
         return userDelegationKeyService.create(request);
+    }
+
+    private Response notImplemented() {
+        return new AzureErrorResponse("NotImplemented", "The requested operation is not implemented.")
+                .toXmlResponse(501);
+    }
+
+    /**
+     * True only for a genuine PutBlob.
+     *
+     * <p>Azure multiplexes many operations onto {@code PUT /{container}/{blob}}: the {@code comp}
+     * values this handler does not implement (lease, snapshot, properties, tier, tags, page,
+     * appendblock, ...), plus CopyBlob and the Data Lake rename, which carry no {@code comp} at all
+     * and are discriminated by a header. Routing any of those to {@code putBlob} replaces the blob
+     * with the request body — usually empty — and answers 201, so the caller sees success while the
+     * content is destroyed. Only an unqualified PUT is a PutBlob.
+     */
+    private boolean isPutBlob(AzureRequest request, String comp) {
+        return comp == null
+                && request.headers().getHeaderString("x-ms-copy-source") == null
+                && request.headers().getHeaderString("x-ms-rename-source") == null;
     }
 
     private Response getBlobServiceProperties() {

--- a/src/test/java/io/floci/az/services/BlobCompDispatchTest.java
+++ b/src/test/java/io/floci/az/services/BlobCompDispatchTest.java
@@ -1,0 +1,168 @@
+package io.floci.az.services;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Guards the blob dispatch against the catch-all {@code PUT} that used to fall through to
+ * {@code putBlob} for every unrecognised {@code comp} value.
+ *
+ * <p>Azure's blob endpoint multiplexes many operations onto {@code PUT /{container}/{blob}},
+ * discriminated by {@code comp} (lease, snapshot, properties, tier, tags, page, appendblock) or by
+ * a header ({@code x-ms-copy-source}). None of those are implemented here. Before this guard they
+ * were all routed to {@code putBlob}, which <em>replaced the blob with the request body</em> —
+ * usually empty — and answered {@code 201 Created}. The SDK saw success while the data was gone.
+ *
+ * <p>These tests pin the two invariants that matter: an unimplemented operation must (1) not be
+ * mistaken for a PutBlob, and (2) leave existing content untouched. Implementing any of these
+ * operations for real should replace the corresponding {@code 501} expectation — not delete it.
+ */
+@QuarkusTest
+public class BlobCompDispatchTest {
+
+    private static final String ACCOUNT = "devstoreaccount1";
+    private static final String CONTAINER = "comp-dispatch";
+    private static final String BLOB = "victim.txt";
+    private static final String CONTENT = "original content";
+
+    @BeforeEach
+    void reset() {
+        given().post("/_admin/reset").then().statusCode(204);
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER)
+                .then().statusCode(201);
+        given()
+                .header("x-ms-blob-type", "BlockBlob")
+                .contentType("text/plain")
+                .body(CONTENT)
+                .when().put("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB)
+                .then().statusCode(201);
+    }
+
+    private void assertBlobIntact() {
+        given()
+                .when().get("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB)
+                .then().statusCode(200).body(equalTo(CONTENT));
+    }
+
+    /**
+     * Every {@code comp} Azure defines on {@code PUT /{container}/{blob}} that floci-az does not
+     * implement. Each one used to be answered by putBlob with a 201 and an empty body.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "lease", "snapshot", "properties", "tier", "tags",
+            "page", "appendblock", "undelete", "expiry", "seal"
+    })
+    void unimplementedBlobCompIsNotMistakenForPutBlob(String comp) {
+        given()
+                .when().put("/{account}/{container}/{blob}?comp={comp}", ACCOUNT, CONTAINER, BLOB, comp)
+                .then().statusCode(501);
+
+        assertBlobIntact();
+    }
+
+    @Test
+    void copyBlobIsNotMistakenForPutBlob() {
+        given()
+                .header("x-ms-copy-source",
+                        "http://127.0.0.1:4577/" + ACCOUNT + "/" + CONTAINER + "/source.txt")
+                .when().put("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, "copy-target.txt")
+                .then().statusCode(501);
+
+        // The destination must not exist: the old behaviour created an empty blob and reported 201.
+        given()
+                .when().get("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, "copy-target.txt")
+                .then().statusCode(404);
+    }
+
+    @Test
+    void datalakeRenameIsNotMistakenForPutBlob() {
+        given()
+                .header("x-ms-rename-source", "/" + CONTAINER + "/" + BLOB)
+                .when().put("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, "renamed.txt")
+                .then().statusCode(501);
+
+        assertBlobIntact();
+        given()
+                .when().get("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, "renamed.txt")
+                .then().statusCode(404);
+    }
+
+    /**
+     * Container-level ops are discriminated the same way, but the old ladder tested
+     * {@code restype=container} <em>before</em> any {@code comp}, so SetContainerMetadata and
+     * SetContainerAccessPolicy both landed in createContainer and answered 409 — a hard failure for
+     * {@code containerClient.setMetadata()}.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"metadata", "acl", "lease"})
+    void unimplementedContainerCompIsNotMistakenForCreateContainer(String comp) {
+        given()
+                .when().put("/{account}/{container}?restype=container&comp={comp}",
+                        ACCOUNT, CONTAINER, comp)
+                .then().statusCode(501);
+    }
+
+    /**
+     * GetContainerAccessPolicy used to fall to getContainer and answer 200 with an empty body,
+     * which the SDK then failed to deserialise as SignedIdentifiers.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"acl", "metadata"})
+    void unimplementedContainerCompOnGetIsNotMistakenForGetContainer(String comp) {
+        given()
+                .when().get("/{account}/{container}?restype=container&comp={comp}",
+                        ACCOUNT, CONTAINER, comp)
+                .then().statusCode(501);
+    }
+
+    // --- the operations that ARE implemented must keep working ---
+
+    @Test
+    void putBlobStillWorks() {
+        given()
+                .header("x-ms-blob-type", "BlockBlob")
+                .contentType("text/plain")
+                .body("replacement")
+                .when().put("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB)
+                .then().statusCode(201);
+
+        given()
+                .when().get("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB)
+                .then().statusCode(200).body(equalTo("replacement"));
+    }
+
+    @Test
+    void setBlobMetadataStillWorks() {
+        given()
+                .header("x-ms-meta-owner", "compat")
+                .when().put("/{account}/{container}/{blob}?comp=metadata", ACCOUNT, CONTAINER, BLOB)
+                .then().statusCode(200);
+
+        given()
+                .when().get("/{account}/{container}/{blob}?comp=metadata", ACCOUNT, CONTAINER, BLOB)
+                .then().statusCode(200).header("x-ms-meta-owner", "compat");
+
+        assertBlobIntact();
+    }
+
+    @Test
+    void getContainerPropertiesStillWorks() {
+        given()
+                .when().get("/{account}/{container}?restype=container", ACCOUNT, CONTAINER)
+                .then().statusCode(200);
+    }
+
+    @Test
+    void listBlobsStillWorks() {
+        given()
+                .when().get("/{account}/{container}?restype=container&comp=list", ACCOUNT, CONTAINER)
+                .then().statusCode(200);
+    }
+}


### PR DESCRIPTION
## Summary

A data-corruption fix. Azure multiplexes many operations onto `PUT /{container}/{blob}`, discriminated by `comp` (lease, snapshot, properties, tier, tags, page, appendblock) or by a header (`x-ms-copy-source`, `x-ms-rename-source`). None are implemented here, and the dispatch ladder ended in an unguarded `else if (PUT)` → `putBlob`: all of them **replaced the blob with the request body** — usually empty — and answered 201 Created, so SDK callers saw success while the content was destroyed.

Only an unqualified PUT is a PutBlob now; everything else answers `501 NotImplemented` in the Azure XML error shape, so callers get an honest failure instead of silent data loss.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

The incorrect behavior: `blobClient.setHttpHeaders(...)` (and lease/snapshot/tier/tags/copy calls) wiped blob content and returned success. Verified against the unmodified handler before fixing. The comp/header discrimination follows the Blob REST operation table in azure-rest-api-specs (`storage/data-plane/Microsoft.BlobStorage`).

## Checklist

- [x] `./mvnw test` passes locally (490 tests)
- [x] New or updated integration test added — `BlobCompDispatchTest` (21 cases: each unimplemented comp answers 501 and leaves content intact; genuine PutBlob still works)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)