### PR TITLE
fix(cosmos): evaluate correlated EXISTS queries

### DIFF
--- a/docs/services/cosmos.md
+++ b/docs/services/cosmos.md
@@ -9,7 +9,7 @@ Compatible with the `azure-cosmos` SDK (Java, Python, JavaScript, .NET).
 - **Documents** — create, get, replace, delete, list; upsert via `x-ms-documentdb-is-upsert` header
 - **Queries** — in-process SQL engine with full Cosmos DB SQL dialect support:
   - `SELECT *`, `SELECT c.field1, c.field2`, `SELECT VALUE c.field`, `SELECT TOP n`
-  - `WHERE` with `=`, `!=`, `<>`, `>`, `>=`, `<`, `<=`, `IN`, `BETWEEN`, `NOT`, `AND`, `OR`
+  - `WHERE` with `=`, `!=`, `<>`, `>`, `>=`, `<`, `<=`, `IN`, `BETWEEN`, `NOT`, `AND`, `OR`, and correlated `EXISTS` over arrays
   - `WHERE` functions: `IS_DEFINED`, `IS_NULL`, `IS_STRING`, `IS_NUMBER`, `IS_BOOL`, `IS_ARRAY`, `IS_OBJECT`, `CONTAINS`, `STARTSWITH`, `ENDSWITH`, `ARRAY_CONTAINS`
   - `ORDER BY field [ASC|DESC]`, multiple fields — like Azure, an `ORDER BY` over two or more properties requires a matching composite index on the container, otherwise the query fails with `400 BadRequest` (error `SC2104`)
   - `OFFSET n LIMIT m` pagination

