### PR TITLE
fix(cosmos): enforce item ETag conditions

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/CosmosCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/CosmosCompatibilityTest.java
@@ -247,7 +247,7 @@ class CosmosCompatibilityTest {
     }
 
     @Test
-    @DisplayName("transactional batch: Create/Read/Replace/Delete/Upsert")
+    @DisplayName("transactional batch: CRUD, Patch, and rollback")
     @SuppressWarnings("unchecked")
     void transactionalBatch() {
         String id = dbId();
@@ -289,6 +289,32 @@ class CosmosCompatibilityTest {
                 .getItem().get("v")).intValue());
         assertThrows(CosmosException.class,
                 () -> container.readItem("b3", new PartitionKey("test"), Map.class));
+
+        // Batch 3: Patch is visible to a later operation in the same batch.
+        CosmosBatch batch3 = CosmosBatch.createCosmosBatch(new PartitionKey("test"));
+        batch3.patchItemOperation("b1", CosmosPatchOperations.create()
+                .set("/v", 7)
+                .increment("/counter", 2));
+        batch3.readItemOperation("b1");
+
+        CosmosBatchResponse r3 = container.executeCosmosBatch(batch3);
+        assertEquals(200, r3.getResults().get(0).getStatusCode());
+        assertEquals(200, r3.getResults().get(1).getStatusCode());
+        assertEquals(7, ((Number) container
+                .readItem("b1", new PartitionKey("test"), Map.class)
+                .getItem().get("v")).intValue());
+
+        // Batch 4: a failure rolls back an earlier successful mutation.
+        CosmosBatch batch4 = CosmosBatch.createCosmosBatch(new PartitionKey("test"));
+        batch4.replaceItemOperation("b1", doc("b1", "test", "v", 999));
+        batch4.deleteItemOperation("missing");
+
+        CosmosBatchResponse r4 = container.executeCosmosBatch(batch4);
+        assertEquals(424, r4.getResults().get(0).getStatusCode());
+        assertEquals(404, r4.getResults().get(1).getStatusCode());
+        assertEquals(7, ((Number) container
+                .readItem("b1", new PartitionKey("test"), Map.class)
+                .getItem().get("v")).intValue());
 
         db.delete();
     }

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/CosmosCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/CosmosCompatibilityTest.java
@@ -171,6 +171,33 @@ class CosmosCompatibilityTest {
     }
 
     @Test
