### PR TITLE
fix(blob): persist upload HTTP properties

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/BlobCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/BlobCompatibilityTest.java
@@ -6,6 +6,7 @@ import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
 import com.azure.storage.blob.models.BlobErrorCode;
+import com.azure.storage.blob.models.BlobHttpHeaders;
 import com.azure.storage.blob.models.BlobItem;
 import com.azure.storage.blob.models.BlobProperties;
 import com.azure.storage.blob.models.BlobRange;
@@ -107,6 +108,44 @@ class BlobCompatibilityTest {
         // creation time must not track last-modified across a metadata update
         blob.setMetadata(Map.of("owner", "compat"));
         assertEquals(props.getCreationTime(), blob.getProperties().getCreationTime());
+
+        client.deleteBlobContainer(name);
+    }
+
+    @Test
+    @DisplayName("blob HTTP headers: upload options round-trip through properties")
+    void blobHttpHeadersRoundTrip() {
+        String name = containerName();
+        BlobContainerClient container = client.createBlobContainer(name);
+        BlobClient blob = container.getBlobClient("image.png");
+        byte[] content = "image".getBytes(StandardCharsets.UTF_8);
+        byte[] md5 = Base64.getDecoder().decode("eIBaIhqYjnnvP0LXxb/UGA==");
+        BlobHttpHeaders headers = new BlobHttpHeaders()
+            .setContentType("image/png")
+            .setCacheControl("public, max-age=31536000")
+            .setContentDisposition("inline; filename=image.png")
+            .setContentEncoding("gzip")
+            .setContentLanguage("en-GB")
+            .setContentMd5(md5);
+
+        blob.getBlockBlobClient().uploadWithResponse(
+            new java.io.ByteArrayInputStream(content),
+            content.length,
+            headers,
+            null,
+            null,
+            null,
+            null,
+            null,
+            Context.NONE);
+
+        BlobProperties properties = blob.getProperties();
+        assertEquals("image/png", properties.getContentType());
+        assertEquals("public, max-age=31536000", properties.getCacheControl());
+        assertEquals("inline; filename=image.png", properties.getContentDisposition());
+        assertEquals("gzip", properties.getContentEncoding());
+        assertEquals("en-GB", properties.getContentLanguage());
+        assertArrayEquals(md5, properties.getContentMd5());
 
         client.deleteBlobContainer(name);
     }

--- a/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
+++ b/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
@@ -319,17 +319,7 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
             Map<String, String> metadata = new HashMap<>();
             String blobType = request.headers().getHeaderString("x-ms-blob-type");
             metadata.put("BlobType", blobType != null ? blobType : "BlockBlob");
-            String ct = request.headers().getHeaderString("x-ms-blob-content-type");
-            if (ct == null) {
-                ct = request.headers().getHeaderString(HttpHeaders.CONTENT_TYPE);
-            }
-            metadata.put("Content-Type", ct != null ? ct : "application/octet-stream");
-            BLOB_HTTP_PROPERTY_HEADERS.forEach((requestHeader, responseHeader) -> {
-                String value = request.headers().getHeaderString(requestHeader);
-                if (value != null) {
-                    metadata.put(responseHeader, value);
-                }
-            });
+            addBlobHttpProperties(request, metadata);
             metadata.put("Name", blobName);
             metadata.put(CREATION_TIME_KEY, createdOn(existing).toString());
             metadata.putAll(readUserMetadata(request));
@@ -408,12 +398,12 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
                 .header("x-ms-lease-status", "unlocked")
                 .header("x-ms-lease-state", "available")
                 .header("x-ms-server-encrypted", "true");
-        BLOB_HTTP_PROPERTY_HEADERS.values().forEach(header -> {
+        for (String header : BLOB_HTTP_PROPERTY_HEADERS.values()) {
             String value = so.metadata().get(header);
-            if (value != null) {
+            if (value != null && !(isRangeRequest && "Content-MD5".equals(header))) {
                 rb.header(header, value);
             }
-        });
+        }
         if (isRangeRequest) {
             rb.header("Content-Range", String.format("bytes %d-%d/%d", rangeStart, rangeEnd, totalSize));
         }
@@ -629,8 +619,7 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
             Map<String, String> metadata = new HashMap<>();
             String blobType = request.headers().getHeaderString("x-ms-blob-type");
             metadata.put("BlobType", blobType != null ? blobType : "BlockBlob");
-            String ct = request.headers().getHeaderString(HttpHeaders.CONTENT_TYPE);
-            metadata.put("Content-Type", ct != null ? ct : "application/octet-stream");
+            addBlobHttpProperties(request, metadata);
             metadata.put("Name", blobName);
             metadata.put(CREATION_TIME_KEY, createdOn(
                     store.get(objKey(request.accountName(), containerName, blobName))).toString());
@@ -659,6 +648,20 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
             LOGGER.errorf(e, "putBlockList I/O error: container=%s blob=%s", containerName, blobName);
             return Response.serverError().build();
         }
