### PR TITLE
feat(servicebus): add duplicate detection

### DIFF
--- a/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
+++ b/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
@@ -174,13 +174,11 @@ public sealed class ServiceBusCompatibilityTests
         await Assert.That(processedMessages[processorSessionB]).IsEqualTo("processor-b");
     }
 
-    [Fact]
-    public async Task DotnetSdkSuppressesDuplicateMessageIdsForQueuesAndTopics()
+    [Test]
+    [Timeout(50_000)]
+    public async Task DotnetSdkSuppressesDuplicateMessageIdsForQueuesAndTopics(
+        CancellationToken cancellationToken)
     {
-        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(
-            TestContext.Current.CancellationToken);
-        timeout.CancelAfter(TimeSpan.FromSeconds(50));
-        CancellationToken cancellationToken = timeout.Token;
         const string serviceBusNamespace = "default";
         string queue = $"duplicate-{Guid.NewGuid():N}";
         await EnsureNamespace(serviceBusNamespace, cancellationToken);
@@ -202,15 +200,16 @@ public sealed class ServiceBusCompatibilityTests
             new ServiceBusMessage("duplicate") { MessageId = messageId }, cancellationToken);
 
         ServiceBusReceivedMessage first = await Receive(receiver, cancellationToken);
-        Assert.Equal("first", first.Body.ToString());
+        await Assert.That(first.Body.ToString()).IsEqualTo("first");
         await receiver.CompleteMessageAsync(first, cancellationToken);
-        Assert.Null(await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(2), cancellationToken));
+        await Assert.That(await receiver.ReceiveMessageAsync(
+            TimeSpan.FromSeconds(2), cancellationToken)).IsNull();
 
         await Task.Delay(TimeSpan.FromSeconds(21), cancellationToken);
         await sender.SendMessageAsync(
             new ServiceBusMessage("after-window") { MessageId = messageId }, cancellationToken);
         ServiceBusReceivedMessage afterWindow = await Receive(receiver, cancellationToken);
-        Assert.Equal("after-window", afterWindow.Body.ToString());
+        await Assert.That(afterWindow.Body.ToString()).IsEqualTo("after-window");
         await receiver.CompleteMessageAsync(afterWindow, cancellationToken);
 
         string topic = $"duplicate-topic-{Guid.NewGuid():N}";
@@ -227,10 +226,10 @@ public sealed class ServiceBusCompatibilityTests
             new ServiceBusMessage("topic-duplicate") { MessageId = messageId }, cancellationToken);
         ServiceBusReceivedMessage topicFirst =
             await Receive(subscriptionReceiver, cancellationToken);
-        Assert.Equal("topic-first", topicFirst.Body.ToString());
+        await Assert.That(topicFirst.Body.ToString()).IsEqualTo("topic-first");
         await subscriptionReceiver.CompleteMessageAsync(topicFirst, cancellationToken);
-        Assert.Null(await subscriptionReceiver.ReceiveMessageAsync(
-            TimeSpan.FromSeconds(2), cancellationToken));
+        await Assert.That(await subscriptionReceiver.ReceiveMessageAsync(
+            TimeSpan.FromSeconds(2), cancellationToken)).IsNull();
     }
 
     private static async Task<ServiceBusReceivedMessage> Receive(

--- a/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
+++ b/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
@@ -175,7 +175,7 @@ public sealed class ServiceBusCompatibilityTests
     }
 
     [Test]
-    [Timeout(50_000)]
+    [Timeout(90_000)]
     public async Task DotnetSdkSuppressesDuplicateMessageIdsForQueuesAndTopics(
         CancellationToken cancellationToken)
     {

--- a/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
+++ b/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
@@ -174,6 +174,65 @@ public sealed class ServiceBusCompatibilityTests
         await Assert.That(processedMessages[processorSessionB]).IsEqualTo("processor-b");
     }
 
+    [Fact]
+    public async Task DotnetSdkSuppressesDuplicateMessageIdsForQueuesAndTopics()
+    {
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(
+            TestContext.Current.CancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(50));
+        CancellationToken cancellationToken = timeout.Token;
+        const string serviceBusNamespace = "default";
+        string queue = $"duplicate-{Guid.NewGuid():N}";
+        await EnsureNamespace(serviceBusNamespace, cancellationToken);
+        await EnsureQueue(serviceBusNamespace, queue, cancellationToken, duplicateDetection: true);
+
+        string connectionString =
+            $"Endpoint=sb://{ServiceBusHost}:{ServiceBusPort};" +
+            "SharedAccessKeyName=RootManageSharedAccessKey;" +
+            "SharedAccessKey=devkey;UseDevelopmentEmulator=true;";
+
+        await using var client = new ServiceBusClient(connectionString);
+        await using ServiceBusSender sender = client.CreateSender(queue);
+        await using ServiceBusReceiver receiver = client.CreateReceiver(queue);
+
+        const string messageId = "same-message-id";
+        await sender.SendMessageAsync(
+            new ServiceBusMessage("first") { MessageId = messageId }, cancellationToken);
+        await sender.SendMessageAsync(
+            new ServiceBusMessage("duplicate") { MessageId = messageId }, cancellationToken);
+
+        ServiceBusReceivedMessage first = await Receive(receiver, cancellationToken);
+        Assert.Equal("first", first.Body.ToString());
+        await receiver.CompleteMessageAsync(first, cancellationToken);
+        Assert.Null(await receiver.ReceiveMessageAsync(TimeSpan.FromSeconds(2), cancellationToken));
+
+        await Task.Delay(TimeSpan.FromSeconds(21), cancellationToken);
+        await sender.SendMessageAsync(
+            new ServiceBusMessage("after-window") { MessageId = messageId }, cancellationToken);
+        ServiceBusReceivedMessage afterWindow = await Receive(receiver, cancellationToken);
+        Assert.Equal("after-window", afterWindow.Body.ToString());
+        await receiver.CompleteMessageAsync(afterWindow, cancellationToken);
+
+        string topic = $"duplicate-topic-{Guid.NewGuid():N}";
+        const string subscription = "subscriber";
+        await EnsureTopic(serviceBusNamespace, topic, cancellationToken);
+        await EnsureSubscription(serviceBusNamespace, topic, subscription, cancellationToken);
+        await using ServiceBusSender topicSender = client.CreateSender(topic);
+        await using ServiceBusReceiver subscriptionReceiver =
+            client.CreateReceiver(topic, subscription);
+
+        await topicSender.SendMessageAsync(
+            new ServiceBusMessage("topic-first") { MessageId = messageId }, cancellationToken);
+        await topicSender.SendMessageAsync(
+            new ServiceBusMessage("topic-duplicate") { MessageId = messageId }, cancellationToken);
+        ServiceBusReceivedMessage topicFirst =
+            await Receive(subscriptionReceiver, cancellationToken);
+        Assert.Equal("topic-first", topicFirst.Body.ToString());
+        await subscriptionReceiver.CompleteMessageAsync(topicFirst, cancellationToken);
+        Assert.Null(await subscriptionReceiver.ReceiveMessageAsync(
+            TimeSpan.FromSeconds(2), cancellationToken));
+    }
+
     private static async Task<ServiceBusReceivedMessage> Receive(
         ServiceBusReceiver receiver, CancellationToken cancellationToken)
     {
@@ -197,52 +256,77 @@ public sealed class ServiceBusCompatibilityTests
     }
 
     private static async Task EnsureQueue(
-        string serviceBusNamespace, string queue, CancellationToken cancellationToken,
-        bool requiresSession = false)
+        string serviceBusNamespace,
+        string queue,
+        CancellationToken cancellationToken,
+        bool requiresSession = false,
+        bool duplicateDetection = false)
     {
-        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
-        using var request = new HttpRequestMessage(HttpMethod.Put,
-            $"{EmulatorEndpoint}/devstoreaccount1-servicebus/{serviceBusNamespace}/queues/{queue}");
-        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/atom+xml"));
-        string body = requiresSession
-            ? "<entry xmlns=\"http://www.w3.org/2005/Atom\"><content type=\"application/xml\">" +
-              "<QueueDescription xmlns=\"http://schemas.microsoft.com/netservices/2010/10/servicebus/connect\">" +
-              "<RequiresSession>true</RequiresSession></QueueDescription></content></entry>"
-            : "";
-        request.Content = new StringContent(body, Encoding.UTF8, "application/atom+xml");
-        HttpResponseMessage response = await http.SendAsync(request, cancellationToken);
-        await Assert.That(response.IsSuccessStatusCode)
-            .IsTrue()
-            .Because($"Queue creation failed: {(int)response.StatusCode} {await response.Content.ReadAsStringAsync(cancellationToken)}");
+        string properties = (requiresSession ? "<RequiresSession>true</RequiresSession>" : "") +
+            (duplicateDetection
+                ? "<RequiresDuplicateDetection>true</RequiresDuplicateDetection>" +
+                  "<DuplicateDetectionHistoryTimeWindow>PT20S</DuplicateDetectionHistoryTimeWindow>"
+                : "");
+        string content = properties.Length == 0
+            ? ""
+            : $"<entry xmlns=\"http://www.w3.org/2005/Atom\"><content type=\"application/xml\">" +
+              $"<QueueDescription xmlns=\"http://schemas.microsoft.com/netservices/2010/10/servicebus/connect\">" +
+              $"{properties}</QueueDescription></content></entry>";
+        await PutEntity(
+            $"{EmulatorEndpoint}/devstoreaccount1-servicebus/{serviceBusNamespace}/queues/{queue}",
+            content,
+            "Queue",
+            cancellationToken);
     }
 
     private static async Task EnsureTopic(
-        string serviceBusNamespace, string topic, CancellationToken cancellationToken)
+        string serviceBusNamespace,
+        string topic,
+        CancellationToken cancellationToken,
+        bool duplicateDetection = false)
     {
-        await EnsureEntity(
+        string description = duplicateDetection
+            ? """
+              <entry xmlns="http://www.w3.org/2005/Atom">
+                <content type="application/xml">
+                  <TopicDescription xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect">
+                    <RequiresDuplicateDetection>true</RequiresDuplicateDetection>
+                    <DuplicateDetectionHistoryTimeWindow>PT20S</DuplicateDetectionHistoryTimeWindow>
+                  </TopicDescription>
+                </content>
+              </entry>
+              """
+            : "";
+        await PutEntity(
             $"{EmulatorEndpoint}/devstoreaccount1-servicebus/{serviceBusNamespace}/topics/{topic}",
-            "Topic", cancellationToken);
+            description,
+            "Topic",
+            cancellationToken);
     }
 