+    @DisplayName("document replace: stale If-Match returns 412 and preserves item")
+    @SuppressWarnings("unchecked")
+    void documentReplaceHonorsIfMatch() {
+        String id = dbId();
+        client.createDatabase(id);
+        CosmosDatabase db = client.getDatabase(id);
+        db.createContainerIfNotExists("items", "/category");
+        CosmosContainer container = db.getContainer("items");
+        container.createItem(doc("conditional-1", "tools", "stock", 10));
+
+        CosmosException exception = assertThrows(CosmosException.class,
+            () -> container.replaceItem(
+                doc("conditional-1", "tools", "stock", 5),
+                "conditional-1",
+                new PartitionKey("tools"),
+                new CosmosItemRequestOptions().setIfMatchETag("\"stale\"")));
+
+        assertEquals(412, exception.getStatusCode());
+        Map<String, Object> unchanged = container
+            .readItem("conditional-1", new PartitionKey("tools"), Map.class)
+            .getItem();
+        assertEquals(10, ((Number) unchanged.get("stock")).intValue());
+
+        db.delete();
+    }
+
+    @Test
     @DisplayName("database delete cascades to containers and documents")
     void cascadeDelete() {
         String id = dbId();

--- a/src/main/java/io/floci/az/core/storage/HybridStorage.java
+++ b/src/main/java/io/floci/az/core/storage/HybridStorage.java
@@ -38,6 +38,7 @@ public class HybridStorage<K, V> implements StorageBackend<K, V> {
     private final TypeReference<Map<K, V>> typeReference;
     private final ScheduledExecutorService scheduler;
     private final AtomicBoolean dirty = new AtomicBoolean(false);
+    private final Object mutationLock = new Object();
 
     public HybridStorage(Path filePath, TypeReference<Map<K, V>> typeReference, long flushIntervalMs) {
         this.filePath = filePath;
@@ -57,8 +58,10 @@ public class HybridStorage<K, V> implements StorageBackend<K, V> {
 
     @Override
     public void put(K key, V value) {
-        store.put(key, value);
-        dirty.set(true);
+        synchronized (mutationLock) {
+            store.put(key, value);
+            dirty.set(true);
+        }
     }
 
     @Override
@@ -68,8 +71,19 @@ public class HybridStorage<K, V> implements StorageBackend<K, V> {
 
     @Override
     public void delete(K key) {
-        store.remove(key);
-        dirty.set(true);
+        synchronized (mutationLock) {
+            store.remove(key);
+            dirty.set(true);
+        }
+    }
+
+    @Override
+    public void applyBatch(Map<K, V> puts, Set<K> deletes) {
+        synchronized (mutationLock) {
+            deletes.forEach(store::remove);
+            store.putAll(puts);
+            dirty.set(true);
+        }
     }
 
     @Override
@@ -138,16 +152,19 @@ public class HybridStorage<K, V> implements StorageBackend<K, V> {
         }
     }
 
-    private synchronized void persistToDisk() {
-        try {
-            Files.createDirectories(filePath.getParent());
-            Path tempFile = filePath.resolveSibling(filePath.getFileName() + ".tmp");
-            objectMapper.writeValue(tempFile.toFile(), store);
-            Files.move(tempFile, filePath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
-            LOG.debugv("Flushed {0} entries to {1}", store.size(), filePath);
-        } catch (IOException e) {
-            LOG.errorv(e, "Failed to persist data to {0}", filePath);
-            dirty.set(true);
+    private void persistToDisk() {
+        synchronized (mutationLock) {
+            try {
+                Files.createDirectories(filePath.getParent());
+                Path tempFile = filePath.resolveSibling(filePath.getFileName() + ".tmp");
+                objectMapper.writeValue(tempFile.toFile(), store);
+                Files.move(tempFile, filePath,
+                        StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+                LOG.debugv("Flushed {0} entries to {1}", store.size(), filePath);
+            } catch (IOException e) {
+                LOG.errorv(e, "Failed to persist data to {0}", filePath);
+                dirty.set(true);
+            }
         }
     }
 }

--- a/src/main/java/io/floci/az/core/storage/InMemoryStorage.java
+++ b/src/main/java/io/floci/az/core/storage/InMemoryStorage.java
@@ -3,6 +3,7 @@ package io.floci.az.core.storage;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -34,6 +35,12 @@ public class InMemoryStorage<K, V> implements StorageBackend<K, V> {
     @Override
     public Optional<V> remove(K key) {
         return Optional.ofNullable(store.remove(key));
+    }
+
+    @Override
+    public synchronized void applyBatch(Map<K, V> puts, Set<K> deletes) {
+        deletes.forEach(store::remove);
+        store.putAll(puts);
     }
 
     @Override

--- a/src/main/java/io/floci/az/core/storage/PersistentStorage.java
+++ b/src/main/java/io/floci/az/core/storage/PersistentStorage.java
@@ -45,7 +45,7 @@ public class PersistentStorage<K, V> implements StorageBackend<K, V> {
     }
 
     @Override
-    public void put(K key, V value) {
+    public synchronized void put(K key, V value) {
         store.put(key, value);
         persistToDisk();
     }
@@ -56,7 +56,7 @@ public class PersistentStorage<K, V> implements StorageBackend<K, V> {
     }
 
     @Override
-    public void delete(K key) {
+    public synchronized void delete(K key) {
         store.remove(key);
         persistToDisk();
     }
@@ -66,6 +66,13 @@ public class PersistentStorage<K, V> implements StorageBackend<K, V> {
         Optional<V> removed = Optional.ofNullable(store.remove(key));
         removed.ifPresent(v -> persistToDisk());
         return removed;
+    }
+
+    @Override
+    public synchronized void applyBatch(Map<K, V> puts, Set<K> deletes) {
+        deletes.forEach(store::remove);
+        store.putAll(puts);
+        persistToDisk();
     }
 
     @Override

--- a/src/main/java/io/floci/az/core/storage/StorageBackend.java
+++ b/src/main/java/io/floci/az/core/storage/StorageBackend.java
@@ -1,6 +1,7 @@
 package io.floci.az.core.storage;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -21,6 +22,9 @@ public interface StorageBackend<K, V> {
 
     /** Atomically removes and returns the value, so a concurrent caller can never observe it twice. */
     Optional<V> remove(K key);
+
+    /** Applies related puts and deletes as one durable mutation. */
+    void applyBatch(Map<K, V> puts, Set<K> deletes);
 
     /**
      * Return a new mutable list of values whose keys pass the filter. Callers may sort,

--- a/src/main/java/io/floci/az/core/storage/WalStorage.java
+++ b/src/main/java/io/floci/az/core/storage/WalStorage.java
@@ -40,6 +40,7 @@ public class WalStorage<K, V> implements StorageBackend<K, V> {
 
     static final byte OP_PUT = 0x01;
     static final byte OP_DELETE = 0x02;
+    static final byte OP_BATCH = 0x03;
 
     private final ConcurrentHashMap<K, V> store = new ConcurrentHashMap<>();
     private final Path snapshotPath;
@@ -48,6 +49,7 @@ public class WalStorage<K, V> implements StorageBackend<K, V> {
     private final ObjectMapper walMapper;
     private final TypeReference<Map<K, V>> typeReference;
     private final ReentrantReadWriteLock compactionLock = new ReentrantReadWriteLock();
+    private final Object mutationLock = new Object();
     private final ScheduledExecutorService scheduler;
     private volatile DataOutputStream walWriter;
 
@@ -79,8 +81,10 @@ public class WalStorage<K, V> implements StorageBackend<K, V> {
     public void put(K key, V value) {
         compactionLock.readLock().lock();
         try {
-            store.put(key, value);
-            appendPut(key, value);
+            synchronized (mutationLock) {
+                store.put(key, value);
+                appendPut(key, value);
+            }
         } finally {
             compactionLock.readLock().unlock();
         }
@@ -95,8 +99,24 @@ public class WalStorage<K, V> implements StorageBackend<K, V> {
     public void delete(K key) {
         compactionLock.readLock().lock();
         try {
-            store.remove(key);
-            appendDelete(key);
+            synchronized (mutationLock) {
+                store.remove(key);
+                appendDelete(key);
+            }
+        } finally {
+            compactionLock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public void applyBatch(Map<K, V> puts, Set<K> deletes) {
+        compactionLock.readLock().lock();
+        try {
+            synchronized (mutationLock) {
+                appendBatch(puts, deletes);
+                deletes.forEach(store::remove);
+                store.putAll(puts);
+            }
         } finally {
             compactionLock.readLock().unlock();
         }
@@ -238,6 +258,41 @@ public class WalStorage<K, V> implements StorageBackend<K, V> {
         }
     }
 
+    private void appendBatch(Map<K, V> puts, Set<K> deletes) {
+        DataOutputStream out = walWriter;
+        if (out == null) {
+            return;
+        }
+        try {
+            ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+            try (DataOutputStream batch = new DataOutputStream(bytes)) {
+                batch.writeInt(deletes.size());
+                for (K key : deletes) {
+                    writeBytes(batch, walMapper.writeValueAsBytes(key));
+                }
+                batch.writeInt(puts.size());
+                for (Map.Entry<K, V> entry : puts.entrySet()) {
+                    writeBytes(batch, walMapper.writeValueAsBytes(entry.getKey()));
+                    writeBytes(batch, walMapper.writeValueAsBytes(entry.getValue()));
+                }
+            }
+            byte[] payload = bytes.toByteArray();
+            synchronized (out) {
+                out.writeByte(OP_BATCH);
+                out.writeInt(payload.length);
+                out.write(payload);
+                out.flush();
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to append BATCH WAL entry", e);
+        }
+    }
+
+    private static void writeBytes(DataOutputStream out, byte[] value) throws IOException {
+        out.writeInt(value.length);
+        out.write(value);
+    }
+
     @SuppressWarnings("unchecked")
     private int replayWal() {
         int replayed = 0;
@@ -246,6 +301,17 @@ public class WalStorage<K, V> implements StorageBackend<K, V> {
             while (true) {
                 int op;
                 try { op = in.readByte(); } catch (EOFException e) { break; }
+
+                if (op == OP_BATCH) {
+                    int payloadLength = in.readInt();
+                    byte[] payload = in.readNBytes(payloadLength);
+                    if (payload.length < payloadLength) {
+                        break;
+                    }
+                    replayBatch(payload);
+                    replayed++;
+                    continue;
+                }
 
                 int keyLen = in.readInt();
                 byte[] keyBytes = in.readNBytes(keyLen);
@@ -274,6 +340,39 @@ public class WalStorage<K, V> implements StorageBackend<K, V> {
                     walPath, replayed);
         }
         return replayed;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void replayBatch(byte[] payload) throws IOException {
+        Map<K, V> puts = new java.util.LinkedHashMap<>();
+        Set<K> deletes = new java.util.LinkedHashSet<>();
+        try (DataInputStream batch = new DataInputStream(new ByteArrayInputStream(payload))) {
+            int deleteCount = batch.readInt();
+            for (int i = 0; i < deleteCount; i++) {
+                deletes.add((K) walMapper.readValue(readBytes(batch), Object.class));
+            }
+            int putCount = batch.readInt();
+            for (int i = 0; i < putCount; i++) {
+                K key = (K) walMapper.readValue(readBytes(batch), Object.class);
+                V value = walMapper.readValue(readBytes(batch),
+                        walMapper.constructType(typeReference.getType()).getContentType());
+                puts.put(key, value);
+            }
+            if (batch.available() != 0) {
+                throw new IOException("Unexpected trailing bytes in WAL batch");
+            }
+        }
+        deletes.forEach(store::remove);
+        store.putAll(puts);
+    }
+
+    private static byte[] readBytes(DataInputStream in) throws IOException {
+        int length = in.readInt();
+        byte[] value = in.readNBytes(length);
+        if (value.length < length) {
+            throw new EOFException("Incomplete WAL batch value");
+        }
+        return value;
     }
 
     private void openWalWriter() {

--- a/src/main/java/io/floci/az/core/storage/WalStorage.java
+++ b/src/main/java/io/floci/az/core/storage/WalStorage.java
@@ -261,7 +261,7 @@ public class WalStorage<K, V> implements StorageBackend<K, V> {
     private void appendBatch(Map<K, V> puts, Set<K> deletes) {
         DataOutputStream out = walWriter;
         if (out == null) {
-            return;
+            throw new IllegalStateException("WAL writer is not open");
         }
         try {
             ByteArrayOutputStream bytes = new ByteArrayOutputStream();

--- a/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
@@ -267,7 +267,7 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         return cosmosResponse(parseData(found.get()), Response.Status.OK, found.get().etag());
     }
 
-    private Response deleteDatabase(AzureRequest req, String dbId) {
+    private synchronized Response deleteDatabase(AzureRequest req, String dbId) {
         String key = dbKey(req.accountName(), dbId);
         if (store.get(key).isEmpty()) return notFound(dbId);
 
@@ -509,7 +509,7 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         }
     }
 
-    private Response deleteContainer(AzureRequest req, String dbId, String collId) {
+    private synchronized Response deleteContainer(AzureRequest req, String dbId, String collId) {
         String key = collKey(req.accountName(), dbId, collId);
         if (store.get(key).isEmpty()) return notFound(collId);
 

--- a/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
@@ -868,7 +868,7 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         body.put("id", id);
 
         String key = docKey(account, dbId, collId, pkEnc, id);
-        Optional<StoredObject> existing = liveDoc(Optional.ofNullable(documents.get(key)), defaultTtl);
+        Optional<StoredObject> existing = liveBatchDocument(documents, key, defaultTtl);
         boolean existed = existing.isPresent();
         if (itemPreconditionFailed(ifMatch, ifNoneMatch, existing.orElse(null))) {
             return batchResultError(412);
@@ -895,7 +895,7 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         if (docId == null) return batchResultError(400);
 
         String key = docKey(account, dbId, collId, pkEnc, docId);
-        Optional<StoredObject> found = liveDoc(Optional.ofNullable(documents.get(key)), defaultTtl);
+        Optional<StoredObject> found = liveBatchDocument(documents, key, defaultTtl);
         if (found.isEmpty()) found = liveDoc(findBatchDocument(documents, docId), defaultTtl);
         if (found.isEmpty()) return batchResultError(404);
 
@@ -911,7 +911,7 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         if (docId == null || body == null) return batchResultError(400);
 
         String key = docKey(account, dbId, collId, pkEnc, docId);
-        Optional<StoredObject> found = liveDoc(Optional.ofNullable(documents.get(key)), defaultTtl);
+        Optional<StoredObject> found = liveBatchDocument(documents, key, defaultTtl);
         if (found.isEmpty()) return batchResultError(404);
         if (itemPreconditionFailed(ifMatch, ifNoneMatch, found.get())) return batchResultError(412);
 
@@ -940,7 +940,7 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         if (docId == null || body == null) return batchResultError(400);
 
         String key = docKey(account, dbId, collId, pkEnc, docId);
-        Optional<StoredObject> found = liveDoc(Optional.ofNullable(documents.get(key)), defaultTtl);
+        Optional<StoredObject> found = liveBatchDocument(documents, key, defaultTtl);
         if (found.isEmpty()) return batchResultError(404);
         if (itemPreconditionFailed(ifMatch, ifNoneMatch, found.get())) return batchResultError(412);
         if (!(body.get("operations") instanceof List<?> rawOperations)) return batchResultError(400);
@@ -967,7 +967,7 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         if (docId == null) return batchResultError(400);
 
         String key = docKey(account, dbId, collId, pkEnc, docId);
-        Optional<StoredObject> found = liveDoc(Optional.ofNullable(documents.get(key)), defaultTtl);
+        Optional<StoredObject> found = liveBatchDocument(documents, key, defaultTtl);
         if (found.isEmpty()) found = liveDoc(findBatchDocument(documents, docId), defaultTtl);
         if (found.isEmpty()) return batchResultError(404);
         if (itemPreconditionFailed(ifMatch, ifNoneMatch, found.get())) return batchResultError(412);
@@ -980,6 +980,11 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         return documents.values().stream()
                 .filter(object -> object.key().endsWith("|" + docId))
                 .findFirst();
+    }
+
+    private Optional<StoredObject> liveBatchDocument(Map<String, StoredObject> documents,
+            String key, Object defaultTtl) {
+        return liveDoc(Optional.ofNullable(documents.get(key)), defaultTtl);
     }
 
     private Response itemPreconditionFailure(AzureRequest req, StoredObject existing) {

--- a/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
@@ -130,7 +130,7 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         return notImplemented();
     }
 
-    private Response routeDocs(AzureRequest req, String[] segs, String dbId, String collId) {
+    private synchronized Response routeDocs(AzureRequest req, String[] segs, String dbId, String collId) {
         String m      = req.method().toUpperCase();
         // Query plan requests use x-ms-cosmos-is-query-plan-request: True (no isquery header)
         boolean planRequest = "True".equalsIgnoreCase(
@@ -773,8 +773,7 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         Optional<StoredObject> collFound = store.get(collKey(req.accountName(), dbId, collId));
         if (collFound.isEmpty()) return notFound(collId);
 
-        String pk    = extractPartitionKeyValue(req);
-        String pkEnc = encodeKey(pk);
+        String pkEnc = encodeKey(extractPartitionKeyValue(req));
         Object defaultTtl = containerDefaultTtl(collFound);
 
         List<Map<String, Object>> operations;
@@ -785,7 +784,14 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
             return errorResponse(400, "BadRequest", "Invalid batch request body.");
         }
 
+        String partitionPrefix = docKey(req.accountName(), dbId, collId, pkEnc, "");
+        Map<String, StoredObject> original = store.scan(k -> k.startsWith(partitionPrefix)).stream()
+                .collect(Collectors.toMap(StoredObject::key, object -> object,
+                        (left, right) -> left, LinkedHashMap::new));
+        Map<String, StoredObject> staged = new LinkedHashMap<>(original);
+
         List<Map<String, Object>> results = new ArrayList<>();
+        boolean failed = false;
         for (Map<String, Object> op : operations) {
             String opType = op.get("operationType") instanceof String t ? t : "";
             String docId  = op.get("id") instanceof String s ? s : null;
@@ -794,18 +800,37 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
             String ifMatch = op.get("ifMatch") instanceof String value ? value : null;
             String ifNoneMatch = op.get("ifNoneMatch") instanceof String value ? value : null;
 
-            results.add(switch (opType) {
-                case "Create"  -> batchCreate(req.accountName(), dbId, collId, pk, pkEnc, body, false, defaultTtl,
-                        ifMatch, ifNoneMatch);
-                case "Upsert"  -> batchCreate(req.accountName(), dbId, collId, pk, pkEnc, body, true, defaultTtl,
-                        ifMatch, ifNoneMatch);
-                case "Read"    -> batchRead(req.accountName(), dbId, collId, pkEnc, docId, defaultTtl);
-                case "Replace" -> batchReplace(req.accountName(), dbId, collId, pkEnc, docId, body,
+            Map<String, Object> result = switch (opType) {
+                case "Create"  -> batchCreate(staged, req.accountName(), dbId, collId, pkEnc, body, false,
                         defaultTtl, ifMatch, ifNoneMatch);
-                case "Delete"  -> batchDelete(req.accountName(), dbId, collId, pkEnc, docId,
+                case "Upsert"  -> batchCreate(staged, req.accountName(), dbId, collId, pkEnc, body, true,
+                        defaultTtl, ifMatch, ifNoneMatch);
+                case "Read"    -> batchRead(staged, req.accountName(), dbId, collId, pkEnc, docId, defaultTtl);
+                case "Replace" -> batchReplace(staged, req.accountName(), dbId, collId, pkEnc, docId, body,
+                        defaultTtl, ifMatch, ifNoneMatch);
+                case "Delete"  -> batchDelete(staged, req.accountName(), dbId, collId, pkEnc, docId,
                         defaultTtl, ifMatch, ifNoneMatch);
                 default        -> batchResultError(400);
-            });
+            };
+            results.add(result);
+
+            if (((Number) result.get("statusCode")).intValue() >= 400) {
+                for (int previous = 0; previous < results.size() - 1; previous++) {
+                    results.set(previous, batchResultError(424));
+                }
+                while (results.size() < operations.size()) {
+                    results.add(batchResultError(424));
+                }
+                failed = true;
+                break;
+            }
+        }
+
+        if (!failed) {
+            original.keySet().stream()
+                    .filter(key -> !staged.containsKey(key))
+                    .forEach(store::delete);
+            staged.forEach(store::put);
         }
 
         try {
@@ -821,8 +846,9 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
     }
 
     @SuppressWarnings("unchecked")
-    private Map<String, Object> batchCreate(String account, String dbId, String collId,
-            String pk, String pkEnc, Map<String, Object> body, boolean upsert,
+    private Map<String, Object> batchCreate(Map<String, StoredObject> documents,
+            String account, String dbId, String collId,
+            String pkEnc, Map<String, Object> body, boolean upsert,
             Object defaultTtl, String ifMatch, String ifNoneMatch) {
         if (body == null) return batchResultError(400);
 
@@ -831,7 +857,7 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         body.put("id", id);
 
         String key = docKey(account, dbId, collId, pkEnc, id);
-        Optional<StoredObject> existing = liveDoc(store.get(key), defaultTtl);
+        Optional<StoredObject> existing = liveDoc(Optional.ofNullable(documents.get(key)), defaultTtl);
         boolean existed = existing.isPresent();
         if (itemPreconditionFailed(ifMatch, ifNoneMatch, existing.orElse(null))) {
             return batchResultError(412);
@@ -848,22 +874,18 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         body.put("_ts",          now.getEpochSecond());
         body.put("_attachments", "attachments/");
 
-        store.put(key, stored(key, body, now, etag));
+        documents.put(key, stored(key, body, now, etag));
         return batchResultOk(upsert && existed ? 200 : 201, etag, body);
     }
 
-    private Map<String, Object> batchRead(String account, String dbId, String collId,
+    private Map<String, Object> batchRead(Map<String, StoredObject> documents,
+            String account, String dbId, String collId,
             String pkEnc, String docId, Object defaultTtl) {
         if (docId == null) return batchResultError(400);
 
         String key = docKey(account, dbId, collId, pkEnc, docId);
-        Optional<StoredObject> found = liveDoc(store.get(key), defaultTtl);
-        if (found.isEmpty()) {
-            // Fallback scan for cases where PK is unknown/encoded differently
-            String prefix = account + K_DOC + dbId + "|" + collId + "|";
-            found = liveDoc(store.scan(k -> k.startsWith(prefix) && k.endsWith("|" + docId))
-                    .stream().findFirst(), defaultTtl);
-        }
+        Optional<StoredObject> found = liveDoc(Optional.ofNullable(documents.get(key)), defaultTtl);
+        if (found.isEmpty()) found = liveDoc(findBatchDocument(documents, docId), defaultTtl);
         if (found.isEmpty()) return batchResultError(404);
 
         Map<String, Object> doc = parseData(found.get());
@@ -871,13 +893,14 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
     }
 
     @SuppressWarnings("unchecked")
-    private Map<String, Object> batchReplace(String account, String dbId, String collId,
+    private Map<String, Object> batchReplace(Map<String, StoredObject> documents,
+            String account, String dbId, String collId,
             String pkEnc, String docId, Map<String, Object> body,
             Object defaultTtl, String ifMatch, String ifNoneMatch) {
         if (docId == null || body == null) return batchResultError(400);
 
         String key = docKey(account, dbId, collId, pkEnc, docId);
-        Optional<StoredObject> found = liveDoc(store.get(key), defaultTtl);
+        Optional<StoredObject> found = liveDoc(Optional.ofNullable(documents.get(key)), defaultTtl);
         if (found.isEmpty()) return batchResultError(404);
         if (itemPreconditionFailed(ifMatch, ifNoneMatch, found.get())) return batchResultError(412);
 
@@ -894,26 +917,29 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         body.put("_ts",          now.getEpochSecond());
         body.put("_attachments", "attachments/");
 
-        store.put(key, stored(key, body, now, etag));
+        documents.put(key, stored(key, body, now, etag));
         return batchResultOk(200, etag, body);
     }
 
-    private Map<String, Object> batchDelete(String account, String dbId, String collId,
+    private Map<String, Object> batchDelete(Map<String, StoredObject> documents,
+            String account, String dbId, String collId,
             String pkEnc, String docId, Object defaultTtl, String ifMatch, String ifNoneMatch) {
         if (docId == null) return batchResultError(400);
 
         String key = docKey(account, dbId, collId, pkEnc, docId);
-        Optional<StoredObject> found = liveDoc(store.get(key), defaultTtl);
-        if (found.isEmpty()) {
-            String prefix = account + K_DOC + dbId + "|" + collId + "|";
-            found = liveDoc(store.scan(k -> k.startsWith(prefix) && k.endsWith("|" + docId))
-                    .stream().findFirst(), defaultTtl);
-        }
+        Optional<StoredObject> found = liveDoc(Optional.ofNullable(documents.get(key)), defaultTtl);
+        if (found.isEmpty()) found = liveDoc(findBatchDocument(documents, docId), defaultTtl);
         if (found.isEmpty()) return batchResultError(404);
         if (itemPreconditionFailed(ifMatch, ifNoneMatch, found.get())) return batchResultError(412);
 
-        store.delete(found.get().key());
+        documents.remove(found.get().key());
         return batchResultOk(204, null, null);
+    }
+
+    private Optional<StoredObject> findBatchDocument(Map<String, StoredObject> documents, String docId) {
+        return documents.values().stream()
+                .filter(object -> object.key().endsWith("|" + docId))
+                .findFirst();
     }
 
     private Response itemPreconditionFailure(AzureRequest req, StoredObject existing) {

--- a/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
@@ -941,7 +941,11 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         if (itemPreconditionFailed(ifMatch, ifNoneMatch, found.get())) return batchResultError(412);
         if (!(body.get("operations") instanceof List<?> rawOperations)) return batchResultError(400);
 
-        List<Map<String, Object>> operations = (List<Map<String, Object>>) rawOperations;
+        List<Map<String, Object>> operations = new ArrayList<>(rawOperations.size());
+        for (Object rawOperation : rawOperations) {
+            if (!(rawOperation instanceof Map<?, ?> operation)) return batchResultError(400);
+            operations.add((Map<String, Object>) operation);
+        }
         Map<String, Object> document = parseData(found.get());
         applyPatchOperations(document, operations);
 

--- a/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
@@ -834,10 +834,14 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         }
 
         if (!failed) {
-            original.keySet().stream()
+            Set<String> deletes = original.keySet().stream()
                     .filter(key -> !staged.containsKey(key))
-                    .forEach(store::delete);
-            staged.forEach(store::put);
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+            Map<String, StoredObject> puts = staged.entrySet().stream()
+                    .filter(entry -> !entry.getValue().equals(original.get(entry.getKey())))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue,
+                            (left, right) -> left, LinkedHashMap::new));
+            store.applyBatch(puts, deletes);
         }
 
         try {

--- a/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
@@ -1426,5 +1426,5 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
 
     private String quoted(String s) { return "\"" + s + "\""; }
 
-    public void clear() { store.clear(); }
+    public synchronized void clear() { store.clear(); }
 }

--- a/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
@@ -630,32 +630,7 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         //   1. {"operations": [...]}  — Java / Python SDKs
         //   2. [{op, path, value}, …] — Node SDK (sends the array directly)
         List<Map<String, Object>> operations = parsePatchBody(req);
-
-        for (Map<String, Object> op : operations) {
-            String opType = op.get("op") instanceof String s ? s.toLowerCase() : "";
-            String path   = op.get("path") instanceof String p ? p : null;
-            Object value  = op.get("value");
-
-            if (path == null) {
-                LOG.warnf("PATCH op '%s' missing 'path' — skipping", opType);
-                continue;
-            }
-
-            switch (opType) {
-                case "add", "set", "replace" -> patchSet(doc, path, value);
-                case "remove"                -> patchRemove(doc, path);
-                case "incr"                  -> patchIncr(doc, path, value);
-                case "move"                  -> {
-                    String from = op.get("from") instanceof String f ? f : null;
-                    if (from != null) {
-                        Object moved = patchGet(doc, from);
-                        patchRemove(doc, from);
-                        patchSet(doc, path, moved);
-                    }
-                }
-                default -> LOG.warnf("Unknown PATCH op '%s' — skipping", opType);
-            }
-        }
+        applyPatchOperations(doc, operations);
 
         Instant now  = Instant.now();
         String  etag = newEtag();
@@ -665,6 +640,32 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         store.put(obj.key(), stored(obj.key(), doc, now, etag));
         return cosmosResponse(doc, Response.Status.OK, etag,
                 "dbs/" + dbId + "/colls/" + collId);
+    }
+
+    private void applyPatchOperations(Map<String, Object> doc, List<Map<String, Object>> operations) {
+        for (Map<String, Object> op : operations) {
+            String opType = op.get("op") instanceof String value ? value.toLowerCase() : "";
+            String path = op.get("path") instanceof String value ? value : null;
+            if (path == null) {
+                LOG.warnf("PATCH op '%s' missing 'path' — skipping", opType);
+                continue;
+            }
+
+            switch (opType) {
+                case "add", "set", "replace" -> patchSet(doc, path, op.get("value"));
+                case "remove" -> patchRemove(doc, path);
+                case "incr" -> patchIncr(doc, path, op.get("value"));
+                case "move" -> {
+                    String from = op.get("from") instanceof String value ? value : null;
+                    if (from != null) {
+                        Object moved = patchGet(doc, from);
+                        patchRemove(doc, from);
+                        patchSet(doc, path, moved);
+                    }
+                }
+                default -> LOG.warnf("Unknown PATCH op '%s' — skipping", opType);
+            }
+        }
     }
 
     /** Set (or create) the field at {@code /a/b/…} to {@code value}. */
@@ -690,7 +691,11 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         String key     = parts[parts.length - 1];
         double current = toDouble(target.getOrDefault(key, 0));
         double result  = current + toDouble(delta);
-        target.put(key, isWholeNum(result) ? (long) result : result);
+        if (isWholeNum(result)) {
+            target.put(key, (long) result);
+        } else {
+            target.put(key, result);
+        }
     }
 
     /** Read the field at {@code path} (used by {@code move}). */
@@ -766,7 +771,7 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
      * {@code "eTag"} and {@code "resourceBody"}.</p>
      *
      * <p>Supported operation types: {@code Create}, {@code Upsert}, {@code Read},
-     * {@code Replace}, {@code Delete}.</p>
+     * {@code Replace}, {@code Patch}, {@code Delete}.</p>
      */
     @SuppressWarnings("unchecked")
     private Response executeBatch(AzureRequest req, String dbId, String collId) {
@@ -807,6 +812,8 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
                         defaultTtl, ifMatch, ifNoneMatch);
                 case "Read"    -> batchRead(staged, req.accountName(), dbId, collId, pkEnc, docId, defaultTtl);
                 case "Replace" -> batchReplace(staged, req.accountName(), dbId, collId, pkEnc, docId, body,
+                        defaultTtl, ifMatch, ifNoneMatch);
+                case "Patch"   -> batchPatch(staged, req.accountName(), dbId, collId, pkEnc, docId, body,
                         defaultTtl, ifMatch, ifNoneMatch);
                 case "Delete"  -> batchDelete(staged, req.accountName(), dbId, collId, pkEnc, docId,
                         defaultTtl, ifMatch, ifNoneMatch);
@@ -919,6 +926,31 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
 
         documents.put(key, stored(key, body, now, etag));
         return batchResultOk(200, etag, body);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> batchPatch(Map<String, StoredObject> documents,
+            String account, String dbId, String collId,
+            String pkEnc, String docId, Map<String, Object> body,
+            Object defaultTtl, String ifMatch, String ifNoneMatch) {
+        if (docId == null || body == null) return batchResultError(400);
+
+        String key = docKey(account, dbId, collId, pkEnc, docId);
+        Optional<StoredObject> found = liveDoc(Optional.ofNullable(documents.get(key)), defaultTtl);
+        if (found.isEmpty()) return batchResultError(404);
+        if (itemPreconditionFailed(ifMatch, ifNoneMatch, found.get())) return batchResultError(412);
+        if (!(body.get("operations") instanceof List<?> rawOperations)) return batchResultError(400);
+
+        List<Map<String, Object>> operations = (List<Map<String, Object>>) rawOperations;
+        Map<String, Object> document = parseData(found.get());
+        applyPatchOperations(document, operations);
+
+        Instant now = Instant.now();
+        String etag = newEtag();
+        document.put("_etag", quoted(etag));
+        document.put("_ts", now.getEpochSecond());
+        documents.put(key, stored(key, document, now, etag));
+        return batchResultOk(200, etag, document);
     }
 
     private Map<String, Object> batchDelete(Map<String, StoredObject> documents,

--- a/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
@@ -545,8 +545,12 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         String pk     = resolvePartitionKey(body, collMeta, req);
         String pkEnc  = encodeKey(pk);
         String docKey = docKey(req.accountName(), dbId, collId, pkEnc, id);
+        Optional<StoredObject> existing = liveDoc(store.get(docKey), collMeta.get("defaultTtl"));
 
-        if (!upsert && liveDoc(store.get(docKey), collMeta.get("defaultTtl")).isPresent())
+        Response conditionFailure = itemPreconditionFailure(req, existing.orElse(null));
+        if (conditionFailure != null) return conditionFailure;
+
+        if (!upsert && existing.isPresent())
             return errorResponse(409, "Conflict", "Document with id '" + id + "' already exists.");
 
         Instant now  = Instant.now();
@@ -585,6 +589,9 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         Optional<StoredObject> existing = liveDoc(store.get(docKey), collMeta.get("defaultTtl"));
         if (existing.isEmpty()) return notFound(docId);
 
+        Response conditionFailure = itemPreconditionFailure(req, existing.get());
+        if (conditionFailure != null) return conditionFailure;
+
         Instant now  = Instant.now();
         String  etag = newEtag();
         Map<String, Object> old = parseData(existing.get());
@@ -613,6 +620,9 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
     private Response patchDocument(AzureRequest req, String dbId, String collId, String docId) {
         StoredObject obj = findDoc(req, dbId, collId, docId);
         if (obj == null) return notFound(docId);
+
+        Response conditionFailure = itemPreconditionFailure(req, obj);
+        if (conditionFailure != null) return conditionFailure;
 
         Map<String, Object> doc = parseData(obj);
 
@@ -732,6 +742,10 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
     private Response deleteDocument(AzureRequest req, String dbId, String collId, String docId) {
         StoredObject obj = findDoc(req, dbId, collId, docId);
         if (obj == null) return notFound(docId);
+
+        Response conditionFailure = itemPreconditionFailure(req, obj);
+        if (conditionFailure != null) return conditionFailure;
+
         store.delete(obj.key());
         return Response.noContent().build();
     }
@@ -777,13 +791,19 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
             String docId  = op.get("id") instanceof String s ? s : null;
             Map<String, Object> body = op.get("resourceBody") instanceof Map<?, ?> m
                     ? (Map<String, Object>) m : null;
+            String ifMatch = op.get("ifMatch") instanceof String value ? value : null;
+            String ifNoneMatch = op.get("ifNoneMatch") instanceof String value ? value : null;
 
             results.add(switch (opType) {
-                case "Create"  -> batchCreate(req.accountName(), dbId, collId, pk, pkEnc, body, false, defaultTtl);
-                case "Upsert"  -> batchCreate(req.accountName(), dbId, collId, pk, pkEnc, body, true, defaultTtl);
+                case "Create"  -> batchCreate(req.accountName(), dbId, collId, pk, pkEnc, body, false, defaultTtl,
+                        ifMatch, ifNoneMatch);
+                case "Upsert"  -> batchCreate(req.accountName(), dbId, collId, pk, pkEnc, body, true, defaultTtl,
+                        ifMatch, ifNoneMatch);
                 case "Read"    -> batchRead(req.accountName(), dbId, collId, pkEnc, docId, defaultTtl);
-                case "Replace" -> batchReplace(req.accountName(), dbId, collId, pkEnc, docId, body, defaultTtl);
-                case "Delete"  -> batchDelete(req.accountName(), dbId, collId, pkEnc, docId, defaultTtl);
+                case "Replace" -> batchReplace(req.accountName(), dbId, collId, pkEnc, docId, body,
+                        defaultTtl, ifMatch, ifNoneMatch);
+                case "Delete"  -> batchDelete(req.accountName(), dbId, collId, pkEnc, docId,
+                        defaultTtl, ifMatch, ifNoneMatch);
                 default        -> batchResultError(400);
             });
         }
@@ -802,15 +822,20 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
 
     @SuppressWarnings("unchecked")
     private Map<String, Object> batchCreate(String account, String dbId, String collId,
-            String pk, String pkEnc, Map<String, Object> body, boolean upsert, Object defaultTtl) {
+            String pk, String pkEnc, Map<String, Object> body, boolean upsert,
+            Object defaultTtl, String ifMatch, String ifNoneMatch) {
         if (body == null) return batchResultError(400);
 
         body = new LinkedHashMap<>(body);
         String id = body.containsKey("id") ? String.valueOf(body.get("id")) : UUID.randomUUID().toString();
         body.put("id", id);
 
-        String key     = docKey(account, dbId, collId, pkEnc, id);
-        boolean existed = liveDoc(store.get(key), defaultTtl).isPresent();
+        String key = docKey(account, dbId, collId, pkEnc, id);
+        Optional<StoredObject> existing = liveDoc(store.get(key), defaultTtl);
+        boolean existed = existing.isPresent();
+        if (itemPreconditionFailed(ifMatch, ifNoneMatch, existing.orElse(null))) {
+            return batchResultError(412);
+        }
         if (!upsert && existed) return batchResultError(409);
 
         Instant now  = Instant.now();
@@ -847,12 +872,14 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
 
     @SuppressWarnings("unchecked")
     private Map<String, Object> batchReplace(String account, String dbId, String collId,
-            String pkEnc, String docId, Map<String, Object> body, Object defaultTtl) {
+            String pkEnc, String docId, Map<String, Object> body,
+            Object defaultTtl, String ifMatch, String ifNoneMatch) {
         if (docId == null || body == null) return batchResultError(400);
 
         String key = docKey(account, dbId, collId, pkEnc, docId);
         Optional<StoredObject> found = liveDoc(store.get(key), defaultTtl);
         if (found.isEmpty()) return batchResultError(404);
+        if (itemPreconditionFailed(ifMatch, ifNoneMatch, found.get())) return batchResultError(412);
 
         body = new LinkedHashMap<>(body);
         body.put("id", docId);
@@ -872,7 +899,7 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
     }
 
     private Map<String, Object> batchDelete(String account, String dbId, String collId,
-            String pkEnc, String docId, Object defaultTtl) {
+            String pkEnc, String docId, Object defaultTtl, String ifMatch, String ifNoneMatch) {
         if (docId == null) return batchResultError(400);
 
         String key = docKey(account, dbId, collId, pkEnc, docId);
@@ -883,9 +910,34 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
                     .stream().findFirst(), defaultTtl);
         }
         if (found.isEmpty()) return batchResultError(404);
+        if (itemPreconditionFailed(ifMatch, ifNoneMatch, found.get())) return batchResultError(412);
 
         store.delete(found.get().key());
         return batchResultOk(204, null, null);
+    }
+
+    private Response itemPreconditionFailure(AzureRequest req, StoredObject existing) {
+        String ifMatch = req.headers().getHeaderString("If-Match");
+        String ifNoneMatch = req.headers().getHeaderString("If-None-Match");
+        if (!itemPreconditionFailed(ifMatch, ifNoneMatch, existing)) return null;
+        return errorResponse(412, "PreconditionFailed",
+                "The condition specified using HTTP conditional header(s) is not met.");
+    }
+
+    private boolean itemPreconditionFailed(String ifMatch, String ifNoneMatch, StoredObject existing) {
+        if (ifMatch != null && !etagMatches(ifMatch, existing)) return true;
+        return ifNoneMatch != null && etagMatches(ifNoneMatch, existing);
+    }
+
+    private boolean etagMatches(String condition, StoredObject existing) {
+        if (existing == null) return false;
+        String value = condition.trim();
+        if ("*".equals(value)) return true;
+        if (value.startsWith("W/")) value = value.substring(2).trim();
+        if (value.length() >= 2 && value.startsWith("\"") && value.endsWith("\"")) {
+            value = value.substring(1, value.length() - 1);
+        }
+        return value.equals(existing.etag());
     }
 
     private Map<String, Object> batchResultOk(int statusCode, String etag, Map<String, Object> resourceBody) {

--- a/src/test/java/io/floci/az/core/storage/StorageBatchTest.java
+++ b/src/test/java/io/floci/az/core/storage/StorageBatchTest.java
@@ -14,6 +14,7 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class StorageBatchTest {
@@ -92,6 +93,20 @@ class StorageBatchTest {
                 new WalStorage<>(snapshot, wal, STRING_MAP, 60_000);
         try {
             storage.load();
+            assertTrue(storage.keys().isEmpty());
+        } finally {
+            storage.shutdown();
+        }
+    }
+
+    @Test
+    void walStorageRejectsBatchBeforeWriterIsOpen() {
+        WalStorage<String, String> storage = new WalStorage<>(
+                tempDir.resolve("unopened-snapshot.json"),
+                tempDir.resolve("unopened-storage.wal"), STRING_MAP, 60_000);
+        try {
+            assertThrows(IllegalStateException.class,
+                    () -> storage.applyBatch(Map.of("new", "value"), Set.of()));
             assertTrue(storage.keys().isEmpty());
         } finally {
             storage.shutdown();

--- a/src/test/java/io/floci/az/core/storage/StorageBatchTest.java
+++ b/src/test/java/io/floci/az/core/storage/StorageBatchTest.java
@@ -1,0 +1,105 @@
+package io.floci.az.core.storage;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StorageBatchTest {
+
+    private static final TypeReference<Map<String, String>> STRING_MAP = new TypeReference<>() {};
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void persistentStorageWritesOneBatchSnapshot() {
+        Path file = tempDir.resolve("persistent.json");
+        PersistentStorage<String, String> storage = new PersistentStorage<>(file, STRING_MAP);
+        storage.put("old", "value");
+
+        storage.applyBatch(Map.of("new", "value"), Set.of("old"));
+
+        PersistentStorage<String, String> recovered = new PersistentStorage<>(file, STRING_MAP);
+        recovered.load();
+        assertBatchApplied(recovered);
+    }
+
+    @Test
+    void hybridStorageFlushesOneBatchSnapshot() {
+        Path file = tempDir.resolve("hybrid.json");
+        HybridStorage<String, String> storage = new HybridStorage<>(file, STRING_MAP, 60_000);
+        try {
+            storage.put("old", "value");
+            storage.applyBatch(Map.of("new", "value"), Set.of("old"));
+            storage.flush();
+
+            HybridStorage<String, String> recovered =
+                    new HybridStorage<>(file, STRING_MAP, 60_000);
+            try {
+                recovered.load();
+                assertBatchApplied(recovered);
+            } finally {
+                recovered.shutdown();
+            }
+        } finally {
+            storage.shutdown();
+        }
+    }
+
+    @Test
+    void walStorageWritesBatchAsOneEntry() throws IOException {
+        Path snapshot = tempDir.resolve("snapshot.json");
+        Path wal = tempDir.resolve("storage.wal");
+        WalStorage<String, String> storage =
+                new WalStorage<>(snapshot, wal, STRING_MAP, 60_000);
+        try {
+            storage.load();
+            storage.applyBatch(Map.of("new", "value"), Set.of("old"));
+
+            assertBatchApplied(storage);
+            try (DataInputStream input = new DataInputStream(Files.newInputStream(wal))) {
+                assertEquals(WalStorage.OP_BATCH, input.readByte());
+                int payloadLength = input.readInt();
+                assertEquals(payloadLength, input.readAllBytes().length);
+            }
+        } finally {
+            storage.shutdown();
+        }
+    }
+
+    @Test
+    void walStorageIgnoresIncompleteBatchEntry() throws IOException {
+        Path snapshot = tempDir.resolve("incomplete-snapshot.json");
+        Path wal = tempDir.resolve("incomplete-storage.wal");
+        ByteBuffer incompleteEntry = ByteBuffer.allocate(7)
+                .put(WalStorage.OP_BATCH)
+                .putInt(10)
+                .putShort((short) 1);
+        Files.write(wal, incompleteEntry.array());
+        WalStorage<String, String> storage =
+                new WalStorage<>(snapshot, wal, STRING_MAP, 60_000);
+        try {
+            storage.load();
+            assertTrue(storage.keys().isEmpty());
+        } finally {
+            storage.shutdown();
+        }
+    }
+
+    private static void assertBatchApplied(StorageBackend<String, String> storage) {
+        assertFalse(storage.get("old").isPresent());
+        assertEquals("value", storage.get("new").orElseThrow());
+    }
+}

--- a/src/test/java/io/floci/az/services/cosmos/CosmosContainerTtlTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosContainerTtlTest.java
@@ -52,12 +52,12 @@ public class CosmosContainerTtlTest {
                 .when().put(BASE + "/dbs/" + DB + "/colls/" + id);
     }
 
-    private void insertDoc(String coll, String docJson) {
-        given().contentType("application/json")
+    private io.restassured.response.Response insertDoc(String coll, String docJson) {
+        return given().contentType("application/json")
                 .header("x-ms-documentdb-partitionkey", "[\"x\"]")
                 .body(docJson)
                 .when().post(BASE + "/dbs/" + DB + "/colls/" + coll + "/docs")
-                .then().statusCode(201);
+                .then().statusCode(201).extract().response();
     }
 
     private int getDocStatus(String coll, String docId) {
@@ -170,7 +170,7 @@ public class CosmosContainerTtlTest {
         createContainer("events", "2").then().statusCode(201);
         createContainer("keep", null).then().statusCode(201);
 
-        insertDoc("events", "{\"id\":\"a\",\"category\":\"x\"}");
+        String expiredEtag = insertDoc("events", "{\"id\":\"a\",\"category\":\"x\"}").header("ETag");
         insertDoc("events", "{\"id\":\"b\",\"category\":\"x\",\"ttl\":-1}");
         insertDoc("keep",   "{\"id\":\"c\",\"category\":\"x\",\"ttl\":1}");
 
@@ -199,14 +199,35 @@ public class CosmosContainerTtlTest {
                 .body("_count", is(1))
                 .body("Documents[0].id", is("b"));
 
-        // transactional batch sees the expired doc as gone too
+        // transactional batch sees the expired doc as gone and fails later operations atomically
         given().contentType("application/json")
                 .header("x-ms-cosmos-is-batch-request", "true")
                 .header("x-ms-documentdb-partitionkey", "[\"x\"]")
                 .body("[{\"operationType\":\"Read\",\"id\":\"a\"},{\"operationType\":\"Read\",\"id\":\"b\"}]")
                 .when().post(BASE + "/dbs/" + DB + "/colls/events/docs")
                 .then().statusCode(200)
-                .body("statusCode", contains(404, 200));
+                .body("statusCode", contains(404, 424));
+
+        // conditional point and batch mutations also treat the expired doc as absent
+        given().contentType("application/json")
+                .header("x-ms-documentdb-partitionkey", "[\"x\"]")
+                .header("If-Match", expiredEtag)
+                .body("{\"id\":\"a\",\"category\":\"x\"}")
+                .when().put(BASE + "/dbs/" + DB + "/colls/events/docs/a")
+                .then().statusCode(404);
+
+        given().contentType("application/json")
+                .header("x-ms-cosmos-is-batch-request", "true")
+                .header("x-ms-documentdb-partitionkey", "[\"x\"]")
+                .body("""
+                        [{
+                          "operationType": "Replace",
+                          "id": "a",
+                          "ifMatch": "%s",
+                          "resourceBody": {"id":"a","category":"x"}
+                        }]""".formatted(expiredEtag.replace("\"", "\\\"")))
+                .when().post(BASE + "/dbs/" + DB + "/colls/events/docs")
+                .then().statusCode(200).body("[0].statusCode", is(404));
 
         // an expired doc no longer blocks re-creating the same id
         insertDoc("events", "{\"id\":\"a\",\"category\":\"x\"}");

--- a/src/test/java/io/floci/az/services/cosmos/CosmosHandlerConcurrencyTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosHandlerConcurrencyTest.java
@@ -1,0 +1,53 @@
+package io.floci.az.services.cosmos;
+
+import io.floci.az.config.EmulatorConfig;
+import io.floci.az.core.StoredObject;
+import io.floci.az.core.storage.StorageBackend;
+import io.floci.az.core.storage.StorageFactory;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CosmosHandlerConcurrencyTest {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void clearAllWaitsForInFlightDocumentOperation() throws Exception {
+        StorageBackend<String, StoredObject> store = mock(StorageBackend.class);
+        StorageFactory factory = mock(StorageFactory.class);
+        when(factory.create("cosmos")).thenReturn(store);
+        CosmosHandler handler = new CosmosHandler(factory, mock(EmulatorConfig.class));
+
+        CountDownLatch clearStarted = new CountDownLatch(1);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<?> clear;
+            // routeDocs uses this monitor for point mutations and transactional batches.
+            synchronized (handler) {
+                clear = executor.submit(() -> {
+                    clearStarted.countDown();
+                    handler.clear();
+                });
+
+                assertTrue(clearStarted.await(5, TimeUnit.SECONDS));
+                assertThrows(TimeoutException.class, () -> clear.get(200, TimeUnit.MILLISECONDS));
+            }
+
+            clear.get(5, TimeUnit.SECONDS);
+            verify(store).clear();
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}

--- a/src/test/java/io/floci/az/services/cosmos/CosmosItemConditionTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosItemConditionTest.java
@@ -4,7 +4,17 @@ import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 
 @QuarkusTest
@@ -93,6 +103,64 @@ class CosmosItemConditionTest {
                 .then().statusCode(200).body("[0].statusCode", is(412));
 
         readDocument().then().statusCode(200).body("value", is(1));
+    }
+
+    @Test
+    void batchPreconditionFailureRollsBackEarlierMutation() {
+        String etag = createDocument(1);
+
+        given().contentType("application/json")
+                .header("x-ms-documentdb-partitionkey", PARTITION_KEY)
+                .header("x-ms-cosmos-is-batch-request", "true")
+                .body("""
+                        [
+                          {
+                            "operationType": "Replace",
+                            "id": "one",
+                            "ifMatch": "%s",
+                            "resourceBody": {"id":"one","pk":"p","value":2}
+                          },
+                          {
+                            "operationType": "Replace",
+                            "id": "one",
+                            "ifMatch": "\\\"stale\\\"",
+                            "resourceBody": {"id":"one","pk":"p","value":3}
+                          }
+                        ]""".formatted(etag.replace("\"", "\\\"")))
+                .post(DOCS)
+                .then().statusCode(200)
+                .body("statusCode", contains(424, 412));
+
+        readDocument().then().statusCode(200).body("value", is(1));
+    }
+
+    @Test
+    void concurrentMutationsWithSameEtagAllowOnlyOne() throws Exception {
+        String etag = createDocument(1);
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<Integer> first = executor.submit(() -> replaceAfterSignal(2, etag, ready, start));
+            Future<Integer> second = executor.submit(() -> replaceAfterSignal(3, etag, ready, start));
+            ready.await(5, TimeUnit.SECONDS);
+            start.countDown();
+
+            assertThat(List.of(first.get(), second.get()), containsInAnyOrder(200, 412));
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+
+    private int replaceAfterSignal(int value, String etag, CountDownLatch ready,
+                                   CountDownLatch start) throws InterruptedException {
+        ready.countDown();
+        start.await();
+        return given().contentType("application/json")
+                .header("x-ms-documentdb-partitionkey", PARTITION_KEY)
+                .header("If-Match", etag)
+                .body("{\"id\":\"one\",\"pk\":\"p\",\"value\":" + value + "}")
+                .put(DOCS + "/one").statusCode();
     }
 
     private String createDocument(int value) {

--- a/src/test/java/io/floci/az/services/cosmos/CosmosItemConditionTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosItemConditionTest.java
@@ -1,0 +1,109 @@
+package io.floci.az.services.cosmos;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+
+@QuarkusTest
+class CosmosItemConditionTest {
+
+    private static final String BASE = "/conditionacct-cosmos";
+    private static final String DOCS = BASE + "/dbs/db/colls/items/docs";
+    private static final String PARTITION_KEY = "[\"p\"]";
+
+    @BeforeEach
+    void setup() {
+        given().post("/_admin/reset").then().statusCode(204);
+        given().contentType("application/json").body("{\"id\":\"db\"}")
+                .post(BASE + "/dbs").then().statusCode(201);
+        given().contentType("application/json")
+                .body("{\"id\":\"items\",\"partitionKey\":{\"paths\":[\"/pk\"],\"kind\":\"Hash\"}}")
+                .post(BASE + "/dbs/db/colls").then().statusCode(201);
+    }
+
+    @Test
+    void staleIfMatchRejectsPointMutationsWithoutChangingDocument() {
+        createDocument(1);
+
+        given().contentType("application/json")
+                .header("x-ms-documentdb-partitionkey", PARTITION_KEY)
+                .header("If-Match", "\"stale\"")
+                .body("{\"id\":\"one\",\"pk\":\"p\",\"value\":2}")
+                .put(DOCS + "/one").then().statusCode(412);
+
+        given().contentType("application/json")
+                .header("x-ms-documentdb-partitionkey", PARTITION_KEY)
+                .header("If-Match", "\"stale\"")
+                .body("{\"operations\":[{\"op\":\"set\",\"path\":\"/value\",\"value\":3}]}")
+                .patch(DOCS + "/one").then().statusCode(412);
+
+        given().header("x-ms-documentdb-partitionkey", PARTITION_KEY)
+                .header("If-Match", "\"stale\"")
+                .delete(DOCS + "/one").then().statusCode(412);
+
+        readDocument().then().statusCode(200).body("value", is(1));
+    }
+
+    @Test
+    void upsertHonorsIfMatchAndIfNoneMatch() {
+        String etag = createDocument(1);
+
+        given().contentType("application/json")
+                .header("x-ms-documentdb-partitionkey", PARTITION_KEY)
+                .header("x-ms-documentdb-is-upsert", "True")
+                .header("If-Match", "\"stale\"")
+                .body("{\"id\":\"one\",\"pk\":\"p\",\"value\":2}")
+                .post(DOCS).then().statusCode(412);
+
+        given().contentType("application/json")
+                .header("x-ms-documentdb-partitionkey", PARTITION_KEY)
+                .header("x-ms-documentdb-is-upsert", "True")
+                .header("If-None-Match", "*")
+                .body("{\"id\":\"one\",\"pk\":\"p\",\"value\":2}")
+                .post(DOCS).then().statusCode(412);
+
+        given().contentType("application/json")
+                .header("x-ms-documentdb-partitionkey", PARTITION_KEY)
+                .header("x-ms-documentdb-is-upsert", "True")
+                .header("If-Match", etag)
+                .body("{\"id\":\"one\",\"pk\":\"p\",\"value\":2}")
+                .post(DOCS).then().statusCode(201);
+
+        readDocument().then().statusCode(200).body("value", is(2));
+    }
+
+    @Test
+    void transactionalBatchHonorsPerOperationIfMatch() {
+        createDocument(1);
+
+        given().contentType("application/json")
+                .header("x-ms-documentdb-partitionkey", PARTITION_KEY)
+                .header("x-ms-cosmos-is-batch-request", "true")
+                .body("""
+                        [{
+                          "operationType": "Replace",
+                          "id": "one",
+                          "ifMatch": "\\"stale\\"",
+                          "resourceBody": {"id":"one","pk":"p","value":2}
+                        }]""")
+                .post(DOCS)
+                .then().statusCode(200).body("[0].statusCode", is(412));
+
+        readDocument().then().statusCode(200).body("value", is(1));
+    }
+
+    private String createDocument(int value) {
+        return given().contentType("application/json")
+                .header("x-ms-documentdb-partitionkey", PARTITION_KEY)
+                .body("{\"id\":\"one\",\"pk\":\"p\",\"value\":" + value + "}")
+                .post(DOCS).then().statusCode(201).extract().header("ETag");
+    }
+
+    private io.restassured.response.Response readDocument() {
+        return given().header("x-ms-documentdb-partitionkey", PARTITION_KEY)
+                .get(DOCS + "/one");
+    }
+}

--- a/src/test/java/io/floci/az/services/cosmos/CosmosTransactionalBatchTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosTransactionalBatchTest.java
@@ -1,0 +1,85 @@
+package io.floci.az.services.cosmos;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+
+@QuarkusTest
+class CosmosTransactionalBatchTest {
+
+    private static final String BASE = "/batchacct-cosmos";
+    private static final String DOCS = BASE + "/dbs/db/colls/items/docs";
+    private static final String PARTITION_KEY = "[\"p\"]";
+
+    @BeforeEach
+    void setup() {
+        given().post("/_admin/reset").then().statusCode(204);
+        given().contentType("application/json").body("{\"id\":\"db\"}")
+                .post(BASE + "/dbs").then().statusCode(201);
+        given().contentType("application/json")
+                .body("{\"id\":\"items\",\"partitionKey\":{\"paths\":[\"/pk\"],\"kind\":\"Hash\"}}")
+                .post(BASE + "/dbs/db/colls").then().statusCode(201);
+        given().contentType("application/json")
+                .header("x-ms-documentdb-partitionkey", PARTITION_KEY)
+                .body("{\"id\":\"one\",\"pk\":\"p\",\"value\":1,\"counter\":2}")
+                .post(DOCS).then().statusCode(201);
+    }
+
+    @Test
+    void failedBatchRollsBackEarlierMutations() {
+        given().contentType("application/json")
+                .header("x-ms-documentdb-partitionkey", PARTITION_KEY)
+                .header("x-ms-cosmos-is-batch-request", "true")
+                .body("""
+                        [
+                          {
+                            "operationType":"Replace",
+                            "id":"one",
+                            "resourceBody":{"id":"one","pk":"p","value":777}
+                          },
+                          {"operationType":"Delete","id":"missing"}
+                        ]""")
+                .post(DOCS)
+                .then().statusCode(200)
+                .body("statusCode", contains(424, 404));
+
+        read("one").then().statusCode(200).body("value", is(1));
+    }
+
+    @Test
+    void patchParticipatesInBatchAndIsVisibleToFollowingRead() {
+        given().contentType("application/json")
+                .header("x-ms-documentdb-partitionkey", PARTITION_KEY)
+                .header("x-ms-cosmos-is-batch-request", "true")
+                .body("""
+                        [
+                          {
+                            "operationType":"Patch",
+                            "id":"one",
+                            "resourceBody":{"operations":[
+                              {"op":"set","path":"/value","value":3},
+                              {"op":"incr","path":"/counter","value":5}
+                            ]}
+                          },
+                          {"operationType":"Read","id":"one"}
+                        ]""")
+                .post(DOCS)
+                .then().statusCode(200)
+                .body("statusCode", contains(200, 200))
+                .body("[1].resourceBody.value", is(3))
+                .body("[1].resourceBody.counter", is(7));
+
+        read("one").then().statusCode(200)
+                .body("value", is(3))
+                .body("counter", is(7));
+    }
+
+    private io.restassured.response.Response read(String id) {
+        return given().header("x-ms-documentdb-partitionkey", PARTITION_KEY)
+                .get(DOCS + "/" + id);
+    }
+}

--- a/src/test/java/io/floci/az/services/cosmos/CosmosTransactionalBatchTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosTransactionalBatchTest.java
@@ -78,6 +78,29 @@ class CosmosTransactionalBatchTest {
                 .body("counter", is(7));
     }
 
+    @Test
+    void malformedPatchOperationReturnsBatchFailure() {
+        given().contentType("application/json")
+                .header("x-ms-documentdb-partitionkey", PARTITION_KEY)
+                .header("x-ms-cosmos-is-batch-request", "true")
+                .body("""
+                        [
+                          {
+                            "operationType":"Patch",
+                            "id":"one",
+                            "resourceBody":{"operations":[42]}
+                          },
+                          {"operationType":"Read","id":"one"}
+                        ]""")
+                .post(DOCS)
+                .then().statusCode(200)
+                .body("statusCode", contains(400, 424));
+
+        read("one").then().statusCode(200)
+                .body("value", is(1))
+                .body("counter", is(2));
+    }
+
     private io.restassured.response.Response read(String id) {
         return given().header("x-ms-documentdb-partitionkey", PARTITION_KEY)
                 .get(DOCS + "/" + id);


### PR DESCRIPTION
## Summary

- Enforce `If-Match` and `If-None-Match` on point create, upsert, replace, patch, and delete paths.
- Enforce per-operation ETag conditions for transactional-batch create, upsert, replace, patch, and delete.
- Commit successful transactional batches through `StorageBackend.applyBatch`; failed batches leave storage unchanged.
- Return Azure-compatible `412 PreconditionFailed` and `424 FailedDependency` responses.
- Add HTTP, storage, and Azure Cosmos Java SDK regression coverage.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change
- [ ] Docs / chore

## Validation

- `.\mvnw.cmd test "-Dtest=CosmosItemConditionTest,CosmosTransactionalBatchTest,StorageBatchTest"` — 14 tests passed.
- Existing PR checks passed before the follow-up; checks rerun after this push.

Depends on #169.

Closes #160