+    }
+
+    private static void addBlobHttpProperties(AzureRequest request, Map<String, String> metadata) {
+        String contentType = request.headers().getHeaderString("x-ms-blob-content-type");
+        if (contentType == null) {
+            contentType = request.headers().getHeaderString(HttpHeaders.CONTENT_TYPE);
+        }
+        metadata.put("Content-Type", contentType != null ? contentType : "application/octet-stream");
+        BLOB_HTTP_PROPERTY_HEADERS.forEach((requestHeader, responseHeader) -> {
+            String value = request.headers().getHeaderString(requestHeader);
+            if (value != null) {
+                metadata.put(responseHeader, value);
+            }
+        });
     }
 
     /**

--- a/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
+++ b/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
@@ -41,6 +41,12 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
     private static final String BLK_PREFIX = "__blk__:";
     private static final String USER_METADATA_PREFIX = "UserMeta:";
     private static final String CREATION_TIME_KEY = "CreationTime";
+    private static final Map<String, String> BLOB_HTTP_PROPERTY_HEADERS = Map.of(
+            "x-ms-blob-cache-control", HttpHeaders.CACHE_CONTROL,
+            "x-ms-blob-content-disposition", "Content-Disposition",
+            "x-ms-blob-content-encoding", HttpHeaders.CONTENT_ENCODING,
+            "x-ms-blob-content-language", HttpHeaders.CONTENT_LANGUAGE,
+            "x-ms-blob-content-md5", "Content-MD5");
     private static final StoredObject NS_SENTINEL =
             new StoredObject("", new byte[0], Map.of(), Instant.EPOCH, "");
 
@@ -313,8 +319,17 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
             Map<String, String> metadata = new HashMap<>();
             String blobType = request.headers().getHeaderString("x-ms-blob-type");
             metadata.put("BlobType", blobType != null ? blobType : "BlockBlob");
-            String ct = request.headers().getHeaderString(HttpHeaders.CONTENT_TYPE);
+            String ct = request.headers().getHeaderString("x-ms-blob-content-type");
+            if (ct == null) {
+                ct = request.headers().getHeaderString(HttpHeaders.CONTENT_TYPE);
+            }
             metadata.put("Content-Type", ct != null ? ct : "application/octet-stream");
+            BLOB_HTTP_PROPERTY_HEADERS.forEach((requestHeader, responseHeader) -> {
+                String value = request.headers().getHeaderString(requestHeader);
+                if (value != null) {
+                    metadata.put(responseHeader, value);
+                }
+            });
             metadata.put("Name", blobName);
             metadata.put(CREATION_TIME_KEY, createdOn(existing).toString());
             metadata.putAll(readUserMetadata(request));
@@ -393,6 +408,12 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
                 .header("x-ms-lease-status", "unlocked")
                 .header("x-ms-lease-state", "available")
                 .header("x-ms-server-encrypted", "true");
+        BLOB_HTTP_PROPERTY_HEADERS.values().forEach(header -> {
+            String value = so.metadata().get(header);
+            if (value != null) {
+                rb.header(header, value);
+            }
+        });
         if (isRangeRequest) {
             rb.header("Content-Range", String.format("bytes %d-%d/%d", rangeStart, rangeEnd, totalSize));
         }

--- a/src/test/java/io/floci/az/services/BlobServiceTest.java
+++ b/src/test/java/io/floci/az/services/BlobServiceTest.java
@@ -495,6 +495,30 @@ public class BlobServiceTest {
     }
 
     @Test
+    void rangeRequestOmitsStoredContentMd5() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        given()
+            .header("x-ms-blob-type", "BlockBlob")
+            .header("x-ms-blob-content-md5", "eB5eJF1ptWaXm4bijSPyxw==")
+            .body("0123456789")
+            .put("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB);
+
+        given()
+            .when().get("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(200)
+            .header("Content-MD5", equalTo("eB5eJF1ptWaXm4bijSPyxw=="));
+
+        given()
+            .header("Range", "bytes=2-5")
+            .when().get("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(206)
+            .header("Content-MD5", nullValue())
+            .body(equalTo("2345"));
+    }
+
+    @Test
     void invalidRangeReturns416() {
         given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
         given()
@@ -646,6 +670,36 @@ public class BlobServiceTest {
             .statusCode(200)
             .header("x-ms-creation-time", not(emptyOrNullString()))
             .header("x-ms-server-encrypted", "true");
+    }
+
+    @Test
+    void committedBlockBlobPersistsBlobHttpHeaders() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        String blockId = java.util.Base64.getEncoder()
+            .encodeToString("block-1".getBytes(StandardCharsets.UTF_8));
+
+        given()
+            .body("chunk")
+            .when().put("/{account}/{container}/{blob}?comp=block&blockid={id}",
+                    ACCOUNT, CONTAINER, BLOB, blockId)
+            .then().statusCode(201);
+
+        given()
+            .header("x-ms-blob-content-type", "text/plain")
+            .header("x-ms-blob-cache-control", "public, max-age=60")
+            .header("x-ms-blob-content-md5", "XrY7u+Ae7tCTyyK7j1rNww==")
+            .contentType("application/xml")
+            .body("<BlockList><Latest>" + blockId + "</Latest></BlockList>")
+            .when().put("/{account}/{container}/{blob}?comp=blocklist", ACCOUNT, CONTAINER, BLOB)
+            .then().statusCode(201);
+
+        given()
+            .when().head("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(200)
+            .header("Content-Type", startsWith("text/plain"))
+            .header("Cache-Control", equalTo("public, max-age=60"))
+            .header("Content-MD5", equalTo("XrY7u+Ae7tCTyyK7j1rNww=="));
     }
 
     private static void putTestBlob(String content) {

--- a/src/test/java/io/floci/az/services/BlobServiceTest.java
+++ b/src/test/java/io/floci/az/services/BlobServiceTest.java
@@ -5,6 +5,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.regex.Matcher;
@@ -79,6 +80,35 @@ public class BlobServiceTest {
             .statusCode(200)
             .header("x-ms-meta-owner", "compat")
             .body(equalTo(BLOB_CONTENT));
+    }
+
+    @Test
+    void putBlobPersistsBlobHttpHeaders() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+
+        given()
+            .header("x-ms-blob-type", "BlockBlob")
+            .header("x-ms-blob-content-type", "image/png")
+            .header("x-ms-blob-cache-control", "public, max-age=31536000")
+            .header("x-ms-blob-content-disposition", "inline; filename=image.png")
+            .header("x-ms-blob-content-encoding", "gzip")
+            .header("x-ms-blob-content-language", "en-GB")
+            .header("x-ms-blob-content-md5", "bLRINaECD0Zc/ikzY3bBuQ==")
+            .header("Content-Type", "application/octet-stream")
+            .body(BLOB_CONTENT.getBytes(StandardCharsets.UTF_8))
+            .when().put("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB)
+            .then().statusCode(201);
+
+        given()
+            .when().head("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(200)
+            .header("Content-Type", startsWith("image/png"))
+            .header("Cache-Control", equalTo("public, max-age=31536000"))
+            .header("Content-Disposition", equalTo("inline; filename=image.png"))
+            .header("Content-Encoding", equalTo("gzip"))
+            .header("Content-Language", equalTo("en-GB"))
+            .header("Content-MD5", equalTo("bLRINaECD0Zc/ikzY3bBuQ=="));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- persist Azure Blob HTTP properties supplied through `x-ms-blob-content-*` during Put Blob
- prefer `x-ms-blob-content-type` over request entity `Content-Type`, matching Azure
- return stored content type, cache control, disposition, encoding, language, and MD5 from HEAD/GET
- add REST regression coverage and Azure Storage Java SDK compatibility coverage

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

0.10.0 stored the request entity `Content-Type` and discarded Blob HTTP property headers. This now follows Put Blob header semantics used by `BlobHttpHeaders`; stored properties round-trip through Get Blob / Get Properties.

## Checklist

- [x] `./mvnw test` passes locally (554 tests)
- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits

Closes #163