-    private static async Task EnsureSubscription(
-        string serviceBusNamespace, string topic, string subscription,
-        CancellationToken cancellationToken)
-    {
-        await EnsureEntity(
-            $"{EmulatorEndpoint}/devstoreaccount1-servicebus/{serviceBusNamespace}/topics/{topic}/subscriptions/{subscription}",
-            "Subscription", cancellationToken);
-    }
+    private static Task EnsureSubscription(
+        string serviceBusNamespace,
+        string topic,
+        string subscription,
+        CancellationToken cancellationToken) =>
+        PutEntity(
+            $"{EmulatorEndpoint}/devstoreaccount1-servicebus/{serviceBusNamespace}/topics/{topic}" +
+            $"/subscriptions/{subscription}",
+            "",
+            "Subscription",
+            cancellationToken);
 
-    private static async Task EnsureEntity(
-        string url, string entityType, CancellationToken cancellationToken)
+    private static async Task PutEntity(
+        string url, string content, string entityType, CancellationToken cancellationToken)
     {
         using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
         using var request = new HttpRequestMessage(HttpMethod.Put, url);
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/atom+xml"));
-        request.Content = new StringContent("", Encoding.UTF8, "application/atom+xml");
+        request.Content = new StringContent(content, Encoding.UTF8, "application/atom+xml");
         HttpResponseMessage response = await http.SendAsync(request, cancellationToken);
         await Assert.That(response.IsSuccessStatusCode)
             .IsTrue()
-            .Because($"{entityType} creation failed: {(int)response.StatusCode} {await response.Content.ReadAsStringAsync(cancellationToken)}");
+            .Because($"{entityType} creation failed: {(int)response.StatusCode} " +
+                     await response.Content.ReadAsStringAsync(cancellationToken));
     }
 }

--- a/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
+++ b/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
@@ -67,8 +67,10 @@ public sealed class ServiceBusCompatibilityTests
 
         await using ServiceBusSender topicSender = client.CreateSender(topic);
         await using ServiceBusReceiver subscriptionReceiver = client.CreateReceiver(topic, subscription);
-        await topicSender.SendMessageAsync(new ServiceBusMessage("subscription-dead-letter"), cancellationToken);
-        ServiceBusReceivedMessage subscriptionMessage = await Receive(subscriptionReceiver, cancellationToken);
+        await topicSender.SendMessageAsync(
+            new ServiceBusMessage("subscription-dead-letter"), cancellationToken);
+        ServiceBusReceivedMessage subscriptionMessage =
+            await Receive(subscriptionReceiver, cancellationToken);
         await subscriptionReceiver.DeadLetterMessageAsync(
             subscriptionMessage, cancellationToken: cancellationToken);
 

--- a/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
+++ b/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
@@ -177,7 +177,7 @@ public sealed class ServiceBusCompatibilityTests
     }
 
     [Test]
