### PR TITLE
fix(cosmos): make transactional batches atomic

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/CosmosCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/CosmosCompatibilityTest.java
@@ -220,7 +220,7 @@ class CosmosCompatibilityTest {
     }
 
     @Test
-    @DisplayName("transactional batch: Create/Read/Replace/Delete/Upsert")
+    @DisplayName("transactional batch: CRUD, Patch, and rollback")
     @SuppressWarnings("unchecked")
     void transactionalBatch() {
         String id = dbId();
@@ -262,6 +262,32 @@ class CosmosCompatibilityTest {
                 .getItem().get("v")).intValue());
         assertThrows(CosmosException.class,
                 () -> container.readItem("b3", new PartitionKey("test"), Map.class));
+
+        // Batch 3: Patch is visible to a later operation in the same batch.
+        CosmosBatch batch3 = CosmosBatch.createCosmosBatch(new PartitionKey("test"));
+        batch3.patchItemOperation("b1", CosmosPatchOperations.create()
+                .set("/v", 7)
+                .increment("/counter", 2));
+        batch3.readItemOperation("b1");
+
+        CosmosBatchResponse r3 = container.executeCosmosBatch(batch3);
+        assertEquals(200, r3.getResults().get(0).getStatusCode());
+        assertEquals(200, r3.getResults().get(1).getStatusCode());
+        assertEquals(7, ((Number) container
+                .readItem("b1", new PartitionKey("test"), Map.class)
+                .getItem().get("v")).intValue());
+
+        // Batch 4: a failure rolls back an earlier successful mutation.
+        CosmosBatch batch4 = CosmosBatch.createCosmosBatch(new PartitionKey("test"));
+        batch4.replaceItemOperation("b1", doc("b1", "test", "v", 999));
+        batch4.deleteItemOperation("missing");
+
+        CosmosBatchResponse r4 = container.executeCosmosBatch(batch4);
+        assertEquals(424, r4.getResults().get(0).getStatusCode());
+        assertEquals(404, r4.getResults().get(1).getStatusCode());
+        assertEquals(7, ((Number) container
+                .readItem("b1", new PartitionKey("test"), Map.class)
+                .getItem().get("v")).intValue());
 
         db.delete();
     }

