### PR TITLE
chore(test): compare delegation-key expiry as instants, not strings

### DIFF
--- a/src/test/java/io/floci/az/services/BlobServiceTest.java
+++ b/src/test/java/io/floci/az/services/BlobServiceTest.java
@@ -151,7 +151,11 @@ public class BlobServiceTest {
 
         assertThat(XmlParser.extractFirst(response, "SignedStart", null),
                 matchesPattern(ISO_UTC_SECONDS));
-        assertThat(XmlParser.extractFirst(response, "SignedExpiry", null), equalTo(expiry));
+        // Compare instants, not strings: OffsetDateTime.toString() omits the seconds field
+        // when it is :00, so a string comparison fails whenever the test runs at a
+        // zero-second wall-clock instant (1-in-60 flake).
+        assertThat(OffsetDateTime.parse(XmlParser.extractFirst(response, "SignedExpiry", null)).toInstant(),
+                equalTo(OffsetDateTime.parse(expiry).toInstant()));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes a 1-in-60 flaky test. `getUserDelegationKeyDefaultsMissingStart` builds its expected expiry with `OffsetDateTime.toString()`, which omits the seconds field when it is `:00` — so whenever CI runs at a zero-second wall-clock instant the expected string (`…T05:42Z`) mismatches the emulator's full `…T05:42:00Z`. First seen failing PR #154's unrelated CI run. The assertion now parses both sides to `Instant`, making it format-independent.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## Azure Compatibility

n/a — test-only; no emulator behavior changes.

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added — n/a, fixes an existing test's flaky assertion
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)