-    [Timeout(90_000)]
+    [Timeout(120_000)]
     public async Task DotnetSdkSuppressesDuplicateMessageIdsForQueuesAndTopics(
         CancellationToken cancellationToken)
     {
@@ -204,8 +204,11 @@ public sealed class ServiceBusCompatibilityTests
         ServiceBusReceivedMessage first = await Receive(receiver, cancellationToken);
         await Assert.That(first.Body.ToString()).IsEqualTo("first");
         await receiver.CompleteMessageAsync(first, cancellationToken);
-        await Assert.That(await receiver.ReceiveMessageAsync(
-            TimeSpan.FromSeconds(2), cancellationToken)).IsNull();
+        await sender.SendMessageAsync(
+            new ServiceBusMessage("marker") { MessageId = "queue-marker" }, cancellationToken);
+        ServiceBusReceivedMessage marker = await Receive(receiver, cancellationToken);
+        await Assert.That(marker.Body.ToString()).IsEqualTo("marker");
+        await receiver.CompleteMessageAsync(marker, cancellationToken);
 
         await Task.Delay(TimeSpan.FromSeconds(21), cancellationToken);
         await sender.SendMessageAsync(
@@ -216,7 +219,8 @@ public sealed class ServiceBusCompatibilityTests
 
         string topic = $"duplicate-topic-{Guid.NewGuid():N}";
         const string subscription = "subscriber";
-        await EnsureTopic(serviceBusNamespace, topic, cancellationToken);
+        await EnsureTopic(
+            serviceBusNamespace, topic, cancellationToken, duplicateDetection: true);
         await EnsureSubscription(serviceBusNamespace, topic, subscription, cancellationToken);
         await using ServiceBusSender topicSender = client.CreateSender(topic);
         await using ServiceBusReceiver subscriptionReceiver =
@@ -230,8 +234,13 @@ public sealed class ServiceBusCompatibilityTests
             await Receive(subscriptionReceiver, cancellationToken);
         await Assert.That(topicFirst.Body.ToString()).IsEqualTo("topic-first");
         await subscriptionReceiver.CompleteMessageAsync(topicFirst, cancellationToken);
-        await Assert.That(await subscriptionReceiver.ReceiveMessageAsync(
-            TimeSpan.FromSeconds(2), cancellationToken)).IsNull();
+        await topicSender.SendMessageAsync(
+            new ServiceBusMessage("topic-marker") { MessageId = "topic-marker" },
+            cancellationToken);
+        ServiceBusReceivedMessage topicMarker =
+            await Receive(subscriptionReceiver, cancellationToken);
+        await Assert.That(topicMarker.Body.ToString()).IsEqualTo("topic-marker");
+        await subscriptionReceiver.CompleteMessageAsync(topicMarker, cancellationToken);
     }
 
     private static async Task<ServiceBusReceivedMessage> Receive(
@@ -288,15 +297,15 @@ public sealed class ServiceBusCompatibilityTests
     {
         string description = duplicateDetection
             ? """
-              <entry xmlns="http://www.w3.org/2005/Atom">
-                <content type="application/xml">
-                  <TopicDescription xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect">
-                    <RequiresDuplicateDetection>true</RequiresDuplicateDetection>
-                    <DuplicateDetectionHistoryTimeWindow>PT20S</DuplicateDetectionHistoryTimeWindow>
-                  </TopicDescription>
-                </content>
-              </entry>
-              """
+            <entry xmlns="http://www.w3.org/2005/Atom">
+              <content type="application/xml">
+                <TopicDescription xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect">
+                  <RequiresDuplicateDetection>true</RequiresDuplicateDetection>
+                  <DuplicateDetectionHistoryTimeWindow>PT20S</DuplicateDetectionHistoryTimeWindow>
+                </TopicDescription>
+              </content>
+            </entry>
+            """
             : "";
         await PutEntity(
             $"{EmulatorEndpoint}/devstoreaccount1-servicebus/{serviceBusNamespace}/topics/{topic}",

--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,7 @@
                                     <includes>
                                         org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java,
                                         org/apache/activemq/artemis/protocol/amqp/proton/DefaultSenderController.java,
+                                        org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerReceiverContext.java,
                                         org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java
                                     </includes>
                                 </artifactItem>
@@ -266,7 +267,7 @@
                                 <replace
                                     file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/DefaultSenderController.java"
                                     token="final String sourceAddress = ParameterisedAddress.extractAddress(source.getAddress());"
-                                    value="final String sourceAddress = ServiceBusSessionSupport.normalizeEntityPath(ParameterisedAddress.extractAddress(source.getAddress()));"
+                                    value="final String sourceAddress = ServiceBusSessionSupport.normalizeEntityPath(ParameterisedAddress.extractAddress(source.getAddress())).replaceFirst(&quot;^/&quot;, &quot;&quot;);"
                                     failOnNoReplacements="true" />
                                 <replace
                                     file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/DefaultSenderController.java"
@@ -277,6 +278,26 @@
                                     file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/DefaultSenderController.java"
                                     token="public void close(boolean remoteClose) throws Exception {"
                                     value="public void close(boolean remoteClose) throws Exception { ServiceBusSessionSupport.release(protonSender);"
+                                    failOnNoReplacements="true" />
+                                <replace
+                                    file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/DefaultSenderController.java"
+                                    token="addressToUse = SimpleString.of(sourceAddress);"
+                                    value="addressToUse = SimpleString.of(sourceAddress);&#10;            directQueue = sessionSPI.queueQuery(QueueConfiguration.of(addressToUse), false);&#10;            if (directQueue.isExists()) {&#10;               queueNameToUse = addressToUse;&#10;               addressToUse = directQueue.getAddress();&#10;            }"
+                                    failOnNoReplacements="true" />
+                                <replace
+                                    file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/DefaultSenderController.java"
+                                    token="final boolean isFQQN;"
+                                    value="final boolean isFQQN;&#10;         QueueQueryResult directQueue = null;"
+                                    failOnNoReplacements="true" />
+                                <replace
+                                    file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/DefaultSenderController.java"
+                                    token="multicast = verifySourceCapability(source, TOPIC_CAPABILITY);"
+                                    value="multicast = directQueue != null &amp;&amp; directQueue.isExists() ? directQueue.getRoutingType() == RoutingType.MULTICAST : verifySourceCapability(source, TOPIC_CAPABILITY);"
+                                    failOnNoReplacements="true" />
+                                <replace
+                                    file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerReceiverContext.java"
+                                    token="address = SimpleString.of(targetAddress);"
+                                    value="address = SimpleString.of(targetAddress.startsWith(&quot;/&quot;) ? targetAddress.substring(1) : targetAddress);"
                                     failOnNoReplacements="true" />
                                 <replace
                                     file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java"

--- a/src/artemis-plugin/java/io/floci/az/artemis/ServiceBusDuplicateDetectionPlugin.java
+++ b/src/artemis-plugin/java/io/floci/az/artemis/ServiceBusDuplicateDetectionPlugin.java
@@ -1,0 +1,170 @@
+package io.floci.az.artemis;
+
+import org.apache.activemq.artemis.api.core.Message;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.postoffice.DuplicateIDCache;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.RoutingContext;
+import org.apache.activemq.artemis.core.server.plugin.ActiveMQServerPlugin;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import java.lang.management.ManagementFactory;
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Maps AMQP message-id to Artemis duplicate detection for configured Service Bus entities.
+ *
+ * <p>Artemis provides the atomic, transactional duplicate check. This plugin limits each
+ * address's cache entries to the Azure duplicate-detection history window.
+ */
+public final class ServiceBusDuplicateDetectionPlugin
+        implements ActiveMQServerPlugin, ServiceBusDuplicateDetectionPluginMBean {
+
+    public static final String OBJECT_NAME =
+            "io.floci.az.artemis:type=ServiceBusDuplicateDetection";
+
+    private final ConcurrentHashMap<String, Long> windowsByAddress = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<DuplicateKey, Long> expiresByKey = new ConcurrentHashMap<>();
+
+    private volatile ActiveMQServer server;
+    private volatile ObjectName objectName;
+
+    @Override
+    public void registered(ActiveMQServer registeredServer) {
+        server = registeredServer;
+        try {
+            objectName = new ObjectName(OBJECT_NAME);
+            MBeanServer mBeanServer = registeredServer.getMBeanServer();
+            if (mBeanServer == null) {
+                mBeanServer = ManagementFactory.getPlatformMBeanServer();
+            }
+            if (mBeanServer.isRegistered(objectName)) {
+                mBeanServer.unregisterMBean(objectName);
+            }
+            mBeanServer.registerMBean(this, objectName);
+        } catch (Exception e) {
+            throw new IllegalStateException("Could not register duplicate detection MBean", e);
+        }
+    }
+
+    @Override
+    public void unregistered(ActiveMQServer unregisteredServer) {
+        try {
+            MBeanServer mBeanServer = unregisteredServer.getMBeanServer();
+            if (mBeanServer == null) {
+                mBeanServer = ManagementFactory.getPlatformMBeanServer();
+            }
+            if (objectName != null && mBeanServer.isRegistered(objectName)) {
+                mBeanServer.unregisterMBean(objectName);
+            }
+        } catch (Exception ignored) {
+            // Broker shutdown must continue even if JMX has already stopped.
+        } finally {
+            windowsByAddress.clear();
+            expiresByKey.clear();
+            server = null;
+        }
+    }
+
+    @Override
+    public void configure(String address, long historyWindowMillis) {
+        if (address == null || address.isBlank()) {
+            throw new IllegalArgumentException("address is required");
+        }
+        if (historyWindowMillis <= 0) {
+            throw new IllegalArgumentException("historyWindowMillis must be positive");
+        }
+        windowsByAddress.put(address, historyWindowMillis);
+    }
+
+    @Override
+    public void remove(String address) {
+        windowsByAddress.remove(address);
+        expiresByKey.keySet().removeIf(key -> key.address().equals(address));
+        ActiveMQServer activeServer = server;
+        if (activeServer != null) {
+            try {
+                activeServer.getPostOffice().getDuplicateIDCache(SimpleString.of(address)).clear();
+            } catch (Exception ignored) {
+                // Removing an entity is best effort during broker teardown.
+            }
+        }
+    }
+
+    @Override
+    public void beforeMessageRoute(
+            Message message, RoutingContext context, boolean direct, boolean rejectDuplicates) {
+        String address = context.getAddress(message).toString();
+        Long historyWindowMillis = windowsByAddress.get(address);
+        Object messageId = message.getUserID();
+        if (historyWindowMillis == null || messageId == null) {
+            return;
+        }
+
+        byte[] duplicateId = messageId.toString().getBytes(StandardCharsets.UTF_8);
+        DuplicateKey key = new DuplicateKey(address, messageId.toString());
+        long now = System.currentTimeMillis();
+        expiresByKey.computeIfPresent(key, (ignored, existingExpiry) -> {
+            if (existingExpiry <= now) {
+                evict(address, duplicateId);
+                return null;
+            }
+            return existingExpiry;
+        });
+
+        ActiveMQServer activeServer = Objects.requireNonNull(server, "plugin is not registered");
+        DuplicateIDCache cache =
+                activeServer.getPostOffice().getDuplicateIDCache(SimpleString.of(address));
+        final boolean accepted;
+        try {
+            accepted = cache.atomicVerify(duplicateId, context.getTransaction());
+        } catch (Exception e) {
+            throw new IllegalStateException("Could not check duplicate id for " + address, e);
+        }
+        if (!accepted) {
+            context.clear();
+            return;
+        }
+
+        expiresByKey.computeIfAbsent(key, ignored -> {
+            long newExpiry = Math.addExact(now, historyWindowMillis);
+            scheduleEviction(key, duplicateId, newExpiry, historyWindowMillis);
+            return newExpiry;
+        });
+    }
+
+    private void scheduleEviction(DuplicateKey key, byte[] duplicateId,
+                                  long expiry, long delayMillis) {
+        ActiveMQServer activeServer = Objects.requireNonNull(server, "plugin is not registered");
+        activeServer.getScheduledPool().schedule(
+                () -> expiresByKey.computeIfPresent(key, (ignored, currentExpiry) -> {
+                    if (currentExpiry == expiry) {
+                        evict(key.address(), duplicateId);
+                        return null;
+                    }
+                    return currentExpiry;
+                }),
+                delayMillis,
+                TimeUnit.MILLISECONDS);
+    }
+
+    private void evict(String address, byte[] duplicateId) {
+        ActiveMQServer activeServer = server;
+        if (activeServer == null) {
+            return;
+        }
+        try {
+            DuplicateIDCache cache = activeServer.getPostOffice()
+                    .getDuplicateIDCache(SimpleString.of(address));
+            cache.deleteFromCache(duplicateId);
+        } catch (Exception e) {
+            throw new IllegalStateException("Could not expire duplicate id for " + address, e);
+        }
+    }
+
+    private record DuplicateKey(String address, String messageId) {}
+}

--- a/src/artemis-plugin/java/io/floci/az/artemis/ServiceBusDuplicateDetectionPlugin.java
+++ b/src/artemis-plugin/java/io/floci/az/artemis/ServiceBusDuplicateDetectionPlugin.java
@@ -24,6 +24,8 @@ import java.util.concurrent.TimeUnit;
 public final class ServiceBusDuplicateDetectionPlugin
         implements ActiveMQServerPlugin, ServiceBusDuplicateDetectionPluginMBean {
 
+    private static final System.Logger LOG =
+            System.getLogger(ServiceBusDuplicateDetectionPlugin.class.getName());
     public static final String OBJECT_NAME =
             "io.floci.az.artemis:type=ServiceBusDuplicateDetection";
 
@@ -61,8 +63,9 @@ public final class ServiceBusDuplicateDetectionPlugin
             if (objectName != null && mBeanServer.isRegistered(objectName)) {
                 mBeanServer.unregisterMBean(objectName);
             }
-        } catch (Exception ignored) {
-            // Broker shutdown must continue even if JMX has already stopped.
+        } catch (Exception e) {
+            LOG.log(System.Logger.Level.WARNING,
+                    "Could not unregister duplicate detection MBean during broker shutdown", e);
         } finally {
             windowsByAddress.clear();
             expiresByKey.clear();
@@ -89,8 +92,9 @@ public final class ServiceBusDuplicateDetectionPlugin
         if (activeServer != null) {
             try {
                 activeServer.getPostOffice().getDuplicateIDCache(SimpleString.of(address)).clear();
-            } catch (Exception ignored) {
-                // Removing an entity is best effort during broker teardown.
+            } catch (Exception e) {
+                LOG.log(System.Logger.Level.WARNING,
+                        "Could not clear duplicate detection cache for " + address, e);
             }
         }
     }

--- a/src/artemis-plugin/java/io/floci/az/artemis/ServiceBusDuplicateDetectionPluginMBean.java
+++ b/src/artemis-plugin/java/io/floci/az/artemis/ServiceBusDuplicateDetectionPluginMBean.java
@@ -1,0 +1,8 @@
+package io.floci.az.artemis;
+
+public interface ServiceBusDuplicateDetectionPluginMBean {
+
+    void configure(String address, long historyWindowMillis);
+
+    void remove(String address);
+}

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusConfigGenerator.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusConfigGenerator.java
@@ -51,6 +51,11 @@ public class ServiceBusConfigGenerator {
                         + ";maxMessageSize=1048576")
                   .end("acceptor")
                 .end("acceptors")
+                .start("broker-plugins")
+                  .startAttr("broker-plugin", "class-name",
+                          "io.floci.az.artemis.ServiceBusDuplicateDetectionPlugin")
+                  .end("broker-plugin")
+                .end("broker-plugins")
                 .start("address-settings")
                   .startAttr("address-setting", "match", "#")
                     .elem("max-delivery-attempts", maxDelivery)

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusEntityXml.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusEntityXml.java
@@ -8,7 +8,9 @@ import java.time.format.DateTimeParseException;
 /** Parses settings shared by Service Bus queue and topic descriptions. */
 final class ServiceBusEntityXml {
 
-    private static final Duration DEFAULT_DUPLICATE_DETECTION_HISTORY = Duration.ofMinutes(10);
+    static final long DEFAULT_DUPLICATE_DETECTION_HISTORY_SECONDS = Duration.ofMinutes(10).toSeconds();
+    private static final Duration DEFAULT_DUPLICATE_DETECTION_HISTORY =
+            Duration.ofSeconds(DEFAULT_DUPLICATE_DETECTION_HISTORY_SECONDS);
     private static final long MIN_DUPLICATE_DETECTION_HISTORY_SECONDS = Duration.ofSeconds(20).toSeconds();
     private static final long MAX_DUPLICATE_DETECTION_HISTORY_SECONDS = Duration.ofDays(7).toSeconds();
 

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusEntityXml.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusEntityXml.java
@@ -1,0 +1,44 @@
+package io.floci.az.services.servicebus;
+
+import io.floci.az.core.XmlParser;
+
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
+
+/** Parses settings shared by Service Bus queue and topic descriptions. */
+final class ServiceBusEntityXml {
+
+    private static final Duration DEFAULT_DUPLICATE_DETECTION_HISTORY = Duration.ofMinutes(10);
+    private static final long MIN_DUPLICATE_DETECTION_HISTORY_SECONDS = Duration.ofSeconds(20).toSeconds();
+    private static final long MAX_DUPLICATE_DETECTION_HISTORY_SECONDS = Duration.ofDays(7).toSeconds();
+
+    private ServiceBusEntityXml() {}
+
+    static DuplicateDetectionSettings duplicateDetection(String xml) {
+        boolean enabled = Boolean.parseBoolean(
+                XmlParser.extractFirst(xml, "RequiresDuplicateDetection", "false").trim());
+        String rawHistory = XmlParser.extractFirst(
+                xml, "DuplicateDetectionHistoryTimeWindow",
+                DEFAULT_DUPLICATE_DETECTION_HISTORY.toString()).trim();
+        long historySeconds;
+        try {
+            Duration history = Duration.parse(rawHistory);
+            if (history.isNegative() || history.isZero() || history.getNano() != 0) {
+                throw new IllegalArgumentException(
+                        "DuplicateDetectionHistoryTimeWindow must be a whole positive number of seconds");
+            }
+            historySeconds = history.getSeconds();
+        } catch (DateTimeParseException e) {
+            throw new IllegalArgumentException(
+                    "DuplicateDetectionHistoryTimeWindow must be an ISO-8601 duration", e);
+        }
+        if (historySeconds < MIN_DUPLICATE_DETECTION_HISTORY_SECONDS
+                || historySeconds > MAX_DUPLICATE_DETECTION_HISTORY_SECONDS) {
+            throw new IllegalArgumentException(
+                    "DuplicateDetectionHistoryTimeWindow must be between PT20S and P7D");
+        }
+        return new DuplicateDetectionSettings(enabled, historySeconds);
+    }
+
+    record DuplicateDetectionSettings(boolean enabled, long historySeconds) {}
+}

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
@@ -672,9 +672,12 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
     private Response handleCreateSubscription(String account, String namespace,
                                                 String topicName, String subName,
                                                 boolean requiresSession, String body) {
-        if (store.get(topicKey(account, namespace, topicName)).isEmpty()) {
+        Optional<StoredObject> storedTopic = store.get(topicKey(account, namespace, topicName));
+        if (storedTopic.isEmpty()) {
             return notFoundAtom("Topic not found: " + topicName);
         }
+        ServiceBusModels.TopicEntity topic = fromBytes(
+                storedTopic.get().data(), ServiceBusModels.TopicEntity.class);
 
         String key = subKey(account, namespace, topicName, subName);
         if (store.get(key).isPresent()) {
@@ -704,8 +707,12 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         warnOnActionIgnored(initialRule);
 
         try {
-            namespaceManager.jolokiaCreateSubscription(namespace, topicName, subName, selector,
-                    sub.requiresSession(), sub.lockDurationSeconds());
+            namespaceManager.jolokiaCreateSubscription(
+                    namespace, topicName, subName, selector,
+                    sub.requiresSession(), sub.lockDurationSeconds(),
+                    new ServiceBusEntityXml.DuplicateDetectionSettings(
+                            topic.requiresDuplicateDetection(),
+                            topic.duplicateDetectionHistorySeconds()));
         } catch (Exception e) {
             LOG.warnf(e, "Failed to provision subscription '%s/%s' in Artemis for namespace '%s'",
                     topicName, subName, namespace);

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
@@ -264,12 +264,18 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         boolean isQueue = body.isEmpty() || body.contains("QueueDescription");
         boolean isTopic = !isQueue && body.contains("TopicDescription");
         boolean requiresSession = body.contains("<RequiresSession>true</RequiresSession>");
+        ServiceBusEntityXml.DuplicateDetectionSettings duplicateDetection;
+        try {
+            duplicateDetection = ServiceBusEntityXml.duplicateDetection(body);
+        } catch (IllegalArgumentException e) {
+            return badRequestAtom(e.getMessage());
+        }
 
         if (isTopic) {
-            return handleCreateTopic(account, ns, entityName);
+            return handleCreateTopic(account, ns, entityName, duplicateDetection);
         }
         // Default to queue (empty body, QueueDescription, or ambiguous)
-        return handleCreateQueue(account, ns, entityName, requiresSession);
+        return handleCreateQueue(account, ns, entityName, requiresSession, duplicateDetection);
     }
 
     private Response handleSpecEntityDelete(String account, String ns, String entityName) {
@@ -468,7 +474,12 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
             case "PUT", "POST"  -> {
                 String body = readBody(req);
                 boolean requiresSession = body.contains("<RequiresSession>true</RequiresSession>");
-                yield handleCreateQueue(account, namespace, queueName, requiresSession);
+                try {
+                    yield handleCreateQueue(account, namespace, queueName, requiresSession,
+                            ServiceBusEntityXml.duplicateDetection(body));
+                } catch (IllegalArgumentException e) {
+                    yield badRequestAtom(e.getMessage());
+                }
             }
             case "DELETE"       -> handleDeleteQueue(account, namespace, queueName);
             default             -> Response.status(405).build();
@@ -486,7 +497,8 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
     }
 
     private Response handleCreateQueue(String account, String namespace, String queueName,
-                                        boolean requiresSession) {
+                                        boolean requiresSession,
+                                        ServiceBusEntityXml.DuplicateDetectionSettings duplicateDetection) {
         String key = queueKey(account, namespace, queueName);
         if (store.get(key).isPresent()) {
             ServiceBusModels.QueueEntity existing =
@@ -499,12 +511,13 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         }
         EmulatorConfig.ServiceBusConfig sb = config.services().serviceBus();
         ServiceBusModels.QueueEntity queue = ServiceBusModels.QueueEntity.defaults(
-                queueName, sb.maxDeliveryCount(), sb.lockDurationSeconds(), requiresSession);
+                queueName, sb.maxDeliveryCount(), sb.lockDurationSeconds(), requiresSession,
+                duplicateDetection);
         store.put(key, toStoredObject(key, queue));
 
         try {
-            namespaceManager.jolokiaCreateQueue(
-                    namespace, queueName, queue.requiresSession(), queue.lockDurationSeconds());
+            namespaceManager.jolokiaCreateQueue(namespace, queueName,
+                    queue.requiresSession(), queue.lockDurationSeconds(), duplicateDetection);
         } catch (Exception e) {
             LOG.warnf(e, "Failed to provision queue '%s' in Artemis for namespace '%s'", queueName, namespace);
         }
@@ -541,7 +554,14 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
     private Response handleTopicCrud(AzureRequest req, String account, String namespace, String topicName) {
         return switch (req.method()) {
             case "GET"          -> handleGetTopic(account, namespace, topicName);
-            case "PUT", "POST"  -> handleCreateTopic(account, namespace, topicName);
+            case "PUT", "POST"  -> {
+                try {
+                    yield handleCreateTopic(account, namespace, topicName,
+                            ServiceBusEntityXml.duplicateDetection(readBody(req)));
+                } catch (IllegalArgumentException e) {
+                    yield badRequestAtom(e.getMessage());
+                }
+            }
             case "DELETE"       -> handleDeleteTopic(account, namespace, topicName);
             default             -> Response.status(405).build();
         };
@@ -557,7 +577,8 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                 .orElseGet(() -> notFoundAtom("Topic not found: " + topicName));
     }
 
-    private Response handleCreateTopic(String account, String namespace, String topicName) {
+    private Response handleCreateTopic(String account, String namespace, String topicName,
+                                        ServiceBusEntityXml.DuplicateDetectionSettings duplicateDetection) {
         String key = topicKey(account, namespace, topicName);
         if (store.get(key).isPresent()) {
             ServiceBusModels.TopicEntity existing =
@@ -568,11 +589,12 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         if (namespaceManager.getNamespace(namespace).isEmpty()) {
             lazyStartNamespace(namespace);
         }
-        ServiceBusModels.TopicEntity topic = ServiceBusModels.TopicEntity.defaults(topicName);
+        ServiceBusModels.TopicEntity topic =
+                ServiceBusModels.TopicEntity.defaults(topicName, duplicateDetection);
         store.put(key, toStoredObject(key, topic));
 
         try {
-            namespaceManager.jolokiaCreateTopic(namespace, topicName);
+            namespaceManager.jolokiaCreateTopic(namespace, topicName, duplicateDetection);
         } catch (Exception e) {
             LOG.warnf(e, "Failed to provision topic '%s' in Artemis for namespace '%s'", topicName, namespace);
         }
@@ -838,7 +860,11 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                 + "<DefaultMessageTimeToLive>P14D</DefaultMessageTimeToLive>"
                 + "<LockDuration>" + lockDuration + "</LockDuration>"
                 + "<MaxDeliveryCount>" + q.maxDeliveryCount() + "</MaxDeliveryCount>"
-                + "<RequiresDuplicateDetection>false</RequiresDuplicateDetection>"
+                + "<RequiresDuplicateDetection>" + q.requiresDuplicateDetection()
+                + "</RequiresDuplicateDetection>"
+                + "<DuplicateDetectionHistoryTimeWindow>"
+                + isoDuration(q.duplicateDetectionHistorySeconds())
+                + "</DuplicateDetectionHistoryTimeWindow>"
                 + "<RequiresSession>" + q.requiresSession() + "</RequiresSession>"
                 + "<DeadLetteringOnMessageExpiration>false</DeadLetteringOnMessageExpiration>"
                 + "<EnableBatchedOperations>true</EnableBatchedOperations>"
@@ -882,7 +908,11 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         return "<TopicDescription xmlns=\"" + SB_NS + "\">"
                 + "<MaxSizeInMegabytes>" + t.maxSizeInMegabytes() + "</MaxSizeInMegabytes>"
                 + "<DefaultMessageTimeToLive>P14D</DefaultMessageTimeToLive>"
-                + "<RequiresDuplicateDetection>false</RequiresDuplicateDetection>"
+                + "<RequiresDuplicateDetection>" + t.requiresDuplicateDetection()
+                + "</RequiresDuplicateDetection>"
+                + "<DuplicateDetectionHistoryTimeWindow>"
+                + isoDuration(t.duplicateDetectionHistorySeconds())
+                + "</DuplicateDetectionHistoryTimeWindow>"
                 + "<EnableBatchedOperations>true</EnableBatchedOperations>"
                 + "<AutoDeleteOnIdle>P10675199DT2H48M5.4775807S</AutoDeleteOnIdle>"
                 + "<Status>Active</Status>"

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusModels.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusModels.java
@@ -27,6 +27,13 @@ public final class ServiceBusModels {
             Instant createdAt,
             Instant updatedAt) {
 
+        public QueueEntity {
+            if (duplicateDetectionHistorySeconds == 0) {
+                duplicateDetectionHistorySeconds =
+                        ServiceBusEntityXml.DEFAULT_DUPLICATE_DETECTION_HISTORY_SECONDS;
+            }
+        }
+
         static QueueEntity defaults(String name, int maxDeliveryCount,
                                      long lockDurationSeconds, boolean requiresSession,
                                      ServiceBusEntityXml.DuplicateDetectionSettings duplicateDetection) {
@@ -45,6 +52,13 @@ public final class ServiceBusModels {
             long duplicateDetectionHistorySeconds,
             Instant createdAt,
             Instant updatedAt) {
+
+        public TopicEntity {
+            if (duplicateDetectionHistorySeconds == 0) {
+                duplicateDetectionHistorySeconds =
+                        ServiceBusEntityXml.DEFAULT_DUPLICATE_DETECTION_HISTORY_SECONDS;
+            }
+        }
 
         static TopicEntity defaults(String name,
                                     ServiceBusEntityXml.DuplicateDetectionSettings duplicateDetection) {

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusModels.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusModels.java
@@ -22,14 +22,18 @@ public final class ServiceBusModels {
             long lockDurationSeconds,
             long maxSizeInMegabytes,
             boolean requiresSession,
+            boolean requiresDuplicateDetection,
+            long duplicateDetectionHistorySeconds,
             Instant createdAt,
             Instant updatedAt) {
 
         static QueueEntity defaults(String name, int maxDeliveryCount,
-                                     long lockDurationSeconds, boolean requiresSession) {
+                                     long lockDurationSeconds, boolean requiresSession,
+                                     ServiceBusEntityXml.DuplicateDetectionSettings duplicateDetection) {
             Instant now = Instant.now();
             return new QueueEntity(name, maxDeliveryCount, lockDurationSeconds,
-                    1024, requiresSession, now, now);
+                    1024, requiresSession, duplicateDetection.enabled(),
+                    duplicateDetection.historySeconds(), now, now);
         }
     }
 
@@ -37,12 +41,16 @@ public final class ServiceBusModels {
     public record TopicEntity(
             String name,
             long maxSizeInMegabytes,
+            boolean requiresDuplicateDetection,
+            long duplicateDetectionHistorySeconds,
             Instant createdAt,
             Instant updatedAt) {
 
-        static TopicEntity defaults(String name) {
+        static TopicEntity defaults(String name,
+                                    ServiceBusEntityXml.DuplicateDetectionSettings duplicateDetection) {
             Instant now = Instant.now();
-            return new TopicEntity(name, 1024, now, now);
+            return new TopicEntity(name, 1024, duplicateDetection.enabled(),
+                    duplicateDetection.historySeconds(), now, now);
         }
     }
 

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -371,9 +371,14 @@ public class ServiceBusNamespaceManager {
      * @param filter Artemis core filter (SQL92 selector) applied to the queue — the compiled
      *               form of the subscription's rules; empty string matches everything
      */
-    public void jolokiaCreateSubscription(String namespaceName, String topicName, String subName,
-                                           String filter, boolean requiresSession,
-                                           long lockDurationSeconds) {
+    public void jolokiaCreateSubscription(
+            String namespaceName,
+            String topicName,
+            String subName,
+            String filter,
+            boolean requiresSession,
+            long lockDurationSeconds,
+            ServiceBusEntityXml.DuplicateDetectionSettings duplicateDetection) {
         String queueName = topicName + "/Subscriptions/" + subName;
         String deadLetterQueue = queueName + DEAD_LETTER_QUEUE_SUFFIX;
         String divertName = queueName + SUBSCRIPTION_DIVERT_SUFFIX;
@@ -403,6 +408,8 @@ public class ServiceBusNamespaceManager {
                     jsonArr(queueName, addressSettings));
             jolokiaCreateDivert(http, baseUrl, auth, mbean, divertName,
                     topicName + TOPIC_ADDRESS_SUFFIX, queueName, filter, false);
+            configureDuplicateDetection(
+                    http, baseUrl, auth, queueName, duplicateDetection);
         });
     }
 
@@ -448,6 +455,7 @@ public class ServiceBusNamespaceManager {
             jolokiaExec(http, baseUrl, auth, mbean,
                     "removeAddressSettings(java.lang.String)",
                     jsonArr(queueName));
+            removeDuplicateDetection(http, baseUrl, auth, queueName);
         });
     }
 

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -118,7 +118,12 @@ public class ServiceBusNamespaceManager {
         this.tlsGenerator = tlsGenerator;
     }
 
-    public NamespaceState startNamespace(String namespaceName, int amqpHostPort, int amqpsHostPort) {
+    public synchronized NamespaceState startNamespace(
+            String namespaceName, int amqpHostPort, int amqpsHostPort) {
+        NamespaceState existing = namespaces.get(namespaceName);
+        if (existing != null) {
+            return existing;
+        }
         String containerName = containerName(namespaceName);
 
         LOG.infov("Starting Artemis broker for Service Bus namespace ''{0}'' (plain:{1}, TLS:{2})",

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -322,7 +322,7 @@ public class ServiceBusNamespaceManager {
         });
     }
 
-    /** Removes a MULTICAST address and all its subscription queues from the running Artemis broker. */
+    /** Removes a topic ingress address and its hidden fan-out address from Artemis. */
     public void jolokiaDeleteTopic(String namespaceName, String topicName) {
         String topicAddress = topicName + TOPIC_ADDRESS_SUFFIX;
         withJolokia(namespaceName, (http, baseUrl, auth, mbean) -> {
@@ -511,7 +511,6 @@ public class ServiceBusNamespaceManager {
         jolokiaExec(http, baseUrl, auth, mbean,
                 "updateQueue(java.lang.String)", jsonArr(queueConfiguration));
     }
-
     private void withJolokia(String namespaceName, JolokiaAction action) {
         NamespaceState state = namespaces.get(namespaceName);
         if (state == null) {

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -46,6 +46,29 @@ public class ServiceBusNamespaceManager {
     private static final String PROTON_J_PATH = "/opt/activemq-artemis/lib/proton-j-0.34.1.jar";
     private static final String ARTEMIS_AMQP_PATH =
             "/opt/activemq-artemis/lib/artemis-amqp-protocol-2.44.0.jar";
+    private static final String MANAGEMENT_XML = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <management-context xmlns="http://activemq.apache.org/schema">
+              <authorisation>
+                <allowlist>
+                  <entry domain="hawtio"/>
+                </allowlist>
+                <default-access>
+                  <access method="list*" roles="amq"/>
+                  <access method="get*" roles="amq"/>
+                  <access method="is*" roles="amq"/>
+                </default-access>
+                <role-access>
+                  <match domain="org.apache.activemq.artemis">
+                    <access method="*" roles="amq"/>
+                  </match>
+                  <match domain="io.floci.az.artemis">
+                    <access method="*" roles="amq"/>
+                  </match>
+                </role-access>
+              </authorisation>
+            </management-context>
+            """;
     private static final int AMQP_PORT = 5672;
     private static final int AMQPS_PORT = 5671;
     private static final int JOLOKIA_PORT = 8161;
@@ -54,6 +77,8 @@ public class ServiceBusNamespaceManager {
     private static final String TOPIC_ADDRESS_SUFFIX = "/$Topic";
     private static final String TOPIC_DIVERT_SUFFIX = "/$TopicDivert";
     private static final String SESSION_METADATA_PREFIX = "floci-az:servicebus-session:";
+    private static final String DUPLICATE_DETECTION_MBEAN =
+            "io.floci.az.artemis:type=ServiceBusDuplicateDetection";
 
     /**
      * Immutable snapshot of a running namespace.
@@ -126,6 +151,8 @@ public class ServiceBusNamespaceManager {
         String containerId = lifecycleManager.create(spec);
         lifecycleManager.copyFileToContainer(containerId, brokerXml,
                 "/var/lib/artemis-instance/etc-override/broker.xml");
+        lifecycleManager.copyFileToContainer(containerId, MANAGEMENT_XML,
+                "/var/lib/artemis-instance/etc-override/management.xml");
         lifecycleManager.copyBytesToContainer(containerId, tls.pkcs12Bytes(),
                 "/var/lib/artemis-instance/etc-override/artemis.p12");
         lifecycleManager.copyBytesToContainer(containerId, loadArtemisExtension(),
@@ -208,8 +235,12 @@ public class ServiceBusNamespaceManager {
     // ── Jolokia entity management ─────────────────────────────────────────────
 
     /** Provisions an ANYCAST queue in the running Artemis broker. */
-    public void jolokiaCreateQueue(String namespaceName, String queueName,
-                                    boolean requiresSession, long lockDurationSeconds) {
+    public void jolokiaCreateQueue(
+            String namespaceName,
+            String queueName,
+            boolean requiresSession,
+            long lockDurationSeconds,
+            ServiceBusEntityXml.DuplicateDetectionSettings duplicateDetection) {
         String deadLetterQueue = queueName + DEAD_LETTER_QUEUE_SUFFIX;
         int maxDeliveryAttempts = config.services().serviceBus().maxDeliveryCount();
         String addressSettings = "{\"deadLetterAddress\":" + jsonString(deadLetterQueue)
@@ -235,6 +266,8 @@ public class ServiceBusNamespaceManager {
             jolokiaExec(http, baseUrl, auth, mbean,
                     "addAddressSettings(java.lang.String,java.lang.String)",
                     jsonArr(queueName, addressSettings));
+            configureDuplicateDetection(
+                    http, baseUrl, auth, queueName, duplicateDetection);
         });
     }
 
@@ -254,6 +287,7 @@ public class ServiceBusNamespaceManager {
             jolokiaExec(http, baseUrl, auth, mbean,
                     "removeAddressSettings(java.lang.String)",
                     jsonArr(queueName));
+            removeDuplicateDetection(http, baseUrl, auth, queueName);
         });
     }
 
@@ -261,7 +295,10 @@ public class ServiceBusNamespaceManager {
      * Provisions an ANYCAST ingress accepted by SDK sender links and diverts it exclusively to a
      * hidden MULTICAST address. Subscription diverts fan messages out from that hidden address.
      */
-    public void jolokiaCreateTopic(String namespaceName, String topicName) {
+    public void jolokiaCreateTopic(
+            String namespaceName,
+            String topicName,
+            ServiceBusEntityXml.DuplicateDetectionSettings duplicateDetection) {
         String topicAddress = topicName + TOPIC_ADDRESS_SUFFIX;
         withJolokia(namespaceName, (http, baseUrl, auth, mbean) -> {
             jolokiaExec(http, baseUrl, auth, mbean,
@@ -275,6 +312,8 @@ public class ServiceBusNamespaceManager {
                     jsonArr(topicAddress, "MULTICAST"));
             jolokiaCreateDivert(http, baseUrl, auth, mbean,
                     topicName + TOPIC_DIVERT_SUFFIX, topicName, topicAddress, "", true);
+            configureDuplicateDetection(
+                    http, baseUrl, auth, topicName, duplicateDetection);
         });
     }
 
@@ -282,6 +321,7 @@ public class ServiceBusNamespaceManager {
     public void jolokiaDeleteTopic(String namespaceName, String topicName) {
         String topicAddress = topicName + TOPIC_ADDRESS_SUFFIX;
         withJolokia(namespaceName, (http, baseUrl, auth, mbean) -> {
+            removeDuplicateDetection(http, baseUrl, auth, topicName);
             jolokiaExec(http, baseUrl, auth, mbean,
                     "destroyDivert(java.lang.String)",
                     jsonArr(topicName + TOPIC_DIVERT_SUFFIX));
@@ -295,6 +335,26 @@ public class ServiceBusNamespaceManager {
                     "deleteAddress(java.lang.String,boolean)",
                     jsonArr(topicAddress, true));
         });
+    }
+
+    private void configureDuplicateDetection(
+            HttpClient http,
+            String baseUrl,
+            String auth,
+            String address,
+            ServiceBusEntityXml.DuplicateDetectionSettings settings) {
+        if (!settings.enabled()) {
+            return;
+        }
+        jolokiaExec(http, baseUrl, auth, DUPLICATE_DETECTION_MBEAN,
+                "configure(java.lang.String,long)",
+                jsonArr(address, Math.multiplyExact(settings.historySeconds(), 1_000L)));
+    }
+
+    private void removeDuplicateDetection(
+            HttpClient http, String baseUrl, String auth, String address) {
+        jolokiaExec(http, baseUrl, auth, DUPLICATE_DETECTION_MBEAN,
+                "remove(java.lang.String)", jsonArr(address));
     }
 
     /**

--- a/src/test/java/io/floci/az/services/ServiceBusServiceTest.java
+++ b/src/test/java/io/floci/az/services/ServiceBusServiceTest.java
@@ -9,6 +9,10 @@ import static org.hamcrest.Matchers.containsString;
 @QuarkusTest
 public class ServiceBusServiceTest {
 
+    private static final String BASE = "/devstoreaccount1-servicebus";
+    private static final String SB_NS =
+            "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect";
+
     @Test
     void testExistingPathRouting() {
         given()
@@ -51,5 +55,68 @@ public class ServiceBusServiceTest {
             .statusCode(200)
             .contentType("application/atom+xml")
             .body(containsString("<NamespaceInfo"));
+    }
+
+    @Test
+    void queuePersistsDuplicateDetectionSettings() {
+        String body = entry("<QueueDescription xmlns=\"" + SB_NS + "\">"
+                + "<RequiresDuplicateDetection>true</RequiresDuplicateDetection>"
+                + "<DuplicateDetectionHistoryTimeWindow>PT20S</DuplicateDetectionHistoryTimeWindow>"
+                + "</QueueDescription>");
+
+        given().body(body).when().put(BASE + "/duplicate-queue")
+                .then().statusCode(201)
+                .body(containsString("<RequiresDuplicateDetection>true</RequiresDuplicateDetection>"))
+                .body(containsString(
+                        "<DuplicateDetectionHistoryTimeWindow>PT20S</DuplicateDetectionHistoryTimeWindow>"));
+
+        given().when().get(BASE + "/duplicate-queue")
+                .then().statusCode(200)
+                .body(containsString("<RequiresDuplicateDetection>true</RequiresDuplicateDetection>"))
+                .body(containsString(
+                        "<DuplicateDetectionHistoryTimeWindow>PT20S</DuplicateDetectionHistoryTimeWindow>"));
+    }
+
+    @Test
+    void topicPersistsDuplicateDetectionSettings() {
+        String body = entry("<TopicDescription xmlns=\"" + SB_NS + "\">"
+                + "<RequiresDuplicateDetection>true</RequiresDuplicateDetection>"
+                + "<DuplicateDetectionHistoryTimeWindow>PT1M</DuplicateDetectionHistoryTimeWindow>"
+                + "</TopicDescription>");
+
+        given().body(body).when().put(BASE + "/duplicate-topic")
+                .then().statusCode(201)
+                .body(containsString("<RequiresDuplicateDetection>true</RequiresDuplicateDetection>"))
+                .body(containsString(
+                        "<DuplicateDetectionHistoryTimeWindow>PT1M</DuplicateDetectionHistoryTimeWindow>"));
+    }
+
+    @Test
+    void duplicateDetectionDefaultsToTenMinutes() {
+        String body = entry("<QueueDescription xmlns=\"" + SB_NS + "\">"
+                + "<RequiresDuplicateDetection>true</RequiresDuplicateDetection>"
+                + "</QueueDescription>");
+
+        given().body(body).when().put(BASE + "/duplicate-default-window")
+                .then().statusCode(201)
+                .body(containsString(
+                        "<DuplicateDetectionHistoryTimeWindow>PT10M</DuplicateDetectionHistoryTimeWindow>"));
+    }
+
+    @Test
+    void rejectsDuplicateDetectionWindowOutsideAzureLimits() {
+        String body = entry("<QueueDescription xmlns=\"" + SB_NS + "\">"
+                + "<RequiresDuplicateDetection>true</RequiresDuplicateDetection>"
+                + "<DuplicateDetectionHistoryTimeWindow>PT19S</DuplicateDetectionHistoryTimeWindow>"
+                + "</QueueDescription>");
+
+        given().body(body).when().put(BASE + "/duplicate-invalid-window")
+                .then().statusCode(400)
+                .body(containsString("between PT20S and P7D"));
+    }
+
+    private static String entry(String description) {
+        return "<entry xmlns=\"http://www.w3.org/2005/Atom\"><content type=\"application/xml\">"
+                + description + "</content></entry>";
     }
 }

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusConfigGeneratorTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusConfigGeneratorTest.java
@@ -34,6 +34,8 @@ class ServiceBusConfigGeneratorTest {
 
         assertEquals(2, brokerXml.split("saslMechanisms=MSSBCBS,ANONYMOUS,PLAIN", -1).length - 1);
         assertEquals(2, brokerXml.split("anycastPrefix=/", -1).length - 1);
+        assertTrue(brokerXml.contains(
+                "class-name=\"io.floci.az.artemis.ServiceBusDuplicateDetectionPlugin\""));
     }
 
     @Test
@@ -107,6 +109,7 @@ class ServiceBusConfigGeneratorTest {
                 "org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.class",
                 "org/apache/activemq/artemis/protocol/amqp/proton/AmqpTransferTagGenerator.class",
                 "org/apache/activemq/artemis/protocol/amqp/proton/DefaultSenderController.class",
+                "org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerReceiverContext.class",
                 "org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.class");
         try (InputStream stream = getClass().getResourceAsStream(
                 ServiceBusNamespaceManager.ARTEMIS_AMQP_PATCH_RESOURCE)) {

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusModelsTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusModelsTest.java
@@ -1,0 +1,40 @@
+package io.floci.az.services.servicebus;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ServiceBusModelsTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void legacyQueueUsesDefaultDuplicateDetectionHistory() throws Exception {
+        ServiceBusModels.QueueEntity queue = objectMapper.readValue("""
+                {
+                  "name": "legacy",
+                  "maxDeliveryCount": 10,
+                  "lockDurationSeconds": 60,
+                  "maxSizeInMegabytes": 1024,
+                  "requiresSession": false,
+                  "requiresDuplicateDetection": false
+                }
+                """, ServiceBusModels.QueueEntity.class);
+
+        assertEquals(600, queue.duplicateDetectionHistorySeconds());
+    }
+
+    @Test
+    void legacyTopicUsesDefaultDuplicateDetectionHistory() throws Exception {
+        ServiceBusModels.TopicEntity topic = objectMapper.readValue("""
+                {
+                  "name": "legacy",
+                  "maxSizeInMegabytes": 1024,
+                  "requiresDuplicateDetection": false
+                }
+                """, ServiceBusModels.TopicEntity.class);
+
+        assertEquals(600, topic.duplicateDetectionHistorySeconds());
+    }
+}


### PR DESCRIPTION
## Summary

- persist and echo queue/topic duplicate-detection settings with Azure-compatible defaults and validation
- add an Artemis broker plugin backed by its atomic duplicate-ID cache, with per-entity history-window eviction
- normalize Azure .NET emulator entity paths and resolve subscription queues without changing canonical topic topology
- cover queues and topics through `Azure.Messaging.ServiceBus` 7.20.1, including suppression and window expiry

## Validation

- `./mvnw test` — 562 passed
- `dotnet build compatibility-tests/sdk-test-dotnet/SdkTestDotnet.csproj --no-restore` — passed
- broker-mode .NET compatibility suite — 2 passed (settlement/DLQ plus queue/topic duplicate detection)

Depends on #170.

Closes #164