### PR TITLE
feat(docker): label emulator containers and volumes, centralize the floci-az name prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **docker:** every emulator-created container and volume is now labelled `floci=true`
+  (umbrella across the Floci emulators) and `floci_emulator=floci-az` (per-emulator
+  discriminator), applied centrally in the container lifecycle layer — so
+  `docker ps --filter label=floci_emulator=floci-az` and
+  `docker volume prune --filter label=floci_emulator=floci-az` target this emulator
+  alone, while `label=floci=true` still matches all Floci emulators. The `floci-az-`
+  name prefix is now owned by a single naming helper instead of being spelled at each
+  call site (container names are unchanged), the Functions runtime container is created
+  through the shared container layer (it previously bypassed it and carried no labels),
+  and the AKS k3s volume is created explicitly so it is labelled too. New optional
+  `floci-az.docker.resource-namespace` (`FLOCI_AZ_DOCKER_RESOURCE_NAMESPACE`) inserts a
+  namespace into child container/volume names (`floci-az-<ns>-...`) and a
+  `floci_namespace` label, for running multiple emulator processes against one Docker
+  daemon. Note: with a namespace set, the Event Hubs broker certificate SAN
+  (`floci-az-artemis`) does not cover the namespaced container name for in-network TLS
+  clients — connect via `localhost` in that setup.
+
+### Added
+
 - **Network**: realistic property synthesis for `Microsoft.Network` load balancers
   (top-level `sku` round-trip, frontend/rule/pool ARM IDs), network security groups
   (rule IDs, the six real-Azure `defaultSecurityRules`, standalone `securityRules`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `floci-az.docker.resource-namespace` (`FLOCI_AZ_DOCKER_RESOURCE_NAMESPACE`) inserts a
   namespace into child container/volume names (`floci-az-<ns>-...`) and a
   `floci_namespace` label, for running multiple emulator processes against one Docker
-  daemon. Note: with a namespace set, the Event Hubs broker certificate SAN
+  daemon. Docker volume labels are immutable, so volumes created by earlier versions
+  keep no labels until recreated (the AKS k3s volume is deleted on shutdown by default,
+  so this resolves itself); such volumes can be listed with
+  `docker volume ls --filter name=floci-az-` and removed manually if needed. Note: with a namespace set, the Event Hubs broker certificate SAN
   (`floci-az-artemis`) does not cover the namespaced container name for in-network TLS
   clients — connect via `localhost` in that setup.
 

--- a/docs/configuration/advanced/application-yml.md
+++ b/docs/configuration/advanced/application-yml.md
@@ -56,6 +56,7 @@ floci-az:
     docker-host: unix:///var/run/docker.sock
     log-max-size: "10m"
     log-max-file: "3"
+    resource-namespace: ""            # Optional; inserted into sidecar container/volume names (floci-az-<ns>-...)
 
   services:
     blob:

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,11 @@
             <artifactId>rest-assured</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5-mockito</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/io/floci/az/config/EmulatorConfig.java
+++ b/src/main/java/io/floci/az/config/EmulatorConfig.java
@@ -685,6 +685,12 @@ public interface EmulatorConfig {
         /** Path to a directory containing Docker's config.json. */
         Optional<String> dockerConfigPath();
 
+        /**
+         * Optional namespace inserted into emulator-managed child container and volume names.
+         * Useful when multiple emulator processes share one Docker daemon.
+         */
+        Optional<String> resourceNamespace();
+
         /** Explicit credentials for private Docker registries. */
         @WithDefault("")
         List<RegistryCredential> registryCredentials();

--- a/src/main/java/io/floci/az/core/docker/ContainerBuilder.java
+++ b/src/main/java/io/floci/az/core/docker/ContainerBuilder.java
@@ -63,6 +63,7 @@ public class ContainerBuilder {
         private final List<Mount> mounts = new ArrayList<>();
         private final List<Bind> binds = new ArrayList<>();
         private final List<String> extraHosts = new ArrayList<>();
+        private final Map<String, String> labels = new HashMap<>();
         private LogConfig logConfig;
         private boolean privileged;
         private final List<String> dnsServers = new ArrayList<>();
@@ -187,6 +188,16 @@ public class ContainerBuilder {
             return this;
         }
 
+        public Builder withLabel(String key, String value) {
+            this.labels.put(key, value);
+            return this;
+        }
+
+        public Builder withLabels(Map<String, String> labels) {
+            this.labels.putAll(labels);
+            return this;
+        }
+
         public Builder withExtraHost(String hostname, String ip) {
             this.extraHosts.add(hostname + ":" + ip);
             return this;
@@ -232,6 +243,7 @@ public class ContainerBuilder {
                     List.copyOf(mounts),
                     List.copyOf(binds),
                     List.copyOf(extraHosts),
+                    Map.copyOf(labels),
                     logConfig,
                     privileged,
                     List.copyOf(dnsServers),

--- a/src/main/java/io/floci/az/core/docker/ContainerLifecycleManager.java
+++ b/src/main/java/io/floci/az/core/docker/ContainerLifecycleManager.java
@@ -1,6 +1,7 @@
 package io.floci.az.core.docker;
 
 import com.github.dockerjava.api.DockerClient;
+import io.floci.az.config.EmulatorConfig;
 import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.command.CreateContainerCmd;
 import com.github.dockerjava.api.command.CreateContainerResponse;
@@ -42,16 +43,19 @@ public class ContainerLifecycleManager {
     private final ImageCacheService imageCacheService;
     private final ContainerDetector containerDetector;
     private final PortAllocator portAllocator;
+    private final EmulatorConfig config;
 
     @Inject
     public ContainerLifecycleManager(DockerClient dockerClient,
                                      ImageCacheService imageCacheService,
                                      ContainerDetector containerDetector,
-                                     PortAllocator portAllocator) {
+                                     PortAllocator portAllocator,
+                                     EmulatorConfig config) {
         this.dockerClient = dockerClient;
         this.imageCacheService = imageCacheService;
         this.containerDetector = containerDetector;
         this.portAllocator = portAllocator;
+        this.config = config;
     }
 
     public ContainerInfo createAndStart(ContainerSpec spec) {
@@ -82,6 +86,7 @@ public class ContainerLifecycleManager {
                     .toArray(ExposedPort[]::new);
             createCmd.withExposedPorts(exposed);
         }
+        createCmd.withLabels(mergedLabels(spec.labels()));
 
         CreateContainerResponse response = createCmd.exec();
         String containerId = response.getId();
@@ -138,14 +143,29 @@ public class ContainerLifecycleManager {
         }
     }
 
+    /**
+     * Creates a named volume if it does not already exist. Idempotent — safe to call on every
+     * container start. Labels the volume {@code floci=true} and {@code floci_emulator=floci-az}
+     * so both {@code docker volume prune --filter label=floci=true} (all emulators) and
+     * {@code --filter label=floci_emulator=floci-az} (this emulator only) work.
+     */
     public void ensureVolume(String volumeName) {
         if (!volumeExists(volumeName)) {
             dockerClient.createVolumeCmd()
                     .withName(volumeName)
-                    .withLabels(Map.of("floci", "true"))
+                    .withLabels(ContainerStorageHelper.defaultLabels(config))
                     .exec();
             LOG.debugv("Created volume {0}", volumeName);
         }
+    }
+
+    /** Default emulator labels merged with per-spec labels; spec labels win on collision. */
+    private Map<String, String> mergedLabels(Map<String, String> specLabels) {
+        Map<String, String> labels = ContainerStorageHelper.defaultLabels(config);
+        if (specLabels != null) {
+            labels.putAll(specLabels);
+        }
+        return labels;
     }
 
     public void removeVolume(String volumeName) {

--- a/src/main/java/io/floci/az/core/docker/ContainerSpec.java
+++ b/src/main/java/io/floci/az/core/docker/ContainerSpec.java
@@ -23,6 +23,7 @@ public record ContainerSpec(
         List<Mount> mounts,
         List<Bind> binds,
         List<String> extraHosts,
+        Map<String, String> labels,
         LogConfig logConfig,
         boolean privileged,
         List<String> dnsServers,
@@ -30,7 +31,7 @@ public record ContainerSpec(
 ) {
     public ContainerSpec(String image) {
         this(image, null, List.of(), null, null, null, Map.of(), List.of(), null,
-                List.of(), List.of(), List.of(), null, false, List.of(), null);
+                List.of(), List.of(), List.of(), Map.of(), null, false, List.of(), null);
     }
 
     public boolean hasPortBindings() {

--- a/src/main/java/io/floci/az/core/docker/ContainerStorageHelper.java
+++ b/src/main/java/io/floci/az/core/docker/ContainerStorageHelper.java
@@ -6,19 +6,32 @@ import org.jboss.logging.Logger;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
- * Central helper for child-container volume management.
+ * Central helper for Docker resource naming, labelling and child-container volume management.
  *
- * Two modes:
- * - Named-volume (default) — floci-az manages per-resource Docker named volumes.
- *   Active when {@code FLOCI_AZ_STORAGE_HOST_PERSISTENT_PATH} is not set to an absolute path.
- * - Host-path (legacy) — active when {@code host-persistent-path} is set to an absolute path;
- *   callers use bind-mounts to the specified directory instead.
+ * <p>Naming convention (shared across the Floci emulators): every emulator-created container
+ * and volume is named {@code floci-az-[<namespace>-]<service>-<id>} and labelled so it is
+ * attributable to exactly one emulator by name and by label. The prefix is owned here —
+ * call sites pass bare {@code <service>-<id>} tokens, never the prefix.</p>
+ *
+ * <p>Volume storage modes:</p>
+ * <ul>
+ *   <li>Named-volume (default) — floci-az manages per-resource Docker named volumes.
+ *       Active when {@code FLOCI_AZ_STORAGE_HOST_PERSISTENT_PATH} is not set to an absolute path.</li>
+ *   <li>Host-path (legacy) — active when {@code host-persistent-path} is set to an absolute path;
+ *       callers use bind-mounts to the specified directory instead.</li>
+ * </ul>
  */
 public final class ContainerStorageHelper {
 
     private static final Logger LOG = Logger.getLogger(ContainerStorageHelper.class);
+
+    static final String CLOUD = "az";
+    static final String CONTAINER_PREFIX = "floci-" + CLOUD + "-";
+    static final String LEGACY_PREFIX = "floci-";
 
     private ContainerStorageHelper() {}
 
@@ -26,8 +39,70 @@ public final class ContainerStorageHelper {
      * Canonical volume/container name for a resource.
      * Uses {@code volumeId} when set; falls back to {@code fallbackId} for legacy resources.
      */
-    public static String resourceName(String service, String volumeId, String fallbackId) {
-        return "floci-az-" + service + "-" + (volumeId != null ? volumeId : fallbackId);
+    public static String resourceName(EmulatorConfig config, String service, String volumeId, String fallbackId) {
+        return dockerName(config, service + "-" + (volumeId != null ? volumeId : fallbackId));
+    }
+
+    /**
+     * Prefixes {@code baseName} with {@code floci-az-} and the configured resource namespace.
+     * Accepts already-prefixed names (current or legacy {@code floci-} prefix) and normalises
+     * them, so the namespace always lands between the cloud token and the service token.
+     */
+    public static String dockerName(EmulatorConfig config, String baseName) {
+        String base = stripPrefix(baseName);
+        String namespace = resourceNamespace(config);
+        if (namespace.isBlank()) {
+            return CONTAINER_PREFIX + base;
+        }
+        return CONTAINER_PREFIX + namespace + "-" + base;
+    }
+
+    /**
+     * Labels applied to every emulator-created container and volume:
+     * {@code floci=true} (umbrella across all Floci emulators),
+     * {@code floci_emulator=floci-az} (per-emulator discriminator), and
+     * {@code floci_namespace} when a resource namespace is configured.
+     */
+    public static Map<String, String> defaultLabels(EmulatorConfig config) {
+        Map<String, String> labels = new LinkedHashMap<>();
+        labels.put("floci", "true");
+        labels.put("floci_emulator", "floci-" + CLOUD);
+        String namespace = resourceNamespace(config);
+        if (!namespace.isBlank()) {
+            labels.put("floci_namespace", namespace);
+        }
+        return labels;
+    }
+
+    private static String stripPrefix(String baseName) {
+        if (baseName.startsWith(CONTAINER_PREFIX)) {
+            return baseName.substring(CONTAINER_PREFIX.length());
+        }
+        if (baseName.startsWith(LEGACY_PREFIX)) {
+            return baseName.substring(LEGACY_PREFIX.length());
+        }
+        return baseName;
+    }
+
+    private static String resourceNamespace(EmulatorConfig config) {
+        if (config == null || config.docker() == null || config.docker().resourceNamespace() == null) {
+            return "";
+        }
+        return sanitizeNamePart(config.docker().resourceNamespace().orElse(""));
+    }
+
+    private static String sanitizeNamePart(String value) {
+        String cleaned = value.trim().replaceAll("[^A-Za-z0-9_.-]+", "-");
+        while (cleaned.startsWith("-")) {
+            cleaned = cleaned.substring(1);
+        }
+        while (cleaned.endsWith("-")) {
+            cleaned = cleaned.substring(0, cleaned.length() - 1);
+        }
+        if (cleaned.equals(".") || cleaned.equals("..")) {
+            return "";
+        }
+        return cleaned;
     }
 
     /**

--- a/src/main/java/io/floci/az/services/acr/AcrRegistryManager.java
+++ b/src/main/java/io/floci/az/services/acr/AcrRegistryManager.java
@@ -1,6 +1,7 @@
 package io.floci.az.services.acr;
 
 import io.floci.az.config.EmulatorConfig;
+import io.floci.az.core.docker.ContainerStorageHelper;
 import io.floci.az.core.docker.ContainerBuilder;
 import io.floci.az.core.docker.ContainerDetector;
 import io.floci.az.core.docker.ContainerLifecycleManager;
@@ -29,7 +30,9 @@ public class AcrRegistryManager {
 
     private static final Logger LOG = Logger.getLogger(AcrRegistryManager.class);
     private static final int REGISTRY_PORT = 5000;
-    private static final String SHARED_NAME = "floci-az-acr-registry";
+    private String sharedName() {
+        return ContainerStorageHelper.dockerName(config, "acr-registry");
+    }
 
     private final ContainerBuilder containerBuilder;
     private final ContainerLifecycleManager lifecycleManager;
@@ -65,17 +68,17 @@ public class AcrRegistryManager {
             if (lifecycleManager.isContainerRunning(containerId)) {
                 return;
             }
-            LOG.warnv("Shared ACR registry {0} is no longer running; restarting it", SHARED_NAME);
+            LOG.warnv("Shared ACR registry {0} is no longer running; restarting it", sharedName());
             started = false;
             containerId = null;
         }
         EmulatorConfig.AcrConfig acrConfig = config.services().acr();
-        lifecycleManager.removeIfExists(SHARED_NAME);
+        lifecycleManager.removeIfExists(sharedName());
 
         int chosenPort = portAllocator.allocate(acrConfig.basePort(), acrConfig.maxPort());
         try {
             ContainerSpec spec = containerBuilder.newContainer(acrConfig.defaultImage())
-                    .withName(SHARED_NAME)
+                    .withName(sharedName())
                     .withEnv("REGISTRY_STORAGE_DELETE_ENABLED", "true")
                     .withEnv("REGISTRY_HTTP_ADDR", "0.0.0.0:" + REGISTRY_PORT)
                     .withPortBinding(REGISTRY_PORT, chosenPort)
@@ -89,12 +92,12 @@ public class AcrRegistryManager {
 
             ContainerLifecycleManager.EndpointInfo ep = info.getEndpoint(REGISTRY_PORT);
             if (containerDetector.isRunningInContainer()) {
-                this.internalEndpoint = SHARED_NAME + ":" + REGISTRY_PORT;
+                this.internalEndpoint = sharedName() + ":" + REGISTRY_PORT;
             } else {
                 this.internalEndpoint = ep != null ? ep.host() + ":" + ep.port() : "localhost:" + chosenPort;
             }
             this.started = true;
-            LOG.infov("Started shared ACR registry {0} on host port {1}", SHARED_NAME, String.valueOf(chosenPort));
+            LOG.infov("Started shared ACR registry {0} on host port {1}", sharedName(), String.valueOf(chosenPort));
         } catch (Exception e) {
             throw new RuntimeException("Failed to start shared ACR registry container: " + e.getMessage(), e);
         }
@@ -103,7 +106,7 @@ public class AcrRegistryManager {
     /** The path-prefixed {@code loginServer} for a registry (host[:port]/{registryName}). */
     public String loginServer(String registryName) {
         String host = containerDetector.isRunningInContainer()
-                ? SHARED_NAME + ":" + REGISTRY_PORT
+                ? sharedName() + ":" + REGISTRY_PORT
                 : "localhost:" + hostPort;
         return host + "/" + registryName;
     }

--- a/src/main/java/io/floci/az/services/aks/AksClusterManager.java
+++ b/src/main/java/io/floci/az/services/aks/AksClusterManager.java
@@ -89,8 +89,12 @@ public class AksClusterManager {
         try {
             info = lifecycleManager.createAndStart(spec);
         } catch (RuntimeException e) {
-            // Only dispose a volume THIS start created — a pre-existing one may hold a
-            // previous cluster's k3s state and must survive a transient start failure.
+            // Dispose whatever this start managed to create. The container is removed first:
+            // a container that started but failed post-start inspection would otherwise keep
+            // running and pin the volume. The volume is only removed when THIS start created
+            // it — a pre-existing one may hold a previous cluster's k3s state and must
+            // survive a transient start failure.
+            lifecycleManager.removeIfExists(containerName);
             if (volumeCreatedByThisStart) {
                 lifecycleManager.removeVolume(volumeName);
             }

--- a/src/main/java/io/floci/az/services/aks/AksClusterManager.java
+++ b/src/main/java/io/floci/az/services/aks/AksClusterManager.java
@@ -1,6 +1,7 @@
 package io.floci.az.services.aks;
 
 import io.floci.az.config.EmulatorConfig;
+import io.floci.az.core.docker.ContainerStorageHelper;
 import io.floci.az.core.docker.ContainerBuilder;
 import io.floci.az.core.docker.ContainerDetector;
 import io.floci.az.core.docker.ContainerLifecycleManager;
@@ -67,7 +68,9 @@ public class AksClusterManager {
         lifecycleManager.removeIfExists(containerName);
 
         // Named volume for k3s data — prevents macOS APFS chmod(EINVAL) that crashes kine.
+        // Created explicitly (not implicitly by the mount) so it carries the emulator labels.
         String volumeName = containerName;
+        lifecycleManager.ensureVolume(volumeName);
         ContainerSpec spec = containerBuilder.newContainer(image)
                 .withName(containerName)
                 .withCmd(List.of("server",
@@ -174,8 +177,8 @@ public class AksClusterManager {
         LOG.infov("Stopped k3s container for AKS cluster {0}", cluster.getName());
     }
 
-    private static String containerName(ManagedCluster cluster) {
-        return "floci-az-aks-" + cluster.getInstanceId();
+    private String containerName(ManagedCluster cluster) {
+        return ContainerStorageHelper.dockerName(config, "aks-" + cluster.getInstanceId());
     }
 
     private String execInContainer(String containerId, String[] cmd) throws Exception {

--- a/src/main/java/io/floci/az/services/aks/AksClusterManager.java
+++ b/src/main/java/io/floci/az/services/aks/AksClusterManager.java
@@ -70,6 +70,7 @@ public class AksClusterManager {
         // Named volume for k3s data — prevents macOS APFS chmod(EINVAL) that crashes kine.
         // Created explicitly (not implicitly by the mount) so it carries the emulator labels.
         String volumeName = containerName;
+        boolean volumeCreatedByThisStart = !lifecycleManager.volumeExists(volumeName);
         lifecycleManager.ensureVolume(volumeName);
         ContainerSpec spec = containerBuilder.newContainer(image)
                 .withName(containerName)
@@ -84,7 +85,17 @@ public class AksClusterManager {
                 .withLogRotation()
                 .build();
 
-        ContainerLifecycleManager.ContainerInfo info = lifecycleManager.createAndStart(spec);
+        ContainerLifecycleManager.ContainerInfo info;
+        try {
+            info = lifecycleManager.createAndStart(spec);
+        } catch (RuntimeException e) {
+            // Only dispose a volume THIS start created — a pre-existing one may hold a
+            // previous cluster's k3s state and must survive a transient start failure.
+            if (volumeCreatedByThisStart) {
+                lifecycleManager.removeVolume(volumeName);
+            }
+            throw e;
+        }
         cluster.setContainerId(info.containerId());
 
         if (containerDetector.isRunningInContainer()) {

--- a/src/main/java/io/floci/az/services/cosmos/engine/CosmosLifecycleManager.java
+++ b/src/main/java/io/floci/az/services/cosmos/engine/CosmosLifecycleManager.java
@@ -1,6 +1,7 @@
 package io.floci.az.services.cosmos.engine;
 
 import io.floci.az.config.EmulatorConfig;
+import io.floci.az.core.docker.ContainerStorageHelper;
 import io.floci.az.core.docker.ContainerBuilder;
 import io.floci.az.core.docker.ContainerLifecycleManager;
 import io.floci.az.core.docker.ContainerSpec;
@@ -140,7 +141,7 @@ public class CosmosLifecycleManager {
 
         LOG.infof("Starting Cosmos engine %s with image=%s port=%d", api, image, hostPort);
 
-        String containerName = "floci-az-cosmos-" + api.name().toLowerCase();
+        String containerName = ContainerStorageHelper.dockerName(config, "cosmos-" + api.name().toLowerCase());
         containerManager.removeIfExists(containerName);
 
         ContainerSpec spec = buildSpec(containerName, image, hostPort, engine.defaultPort(), api);

--- a/src/main/java/io/floci/az/services/eventhub/EventHubNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/eventhub/EventHubNamespaceManager.java
@@ -1,6 +1,7 @@
 package io.floci.az.services.eventhub;
 
 import io.floci.az.config.EmulatorConfig;
+import io.floci.az.core.docker.ContainerStorageHelper;
 import io.floci.az.core.docker.ContainerBuilder;
 import io.floci.az.core.docker.ContainerLifecycleManager;
 import io.floci.az.core.docker.ContainerLifecycleManager.EndpointInfo;
@@ -182,8 +183,8 @@ public class EventHubNamespaceManager {
 
     // ── Private helpers ──────────────────────────────────────────────────────
 
-    static String containerName(String namespaceName) {
-        return "floci-az-artemis-" + namespaceName;
+    String containerName(String namespaceName) {
+        return ContainerStorageHelper.dockerName(config, "artemis-" + namespaceName);
     }
 
     private void waitForJolokia(EndpointInfo endpoint) {

--- a/src/main/java/io/floci/az/services/eventhub/EventHubsKafkaManager.java
+++ b/src/main/java/io/floci/az/services/eventhub/EventHubsKafkaManager.java
@@ -1,6 +1,7 @@
 package io.floci.az.services.eventhub;
 
 import io.floci.az.config.EmulatorConfig;
+import io.floci.az.core.docker.ContainerStorageHelper;
 import io.floci.az.core.docker.ContainerBuilder;
 import io.floci.az.core.docker.ContainerLifecycleManager;
 import io.floci.az.core.docker.ContainerSpec;
@@ -20,7 +21,9 @@ import java.util.List;
 public class EventHubsKafkaManager {
 
     private static final Logger LOG = Logger.getLogger(EventHubsKafkaManager.class);
-    private static final String CONTAINER_NAME = "floci-az-eventhubs-kafka";
+    private String containerName() {
+        return ContainerStorageHelper.dockerName(config, "eventhubs-kafka");
+    }
     private static final int KAFKA_PORT = 9092;
     private static final int ADMIN_PORT = 9644;
 
@@ -49,10 +52,10 @@ public class EventHubsKafkaManager {
         EmulatorConfig.EventHubConfig eh = config.services().eventHub();
         LOG.infov("Starting Redpanda (Kafka) sidecar for Event Hubs on port {0}", eh.kafkaPort());
 
-        lifecycleManager.removeIfExists(CONTAINER_NAME);
+        lifecycleManager.removeIfExists(containerName());
 
         ContainerSpec spec = containerBuilder.newContainer(eh.redpandaImage())
-                .withName(CONTAINER_NAME)
+                .withName(containerName())
                 .withCmd(List.of(
                         "redpanda", "start",
                         "--overprovisioned",

--- a/src/main/java/io/floci/az/services/functions/ContainerLauncher.java
+++ b/src/main/java/io/floci/az/services/functions/ContainerLauncher.java
@@ -1,20 +1,16 @@
 package io.floci.az.services.functions;
 
 import com.github.dockerjava.api.DockerClient;
-import com.github.dockerjava.api.command.CreateContainerResponse;
-import com.github.dockerjava.api.command.InspectContainerResponse;
-import com.github.dockerjava.api.command.PullImageResultCallback;
-import com.github.dockerjava.api.exception.NotFoundException;
-import com.github.dockerjava.api.model.ExposedPort;
-import com.github.dockerjava.api.model.HostConfig;
-import com.github.dockerjava.api.model.LogConfig;
-import com.github.dockerjava.api.model.Ports;
 import io.floci.az.config.EmulatorConfig;
-import io.floci.az.core.dns.EmbeddedDnsServer;
+import io.floci.az.core.docker.ContainerBuilder;
 import io.floci.az.core.docker.ContainerDetector;
+import io.floci.az.core.docker.ContainerLifecycleManager;
+import io.floci.az.core.docker.ContainerLifecycleManager.ContainerInfo;
+import io.floci.az.core.docker.ContainerLifecycleManager.EndpointInfo;
+import io.floci.az.core.docker.ContainerSpec;
+import io.floci.az.core.docker.ContainerStorageHelper;
 import io.floci.az.core.docker.DockerHostResolver;
 import io.floci.az.services.functions.FunctionModels.FunctionDefinition;
-import java.util.List;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
@@ -35,18 +31,16 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Creates and destroys Docker containers for Azure Functions execution.
  *
  * Launch sequence:
- *   1. Ensure runtime image is present locally (pull if needed)
+ *   1. Build the container spec ({@link ContainerBuilder}; image pull handled by the core layer)
  *   2. Create container, binding port 80 → random host port
- *   3. Start container
- *   4. Inject code via TAR stream to /home/site/wwwroot (works even inside Docker)
+ *   3. Inject host.json and code via TAR stream to /home/site/wwwroot (works even inside Docker)
+ *   4. Start container
  *   5. Poll /admin/host/status until the Functions host reports ready
  *   6. Return ContainerHandle with resolved host:port
  */
@@ -59,23 +53,26 @@ public class ContainerLauncher {
     private static final int FUNCTIONS_PORT = 80;
 
     private final DockerClient dockerClient;
+    private final ContainerBuilder containerBuilder;
+    private final ContainerLifecycleManager lifecycleManager;
     private final DockerHostResolver hostResolver;
     private final ContainerDetector containerDetector;
-    private final EmbeddedDnsServer embeddedDnsServer;
     private final EmulatorConfig config;
     private final HttpClient httpClient;
     private volatile String cachedNetworkMode;
 
     @Inject
     public ContainerLauncher(DockerClient dockerClient,
+                             ContainerBuilder containerBuilder,
+                             ContainerLifecycleManager lifecycleManager,
                              DockerHostResolver hostResolver,
                              ContainerDetector containerDetector,
-                             EmbeddedDnsServer embeddedDnsServer,
                              EmulatorConfig config) {
         this.dockerClient    = dockerClient;
+        this.containerBuilder = containerBuilder;
+        this.lifecycleManager = lifecycleManager;
         this.hostResolver    = hostResolver;
         this.containerDetector = containerDetector;
-        this.embeddedDnsServer = embeddedDnsServer;
         this.config          = config;
         this.httpClient      = HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(2))
@@ -94,55 +91,28 @@ public class ContainerLauncher {
                 primary.appName(), appDefs.size());
 
         String image = FunctionRuntime.resolveImage(primary.runtime(), primary.linuxFxVersion());
-        ensureImage(image);
-
         List<String> env = buildEnv(primary);
 
         String shortId = UUID.randomUUID().toString().replace("-", "").substring(0, 8);
-        String containerName = "floci-az-fn-" + primary.appName() + "-" + shortId;
+        String containerName = ContainerStorageHelper.dockerName(config,
+                "fn-" + primary.appName() + "-" + shortId);
 
-        // Use primary as `def` alias for the remainder of the method
-        FunctionDefinition def = primary;
-
-        // Create container with port 80 bound to a dynamic host port
-        ExposedPort exposed  = ExposedPort.tcp(FUNCTIONS_PORT);
-        Ports portBindings   = new Ports();
-        portBindings.bind(exposed, Ports.Binding.bindPort(0));
-
-        List<String> extraHosts = new ArrayList<>();
-        if (hostResolver.isLinuxHost()) {
-            // On native Linux Docker, host.docker.internal is not auto-injected into
-            // containers (unlike Docker Desktop on macOS/Windows). Adding host-gateway
-            // makes it resolvable from inside function containers on all Linux setups.
-            extraHosts.add("host.docker.internal:host-gateway");
-        }
-
-        LogConfig logConfig = new LogConfig(LogConfig.LoggingType.JSON_FILE, Map.of(
-                "max-size", config.docker().logMaxSize(),
-                "max-file", config.docker().logMaxFile()
-        ));
-
-        HostConfig hostConfig = HostConfig.newHostConfig()
-                .withPortBindings(portBindings)
-                .withExtraHosts(extraHosts.toArray(new String[0]))
-                .withLogConfig(logConfig);
-
-        embeddedDnsServer.getServerIp().ifPresent(dnsIp -> {
-            hostConfig.withDns(dnsIp);
-            LOG.debugv("Injecting embedded DNS server {0} into function container {1}", dnsIp, containerName);
-        });
-
-        String networkMode = resolveNetworkMode();
-
-        CreateContainerResponse created = dockerClient.createContainerCmd(image)
+        ContainerBuilder.Builder builder = containerBuilder.newContainer(image)
                 .withName(containerName)
-                .withExposedPorts(exposed)
-                .withHostConfig(hostConfig)
-                .withNetworkMode(networkMode)
+                .withDynamicPort(FUNCTIONS_PORT)
                 .withEnv(env)
-                .exec();
+                .withHostDockerInternalOnLinux()
+                .withEmbeddedDns()
+                .withLogRotation();
+        String networkMode = resolveNetworkMode();
+        if (!"bridge".equals(networkMode)) {
+            // "bridge" is Docker's default; setting it explicitly would make startCreated try to
+            // re-connect the container to a network it is already on.
+            builder.withNetworkMode(networkMode);
+        }
+        ContainerSpec spec = builder.build();
 
-        String containerId = created.getId();
+        String containerId = lifecycleManager.create(spec);
         LOG.infov("Created container {0} ({1})", containerName, containerId.substring(0, 12));
 
         // Inject a shared host.json at the wwwroot root so the Functions host starts
@@ -157,45 +127,20 @@ public class ContainerLauncher {
             }
         }
 
-        dockerClient.startContainerCmd(containerId).exec();
+        ContainerInfo info = lifecycleManager.startCreated(containerId, spec);
+        EndpointInfo endpoint = info.getEndpoint(FUNCTIONS_PORT);
 
-        // Discover the dynamically assigned host port
-        InspectContainerResponse inspect = dockerClient.inspectContainerCmd(containerId).exec();
-        int hostPort = resolveHostPort(inspect, exposed);
+        LOG.infov("Container {0} listening on {1}", containerId.substring(0, 12), endpoint);
 
-        String targetHost = "localhost";
-        if (containerDetector.isRunningInContainer()) {
-            // Use the container's IP on the shared network
-            var networks = inspect.getNetworkSettings().getNetworks();
-            if (!networks.isEmpty()) {
-                targetHost = networks.values().iterator().next().getIpAddress();
-                LOG.infov("Container {0} detected at IP {1} on network {2}",
-                        containerId.substring(0, 12), targetHost, networks.keySet().iterator().next());
-            }
-        }
+        waitForReady(endpoint.host(), endpoint.port(), 60);
 
-        LOG.infov("Container {0} listening on {1}:{2}", containerId.substring(0, 12), targetHost, hostPort);
-
-        // Wait for Azure Functions host to become ready
-        int targetPort = targetHost.equals("localhost") ? hostPort : 80;
-        waitForReady(targetHost, targetPort, 60);
-
-        return new ContainerHandle(containerId, def.appKey(), targetHost, targetPort);
+        return new ContainerHandle(containerId, primary.appKey(), endpoint.host(), endpoint.port());
     }
 
     public void stop(ContainerHandle handle) {
         LOG.infov("Stopping container {0}", handle.containerId().substring(0, 12));
         handle.setState(ContainerHandle.State.STOPPED);
-        try {
-            dockerClient.stopContainerCmd(handle.containerId()).withTimeout(5).exec();
-        } catch (NotFoundException e) {
-            // Already gone
-        } catch (Exception e) {
-            LOG.warnv("Error stopping container {0}: {1}", handle.containerId(), e.getMessage());
-        }
-        try {
-            dockerClient.removeContainerCmd(handle.containerId()).withForce(true).exec();
-        } catch (Exception ignored) {}
+        lifecycleManager.stopAndRemove(handle.containerId(), null);
     }
 
     // ── Private helpers ───────────────────────────────────────────────────────
@@ -220,25 +165,6 @@ public class ContainerLauncher {
         return "bridge";
     }
 
-    private void ensureImage(String image) {
-        try {
-            dockerClient.inspectImageCmd(image).exec();
-            LOG.debugv("Image already present: {0}", image);
-        } catch (NotFoundException e) {
-            LOG.infov("Pulling image: {0}", image);
-            try {
-                boolean pulled = dockerClient.pullImageCmd(image)
-                        .exec(new PullImageResultCallback())
-                        .awaitCompletion(10, TimeUnit.MINUTES);
-                if (!pulled) throw new RuntimeException("Timed out pulling image: " + image);
-                LOG.infov("Pulled image: {0}", image);
-            } catch (InterruptedException ie) {
-                Thread.currentThread().interrupt();
-                throw new RuntimeException("Interrupted while pulling image: " + image, ie);
-            }
-        }
-    }
-
     private List<String> buildEnv(FunctionDefinition def) {
         String flociHost = hostResolver.resolve();
         int flociPort    = config.port();
@@ -258,15 +184,6 @@ public class ContainerLauncher {
             def.environment().forEach((k, v) -> env.add(k + "=" + v));
         }
         return env;
-    }
-
-    private static int resolveHostPort(InspectContainerResponse inspect, ExposedPort exposed) {
-        var bindings = inspect.getNetworkSettings().getPorts().getBindings();
-        var binding  = bindings.get(exposed);
-        if (binding == null || binding.length == 0) {
-            throw new RuntimeException("No host port binding found for container port " + exposed.getPort());
-        }
-        return Integer.parseInt(binding[0].getHostPortSpec());
     }
 
     private void injectHostJson(String containerId) {
@@ -353,8 +270,8 @@ public class ContainerLauncher {
         return tar;
     }
 
-    private void waitForReady(String targetHost, int hostPort, int timeoutSeconds) {
-        String url = "http://" + targetHost + ":" + (targetHost.equals("localhost") ? hostPort : 80) + "/admin/host/status";
+    private void waitForReady(String targetHost, int targetPort, int timeoutSeconds) {
+        String url = "http://" + targetHost + ":" + targetPort + "/admin/host/status";
         long deadline = System.currentTimeMillis() + (timeoutSeconds * 1000L);
         LOG.infov("Waiting for Azure Functions host on {0}...", url);
 

--- a/src/main/java/io/floci/az/services/mariadb/MariaDbServerManager.java
+++ b/src/main/java/io/floci/az/services/mariadb/MariaDbServerManager.java
@@ -1,6 +1,7 @@
 package io.floci.az.services.mariadb;
 
 import io.floci.az.config.EmulatorConfig;
+import io.floci.az.core.docker.ContainerStorageHelper;
 import io.floci.az.core.docker.ContainerBuilder;
 import io.floci.az.core.docker.ContainerDetector;
 import io.floci.az.core.docker.ContainerLifecycleManager;
@@ -176,8 +177,8 @@ public class MariaDbServerManager {
         }
     }
 
-    private static String containerName(String serverName) {
-        return "floci-az-mariadb-" + serverName.toLowerCase().replaceAll("[^a-z0-9-]", "-");
+    private String containerName(String serverName) {
+        return ContainerStorageHelper.dockerName(config, "mariadb-" + serverName.toLowerCase().replaceAll("[^a-z0-9-]", "-"));
     }
 
     @PreDestroy

--- a/src/main/java/io/floci/az/services/mysql/MySqlServerManager.java
+++ b/src/main/java/io/floci/az/services/mysql/MySqlServerManager.java
@@ -1,6 +1,7 @@
 package io.floci.az.services.mysql;
 
 import io.floci.az.config.EmulatorConfig;
+import io.floci.az.core.docker.ContainerStorageHelper;
 import io.floci.az.core.docker.ContainerBuilder;
 import io.floci.az.core.docker.ContainerDetector;
 import io.floci.az.core.docker.ContainerLifecycleManager;
@@ -176,8 +177,8 @@ public class MySqlServerManager {
         }
     }
 
-    private static String containerName(String serverName) {
-        return "floci-az-mysql-" + serverName.toLowerCase().replaceAll("[^a-z0-9-]", "-");
+    private String containerName(String serverName) {
+        return ContainerStorageHelper.dockerName(config, "mysql-" + serverName.toLowerCase().replaceAll("[^a-z0-9-]", "-"));
     }
 
     @PreDestroy

--- a/src/main/java/io/floci/az/services/postgres/PostgresServerManager.java
+++ b/src/main/java/io/floci/az/services/postgres/PostgresServerManager.java
@@ -1,6 +1,7 @@
 package io.floci.az.services.postgres;
 
 import io.floci.az.config.EmulatorConfig;
+import io.floci.az.core.docker.ContainerStorageHelper;
 import io.floci.az.core.docker.ContainerBuilder;
 import io.floci.az.core.docker.ContainerDetector;
 import io.floci.az.core.docker.ContainerLifecycleManager;
@@ -156,8 +157,8 @@ public class PostgresServerManager {
         }
     }
 
-    private static String containerName(String serverName) {
-        return "floci-az-pg-" + serverName.toLowerCase().replaceAll("[^a-z0-9-]", "-");
+    private String containerName(String serverName) {
+        return ContainerStorageHelper.dockerName(config, "pg-" + serverName.toLowerCase().replaceAll("[^a-z0-9-]", "-"));
     }
 
     @PreDestroy

--- a/src/main/java/io/floci/az/services/redis/RedisCacheManager.java
+++ b/src/main/java/io/floci/az/services/redis/RedisCacheManager.java
@@ -4,6 +4,7 @@ import com.github.dockerjava.api.async.ResultCallback;
 import com.github.dockerjava.api.command.ExecCreateCmdResponse;
 import com.github.dockerjava.api.model.Frame;
 import io.floci.az.config.EmulatorConfig;
+import io.floci.az.core.docker.ContainerStorageHelper;
 import io.floci.az.core.docker.ContainerBuilder;
 import io.floci.az.core.docker.ContainerDetector;
 import io.floci.az.core.docker.ContainerLifecycleManager;
@@ -171,8 +172,8 @@ public class RedisCacheManager {
         LOG.infov("Stopped Redis container for cache {0}", cache.getName());
     }
 
-    private static String containerName(RedisCache cache) {
-        return "floci-az-redis-" + cache.getInstanceId();
+    private String containerName(RedisCache cache) {
+        return ContainerStorageHelper.dockerName(config, "redis-" + cache.getInstanceId());
     }
 
     private String execInContainer(String containerId, String[] cmd) throws Exception {

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -1,6 +1,7 @@
 package io.floci.az.services.servicebus;
 
 import io.floci.az.config.EmulatorConfig;
+import io.floci.az.core.docker.ContainerStorageHelper;
 import io.floci.az.core.docker.ContainerBuilder;
 import io.floci.az.core.docker.ContainerLifecycleManager;
 import io.floci.az.core.docker.ContainerLifecycleManager.EndpointInfo;
@@ -274,8 +275,8 @@ public class ServiceBusNamespaceManager {
 
     // ── Private helpers ───────────────────────────────────────────────────────
 
-    static String containerName(String namespaceName) {
-        return "floci-az-servicebus-" + namespaceName;
+    String containerName(String namespaceName) {
+        return ContainerStorageHelper.dockerName(config, "servicebus-" + namespaceName);
     }
 
     private static String rootMessage(Throwable error) {

--- a/src/main/java/io/floci/az/services/sql/SqlServerManager.java
+++ b/src/main/java/io/floci/az/services/sql/SqlServerManager.java
@@ -1,6 +1,7 @@
 package io.floci.az.services.sql;
 
 import io.floci.az.config.EmulatorConfig;
+import io.floci.az.core.docker.ContainerStorageHelper;
 import io.floci.az.core.docker.ContainerBuilder;
 import io.floci.az.core.docker.ContainerDetector;
 import io.floci.az.core.docker.ContainerLifecycleManager;
@@ -169,8 +170,8 @@ public class SqlServerManager {
         }
     }
 
-    private static String containerName(String serverName) {
-        return "floci-az-sql-" + serverName.toLowerCase().replaceAll("[^a-z0-9-]", "-");
+    private String containerName(String serverName) {
+        return ContainerStorageHelper.dockerName(config, "sql-" + serverName.toLowerCase().replaceAll("[^a-z0-9-]", "-"));
     }
 
     @PreDestroy

--- a/src/main/java/io/floci/az/services/vm/VmContainerManager.java
+++ b/src/main/java/io/floci/az/services/vm/VmContainerManager.java
@@ -1,6 +1,7 @@
 package io.floci.az.services.vm;
 
 import io.floci.az.config.EmulatorConfig;
+import io.floci.az.core.docker.ContainerStorageHelper;
 import io.floci.az.core.docker.ContainerBuilder;
 import io.floci.az.core.docker.ContainerLifecycleManager;
 import io.floci.az.core.docker.ContainerLifecycleManager.ContainerInfo;
@@ -142,14 +143,14 @@ public class VmContainerManager {
         return null;
     }
 
-    static String containerName(VirtualMachine vm) {
+    String containerName(VirtualMachine vm) {
         String id = vm.getVmId() != null
                 ? vm.getVmId().replace("-", "")
                 : sanitize(vm.getName());
         if (id.length() > 12) {
             id = id.substring(0, 12);
         }
-        return "floci-az-vm-" + id;
+        return ContainerStorageHelper.dockerName(config, "vm-" + id);
     }
 
     private static String sanitize(String name) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -76,6 +76,7 @@ floci-az:
     docker-host: unix:///var/run/docker.sock
     log-max-size: "10m"
     log-max-file: "3"
+    resource-namespace: ""
 
   services:
     blob:

--- a/src/test/java/io/floci/az/core/docker/ContainerLifecycleManagerLabelsTest.java
+++ b/src/test/java/io/floci/az/core/docker/ContainerLifecycleManagerLabelsTest.java
@@ -1,0 +1,140 @@
+package io.floci.az.core.docker;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.CreateContainerCmd;
+import com.github.dockerjava.api.command.CreateContainerResponse;
+import com.github.dockerjava.api.command.CreateVolumeCmd;
+import com.github.dockerjava.api.command.InspectVolumeCmd;
+import com.github.dockerjava.api.exception.NotFoundException;
+import io.floci.az.config.EmulatorConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.RETURNS_SELF;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Asserts the default Docker labels at the single choke point every emulator-created
+ * container and volume passes through. All container-backed services funnel into
+ * {@link ContainerLifecycleManager#create}, so asserting here covers every service
+ * by construction.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ContainerLifecycleManager — default emulator labels")
+class ContainerLifecycleManagerLabelsTest {
+
+    @Mock
+    DockerClient dockerClient;
+
+    @Mock
+    ImageCacheService imageCacheService;
+
+    @Mock
+    ContainerDetector containerDetector;
+
+    @Mock
+    PortAllocator portAllocator;
+
+    @Mock
+    EmulatorConfig config;
+
+    @Mock
+    EmulatorConfig.DockerConfig dockerConfig;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(config.docker()).thenReturn(dockerConfig);
+        lenient().when(dockerConfig.resourceNamespace()).thenReturn(Optional.empty());
+    }
+
+    @Test
+    void createAppliesDefaultLabelsToEveryContainer() {
+        CreateContainerCmd createCmd = stubCreateContainer();
+
+        manager().create(new ContainerSpec("busybox:stable"));
+
+        assertEquals(
+                Map.of("floci", "true", "floci_emulator", "floci-az"),
+                capturedLabels(createCmd));
+    }
+
+    @Test
+    void createMergesSpecLabelsOverDefaults() {
+        CreateContainerCmd createCmd = stubCreateContainer();
+        ContainerSpec spec = new ContainerSpec(
+                "busybox:stable", null, List.of(), null, null, null, Map.of(), List.of(), null,
+                List.of(), List.of(), List.of(), Map.of("floci_service", "functions"), null, false,
+                List.of(), null);
+
+        manager().create(spec);
+
+        assertEquals(
+                Map.of("floci", "true", "floci_emulator", "floci-az", "floci_service", "functions"),
+                capturedLabels(createCmd));
+    }
+
+    @Test
+    void createIncludesNamespaceLabelWhenConfigured() {
+        when(dockerConfig.resourceNamespace()).thenReturn(Optional.of("run-one"));
+        CreateContainerCmd createCmd = stubCreateContainer();
+
+        manager().create(new ContainerSpec("busybox:stable"));
+
+        assertEquals(
+                Map.of("floci", "true", "floci_emulator", "floci-az", "floci_namespace", "run-one"),
+                capturedLabels(createCmd));
+    }
+
+    @Test
+    void ensureVolumeAppliesTheSameDefaultLabels() {
+        InspectVolumeCmd inspectVolumeCmd = mock(InspectVolumeCmd.class);
+        when(dockerClient.inspectVolumeCmd("volume-1")).thenReturn(inspectVolumeCmd);
+        when(inspectVolumeCmd.exec()).thenThrow(new NotFoundException("missing"));
+        CreateVolumeCmd createVolumeCmd = mock(CreateVolumeCmd.class, RETURNS_SELF);
+        when(dockerClient.createVolumeCmd()).thenReturn(createVolumeCmd);
+
+        manager().ensureVolume("volume-1");
+
+        ArgumentCaptor<Map<String, String>> labels = labelsCaptor();
+        verify(createVolumeCmd).withLabels(labels.capture());
+        assertEquals(Map.of("floci", "true", "floci_emulator", "floci-az"), labels.getValue());
+    }
+
+    private ContainerLifecycleManager manager() {
+        return new ContainerLifecycleManager(
+                dockerClient, imageCacheService, containerDetector, portAllocator, config);
+    }
+
+    private CreateContainerCmd stubCreateContainer() {
+        CreateContainerCmd createCmd = mock(CreateContainerCmd.class, RETURNS_SELF);
+        when(dockerClient.createContainerCmd("busybox:stable")).thenReturn(createCmd);
+        CreateContainerResponse response = mock(CreateContainerResponse.class);
+        when(response.getId()).thenReturn("container-id");
+        when(createCmd.exec()).thenReturn(response);
+        return createCmd;
+    }
+
+    private Map<String, String> capturedLabels(CreateContainerCmd createCmd) {
+        ArgumentCaptor<Map<String, String>> labels = labelsCaptor();
+        verify(createCmd).withLabels(labels.capture());
+        return labels.getValue();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ArgumentCaptor<Map<String, String>> labelsCaptor() {
+        return ArgumentCaptor.forClass((Class<Map<String, String>>) (Class<?>) Map.class);
+    }
+}

--- a/src/test/java/io/floci/az/core/docker/ContainerStorageHelperTest.java
+++ b/src/test/java/io/floci/az/core/docker/ContainerStorageHelperTest.java
@@ -1,0 +1,74 @@
+package io.floci.az.core.docker;
+
+import io.floci.az.config.EmulatorConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("ContainerStorageHelper — naming and labels")
+class ContainerStorageHelperTest {
+
+    @Test
+    void namesCarryTheAzPrefixWithoutNamespace() {
+        assertEquals("floci-az-pg-server1", ContainerStorageHelper.dockerName(config(""), "pg-server1"));
+        assertEquals("floci-az-aks-abc123",
+                ContainerStorageHelper.resourceName(config(""), "aks", null, "abc123"));
+        assertEquals("floci-az-aks-vol9",
+                ContainerStorageHelper.resourceName(config(""), "aks", "vol9", "abc123"));
+    }
+
+    @Test
+    void nullConfigYieldsDefaultModeNames() {
+        assertEquals("floci-az-pg-server1", ContainerStorageHelper.dockerName(null, "pg-server1"));
+    }
+
+    @Test
+    void namespaceLandsBetweenCloudAndServiceTokens() {
+        assertEquals("floci-az-run-one-pg-server1",
+                ContainerStorageHelper.dockerName(config("run-one"), "pg-server1"));
+    }
+
+    @Test
+    void alreadyPrefixedNamesAreNormalized() {
+        assertEquals("floci-az-pg-x", ContainerStorageHelper.dockerName(config(""), "floci-az-pg-x"));
+        assertEquals("floci-az-pg-x", ContainerStorageHelper.dockerName(config(""), "floci-pg-x"));
+        assertEquals("floci-az-run-one-pg-x",
+                ContainerStorageHelper.dockerName(config("run-one"), "floci-az-pg-x"));
+    }
+
+    @Test
+    void defaultLabelsIdentifyThisEmulator() {
+        assertEquals(
+                Map.of("floci", "true", "floci_emulator", "floci-az"),
+                ContainerStorageHelper.defaultLabels(config("")));
+        assertEquals(
+                Map.of("floci", "true", "floci_emulator", "floci-az", "floci_namespace", "run-one"),
+                ContainerStorageHelper.defaultLabels(config(" run/one ")));
+        assertEquals(
+                Map.of("floci", "true", "floci_emulator", "floci-az"),
+                ContainerStorageHelper.defaultLabels(null));
+    }
+
+    @Test
+    void unsafeNamespaceSegmentsAreIgnored() {
+        assertEquals("floci-az-pg-x", ContainerStorageHelper.dockerName(config(".."), "pg-x"));
+        assertEquals(
+                Map.of("floci", "true", "floci_emulator", "floci-az"),
+                ContainerStorageHelper.defaultLabels(config("..")));
+    }
+
+    private static EmulatorConfig config(String namespace) {
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        EmulatorConfig.DockerConfig docker = mock(EmulatorConfig.DockerConfig.class);
+        when(config.docker()).thenReturn(docker);
+        when(docker.resourceNamespace()).thenReturn(
+                namespace.isBlank() ? Optional.empty() : Optional.of(namespace));
+        return config;
+    }
+}


### PR DESCRIPTION
## Summary

Implements the cross-emulator Docker attribution convention for floci-az: every emulator-created container and volume is labeled `floci=true` (umbrella across the Floci emulators) plus `floci_emulator=floci-az` (per-emulator discriminator), and `floci_namespace` when configured — applied centrally at the container lifecycle choke point, so `docker ps --filter label=floci_emulator=floci-az` and `docker volume prune --filter label=floci_emulator=floci-az` target this emulator alone while `label=floci=true` still matches all of them.

- The `floci-az-` name prefix is now owned by `ContainerStorageHelper` instead of being spelled at eleven call sites — **container names are unchanged**.
- The Functions runtime container is created through the shared `ContainerBuilder`/`ContainerLifecycleManager` layer (it previously issued its own `createContainerCmd` and carried no labels).
- The AKS k3s volume is created explicitly via `ensureVolume` (its first caller) so it is labeled too.
- New optional `floci-az.docker.resource-namespace` (`FLOCI_AZ_DOCKER_RESOURCE_NAMESPACE`) inserts a namespace into child container/volume names (`floci-az-<ns>-…`) and a `floci_namespace` label, for running multiple emulator processes against one Docker daemon.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

n/a for wire protocol — operational Docker hygiene. Verified live: `docker inspect` on an emulator-created container shows `{"floci":"true","floci_emulator":"floci-az"}` and the name is byte-identical to before (`floci-az-pg-…`). Documented caveat: with a resource-namespace set, the Event Hubs broker certificate SAN (`floci-az-artemis`) does not cover the namespaced container name for in-network TLS clients — connect via `localhost` in that setup.

## Checklist

- [x] `./mvnw test` passes locally (567 tests)
- [x] New or updated integration test added — `ContainerLifecycleManagerLabelsTest` + `ContainerStorageHelperTest` (10 cases asserting labels/naming at the choke point, mirroring the floci-gcp reference implementation), plus a live-Docker label verification
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)