--- a/src/main/java/io/floci/az/core/storage/HybridStorage.java
+++ b/src/main/java/io/floci/az/core/storage/HybridStorage.java
@@ -38,6 +38,7 @@ public class HybridStorage<K, V> implements StorageBackend<K, V> {
     private final TypeReference<Map<K, V>> typeReference;
     private final ScheduledExecutorService scheduler;
     private final AtomicBoolean dirty = new AtomicBoolean(false);
+    private final Object mutationLock = new Object();
 
     public HybridStorage(Path filePath, TypeReference<Map<K, V>> typeReference, long flushIntervalMs) {
         this.filePath = filePath;
@@ -57,8 +58,10 @@ public class HybridStorage<K, V> implements StorageBackend<K, V> {
 
     @Override
     public void put(K key, V value) {
-        store.put(key, value);
-        dirty.set(true);
+        synchronized (mutationLock) {
+            store.put(key, value);
+            dirty.set(true);
+        }
     }
 
     @Override
@@ -68,8 +71,19 @@ public class HybridStorage<K, V> implements StorageBackend<K, V> {
 
     @Override
     public void delete(K key) {
-        store.remove(key);
-        dirty.set(true);
+        synchronized (mutationLock) {
+            store.remove(key);
+            dirty.set(true);
+        }
+    }
+
+    @Override
+    public void applyBatch(Map<K, V> puts, Set<K> deletes) {
+        synchronized (mutationLock) {
+            deletes.forEach(store::remove);
+            store.putAll(puts);
+            dirty.set(true);
+        }
     }
 
     @Override
@@ -138,16 +152,19 @@ public class HybridStorage<K, V> implements StorageBackend<K, V> {
         }
     }
 
-    private synchronized void persistToDisk() {
-        try {
-            Files.createDirectories(filePath.getParent());
-            Path tempFile = filePath.resolveSibling(filePath.getFileName() + ".tmp");
-            objectMapper.writeValue(tempFile.toFile(), store);
-            Files.move(tempFile, filePath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
-            LOG.debugv("Flushed {0} entries to {1}", store.size(), filePath);
-        } catch (IOException e) {
-            LOG.errorv(e, "Failed to persist data to {0}", filePath);
-            dirty.set(true);
+    private void persistToDisk() {
+        synchronized (mutationLock) {
+            try {
+                Files.createDirectories(filePath.getParent());
+                Path tempFile = filePath.resolveSibling(filePath.getFileName() + ".tmp");
+                objectMapper.writeValue(tempFile.toFile(), store);
+                Files.move(tempFile, filePath,
+                        StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+                LOG.debugv("Flushed {0} entries to {1}", store.size(), filePath);
+            } catch (IOException e) {
+                LOG.errorv(e, "Failed to persist data to {0}", filePath);
+                dirty.set(true);
+            }
         }
     }
 }

--- a/src/main/java/io/floci/az/core/storage/InMemoryStorage.java
+++ b/src/main/java/io/floci/az/core/storage/InMemoryStorage.java
@@ -3,6 +3,7 @@ package io.floci.az.core.storage;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -34,6 +35,12 @@ public class InMemoryStorage<K, V> implements StorageBackend<K, V> {
     @Override
     public Optional<V> remove(K key) {
         return Optional.ofNullable(store.remove(key));
+    }
+
+    @Override
+    public synchronized void applyBatch(Map<K, V> puts, Set<K> deletes) {
+        deletes.forEach(store::remove);
+        store.putAll(puts);
     }
 
     @Override

--- a/src/main/java/io/floci/az/core/storage/PersistentStorage.java
+++ b/src/main/java/io/floci/az/core/storage/PersistentStorage.java
@@ -45,7 +45,7 @@ public class PersistentStorage<K, V> implements StorageBackend<K, V> {
     }
 
     @Override
-    public void put(K key, V value) {
+    public synchronized void put(K key, V value) {
         store.put(key, value);
         persistToDisk();
     }
@@ -56,7 +56,7 @@ public class PersistentStorage<K, V> implements StorageBackend<K, V> {
     }
 
     @Override
-    public void delete(K key) {
+    public synchronized void delete(K key) {
         store.remove(key);
         persistToDisk();
     }
@@ -66,6 +66,13 @@ public class PersistentStorage<K, V> implements StorageBackend<K, V> {
         Optional<V> removed = Optional.ofNullable(store.remove(key));
         removed.ifPresent(v -> persistToDisk());
         return removed;
+    }
+
+    @Override
+    public synchronized void applyBatch(Map<K, V> puts, Set<K> deletes) {
+        deletes.forEach(store::remove);
+        store.putAll(puts);
+        persistToDisk();
     }
 
     @Override

--- a/src/main/java/io/floci/az/core/storage/StorageBackend.java
+++ b/src/main/java/io/floci/az/core/storage/StorageBackend.java
@@ -1,6 +1,7 @@
 package io.floci.az.core.storage;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -21,6 +22,9 @@ public interface StorageBackend<K, V> {
 
     /** Atomically removes and returns the value, so a concurrent caller can never observe it twice. */
     Optional<V> remove(K key);
+
+    /** Applies related puts and deletes as one durable mutation. */
+    void applyBatch(Map<K, V> puts, Set<K> deletes);
 
     /**
      * Return a new mutable list of values whose keys pass the filter. Callers may sort,

--- a/src/main/java/io/floci/az/core/storage/WalStorage.java
+++ b/src/main/java/io/floci/az/core/storage/WalStorage.java
@@ -40,6 +40,7 @@ public class WalStorage<K, V> implements StorageBackend<K, V> {
 
     static final byte OP_PUT = 0x01;
     static final byte OP_DELETE = 0x02;
+    static final byte OP_BATCH = 0x03;
 
     private final ConcurrentHashMap<K, V> store = new ConcurrentHashMap<>();
     private final Path snapshotPath;
@@ -48,6 +49,7 @@ public class WalStorage<K, V> implements StorageBackend<K, V> {
     private final ObjectMapper walMapper;
     private final TypeReference<Map<K, V>> typeReference;
     private final ReentrantReadWriteLock compactionLock = new ReentrantReadWriteLock();
+    private final Object mutationLock = new Object();
     private final ScheduledExecutorService scheduler;
     private volatile DataOutputStream walWriter;
 
@@ -79,8 +81,10 @@ public class WalStorage<K, V> implements StorageBackend<K, V> {
     public void put(K key, V value) {
         compactionLock.readLock().lock();
         try {
-            store.put(key, value);
-            appendPut(key, value);
+            synchronized (mutationLock) {
+                store.put(key, value);
+                appendPut(key, value);
+            }
         } finally {
             compactionLock.readLock().unlock();
         }
@@ -95,8 +99,24 @@ public class WalStorage<K, V> implements StorageBackend<K, V> {
     public void delete(K key) {
         compactionLock.readLock().lock();
         try {
-            store.remove(key);
-            appendDelete(key);
+            synchronized (mutationLock) {
+                store.remove(key);
+                appendDelete(key);
+            }
+        } finally {
+            compactionLock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public void applyBatch(Map<K, V> puts, Set<K> deletes) {
+        compactionLock.readLock().lock();
+        try {
+            synchronized (mutationLock) {
+                appendBatch(puts, deletes);
+                deletes.forEach(store::remove);
+                store.putAll(puts);
+            }
         } finally {
             compactionLock.readLock().unlock();
         }
@@ -238,6 +258,41 @@ public class WalStorage<K, V> implements StorageBackend<K, V> {
         }
     }
 
+    private void appendBatch(Map<K, V> puts, Set<K> deletes) {
+        DataOutputStream out = walWriter;
+        if (out == null) {
+            return;
+        }
+        try {
+            ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+            try (DataOutputStream batch = new DataOutputStream(bytes)) {
+                batch.writeInt(deletes.size());
+                for (K key : deletes) {
+                    writeBytes(batch, walMapper.writeValueAsBytes(key));
+                }
+                batch.writeInt(puts.size());
+                for (Map.Entry<K, V> entry : puts.entrySet()) {
+                    writeBytes(batch, walMapper.writeValueAsBytes(entry.getKey()));
+                    writeBytes(batch, walMapper.writeValueAsBytes(entry.getValue()));
+                }
+            }
+            byte[] payload = bytes.toByteArray();
+            synchronized (out) {
+                out.writeByte(OP_BATCH);
+                out.writeInt(payload.length);
+                out.write(payload);
+                out.flush();
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to append BATCH WAL entry", e);
+        }
+    }
+
+    private static void writeBytes(DataOutputStream out, byte[] value) throws IOException {
+        out.writeInt(value.length);
+        out.write(value);
+    }
+
     @SuppressWarnings("unchecked")
     private int replayWal() {
         int replayed = 0;
@@ -246,6 +301,17 @@ public class WalStorage<K, V> implements StorageBackend<K, V> {
             while (true) {
                 int op;
                 try { op = in.readByte(); } catch (EOFException e) { break; }
+
+                if (op == OP_BATCH) {
+                    int payloadLength = in.readInt();
+                    byte[] payload = in.readNBytes(payloadLength);
+                    if (payload.length < payloadLength) {
+                        break;
+                    }
+                    replayBatch(payload);
+                    replayed++;
+                    continue;
+                }
 
                 int keyLen = in.readInt();
                 byte[] keyBytes = in.readNBytes(keyLen);
@@ -274,6 +340,39 @@ public class WalStorage<K, V> implements StorageBackend<K, V> {
                     walPath, replayed);
         }
         return replayed;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void replayBatch(byte[] payload) throws IOException {
+        Map<K, V> puts = new java.util.LinkedHashMap<>();
+        Set<K> deletes = new java.util.LinkedHashSet<>();
+        try (DataInputStream batch = new DataInputStream(new ByteArrayInputStream(payload))) {
+            int deleteCount = batch.readInt();
+            for (int i = 0; i < deleteCount; i++) {
+                deletes.add((K) walMapper.readValue(readBytes(batch), Object.class));
+            }
+            int putCount = batch.readInt();
+            for (int i = 0; i < putCount; i++) {
+                K key = (K) walMapper.readValue(readBytes(batch), Object.class);
+                V value = walMapper.readValue(readBytes(batch),
+                        walMapper.constructType(typeReference.getType()).getContentType());
+                puts.put(key, value);
+            }
+            if (batch.available() != 0) {
+                throw new IOException("Unexpected trailing bytes in WAL batch");
+            }
+        }
+        deletes.forEach(store::remove);
+        store.putAll(puts);
+    }
+
+    private static byte[] readBytes(DataInputStream in) throws IOException {
+        int length = in.readInt();
+        byte[] value = in.readNBytes(length);
+        if (value.length < length) {
+            throw new EOFException("Incomplete WAL batch value");
+        }
+        return value;
     }
 
     private void openWalWriter() {

--- a/src/main/java/io/floci/az/core/storage/WalStorage.java
+++ b/src/main/java/io/floci/az/core/storage/WalStorage.java
@@ -261,7 +261,7 @@ public class WalStorage<K, V> implements StorageBackend<K, V> {
     private void appendBatch(Map<K, V> puts, Set<K> deletes) {
         DataOutputStream out = walWriter;
         if (out == null) {
-            return;
+            throw new IllegalStateException("WAL writer is not open");
         }
         try {
             ByteArrayOutputStream bytes = new ByteArrayOutputStream();

--- a/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
@@ -267,7 +267,7 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         return cosmosResponse(parseData(found.get()), Response.Status.OK, found.get().etag());
     }
 
-    private Response deleteDatabase(AzureRequest req, String dbId) {
+    private synchronized Response deleteDatabase(AzureRequest req, String dbId) {
         String key = dbKey(req.accountName(), dbId);
         if (store.get(key).isEmpty()) return notFound(dbId);
 
@@ -501,7 +501,7 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         }
     }
 
-    private Response deleteContainer(AzureRequest req, String dbId, String collId) {
+    private synchronized Response deleteContainer(AzureRequest req, String dbId, String collId) {
         String key = collKey(req.accountName(), dbId, collId);
         if (store.get(key).isEmpty()) return notFound(collId);
 

--- a/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
@@ -611,32 +611,7 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         //   1. {"operations": [...]}  — Java / Python SDKs
         //   2. [{op, path, value}, …] — Node SDK (sends the array directly)
         List<Map<String, Object>> operations = parsePatchBody(req);
-
-        for (Map<String, Object> op : operations) {
-            String opType = op.get("op") instanceof String s ? s.toLowerCase() : "";
-            String path   = op.get("path") instanceof String p ? p : null;
-            Object value  = op.get("value");
-
-            if (path == null) {
-                LOG.warnf("PATCH op '%s' missing 'path' — skipping", opType);
-                continue;
-            }
-
-            switch (opType) {
-                case "add", "set", "replace" -> patchSet(doc, path, value);
-                case "remove"                -> patchRemove(doc, path);
-                case "incr"                  -> patchIncr(doc, path, value);
-                case "move"                  -> {
-                    String from = op.get("from") instanceof String f ? f : null;
-                    if (from != null) {
-                        Object moved = patchGet(doc, from);
-                        patchRemove(doc, from);
-                        patchSet(doc, path, moved);
-                    }
-                }
-                default -> LOG.warnf("Unknown PATCH op '%s' — skipping", opType);
-            }
-        }
+        applyPatchOperations(doc, operations);
 
         Instant now  = Instant.now();
         String  etag = newEtag();
@@ -646,6 +621,32 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         store.put(obj.key(), stored(obj.key(), doc, now, etag));
         return cosmosResponse(doc, Response.Status.OK, etag,
                 "dbs/" + dbId + "/colls/" + collId);
+    }
+
+    private void applyPatchOperations(Map<String, Object> doc, List<Map<String, Object>> operations) {
+        for (Map<String, Object> op : operations) {
+            String opType = op.get("op") instanceof String value ? value.toLowerCase() : "";
+            String path = op.get("path") instanceof String value ? value : null;
+            if (path == null) {
+                LOG.warnf("PATCH op '%s' missing 'path' — skipping", opType);
+                continue;
+            }
+
+            switch (opType) {
+                case "add", "set", "replace" -> patchSet(doc, path, op.get("value"));
+                case "remove" -> patchRemove(doc, path);
+                case "incr" -> patchIncr(doc, path, op.get("value"));
+                case "move" -> {
+                    String from = op.get("from") instanceof String value ? value : null;
+                    if (from != null) {
+                        Object moved = patchGet(doc, from);
+                        patchRemove(doc, from);
+                        patchSet(doc, path, moved);
+                    }
+                }
+                default -> LOG.warnf("Unknown PATCH op '%s' — skipping", opType);
+            }
+        }
     }
 
     /** Set (or create) the field at {@code /a/b/…} to {@code value}. */
@@ -671,7 +672,11 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         String key     = parts[parts.length - 1];
         double current = toDouble(target.getOrDefault(key, 0));
         double result  = current + toDouble(delta);
-        target.put(key, isWholeNum(result) ? (long) result : result);
+        if (isWholeNum(result)) {
+            target.put(key, (long) result);
+        } else {
+            target.put(key, result);
+        }
     }
 
     /** Read the field at {@code path} (used by {@code move}). */
@@ -743,15 +748,14 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
      * {@code "eTag"} and {@code "resourceBody"}.</p>
      *
      * <p>Supported operation types: {@code Create}, {@code Upsert}, {@code Read},
-     * {@code Replace}, {@code Delete}.</p>
+     * {@code Replace}, {@code Patch}, {@code Delete}.</p>
      */
     @SuppressWarnings("unchecked")
     private Response executeBatch(AzureRequest req, String dbId, String collId) {
         Optional<StoredObject> collFound = store.get(collKey(req.accountName(), dbId, collId));
         if (collFound.isEmpty()) return notFound(collId);
 
-        String pk    = extractPartitionKeyValue(req);
-        String pkEnc = encodeKey(pk);
+        String pkEnc = encodeKey(extractPartitionKeyValue(req));
 
         List<Map<String, Object>> operations;
         try {
@@ -761,21 +765,48 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
             return errorResponse(400, "BadRequest", "Invalid batch request body.");
         }
 
+        String partitionPrefix = docKey(req.accountName(), dbId, collId, pkEnc, "");
+        Map<String, StoredObject> original = store.scan(k -> k.startsWith(partitionPrefix)).stream()
+                .collect(Collectors.toMap(StoredObject::key, object -> object,
+                        (left, right) -> left, LinkedHashMap::new));
+        Map<String, StoredObject> staged = new LinkedHashMap<>(original);
+
         List<Map<String, Object>> results = new ArrayList<>();
+        boolean failed = false;
         for (Map<String, Object> op : operations) {
             String opType = op.get("operationType") instanceof String t ? t : "";
             String docId  = op.get("id") instanceof String s ? s : null;
             Map<String, Object> body = op.get("resourceBody") instanceof Map<?, ?> m
                     ? (Map<String, Object>) m : null;
 
-            results.add(switch (opType) {
-                case "Create"  -> batchCreate(req.accountName(), dbId, collId, pk, pkEnc, body, false);
-                case "Upsert"  -> batchCreate(req.accountName(), dbId, collId, pk, pkEnc, body, true);
-                case "Read"    -> batchRead(req.accountName(), dbId, collId, pkEnc, docId);
-                case "Replace" -> batchReplace(req.accountName(), dbId, collId, pkEnc, docId, body);
-                case "Delete"  -> batchDelete(req.accountName(), dbId, collId, pkEnc, docId);
+            Map<String, Object> result = switch (opType) {
+                case "Create"  -> batchCreate(staged, req.accountName(), dbId, collId, pkEnc, body, false);
+                case "Upsert"  -> batchCreate(staged, req.accountName(), dbId, collId, pkEnc, body, true);
+                case "Read"    -> batchRead(staged, req.accountName(), dbId, collId, pkEnc, docId);
+                case "Replace" -> batchReplace(staged, req.accountName(), dbId, collId, pkEnc, docId, body);
+                case "Patch"   -> batchPatch(staged, req.accountName(), dbId, collId, pkEnc, docId, body);
+                case "Delete"  -> batchDelete(staged, req.accountName(), dbId, collId, pkEnc, docId);
                 default        -> batchResultError(400);
-            });
+            };
+            results.add(result);
+
+            if (((Number) result.get("statusCode")).intValue() >= 400) {
+                for (int previous = 0; previous < results.size() - 1; previous++) {
+                    results.set(previous, batchResultError(424));
+                }
+                while (results.size() < operations.size()) {
+                    results.add(batchResultError(424));
+                }
+                failed = true;
+                break;
+            }
+        }
+
+        if (!failed) {
+            original.keySet().stream()
+                    .filter(key -> !staged.containsKey(key))
+                    .forEach(store::delete);
+            staged.forEach(store::put);
         }
 
         try {
@@ -790,17 +821,17 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         }
     }
 
-    @SuppressWarnings("unchecked")
-    private Map<String, Object> batchCreate(String account, String dbId, String collId,
-            String pk, String pkEnc, Map<String, Object> body, boolean upsert) {
+    private Map<String, Object> batchCreate(Map<String, StoredObject> documents,
+            String account, String dbId, String collId,
+            String pkEnc, Map<String, Object> body, boolean upsert) {
         if (body == null) return batchResultError(400);
 
         body = new LinkedHashMap<>(body);
         String id = body.containsKey("id") ? String.valueOf(body.get("id")) : UUID.randomUUID().toString();
         body.put("id", id);
 
-        String key     = docKey(account, dbId, collId, pkEnc, id);
-        boolean existed = store.get(key).isPresent();
+        String key = docKey(account, dbId, collId, pkEnc, id);
+        boolean existed = documents.containsKey(key);
         if (!upsert && existed) return batchResultError(409);
 
         Instant now  = Instant.now();
@@ -813,35 +844,31 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         body.put("_ts",          now.getEpochSecond());
         body.put("_attachments", "attachments/");
 
-        store.put(key, stored(key, body, now, etag));
+        documents.put(key, stored(key, body, now, etag));
         return batchResultOk(upsert && existed ? 200 : 201, etag, body);
     }
 
-    private Map<String, Object> batchRead(String account, String dbId, String collId,
+    private Map<String, Object> batchRead(Map<String, StoredObject> documents,
+            String account, String dbId, String collId,
             String pkEnc, String docId) {
         if (docId == null) return batchResultError(400);
 
         String key = docKey(account, dbId, collId, pkEnc, docId);
-        Optional<StoredObject> found = store.get(key);
-        if (found.isEmpty()) {
-            // Fallback scan for cases where PK is unknown/encoded differently
-            String prefix = account + K_DOC + dbId + "|" + collId + "|";
-            found = store.scan(k -> k.startsWith(prefix) && k.endsWith("|" + docId))
-                    .stream().findFirst();
-        }
+        Optional<StoredObject> found = Optional.ofNullable(documents.get(key));
+        if (found.isEmpty()) found = findBatchDocument(documents, docId);
         if (found.isEmpty()) return batchResultError(404);
 
         Map<String, Object> doc = parseData(found.get());
         return batchResultOk(200, found.get().etag(), doc);
     }
 
-    @SuppressWarnings("unchecked")
-    private Map<String, Object> batchReplace(String account, String dbId, String collId,
+    private Map<String, Object> batchReplace(Map<String, StoredObject> documents,
+            String account, String dbId, String collId,
             String pkEnc, String docId, Map<String, Object> body) {
         if (docId == null || body == null) return batchResultError(400);
 
         String key = docKey(account, dbId, collId, pkEnc, docId);
-        Optional<StoredObject> found = store.get(key);
+        Optional<StoredObject> found = Optional.ofNullable(documents.get(key));
         if (found.isEmpty()) return batchResultError(404);
 
         body = new LinkedHashMap<>(body);
@@ -857,25 +884,51 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         body.put("_ts",          now.getEpochSecond());
         body.put("_attachments", "attachments/");
 
-        store.put(key, stored(key, body, now, etag));
+        documents.put(key, stored(key, body, now, etag));
         return batchResultOk(200, etag, body);
     }
 
-    private Map<String, Object> batchDelete(String account, String dbId, String collId,
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> batchPatch(Map<String, StoredObject> documents,
+            String account, String dbId, String collId,
+            String pkEnc, String docId, Map<String, Object> body) {
+        if (docId == null || body == null) return batchResultError(400);
+
+        String key = docKey(account, dbId, collId, pkEnc, docId);
+        Optional<StoredObject> found = Optional.ofNullable(documents.get(key));
+        if (found.isEmpty()) return batchResultError(404);
+        if (!(body.get("operations") instanceof List<?> rawOperations)) return batchResultError(400);
+
+        List<Map<String, Object>> operations = (List<Map<String, Object>>) rawOperations;
+        Map<String, Object> document = parseData(found.get());
+        applyPatchOperations(document, operations);
+
+        Instant now = Instant.now();
+        String etag = newEtag();
+        document.put("_etag", quoted(etag));
+        document.put("_ts", now.getEpochSecond());
+        documents.put(key, stored(key, document, now, etag));
+        return batchResultOk(200, etag, document);
+    }
+
+    private Map<String, Object> batchDelete(Map<String, StoredObject> documents,
+            String account, String dbId, String collId,
             String pkEnc, String docId) {
         if (docId == null) return batchResultError(400);
 
         String key = docKey(account, dbId, collId, pkEnc, docId);
-        Optional<StoredObject> found = store.get(key);
-        if (found.isEmpty()) {
-            String prefix = account + K_DOC + dbId + "|" + collId + "|";
-            found = store.scan(k -> k.startsWith(prefix) && k.endsWith("|" + docId))
-                    .stream().findFirst();
-        }
+        Optional<StoredObject> found = Optional.ofNullable(documents.get(key));
+        if (found.isEmpty()) found = findBatchDocument(documents, docId);
         if (found.isEmpty()) return batchResultError(404);
 
-        store.delete(found.get().key());
+        documents.remove(found.get().key());
         return batchResultOk(204, null, null);
+    }
+
+    private Optional<StoredObject> findBatchDocument(Map<String, StoredObject> documents, String docId) {
+        return documents.values().stream()
+                .filter(object -> object.key().endsWith("|" + docId))
+                .findFirst();
     }
 
     private Map<String, Object> batchResultOk(int statusCode, String etag, Map<String, Object> resourceBody) {

--- a/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
@@ -1326,5 +1326,5 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
 
     private String quoted(String s) { return "\"" + s + "\""; }
 
-    public void clear() { store.clear(); }
+    public synchronized void clear() { store.clear(); }
 }

--- a/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
@@ -130,7 +130,7 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         return notImplemented();
     }
 
-    private Response routeDocs(AzureRequest req, String[] segs, String dbId, String collId) {
+    private synchronized Response routeDocs(AzureRequest req, String[] segs, String dbId, String collId) {
         String m      = req.method().toUpperCase();
         // Query plan requests use x-ms-cosmos-is-query-plan-request: True (no isquery header)
         boolean planRequest = "True".equalsIgnoreCase(
@@ -899,7 +899,11 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         if (found.isEmpty()) return batchResultError(404);
         if (!(body.get("operations") instanceof List<?> rawOperations)) return batchResultError(400);
 
-        List<Map<String, Object>> operations = (List<Map<String, Object>>) rawOperations;
+        List<Map<String, Object>> operations = new ArrayList<>(rawOperations.size());
+        for (Object rawOperation : rawOperations) {
+            if (!(rawOperation instanceof Map<?, ?> operation)) return batchResultError(400);
+            operations.add((Map<String, Object>) operation);
+        }
         Map<String, Object> document = parseData(found.get());
         applyPatchOperations(document, operations);
 

--- a/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
@@ -803,10 +803,14 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         }
 
         if (!failed) {
-            original.keySet().stream()
+            Set<String> deletes = original.keySet().stream()
                     .filter(key -> !staged.containsKey(key))
-                    .forEach(store::delete);
-            staged.forEach(store::put);
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+            Map<String, StoredObject> puts = staged.entrySet().stream()
+                    .filter(entry -> !entry.getValue().equals(original.get(entry.getKey())))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue,
+                            (left, right) -> left, LinkedHashMap::new));
+            store.applyBatch(puts, deletes);
         }
 
         try {

--- a/src/test/java/io/floci/az/core/storage/StorageBatchTest.java
+++ b/src/test/java/io/floci/az/core/storage/StorageBatchTest.java
@@ -14,6 +14,7 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class StorageBatchTest {
@@ -92,6 +93,20 @@ class StorageBatchTest {
                 new WalStorage<>(snapshot, wal, STRING_MAP, 60_000);
         try {
             storage.load();
+            assertTrue(storage.keys().isEmpty());
+        } finally {
+            storage.shutdown();
+        }
+    }
+
+    @Test
+    void walStorageRejectsBatchBeforeWriterIsOpen() {
+        WalStorage<String, String> storage = new WalStorage<>(
+                tempDir.resolve("unopened-snapshot.json"),
+                tempDir.resolve("unopened-storage.wal"), STRING_MAP, 60_000);
+        try {
+            assertThrows(IllegalStateException.class,
+                    () -> storage.applyBatch(Map.of("new", "value"), Set.of()));
             assertTrue(storage.keys().isEmpty());
         } finally {
             storage.shutdown();

--- a/src/test/java/io/floci/az/core/storage/StorageBatchTest.java
+++ b/src/test/java/io/floci/az/core/storage/StorageBatchTest.java
@@ -1,0 +1,105 @@
+package io.floci.az.core.storage;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StorageBatchTest {
+
+    private static final TypeReference<Map<String, String>> STRING_MAP = new TypeReference<>() {};
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void persistentStorageWritesOneBatchSnapshot() {
+        Path file = tempDir.resolve("persistent.json");
+        PersistentStorage<String, String> storage = new PersistentStorage<>(file, STRING_MAP);
+        storage.put("old", "value");
+
+        storage.applyBatch(Map.of("new", "value"), Set.of("old"));
+
+        PersistentStorage<String, String> recovered = new PersistentStorage<>(file, STRING_MAP);
+        recovered.load();
+        assertBatchApplied(recovered);
+    }
+
+    @Test
+    void hybridStorageFlushesOneBatchSnapshot() {
+        Path file = tempDir.resolve("hybrid.json");
+        HybridStorage<String, String> storage = new HybridStorage<>(file, STRING_MAP, 60_000);
+        try {
+            storage.put("old", "value");
+            storage.applyBatch(Map.of("new", "value"), Set.of("old"));
+            storage.flush();
+
+            HybridStorage<String, String> recovered =
+                    new HybridStorage<>(file, STRING_MAP, 60_000);
+            try {
+                recovered.load();
+                assertBatchApplied(recovered);
+            } finally {
+                recovered.shutdown();
+            }
+        } finally {
+            storage.shutdown();
+        }
+    }
+
+    @Test
+    void walStorageWritesBatchAsOneEntry() throws IOException {
+        Path snapshot = tempDir.resolve("snapshot.json");
+        Path wal = tempDir.resolve("storage.wal");
+        WalStorage<String, String> storage =
+                new WalStorage<>(snapshot, wal, STRING_MAP, 60_000);
+        try {
+            storage.load();
+            storage.applyBatch(Map.of("new", "value"), Set.of("old"));
+
+            assertBatchApplied(storage);
+            try (DataInputStream input = new DataInputStream(Files.newInputStream(wal))) {
+                assertEquals(WalStorage.OP_BATCH, input.readByte());
+                int payloadLength = input.readInt();
+                assertEquals(payloadLength, input.readAllBytes().length);
+            }
+        } finally {
+            storage.shutdown();
+        }
+    }
+
+    @Test
+    void walStorageIgnoresIncompleteBatchEntry() throws IOException {
+        Path snapshot = tempDir.resolve("incomplete-snapshot.json");
+        Path wal = tempDir.resolve("incomplete-storage.wal");
+        ByteBuffer incompleteEntry = ByteBuffer.allocate(7)
+                .put(WalStorage.OP_BATCH)
+                .putInt(10)
+                .putShort((short) 1);
+        Files.write(wal, incompleteEntry.array());
+        WalStorage<String, String> storage =
+                new WalStorage<>(snapshot, wal, STRING_MAP, 60_000);
+        try {
+            storage.load();
+            assertTrue(storage.keys().isEmpty());
+        } finally {
+            storage.shutdown();
+        }
+    }
+
+    private static void assertBatchApplied(StorageBackend<String, String> storage) {
+        assertFalse(storage.get("old").isPresent());
+        assertEquals("value", storage.get("new").orElseThrow());
+    }
+}

--- a/src/test/java/io/floci/az/services/cosmos/CosmosHandlerConcurrencyTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosHandlerConcurrencyTest.java
@@ -1,0 +1,53 @@
+package io.floci.az.services.cosmos;
+
+import io.floci.az.config.EmulatorConfig;
+import io.floci.az.core.StoredObject;
+import io.floci.az.core.storage.StorageBackend;
+import io.floci.az.core.storage.StorageFactory;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CosmosHandlerConcurrencyTest {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void clearAllWaitsForInFlightDocumentOperation() throws Exception {
+        StorageBackend<String, StoredObject> store = mock(StorageBackend.class);
+        StorageFactory factory = mock(StorageFactory.class);
+        when(factory.create("cosmos")).thenReturn(store);
+        CosmosHandler handler = new CosmosHandler(factory, mock(EmulatorConfig.class));
+
+        CountDownLatch clearStarted = new CountDownLatch(1);
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<?> clear;
+            // routeDocs uses this monitor for point mutations and transactional batches.
+            synchronized (handler) {
+                clear = executor.submit(() -> {
+                    clearStarted.countDown();
+                    handler.clear();
+                });
+
+                assertTrue(clearStarted.await(5, TimeUnit.SECONDS));
+                assertThrows(TimeoutException.class, () -> clear.get(200, TimeUnit.MILLISECONDS));
+            }
+
+            clear.get(5, TimeUnit.SECONDS);
+            verify(store).clear();
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}

--- a/src/test/java/io/floci/az/services/cosmos/CosmosTransactionalBatchTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosTransactionalBatchTest.java
@@ -1,0 +1,85 @@
+package io.floci.az.services.cosmos;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+
+@QuarkusTest
+class CosmosTransactionalBatchTest {
+
+    private static final String BASE = "/batchacct-cosmos";
+    private static final String DOCS = BASE + "/dbs/db/colls/items/docs";
+    private static final String PARTITION_KEY = "[\"p\"]";
+
+    @BeforeEach
+    void setup() {
+        given().post("/_admin/reset").then().statusCode(204);
+        given().contentType("application/json").body("{\"id\":\"db\"}")
+                .post(BASE + "/dbs").then().statusCode(201);
+        given().contentType("application/json")
+                .body("{\"id\":\"items\",\"partitionKey\":{\"paths\":[\"/pk\"],\"kind\":\"Hash\"}}")
+                .post(BASE + "/dbs/db/colls").then().statusCode(201);
+        given().contentType("application/json")
+                .header("x-ms-documentdb-partitionkey", PARTITION_KEY)
+                .body("{\"id\":\"one\",\"pk\":\"p\",\"value\":1,\"counter\":2}")
+                .post(DOCS).then().statusCode(201);
+    }
+
+    @Test
+    void failedBatchRollsBackEarlierMutations() {
+        given().contentType("application/json")
+                .header("x-ms-documentdb-partitionkey", PARTITION_KEY)
+                .header("x-ms-cosmos-is-batch-request", "true")
+                .body("""
+                        [
+                          {
+                            "operationType":"Replace",
+                            "id":"one",
+                            "resourceBody":{"id":"one","pk":"p","value":777}
+                          },
+                          {"operationType":"Delete","id":"missing"}
+                        ]""")
+                .post(DOCS)
+                .then().statusCode(200)
+                .body("statusCode", contains(424, 404));
+
+        read("one").then().statusCode(200).body("value", is(1));
+    }
+
+    @Test
+    void patchParticipatesInBatchAndIsVisibleToFollowingRead() {
+        given().contentType("application/json")
+                .header("x-ms-documentdb-partitionkey", PARTITION_KEY)
+                .header("x-ms-cosmos-is-batch-request", "true")
+                .body("""
+                        [
+                          {
+                            "operationType":"Patch",
+                            "id":"one",
+                            "resourceBody":{"operations":[
+                              {"op":"set","path":"/value","value":3},
+                              {"op":"incr","path":"/counter","value":5}
+                            ]}
+                          },
+                          {"operationType":"Read","id":"one"}
+                        ]""")
+                .post(DOCS)
+                .then().statusCode(200)
+                .body("statusCode", contains(200, 200))
+                .body("[1].resourceBody.value", is(3))
+                .body("[1].resourceBody.counter", is(7));
+
+        read("one").then().statusCode(200)
+                .body("value", is(3))
+                .body("counter", is(7));
+    }
+
+    private io.restassured.response.Response read(String id) {
+        return given().header("x-ms-documentdb-partitionkey", PARTITION_KEY)
+                .get(DOCS + "/" + id);
+    }
+}

--- a/src/test/java/io/floci/az/services/cosmos/CosmosTransactionalBatchTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosTransactionalBatchTest.java
@@ -78,6 +78,29 @@ class CosmosTransactionalBatchTest {
                 .body("counter", is(7));
     }
 
+    @Test
+    void malformedPatchOperationReturnsBatchFailure() {
+        given().contentType("application/json")
+                .header("x-ms-documentdb-partitionkey", PARTITION_KEY)
+                .header("x-ms-cosmos-is-batch-request", "true")
+                .body("""
+                        [
+                          {
+                            "operationType":"Patch",
+                            "id":"one",
+                            "resourceBody":{"operations":[42]}
+                          },
+                          {"operationType":"Read","id":"one"}
+                        ]""")
+                .post(DOCS)
+                .then().statusCode(200)
+                .body("statusCode", contains(400, 424));
+
+        read("one").then().statusCode(200)
+                .body("value", is(1))
+                .body("counter", is(2));
+    }
+
     private io.restassured.response.Response read(String id) {
         return given().header("x-ms-documentdb-partitionkey", PARTITION_KEY)
                 .get(DOCS + "/" + id);


### PR DESCRIPTION
## Summary

- execute transactional-batch operations against a partition-local staged snapshot
- commit staged writes only when every operation succeeds; failed batches leave storage unchanged
- return the failing status for the failed operation and `424 Failed Dependency` for rolled-back/skipped operations
- support transactional-batch Patch using the same `add`, `set`, `replace`, `remove`, `incr`, and `move` implementation as point Patch
- add HTTP rollback/Patch tests and expand Azure Cosmos Java SDK compatibility coverage

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

0.10.0 mutated storage operation-by-operation, so failed batches partially committed, and returned 400 for Patch. Batches now have all-or-nothing commit behavior and Azure-style per-operation results.

## Checklist

- [x] `./mvnw test` passes locally (555 tests)
- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits

Closes #161