--- a/src/main/java/io/floci/az/services/cosmos/CosmosQueryEngine.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosQueryEngine.java
@@ -295,11 +295,14 @@ public class CosmosQueryEngine {
         // EXISTS(SELECT VALUE item FROM item IN c.items WHERE item.field = value)
         m = CORRELATED_EXISTS_PATTERN.matcher(pred);
         if (m.matches()) {
-            Object source = resolve(doc, m.group(2));
+            String itemAlias = m.group(1);
+            String sourcePath = m.group(2);
+            Object source = resolve(doc, sourcePath);
             if (!(source instanceof List<?> items)) return false;
             String where = m.group(3);
             if (where == null) return !items.isEmpty();
-            return items.stream().anyMatch(item -> evalExistsItem(item, where));
+            String outerAlias = sourcePath.contains(".") ? sourcePath.substring(0, sourcePath.indexOf('.')) : null;
+            return items.stream().anyMatch(item -> evalExistsItem(doc, item, itemAlias, outerAlias, where));
         }
 
         // IS_DEFINED(c.field)
@@ -439,11 +442,14 @@ public class CosmosQueryEngine {
         return false;
     }
 
-    private boolean evalExistsItem(Object item, String where) {
-        if (!(item instanceof Map<?, ?> map)) return false;
-        Map<String, Object> nestedDocument = new LinkedHashMap<>();
-        map.forEach((key, value) -> nestedDocument.put(String.valueOf(key), value));
-        return evalExpr(nestedDocument, where);
+    private boolean evalExistsItem(Map<String, Object> outerDocument, Object item, String itemAlias,
+                                   String outerAlias, String where) {
+        QueryScope scope = new QueryScope(outerDocument);
+        scope.bind(itemAlias, item);
+        if (outerAlias != null) {
+            scope.bind(outerAlias, outerDocument);
+        }
+        return evalExpr(scope, where);
     }
 
     /** Convert a SQL LIKE pattern (% and _ wildcards) to a regex and match. */
@@ -479,16 +485,45 @@ public class CosmosQueryEngine {
     }
 
     Object resolve(Map<String, Object> doc, String path) {
-        path = stripAlias(path);
-        Object current = doc;
-        for (String seg : path.split("\\.")) {
+        String[] segments = path.split("\\.");
+        Object current;
+        int startIndex;
+        if (doc instanceof QueryScope scope && scope.hasBinding(segments[0])) {
+            current = scope.binding(segments[0]);
+            startIndex = 1;
+        } else {
+            segments = stripAlias(path).split("\\.");
+            current = doc;
+            startIndex = 0;
+        }
+        for (int i = startIndex; i < segments.length; i++) {
             if (current instanceof Map<?, ?> map) {
-                current = map.get(seg);
+                current = map.get(segments[i]);
             } else {
                 return null;
             }
         }
         return current;
+    }
+
+    private static final class QueryScope extends LinkedHashMap<String, Object> {
+        private final Map<String, Object> bindings = new HashMap<>();
+
+        private QueryScope(Map<String, Object> document) {
+            super(document);
+        }
+
+        private void bind(String alias, Object value) {
+            bindings.put(alias, value);
+        }
+
+        private boolean hasBinding(String alias) {
+            return bindings.containsKey(alias);
+        }
+
+        private Object binding(String alias) {
+            return bindings.get(alias);
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/src/main/java/io/floci/az/services/cosmos/CosmosQueryEngine.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosQueryEngine.java
@@ -143,6 +143,10 @@ public class CosmosQueryEngine {
             Pattern.compile("(?i)\\bSELECT\\s+TOP\\s+(\\d+)");
     private static final Pattern OFFSET_LIMIT_PATTERN =
             Pattern.compile("(?i)\\bOFFSET\\s+(\\d+)\\s+LIMIT\\s+(\\d+)");
+    private static final Pattern CORRELATED_EXISTS_PATTERN = Pattern.compile(
+            "(?is)EXISTS\\s*\\(\\s*SELECT\\s+VALUE\\s+(\\w+)\\s+"
+                    + "FROM\\s+\\1\\s+IN\\s+([\\w.]+)"
+                    + "(?:\\s+WHERE\\s+(.+))?\\s*\\)");
 
     ParsedQuery parse(String sql) {
         String upper = sql.toUpperCase();
@@ -288,6 +292,16 @@ public class CosmosQueryEngine {
         pred = pred.trim();
         Matcher m;
 
+        // EXISTS(SELECT VALUE item FROM item IN c.items WHERE item.field = value)
+        m = CORRELATED_EXISTS_PATTERN.matcher(pred);
+        if (m.matches()) {
+            Object source = resolve(doc, m.group(2));
+            if (!(source instanceof List<?> items)) return false;
+            String where = m.group(3);
+            if (where == null) return !items.isEmpty();
+            return items.stream().anyMatch(item -> evalExistsItem(item, where));
+        }
+
         // IS_DEFINED(c.field)
         m = Pattern.compile("(?i)IS_DEFINED\\s*\\(([^)]+)\\)").matcher(pred);
         if (m.matches()) return resolve(doc, m.group(1).trim()) != null;
@@ -423,6 +437,13 @@ public class CosmosQueryEngine {
         }
 
         return false;
+    }
+
+    private boolean evalExistsItem(Object item, String where) {
+        if (!(item instanceof Map<?, ?> map)) return false;
+        Map<String, Object> nestedDocument = new LinkedHashMap<>();
+        map.forEach((key, value) -> nestedDocument.put(String.valueOf(key), value));
+        return evalExpr(nestedDocument, where);
     }
 
     /** Convert a SQL LIKE pattern (% and _ wildcards) to a regex and match. */

--- a/src/test/java/io/floci/az/services/cosmos/CosmosCorrelatedExistsTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosCorrelatedExistsTest.java
@@ -1,0 +1,52 @@
+package io.floci.az.services.cosmos;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.contains;
+
+@QuarkusTest
+class CosmosCorrelatedExistsTest {
+
+    private static final String BASE = "/existsacct-cosmos";
+    private static final String DOCS = BASE + "/dbs/db/colls/items/docs";
+
+    @BeforeEach
+    void setup() {
+        given().post("/_admin/reset").then().statusCode(204);
+        given().contentType("application/json").body("{\"id\":\"db\"}")
+                .post(BASE + "/dbs").then().statusCode(201);
+        given().contentType("application/json")
+                .body("{\"id\":\"items\",\"partitionKey\":{\"paths\":[\"/pk\"],\"kind\":\"Hash\"}}")
+                .post(BASE + "/dbs/db/colls").then().statusCode(201);
+
+        create("matching", """
+                [{"resolvesOn":{"type":"rsvp"}},{"resolvesOn":{"type":"poll"}}]""");
+        create("non-matching", """
+                [{"resolvesOn":{"type":"comment"}}]""");
+        create("empty", "[]");
+    }
+
+    @Test
+    void correlatedExistsReturnsOnlyDocumentsWithMatchingArrayItem() {
+        given().contentType("application/query+json")
+                .header("x-ms-documentdb-isquery", "True")
+                .body("""
+                        {
+                          "query": "SELECT * FROM c WHERE EXISTS(SELECT VALUE action FROM action IN c.actions WHERE action.resolvesOn.type = @type)",
+                          "parameters": [{"name":"@type","value":"rsvp"}]
+                        }""")
+                .post(DOCS)
+                .then().statusCode(200)
+                .body("Documents.id", contains("matching"));
+    }
+
+    private void create(String id, String actions) {
+        given().contentType("application/json")
+                .header("x-ms-documentdb-partitionkey", "[\"p\"]")
+                .body("{\"id\":\"" + id + "\",\"pk\":\"p\",\"actions\":" + actions + "}")
+                .post(DOCS).then().statusCode(201);
+    }
+}

--- a/src/test/java/io/floci/az/services/cosmos/CosmosQueryEngineExistsTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosQueryEngineExistsTest.java
@@ -1,0 +1,33 @@
+package io.floci.az.services.cosmos;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CosmosQueryEngineExistsTest {
+
+    @Test
+    void evaluatesCorrelatedExistsOverNestedArray() {
+        CosmosQueryEngine engine = new CosmosQueryEngine();
+        List<Map<String, Object>> documents = List.of(
+                Map.of("id", "matching", "actions", List.of(
+                        Map.of("resolvesOn", Map.of("type", "rsvp")))),
+                Map.of("id", "non-matching", "actions", List.of(
+                        Map.of("resolvesOn", Map.of("type", "comment")))),
+                Map.of("id", "empty", "actions", List.of()));
+
+        CosmosQueryEngine.QueryResult result = engine.execute(
+                "SELECT * FROM c WHERE EXISTS("
+                        + "SELECT VALUE action FROM action IN c.actions "
+                        + "WHERE action.resolvesOn.type = @type)",
+                List.of(Map.of("name", "@type", "value", "rsvp")),
+                documents);
+
+        assertEquals(List.of("matching"), result.items().stream()
+                .map(item -> ((Map<?, ?>) item).get("id"))
+                .toList());
+    }
+}

--- a/src/test/java/io/floci/az/services/cosmos/CosmosQueryEngineExistsTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosQueryEngineExistsTest.java
@@ -30,4 +30,43 @@ class CosmosQueryEngineExistsTest {
                 .map(item -> ((Map<?, ?>) item).get("id"))
                 .toList());
     }
+
+    @Test
+    void evaluatesCorrelatedExistsOverScalarArray() {
+        CosmosQueryEngine engine = new CosmosQueryEngine();
+        List<Map<String, Object>> documents = List.of(
+                Map.of("id", "matching", "tags", List.of("azure", "local")),
+                Map.of("id", "non-matching", "tags", List.of("aws")));
+
+        CosmosQueryEngine.QueryResult result = engine.execute(
+                "SELECT * FROM c WHERE EXISTS("
+                        + "SELECT VALUE tag FROM tag IN c.tags WHERE tag = 'azure')",
+                List.of(),
+                documents);
+
+        assertEquals(List.of("matching"), result.items().stream()
+                .map(item -> ((Map<?, ?>) item).get("id"))
+                .toList());
+    }
+
+    @Test
+    void evaluatesCorrelatedExistsWithOuterAliasReference() {
+        CosmosQueryEngine engine = new CosmosQueryEngine();
+        List<Map<String, Object>> documents = List.of(
+                Map.of("id", "matching", "threshold", 3,
+                        "actions", List.of(Map.of("value", 4, "threshold", 100))),
+                Map.of("id", "non-matching", "threshold", 5,
+                        "actions", List.of(Map.of("value", 4, "threshold", 1))));
+
+        CosmosQueryEngine.QueryResult result = engine.execute(
+                "SELECT * FROM c WHERE EXISTS("
+                        + "SELECT VALUE action FROM action IN c.actions "
+                        + "WHERE action.value > c.threshold)",
+                List.of(),
+                documents);
+
+        assertEquals(List.of("matching"), result.items().stream()
+                .map(item -> ((Map<?, ?>) item).get("id"))
+                .toList());
+    }
 }


### PR DESCRIPTION
## Summary

- evaluate correlated `EXISTS` subqueries over nested document arrays
- bind each array object as the subquery alias and evaluate its nested `WHERE` predicate
- handle empty, non-matching, and matching arrays without false positives
- document correlated `EXISTS` support and add engine plus HTTP regression tests

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

0.10.0 interpreted the comparison inside an unsupported `EXISTS` expression as `null = null`, returning every document. The query engine now follows Cosmos correlated array-subquery semantics for `SELECT VALUE alias FROM alias IN c.array [WHERE ...]`.

## Checklist

- [x] `./mvnw test` passes locally (555 tests)
- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits

Closes #162