### PR TITLE
feat(servicebus): add entity message expiration

### DIFF
--- a/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
+++ b/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
@@ -17,6 +17,7 @@ public sealed class ServiceBusCompatibilityTests
         int.Parse(Environment.GetEnvironmentVariable("SERVICEBUS_AMQP_PORT") ?? "5673");
 
     [Test]
+    [NotInParallel("servicebus-broker")]
     [Timeout(90_000)]
     public async Task DotnetSdkSupportsSettlementOperations(CancellationToken cancellationToken)
     {
@@ -244,6 +245,7 @@ public sealed class ServiceBusCompatibilityTests
     }
 
     [Test]
+    [NotInParallel("servicebus-broker")]
     [Timeout(120_000)]
     public async Task EntityAndMessageTtlExpireIntoDeadLetterQueue(
         CancellationToken cancellationToken)

--- a/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
+++ b/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
@@ -17,7 +17,7 @@ public sealed class ServiceBusCompatibilityTests
         int.Parse(Environment.GetEnvironmentVariable("SERVICEBUS_AMQP_PORT") ?? "5673");
 
     [Test]
-    [Timeout(60_000)]
+    [Timeout(90_000)]
     public async Task DotnetSdkSupportsSettlementOperations(CancellationToken cancellationToken)
     {
         const string serviceBusNamespace = "default";
@@ -32,7 +32,7 @@ public sealed class ServiceBusCompatibilityTests
 
         await using var client = new ServiceBusClient(connectionString, new ServiceBusClientOptions
         {
-            RetryOptions = { TryTimeout = TimeSpan.FromSeconds(10) }
+            RetryOptions = { TryTimeout = TimeSpan.FromSeconds(30) }
         });
         await using ServiceBusSender sender = client.CreateSender(queue);
         await using ServiceBusReceiver receiver = client.CreateReceiver(queue);

--- a/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
+++ b/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
@@ -273,6 +273,40 @@ public sealed class ServiceBusCompatibilityTests
             cancellationToken);
     }
 
+    [Test]
+    [NotInParallel("servicebus-broker")]
+    [Timeout(90_000)]
+    public async Task ExpiredLockedMessageDeadLettersWhenAbandoned(
+        CancellationToken cancellationToken)
+    {
+        const string serviceBusNamespace = "default";
+        string queue = $"locked-ttl-{Guid.NewGuid():N}";
+        await EnsureNamespace(serviceBusNamespace, cancellationToken);
+        await EnsureQueue(
+            serviceBusNamespace, queue, TimeSpan.FromSeconds(1), cancellationToken);
+
+        string connectionString =
+            $"Endpoint=sb://{ServiceBusHost}:{ServiceBusPort};" +
+            "SharedAccessKeyName=RootManageSharedAccessKey;" +
+            "SharedAccessKey=devkey;UseDevelopmentEmulator=true;";
+        await using var client = new ServiceBusClient(connectionString);
+        await using ServiceBusSender sender = client.CreateSender(queue);
+        await using ServiceBusReceiver receiver = client.CreateReceiver(queue);
+
+        await sender.SendMessageAsync(new ServiceBusMessage("locked-expiry"), cancellationToken);
+        ServiceBusReceivedMessage locked = await Receive(receiver, cancellationToken);
+        await Task.Delay(TimeSpan.FromSeconds(2), cancellationToken);
+        await receiver.AbandonMessageAsync(locked, cancellationToken: cancellationToken);
+
+        await Assert.That(await receiver.ReceiveMessageAsync(
+            TimeSpan.FromSeconds(1), cancellationToken)).IsNull();
+        await using ServiceBusReceiver deadLetterReceiver = client.CreateReceiver(
+            queue, new ServiceBusReceiverOptions { SubQueue = SubQueue.DeadLetter });
+        ServiceBusReceivedMessage expired = await Receive(deadLetterReceiver, cancellationToken);
+        await Assert.That(expired.Body.ToString()).IsEqualTo("locked-expiry");
+        await deadLetterReceiver.CompleteMessageAsync(expired, cancellationToken);
+    }
+
     private static async Task AssertExpiresIntoDeadLetterQueue(
         ServiceBusClient client,
         string queue,

--- a/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
+++ b/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
@@ -243,13 +243,11 @@ public sealed class ServiceBusCompatibilityTests
         await subscriptionReceiver.CompleteMessageAsync(topicMarker, cancellationToken);
     }
 
-    [Fact]
-    public async Task EntityAndMessageTtlExpireIntoDeadLetterQueue()
+    [Test]
+    [Timeout(45_000)]
+    public async Task EntityAndMessageTtlExpireIntoDeadLetterQueue(
+        CancellationToken cancellationToken)
     {
-        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(
-            TestContext.Current.CancellationToken);
-        timeout.CancelAfter(TimeSpan.FromSeconds(45));
-        CancellationToken cancellationToken = timeout.Token;
         const string serviceBusNamespace = "default";
         string entityTtlQueue = $"entity-ttl-{Guid.NewGuid():N}";
         string messageTtlQueue = $"message-ttl-{Guid.NewGuid():N}";
@@ -284,13 +282,13 @@ public sealed class ServiceBusCompatibilityTests
         await Task.Delay(TimeSpan.FromSeconds(3), cancellationToken);
 
         await using ServiceBusReceiver normalReceiver = client.CreateReceiver(queue);
-        Assert.Null(await normalReceiver.ReceiveMessageAsync(
-            TimeSpan.FromSeconds(1), cancellationToken));
+        await Assert.That(await normalReceiver.ReceiveMessageAsync(
+            TimeSpan.FromSeconds(1), cancellationToken)).IsNull();
 
         await using ServiceBusReceiver deadLetterReceiver = client.CreateReceiver(
             queue, new ServiceBusReceiverOptions { SubQueue = SubQueue.DeadLetter });
         ServiceBusReceivedMessage expired = await Receive(deadLetterReceiver, cancellationToken);
-        Assert.Equal(message.Body.ToString(), expired.Body.ToString());
+        await Assert.That(expired.Body.ToString()).IsEqualTo(message.Body.ToString());
         await deadLetterReceiver.CompleteMessageAsync(expired, cancellationToken);
     }
 

--- a/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
+++ b/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
@@ -244,7 +244,7 @@ public sealed class ServiceBusCompatibilityTests
     }
 
     [Test]
-    [Timeout(45_000)]
+    [Timeout(120_000)]
     public async Task EntityAndMessageTtlExpireIntoDeadLetterQueue(
         CancellationToken cancellationToken)
     {

--- a/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
+++ b/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
@@ -243,6 +243,57 @@ public sealed class ServiceBusCompatibilityTests
         await subscriptionReceiver.CompleteMessageAsync(topicMarker, cancellationToken);
     }
 
+    [Fact]
+    public async Task EntityAndMessageTtlExpireIntoDeadLetterQueue()
+    {
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(
+            TestContext.Current.CancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(45));
+        CancellationToken cancellationToken = timeout.Token;
+        const string serviceBusNamespace = "default";
+        string entityTtlQueue = $"entity-ttl-{Guid.NewGuid():N}";
+        string messageTtlQueue = $"message-ttl-{Guid.NewGuid():N}";
+        await EnsureNamespace(serviceBusNamespace, cancellationToken);
+        await EnsureQueue(
+            serviceBusNamespace, entityTtlQueue, TimeSpan.FromSeconds(2), cancellationToken);
+        await EnsureQueue(
+            serviceBusNamespace, messageTtlQueue, TimeSpan.FromSeconds(10), cancellationToken);
+
+        string connectionString =
+            $"Endpoint=sb://{ServiceBusHost}:{ServiceBusPort};" +
+            "SharedAccessKeyName=RootManageSharedAccessKey;" +
+            "SharedAccessKey=devkey;UseDevelopmentEmulator=true;";
+        await using var client = new ServiceBusClient(connectionString);
+
+        await AssertExpiresIntoDeadLetterQueue(
+            client, entityTtlQueue, new ServiceBusMessage("entity-default"), cancellationToken);
+        await AssertExpiresIntoDeadLetterQueue(
+            client, messageTtlQueue,
+            new ServiceBusMessage("message-override") { TimeToLive = TimeSpan.FromSeconds(1) },
+            cancellationToken);
+    }
+
+    private static async Task AssertExpiresIntoDeadLetterQueue(
+        ServiceBusClient client,
+        string queue,
+        ServiceBusMessage message,
+        CancellationToken cancellationToken)
+    {
+        await using ServiceBusSender sender = client.CreateSender(queue);
+        await sender.SendMessageAsync(message, cancellationToken);
+        await Task.Delay(TimeSpan.FromSeconds(3), cancellationToken);
+
+        await using ServiceBusReceiver normalReceiver = client.CreateReceiver(queue);
+        Assert.Null(await normalReceiver.ReceiveMessageAsync(
+            TimeSpan.FromSeconds(1), cancellationToken));
+
+        await using ServiceBusReceiver deadLetterReceiver = client.CreateReceiver(
+            queue, new ServiceBusReceiverOptions { SubQueue = SubQueue.DeadLetter });
+        ServiceBusReceivedMessage expired = await Receive(deadLetterReceiver, cancellationToken);
+        Assert.Equal(message.Body.ToString(), expired.Body.ToString());
+        await deadLetterReceiver.CompleteMessageAsync(expired, cancellationToken);
+    }
+
     private static async Task<ServiceBusReceivedMessage> Receive(
         ServiceBusReceiver receiver, CancellationToken cancellationToken)
     {
@@ -325,6 +376,30 @@ public sealed class ServiceBusCompatibilityTests
             "",
             "Subscription",
             cancellationToken);
+
+    private static async Task EnsureQueue(
+        string serviceBusNamespace,
+        string queue,
+        TimeSpan defaultMessageTtl,
+        CancellationToken cancellationToken,
+        bool deadLetterOnExpiration = true)
+    {
+        string body = $"""
+            <entry xmlns="http://www.w3.org/2005/Atom">
+              <content type="application/xml">
+                <QueueDescription xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect">
+                  <DefaultMessageTimeToLive>{System.Xml.XmlConvert.ToString(defaultMessageTtl)}</DefaultMessageTimeToLive>
+                  <DeadLetteringOnMessageExpiration>{deadLetterOnExpiration.ToString().ToLowerInvariant()}</DeadLetteringOnMessageExpiration>
+                </QueueDescription>
+              </content>
+            </entry>
+            """;
+        await PutEntity(
+            $"{EmulatorEndpoint}/devstoreaccount1-servicebus/{serviceBusNamespace}/queues/{queue}",
+            body,
+            "Queue",
+            cancellationToken);
+    }
 
     private static async Task PutEntity(
         string url, string content, string entityType, CancellationToken cancellationToken)

--- a/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
+++ b/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
@@ -414,4 +414,5 @@ public sealed class ServiceBusCompatibilityTests
             .Because($"{entityType} creation failed: {(int)response.StatusCode} " +
                      await response.Content.ReadAsStringAsync(cancellationToken));
     }
+
 }

--- a/src/artemis-plugin/java/io/floci/az/artemis/ServiceBusExpiryPlugin.java
+++ b/src/artemis-plugin/java/io/floci/az/artemis/ServiceBusExpiryPlugin.java
@@ -1,0 +1,145 @@
+package io.floci.az.artemis;
+
+import org.apache.activemq.artemis.api.core.Message;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.postoffice.RoutingStatus;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.Queue;
+import org.apache.activemq.artemis.core.server.RoutingContext;
+import org.apache.activemq.artemis.core.server.plugin.ActiveMQServerPlugin;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import java.lang.management.ManagementFactory;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Applies Azure Service Bus default TTL independently to every routed queue.
+ *
+ * <p>Artemis address settings cannot model subscription-specific TTL because every
+ * subscription queue shares its topic address. Scheduling expiration per routed queue
+ * preserves that distinction while using Artemis's queue expiry and move operations.
+ */
+public final class ServiceBusExpiryPlugin
+        implements ActiveMQServerPlugin, ServiceBusExpiryPluginMBean {
+
+    public static final String OBJECT_NAME = "io.floci.az.artemis:type=ServiceBusExpiry";
+
+    private final ConcurrentHashMap<String, ExpirySettings> settingsByQueue =
+            new ConcurrentHashMap<>();
+    private volatile ActiveMQServer server;
+    private volatile ObjectName objectName;
+
+    @Override
+    public void registered(ActiveMQServer registeredServer) {
+        server = registeredServer;
+        try {
+            objectName = new ObjectName(OBJECT_NAME);
+            MBeanServer mBeanServer = registeredServer.getMBeanServer();
+            if (mBeanServer == null) {
+                mBeanServer = ManagementFactory.getPlatformMBeanServer();
+            }
+            if (mBeanServer.isRegistered(objectName)) {
+                mBeanServer.unregisterMBean(objectName);
+            }
+            mBeanServer.registerMBean(this, objectName);
+        } catch (Exception e) {
+            throw new IllegalStateException("Could not register message expiry MBean", e);
+        }
+    }
+
+    @Override
+    public void unregistered(ActiveMQServer unregisteredServer) {
+        try {
+            MBeanServer mBeanServer = unregisteredServer.getMBeanServer();
+            if (mBeanServer == null) {
+                mBeanServer = ManagementFactory.getPlatformMBeanServer();
+            }
+            if (objectName != null && mBeanServer.isRegistered(objectName)) {
+                mBeanServer.unregisterMBean(objectName);
+            }
+        } catch (Exception ignored) {
+            // Broker shutdown must continue if JMX already stopped.
+        } finally {
+            settingsByQueue.clear();
+            server = null;
+        }
+    }
+
+    @Override
+    public void configure(String queueName, long defaultTtlMillis, String deadLetterAddress) {
+        if (queueName == null || queueName.isBlank()) {
+            throw new IllegalArgumentException("queueName is required");
+        }
+        if (defaultTtlMillis <= 0) {
+            throw new IllegalArgumentException("defaultTtlMillis must be positive");
+        }
+        settingsByQueue.put(queueName, new ExpirySettings(
+                defaultTtlMillis,
+                deadLetterAddress == null || deadLetterAddress.isBlank()
+                        ? null : deadLetterAddress));
+    }
+
+    @Override
+    public void remove(String queueName) {
+        settingsByQueue.remove(queueName);
+    }
+
+    @Override
+    public void afterMessageRoute(
+            Message message,
+            RoutingContext context,
+            boolean direct,
+            boolean rejectDuplicates,
+            RoutingStatus result) {
+        if (result != RoutingStatus.OK) {
+            return;
+        }
+
+        Set<Queue> queues = new HashSet<>(context.getDurableQueues(context.getAddress()));
+        queues.addAll(context.getNonDurableQueues(context.getAddress()));
+        ActiveMQServer activeServer = server;
+        if (activeServer == null) {
+            return;
+        }
+        long now = System.currentTimeMillis();
+        for (Queue queue : queues) {
+            ExpirySettings settings = settingsByQueue.get(queue.getName().toString());
+            if (settings == null) {
+                continue;
+            }
+            long delayMillis = effectiveDelay(
+                    message.getExpiration(), now, settings.defaultTtlMillis());
+            long messageId = message.getMessageID();
+            activeServer.getScheduledPool().schedule(
+                    () -> expire(queue, messageId, settings.deadLetterAddress()),
+                    delayMillis, TimeUnit.MILLISECONDS);
+        }
+    }
+
+    private static long effectiveDelay(long messageExpiration, long now, long defaultTtlMillis) {
+        if (messageExpiration <= 0) {
+            return defaultTtlMillis;
+        }
+        return Math.min(defaultTtlMillis, Math.max(0, messageExpiration - now));
+    }
+
+    private static void expire(Queue queue, long messageId, String deadLetterAddress) {
+        try {
+            if (deadLetterAddress == null) {
+                queue.expireReference(messageId);
+            } else {
+                queue.moveReference(
+                        messageId, SimpleString.of(deadLetterAddress), null, false);
+            }
+        } catch (Exception e) {
+            throw new IllegalStateException(
+                    "Could not expire message " + messageId + " from " + queue.getName(), e);
+        }
+    }
+
+    private record ExpirySettings(long defaultTtlMillis, String deadLetterAddress) {}
+}

--- a/src/artemis-plugin/java/io/floci/az/artemis/ServiceBusExpiryPlugin.java
+++ b/src/artemis-plugin/java/io/floci/az/artemis/ServiceBusExpiryPlugin.java
@@ -26,6 +26,8 @@ import java.util.concurrent.TimeUnit;
 public final class ServiceBusExpiryPlugin
         implements ActiveMQServerPlugin, ServiceBusExpiryPluginMBean {
 
+    private static final System.Logger LOG =
+            System.getLogger(ServiceBusExpiryPlugin.class.getName());
     public static final String OBJECT_NAME = "io.floci.az.artemis:type=ServiceBusExpiry";
 
     private final ConcurrentHashMap<String, ExpirySettings> settingsByQueue =
@@ -61,8 +63,9 @@ public final class ServiceBusExpiryPlugin
             if (objectName != null && mBeanServer.isRegistered(objectName)) {
                 mBeanServer.unregisterMBean(objectName);
             }
-        } catch (Exception ignored) {
-            // Broker shutdown must continue if JMX already stopped.
+        } catch (Exception e) {
+            LOG.log(System.Logger.Level.WARNING,
+                    "Could not unregister message expiry MBean during broker shutdown", e);
         } finally {
             settingsByQueue.clear();
             server = null;

--- a/src/artemis-plugin/java/io/floci/az/artemis/ServiceBusExpiryPlugin.java
+++ b/src/artemis-plugin/java/io/floci/az/artemis/ServiceBusExpiryPlugin.java
@@ -4,9 +4,13 @@ import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.postoffice.RoutingStatus;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.MessageReference;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.server.RoutingContext;
+import org.apache.activemq.artemis.core.server.ServerConsumer;
+import org.apache.activemq.artemis.core.server.impl.AckReason;
 import org.apache.activemq.artemis.core.server.plugin.ActiveMQServerPlugin;
+import org.apache.activemq.artemis.core.transaction.Transaction;
 
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
@@ -14,6 +18,7 @@ import java.lang.management.ManagementFactory;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -31,6 +36,8 @@ public final class ServiceBusExpiryPlugin
     public static final String OBJECT_NAME = "io.floci.az.artemis:type=ServiceBusExpiry";
 
     private final ConcurrentHashMap<String, ExpirySettings> settingsByQueue =
+            new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<ExpiryKey, ScheduledFuture<?>> scheduledExpirations =
             new ConcurrentHashMap<>();
     private volatile ActiveMQServer server;
     private volatile ObjectName objectName;
@@ -67,6 +74,8 @@ public final class ServiceBusExpiryPlugin
             LOG.log(System.Logger.Level.WARNING,
                     "Could not unregister message expiry MBean during broker shutdown", e);
         } finally {
+            scheduledExpirations.values().forEach(task -> task.cancel(false));
+            scheduledExpirations.clear();
             settingsByQueue.clear();
             server = null;
         }
@@ -89,6 +98,12 @@ public final class ServiceBusExpiryPlugin
     @Override
     public void remove(String queueName) {
         settingsByQueue.remove(queueName);
+        scheduledExpirations.forEach((key, task) -> {
+            if (key.queueName().equals(queueName)
+                    && scheduledExpirations.remove(key, task)) {
+                task.cancel(false);
+            }
+        });
     }
 
     @Override
@@ -117,10 +132,32 @@ public final class ServiceBusExpiryPlugin
             long delayMillis = effectiveDelay(
                     message.getExpiration(), now, settings.defaultTtlMillis());
             long messageId = message.getMessageID();
-            activeServer.getScheduledPool().schedule(
-                    () -> expire(queue, messageId, settings.deadLetterAddress()),
-                    delayMillis, TimeUnit.MILLISECONDS);
+            scheduleExpiry(activeServer, queue, messageId, settings, delayMillis);
         }
+    }
+
+    @Override
+    public void messageAcknowledged(MessageReference reference, AckReason reason) {
+        cancelExpiry(reference);
+    }
+
+    @Override
+    public void messageExpired(
+            MessageReference reference, SimpleString expiryAddress, ServerConsumer consumer) {
+        cancelExpiry(reference);
+    }
+
+    @Override
+    public void messageMoved(
+            Transaction transaction,
+            MessageReference reference,
+            AckReason reason,
+            SimpleString destinationAddress,
+            Long destinationQueueId,
+            ServerConsumer consumer,
+            Message newMessage,
+            RoutingStatus result) {
+        cancelExpiry(reference);
     }
 
     private static long effectiveDelay(long messageExpiration, long now, long defaultTtlMillis) {
@@ -128,6 +165,37 @@ public final class ServiceBusExpiryPlugin
             return defaultTtlMillis;
         }
         return Math.min(defaultTtlMillis, Math.max(0, messageExpiration - now));
+    }
+
+    private void scheduleExpiry(
+            ActiveMQServer activeServer,
+            Queue queue,
+            long messageId,
+            ExpirySettings settings,
+            long delayMillis) {
+        ExpiryKey key = new ExpiryKey(queue.getName().toString(), messageId);
+        synchronized (scheduledExpirations) {
+            if (scheduledExpirations.containsKey(key)) {
+                return;
+            }
+            ScheduledFuture<?> task = activeServer.getScheduledPool().schedule(() -> {
+                try {
+                    expire(queue, messageId, settings.deadLetterAddress());
+                } finally {
+                    scheduledExpirations.remove(key);
+                }
+            }, delayMillis, TimeUnit.MILLISECONDS);
+            scheduledExpirations.put(key, task);
+        }
+    }
+
+    private void cancelExpiry(MessageReference reference) {
+        ExpiryKey key = new ExpiryKey(
+                reference.getQueue().getName().toString(), reference.getMessageID());
+        ScheduledFuture<?> task = scheduledExpirations.remove(key);
+        if (task != null) {
+            task.cancel(false);
+        }
     }
 
     private static void expire(Queue queue, long messageId, String deadLetterAddress) {
@@ -145,4 +213,6 @@ public final class ServiceBusExpiryPlugin
     }
 
     private record ExpirySettings(long defaultTtlMillis, String deadLetterAddress) {}
+
+    private record ExpiryKey(String queueName, long messageId) {}
 }

--- a/src/artemis-plugin/java/io/floci/az/artemis/ServiceBusExpiryPlugin.java
+++ b/src/artemis-plugin/java/io/floci/az/artemis/ServiceBusExpiryPlugin.java
@@ -15,6 +15,7 @@ import org.apache.activemq.artemis.core.transaction.Transaction;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import java.lang.management.ManagementFactory;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -36,6 +37,8 @@ public final class ServiceBusExpiryPlugin
     public static final String OBJECT_NAME = "io.floci.az.artemis:type=ServiceBusExpiry";
 
     private final ConcurrentHashMap<String, ExpirySettings> settingsByQueue =
+            new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<ExpiryKey, ExpiryDeadline> expiryDeadlines =
             new ConcurrentHashMap<>();
     private final ConcurrentHashMap<ExpiryKey, ScheduledFuture<?>> scheduledExpirations =
             new ConcurrentHashMap<>();
@@ -76,6 +79,7 @@ public final class ServiceBusExpiryPlugin
         } finally {
             scheduledExpirations.values().forEach(task -> task.cancel(false));
             scheduledExpirations.clear();
+            expiryDeadlines.clear();
             settingsByQueue.clear();
             server = null;
         }
@@ -104,6 +108,7 @@ public final class ServiceBusExpiryPlugin
                 task.cancel(false);
             }
         });
+        expiryDeadlines.keySet().removeIf(key -> key.queueName().equals(queueName));
     }
 
     @Override
@@ -132,8 +137,21 @@ public final class ServiceBusExpiryPlugin
             long delayMillis = effectiveDelay(
                     message.getExpiration(), now, settings.defaultTtlMillis());
             long messageId = message.getMessageID();
-            scheduleExpiry(activeServer, queue, messageId, settings, delayMillis);
+            scheduleExpiry(activeServer, queue, messageId, settings, now, delayMillis);
         }
+    }
+
+    @Override
+    public boolean canAccept(ServerConsumer consumer, MessageReference reference) {
+        ExpiryKey key = expiryKey(reference);
+        ExpiryDeadline deadline = expiryDeadlines.get(key);
+        if (deadline == null || deadline.expiresAtMillis() > System.currentTimeMillis()) {
+            return true;
+        }
+        if (expire(reference.getQueue(), reference.getMessageID(), deadline.deadLetterAddress())) {
+            clearExpiry(key);
+        }
+        return false;
     }
 
     @Override
@@ -172,40 +190,63 @@ public final class ServiceBusExpiryPlugin
             Queue queue,
             long messageId,
             ExpirySettings settings,
+            long now,
             long delayMillis) {
         ExpiryKey key = new ExpiryKey(queue.getName().toString(), messageId);
         synchronized (scheduledExpirations) {
-            if (scheduledExpirations.containsKey(key)) {
+            if (expiryDeadlines.putIfAbsent(key, new ExpiryDeadline(
+                    saturatingAdd(now, delayMillis), settings.deadLetterAddress())) != null) {
                 return;
             }
             ScheduledFuture<?> task = activeServer.getScheduledPool().schedule(() -> {
-                try {
-                    expire(queue, messageId, settings.deadLetterAddress());
-                } finally {
+                synchronized (scheduledExpirations) {
                     scheduledExpirations.remove(key);
+                    if (isDelivering(queue, messageId)) {
+                        return;
+                    }
+                    if (expire(queue, messageId, settings.deadLetterAddress())) {
+                        expiryDeadlines.remove(key);
+                    }
                 }
             }, delayMillis, TimeUnit.MILLISECONDS);
             scheduledExpirations.put(key, task);
         }
     }
 
+    private static long saturatingAdd(long left, long right) {
+        return Long.MAX_VALUE - left < right ? Long.MAX_VALUE : left + right;
+    }
+
     private void cancelExpiry(MessageReference reference) {
-        ExpiryKey key = new ExpiryKey(
-                reference.getQueue().getName().toString(), reference.getMessageID());
+        clearExpiry(expiryKey(reference));
+    }
+
+    private void clearExpiry(ExpiryKey key) {
+        expiryDeadlines.remove(key);
         ScheduledFuture<?> task = scheduledExpirations.remove(key);
         if (task != null) {
             task.cancel(false);
         }
     }
 
-    private static void expire(Queue queue, long messageId, String deadLetterAddress) {
+    private static ExpiryKey expiryKey(MessageReference reference) {
+        return new ExpiryKey(
+                reference.getQueue().getName().toString(), reference.getMessageID());
+    }
+
+    private static boolean isDelivering(Queue queue, long messageId) {
+        return queue.getDeliveringMessages().values().stream()
+                .flatMap(Collection::stream)
+                .anyMatch(reference -> reference.getMessageID() == messageId);
+    }
+
+    private static boolean expire(Queue queue, long messageId, String deadLetterAddress) {
         try {
             if (deadLetterAddress == null) {
-                queue.expireReference(messageId);
-            } else {
-                queue.moveReference(
-                        messageId, SimpleString.of(deadLetterAddress), null, false);
+                return queue.expireReference(messageId);
             }
+            return queue.moveReference(
+                    messageId, SimpleString.of(deadLetterAddress), null, false);
         } catch (Exception e) {
             throw new IllegalStateException(
                     "Could not expire message " + messageId + " from " + queue.getName(), e);
@@ -213,6 +254,8 @@ public final class ServiceBusExpiryPlugin
     }
 
     private record ExpirySettings(long defaultTtlMillis, String deadLetterAddress) {}
+
+    private record ExpiryDeadline(long expiresAtMillis, String deadLetterAddress) {}
 
     private record ExpiryKey(String queueName, long messageId) {}
 }

--- a/src/artemis-plugin/java/io/floci/az/artemis/ServiceBusExpiryPluginMBean.java
+++ b/src/artemis-plugin/java/io/floci/az/artemis/ServiceBusExpiryPluginMBean.java
@@ -1,0 +1,8 @@
+package io.floci.az.artemis;
+
+public interface ServiceBusExpiryPluginMBean {
+
+    void configure(String queueName, long defaultTtlMillis, String deadLetterAddress);
+
+    void remove(String queueName);
+}

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusConfigGenerator.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusConfigGenerator.java
@@ -55,6 +55,9 @@ public class ServiceBusConfigGenerator {
                   .startAttr("broker-plugin", "class-name",
                           "io.floci.az.artemis.ServiceBusDuplicateDetectionPlugin")
                   .end("broker-plugin")
+                  .startAttr("broker-plugin", "class-name",
+                          "io.floci.az.artemis.ServiceBusExpiryPlugin")
+                  .end("broker-plugin")
                 .end("broker-plugins")
                 .start("address-settings")
                   .startAttr("address-setting", "match", "#")

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusEntityXml.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusEntityXml.java
@@ -9,6 +9,7 @@ import java.time.format.DateTimeParseException;
 final class ServiceBusEntityXml {
 
     static final long DEFAULT_DUPLICATE_DETECTION_HISTORY_SECONDS = Duration.ofMinutes(10).toSeconds();
+    static final long DEFAULT_MESSAGE_TTL_MILLIS = Duration.ofDays(14).toMillis();
     private static final Duration DEFAULT_DUPLICATE_DETECTION_HISTORY =
             Duration.ofSeconds(DEFAULT_DUPLICATE_DETECTION_HISTORY_SECONDS);
     private static final long MIN_DUPLICATE_DETECTION_HISTORY_SECONDS = Duration.ofSeconds(20).toSeconds();
@@ -43,4 +44,23 @@ final class ServiceBusEntityXml {
     }
 
     record DuplicateDetectionSettings(boolean enabled, long historySeconds) {}
+
+    static MessageLifetimeSettings parseMessageLifetime(String xml) {
+        String value = XmlParser.extractFirst(xml, "DefaultMessageTimeToLive", "P14D").trim();
+        final long ttlMillis;
+        try {
+            ttlMillis = Duration.parse(value).toMillis();
+        } catch (DateTimeParseException | ArithmeticException e) {
+            throw new IllegalArgumentException(
+                    "DefaultMessageTimeToLive must be a valid ISO 8601 duration", e);
+        }
+        if (ttlMillis <= 0) {
+            throw new IllegalArgumentException("DefaultMessageTimeToLive must be positive");
+        }
+        boolean deadLetterOnExpiration = Boolean.parseBoolean(
+                XmlParser.extractFirst(xml, "DeadLetteringOnMessageExpiration", "false").trim());
+        return new MessageLifetimeSettings(ttlMillis, deadLetterOnExpiration);
+    }
+
+    record MessageLifetimeSettings(long ttlMillis, boolean deadLetterOnExpiration) {}
 }

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
@@ -746,12 +746,9 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
     private Response handleDeleteSubscription(String account, String namespace,
                                                String topicName, String subName) {
         String key = subKey(account, namespace, topicName, subName);
-        Optional<StoredObject> storedSubscription = store.get(key);
-        if (storedSubscription.isEmpty()) {
+        if (store.get(key).isEmpty()) {
             return notFoundAtom("Subscription not found: " + subName);
         }
-        ServiceBusModels.SubscriptionEntity subscription = fromBytes(
-                storedSubscription.get().data(), ServiceBusModels.SubscriptionEntity.class);
         String rulePrefix = rulePrefix(account, namespace, topicName, subName);
         store.scan(k -> k.startsWith(rulePrefix)).forEach(obj -> store.delete(obj.key()));
         store.delete(key);

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
@@ -19,6 +19,7 @@ import org.jboss.logging.Logger;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -265,17 +266,20 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         boolean isTopic = !isQueue && body.contains("TopicDescription");
         boolean requiresSession = body.contains("<RequiresSession>true</RequiresSession>");
         ServiceBusEntityXml.DuplicateDetectionSettings duplicateDetection;
+        ServiceBusEntityXml.MessageLifetimeSettings lifetime;
         try {
             duplicateDetection = ServiceBusEntityXml.duplicateDetection(body);
+            lifetime = ServiceBusEntityXml.parseMessageLifetime(body);
         } catch (IllegalArgumentException e) {
             return badRequestAtom(e.getMessage());
         }
 
         if (isTopic) {
-            return handleCreateTopic(account, ns, entityName, duplicateDetection);
+            return handleCreateTopic(account, ns, entityName, duplicateDetection, lifetime);
         }
         // Default to queue (empty body, QueueDescription, or ambiguous)
-        return handleCreateQueue(account, ns, entityName, requiresSession, duplicateDetection);
+        return handleCreateQueue(
+                account, ns, entityName, requiresSession, duplicateDetection, lifetime);
     }
 
     private Response handleSpecEntityDelete(String account, String ns, String entityName) {
@@ -476,7 +480,8 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                 boolean requiresSession = body.contains("<RequiresSession>true</RequiresSession>");
                 try {
                     yield handleCreateQueue(account, namespace, queueName, requiresSession,
-                            ServiceBusEntityXml.duplicateDetection(body));
+                            ServiceBusEntityXml.duplicateDetection(body),
+                            ServiceBusEntityXml.parseMessageLifetime(body));
                 } catch (IllegalArgumentException e) {
                     yield badRequestAtom(e.getMessage());
                 }
@@ -498,7 +503,8 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
 
     private Response handleCreateQueue(String account, String namespace, String queueName,
                                         boolean requiresSession,
-                                        ServiceBusEntityXml.DuplicateDetectionSettings duplicateDetection) {
+                                        ServiceBusEntityXml.DuplicateDetectionSettings duplicateDetection,
+                                        ServiceBusEntityXml.MessageLifetimeSettings lifetime) {
         String key = queueKey(account, namespace, queueName);
         if (store.get(key).isPresent()) {
             ServiceBusModels.QueueEntity existing =
@@ -512,12 +518,12 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         EmulatorConfig.ServiceBusConfig sb = config.services().serviceBus();
         ServiceBusModels.QueueEntity queue = ServiceBusModels.QueueEntity.defaults(
                 queueName, sb.maxDeliveryCount(), sb.lockDurationSeconds(), requiresSession,
-                duplicateDetection);
+                duplicateDetection, lifetime);
         store.put(key, toStoredObject(key, queue));
 
         try {
             namespaceManager.jolokiaCreateQueue(namespace, queueName,
-                    queue.requiresSession(), queue.lockDurationSeconds(), duplicateDetection);
+                    queue.requiresSession(), queue.lockDurationSeconds(), duplicateDetection, lifetime);
         } catch (Exception e) {
             LOG.warnf(e, "Failed to provision queue '%s' in Artemis for namespace '%s'", queueName, namespace);
         }
@@ -555,9 +561,11 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         return switch (req.method()) {
             case "GET"          -> handleGetTopic(account, namespace, topicName);
             case "PUT", "POST"  -> {
+                String body = readBody(req);
                 try {
                     yield handleCreateTopic(account, namespace, topicName,
-                            ServiceBusEntityXml.duplicateDetection(readBody(req)));
+                            ServiceBusEntityXml.duplicateDetection(body),
+                            ServiceBusEntityXml.parseMessageLifetime(body));
                 } catch (IllegalArgumentException e) {
                     yield badRequestAtom(e.getMessage());
                 }
@@ -577,8 +585,10 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                 .orElseGet(() -> notFoundAtom("Topic not found: " + topicName));
     }
 
-    private Response handleCreateTopic(String account, String namespace, String topicName,
-                                        ServiceBusEntityXml.DuplicateDetectionSettings duplicateDetection) {
+    private Response handleCreateTopic(
+            String account, String namespace, String topicName,
+            ServiceBusEntityXml.DuplicateDetectionSettings duplicateDetection,
+            ServiceBusEntityXml.MessageLifetimeSettings lifetime) {
         String key = topicKey(account, namespace, topicName);
         if (store.get(key).isPresent()) {
             ServiceBusModels.TopicEntity existing =
@@ -590,7 +600,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
             lazyStartNamespace(namespace);
         }
         ServiceBusModels.TopicEntity topic =
-                ServiceBusModels.TopicEntity.defaults(topicName, duplicateDetection);
+                ServiceBusModels.TopicEntity.defaults(topicName, duplicateDetection, lifetime);
         store.put(key, toStoredObject(key, topic));
 
         try {
@@ -649,8 +659,13 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
             case "PUT", "POST"  -> {
                 String body = readBody(req);
                 boolean requiresSession = body.contains("<RequiresSession>true</RequiresSession>");
-                yield handleCreateSubscription(account, namespace, topicName, subName,
-                        requiresSession, body);
+                try {
+                    yield handleCreateSubscription(account, namespace, topicName, subName,
+                            requiresSession, body,
+                            ServiceBusEntityXml.parseMessageLifetime(body));
+                } catch (IllegalArgumentException e) {
+                    yield badRequestAtom(e.getMessage());
+                }
             }
             case "DELETE"       -> handleDeleteSubscription(account, namespace, topicName, subName);
             default             -> Response.status(405).build();
@@ -671,7 +686,8 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
 
     private Response handleCreateSubscription(String account, String namespace,
                                                 String topicName, String subName,
-                                                boolean requiresSession, String body) {
+                                                boolean requiresSession, String body,
+                                                ServiceBusEntityXml.MessageLifetimeSettings lifetime) {
         Optional<StoredObject> storedTopic = store.get(topicKey(account, namespace, topicName));
         if (storedTopic.isEmpty()) {
             return notFoundAtom("Topic not found: " + topicName);
@@ -700,19 +716,25 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
 
         EmulatorConfig.ServiceBusConfig sb = config.services().serviceBus();
         ServiceBusModels.SubscriptionEntity sub = ServiceBusModels.SubscriptionEntity.defaults(
-                topicName, subName, sb.maxDeliveryCount(), sb.lockDurationSeconds(), requiresSession);
+                topicName, subName, sb.maxDeliveryCount(), sb.lockDurationSeconds(),
+                requiresSession, lifetime);
         store.put(key, toStoredObject(key, sub));
         String ruleStoreKey = ruleKey(account, namespace, topicName, subName, initialRule.name());
         store.put(ruleStoreKey, toStoredObject(ruleStoreKey, initialRule));
         warnOnActionIgnored(initialRule);
 
         try {
+            ServiceBusEntityXml.MessageLifetimeSettings effectiveLifetime =
+                    new ServiceBusEntityXml.MessageLifetimeSettings(
+                            Math.min(topic.defaultMessageTtlMillis(), lifetime.ttlMillis()),
+                            lifetime.deadLetterOnExpiration());
             namespaceManager.jolokiaCreateSubscription(
                     namespace, topicName, subName, selector,
                     sub.requiresSession(), sub.lockDurationSeconds(),
                     new ServiceBusEntityXml.DuplicateDetectionSettings(
                             topic.requiresDuplicateDetection(),
-                            topic.duplicateDetectionHistorySeconds()));
+                            topic.duplicateDetectionHistorySeconds()),
+                    effectiveLifetime);
         } catch (Exception e) {
             LOG.warnf(e, "Failed to provision subscription '%s/%s' in Artemis for namespace '%s'",
                     topicName, subName, namespace);
@@ -724,14 +746,18 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
     private Response handleDeleteSubscription(String account, String namespace,
                                                String topicName, String subName) {
         String key = subKey(account, namespace, topicName, subName);
-        if (store.get(key).isEmpty()) {
+        Optional<StoredObject> storedSubscription = store.get(key);
+        if (storedSubscription.isEmpty()) {
             return notFoundAtom("Subscription not found: " + subName);
         }
+        ServiceBusModels.SubscriptionEntity subscription = fromBytes(
+                storedSubscription.get().data(), ServiceBusModels.SubscriptionEntity.class);
         String rulePrefix = rulePrefix(account, namespace, topicName, subName);
         store.scan(k -> k.startsWith(rulePrefix)).forEach(obj -> store.delete(obj.key()));
         store.delete(key);
         try {
-            namespaceManager.jolokiaDeleteSubscription(namespace, topicName, subName);
+            namespaceManager.jolokiaDeleteSubscription(
+                    namespace, topicName, subName);
         } catch (Exception e) {
             LOG.warnf(e, "Failed to remove subscription '%s/%s' from Artemis", topicName, subName);
         }
@@ -864,7 +890,8 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         String lockDuration = isoDuration(q.lockDurationSeconds());
         return "<QueueDescription xmlns=\"" + SB_NS + "\">"
                 + "<MaxSizeInMegabytes>" + q.maxSizeInMegabytes() + "</MaxSizeInMegabytes>"
-                + "<DefaultMessageTimeToLive>P14D</DefaultMessageTimeToLive>"
+                + "<DefaultMessageTimeToLive>" + isoDurationMillis(q.defaultMessageTtlMillis())
+                + "</DefaultMessageTimeToLive>"
                 + "<LockDuration>" + lockDuration + "</LockDuration>"
                 + "<MaxDeliveryCount>" + q.maxDeliveryCount() + "</MaxDeliveryCount>"
                 + "<RequiresDuplicateDetection>" + q.requiresDuplicateDetection()
@@ -873,7 +900,8 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                 + isoDuration(q.duplicateDetectionHistorySeconds())
                 + "</DuplicateDetectionHistoryTimeWindow>"
                 + "<RequiresSession>" + q.requiresSession() + "</RequiresSession>"
-                + "<DeadLetteringOnMessageExpiration>false</DeadLetteringOnMessageExpiration>"
+                + "<DeadLetteringOnMessageExpiration>" + q.deadLetteringOnMessageExpiration()
+                + "</DeadLetteringOnMessageExpiration>"
                 + "<EnableBatchedOperations>true</EnableBatchedOperations>"
                 + "<AutoDeleteOnIdle>P10675199DT2H48M5.4775807S</AutoDeleteOnIdle>"
                 + "<Status>Active</Status>"
@@ -914,7 +942,8 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
     private String topicDescriptionXml(ServiceBusModels.TopicEntity t) {
         return "<TopicDescription xmlns=\"" + SB_NS + "\">"
                 + "<MaxSizeInMegabytes>" + t.maxSizeInMegabytes() + "</MaxSizeInMegabytes>"
-                + "<DefaultMessageTimeToLive>P14D</DefaultMessageTimeToLive>"
+                + "<DefaultMessageTimeToLive>" + isoDurationMillis(t.defaultMessageTtlMillis())
+                + "</DefaultMessageTimeToLive>"
                 + "<RequiresDuplicateDetection>" + t.requiresDuplicateDetection()
                 + "</RequiresDuplicateDetection>"
                 + "<DuplicateDetectionHistoryTimeWindow>"
@@ -964,8 +993,10 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                 + "<LockDuration>" + lockDuration + "</LockDuration>"
                 + "<MaxDeliveryCount>" + s.maxDeliveryCount() + "</MaxDeliveryCount>"
                 + "<RequiresSession>" + s.requiresSession() + "</RequiresSession>"
-                + "<DefaultMessageTimeToLive>P14D</DefaultMessageTimeToLive>"
-                + "<DeadLetteringOnMessageExpiration>false</DeadLetteringOnMessageExpiration>"
+                + "<DefaultMessageTimeToLive>" + isoDurationMillis(s.defaultMessageTtlMillis())
+                + "</DefaultMessageTimeToLive>"
+                + "<DeadLetteringOnMessageExpiration>" + s.deadLetteringOnMessageExpiration()
+                + "</DeadLetteringOnMessageExpiration>"
                 + "<DeadLetteringOnFilterEvaluationExceptions>true</DeadLetteringOnFilterEvaluationExceptions>"
                 + "<EnableBatchedOperations>true</EnableBatchedOperations>"
                 + "<AutoDeleteOnIdle>P10675199DT2H48M5.4775807S</AutoDeleteOnIdle>"
@@ -1157,6 +1188,13 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         long secs = seconds % 60;
         if (secs == 0) return "PT" + minutes + "M";
         return "PT" + minutes + "M" + secs + "S";
+    }
+
+    private static String isoDurationMillis(long millis) {
+        if (millis == ServiceBusEntityXml.DEFAULT_MESSAGE_TTL_MILLIS) {
+            return "P14D";
+        }
+        return Duration.ofMillis(millis).toString();
     }
 
     /** Minimal XML attribute/content escaping. */

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusModels.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusModels.java
@@ -24,6 +24,8 @@ public final class ServiceBusModels {
             boolean requiresSession,
             boolean requiresDuplicateDetection,
             long duplicateDetectionHistorySeconds,
+            long defaultMessageTtlMillis,
+            boolean deadLetteringOnMessageExpiration,
             Instant createdAt,
             Instant updatedAt) {
 
@@ -36,11 +38,13 @@ public final class ServiceBusModels {
 
         static QueueEntity defaults(String name, int maxDeliveryCount,
                                      long lockDurationSeconds, boolean requiresSession,
-                                     ServiceBusEntityXml.DuplicateDetectionSettings duplicateDetection) {
+                                     ServiceBusEntityXml.DuplicateDetectionSettings duplicateDetection,
+                                     ServiceBusEntityXml.MessageLifetimeSettings lifetime) {
             Instant now = Instant.now();
             return new QueueEntity(name, maxDeliveryCount, lockDurationSeconds,
                     1024, requiresSession, duplicateDetection.enabled(),
-                    duplicateDetection.historySeconds(), now, now);
+                    duplicateDetection.historySeconds(), lifetime.ttlMillis(),
+                    lifetime.deadLetterOnExpiration(), now, now);
         }
     }
 
@@ -50,6 +54,7 @@ public final class ServiceBusModels {
             long maxSizeInMegabytes,
             boolean requiresDuplicateDetection,
             long duplicateDetectionHistorySeconds,
+            long defaultMessageTtlMillis,
             Instant createdAt,
             Instant updatedAt) {
 
@@ -60,11 +65,13 @@ public final class ServiceBusModels {
             }
         }
 
-        static TopicEntity defaults(String name,
-                                    ServiceBusEntityXml.DuplicateDetectionSettings duplicateDetection) {
+        static TopicEntity defaults(
+                String name,
+                ServiceBusEntityXml.DuplicateDetectionSettings duplicateDetection,
+                ServiceBusEntityXml.MessageLifetimeSettings lifetime) {
             Instant now = Instant.now();
             return new TopicEntity(name, 1024, duplicateDetection.enabled(),
-                    duplicateDetection.historySeconds(), now, now);
+                    duplicateDetection.historySeconds(), lifetime.ttlMillis(), now, now);
         }
     }
 
@@ -117,15 +124,19 @@ public final class ServiceBusModels {
             int maxDeliveryCount,
             long lockDurationSeconds,
             boolean requiresSession,
+            long defaultMessageTtlMillis,
+            boolean deadLetteringOnMessageExpiration,
             Instant createdAt,
             Instant updatedAt) {
 
         static SubscriptionEntity defaults(String topicName, String name,
                                             int maxDeliveryCount, long lockDurationSeconds,
-                                            boolean requiresSession) {
+                                            boolean requiresSession,
+                                            ServiceBusEntityXml.MessageLifetimeSettings lifetime) {
             Instant now = Instant.now();
             return new SubscriptionEntity(topicName, name, maxDeliveryCount, lockDurationSeconds,
-                    requiresSession, now, now);
+                    requiresSession, lifetime.ttlMillis(),
+                    lifetime.deadLetterOnExpiration(), now, now);
         }
     }
 }

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusModels.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusModels.java
@@ -34,6 +34,9 @@ public final class ServiceBusModels {
                 duplicateDetectionHistorySeconds =
                         ServiceBusEntityXml.DEFAULT_DUPLICATE_DETECTION_HISTORY_SECONDS;
             }
+            if (defaultMessageTtlMillis == 0) {
+                defaultMessageTtlMillis = ServiceBusEntityXml.DEFAULT_MESSAGE_TTL_MILLIS;
+            }
         }
 
         static QueueEntity defaults(String name, int maxDeliveryCount,
@@ -62,6 +65,9 @@ public final class ServiceBusModels {
             if (duplicateDetectionHistorySeconds == 0) {
                 duplicateDetectionHistorySeconds =
                         ServiceBusEntityXml.DEFAULT_DUPLICATE_DETECTION_HISTORY_SECONDS;
+            }
+            if (defaultMessageTtlMillis == 0) {
+                defaultMessageTtlMillis = ServiceBusEntityXml.DEFAULT_MESSAGE_TTL_MILLIS;
             }
         }
 
@@ -128,6 +134,12 @@ public final class ServiceBusModels {
             boolean deadLetteringOnMessageExpiration,
             Instant createdAt,
             Instant updatedAt) {
+
+        public SubscriptionEntity {
+            if (defaultMessageTtlMillis == 0) {
+                defaultMessageTtlMillis = ServiceBusEntityXml.DEFAULT_MESSAGE_TTL_MILLIS;
+            }
+        }
 
         static SubscriptionEntity defaults(String topicName, String name,
                                             int maxDeliveryCount, long lockDurationSeconds,

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -340,6 +340,12 @@ public class ServiceBusNamespaceManager {
                     "destroyQueue(java.lang.String,boolean,boolean)",
                     jsonArr(topicName, true, true));
             jolokiaExec(http, baseUrl, auth, mbean,
+                    "destroyDivert(java.lang.String)",
+                    jsonArr(topicName + TOPIC_DIVERT_SUFFIX));
+            jolokiaExec(http, baseUrl, auth, mbean,
+                    "destroyQueue(java.lang.String,boolean,boolean)",
+                    jsonArr(topicName, true, true));
+            jolokiaExec(http, baseUrl, auth, mbean,
                     "deleteAddress(java.lang.String,boolean)",
                     jsonArr(topicName, true));
             jolokiaExec(http, baseUrl, auth, mbean,

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -79,6 +79,7 @@ public class ServiceBusNamespaceManager {
     private static final String SESSION_METADATA_PREFIX = "floci-az:servicebus-session:";
     private static final String DUPLICATE_DETECTION_MBEAN =
             "io.floci.az.artemis:type=ServiceBusDuplicateDetection";
+    private static final String EXPIRY_MBEAN = "io.floci.az.artemis:type=ServiceBusExpiry";
 
     /**
      * Immutable snapshot of a running namespace.
@@ -245,7 +246,8 @@ public class ServiceBusNamespaceManager {
             String queueName,
             boolean requiresSession,
             long lockDurationSeconds,
-            ServiceBusEntityXml.DuplicateDetectionSettings duplicateDetection) {
+            ServiceBusEntityXml.DuplicateDetectionSettings duplicateDetection,
+            ServiceBusEntityXml.MessageLifetimeSettings lifetime) {
         String deadLetterQueue = queueName + DEAD_LETTER_QUEUE_SUFFIX;
         int maxDeliveryAttempts = config.services().serviceBus().maxDeliveryCount();
         String addressSettings = "{\"deadLetterAddress\":" + jsonString(deadLetterQueue)
@@ -273,6 +275,9 @@ public class ServiceBusNamespaceManager {
                     jsonArr(queueName, addressSettings));
             configureDuplicateDetection(
                     http, baseUrl, auth, queueName, duplicateDetection);
+            configureExpiry(
+                    http, baseUrl, auth, queueName, lifetime.ttlMillis(),
+                    lifetime.deadLetterOnExpiration() ? deadLetterQueue : "");
         });
     }
 
@@ -293,6 +298,7 @@ public class ServiceBusNamespaceManager {
                     "removeAddressSettings(java.lang.String)",
                     jsonArr(queueName));
             removeDuplicateDetection(http, baseUrl, auth, queueName);
+            removeExpiry(http, baseUrl, auth, queueName);
         });
     }
 
@@ -378,7 +384,8 @@ public class ServiceBusNamespaceManager {
             String filter,
             boolean requiresSession,
             long lockDurationSeconds,
-            ServiceBusEntityXml.DuplicateDetectionSettings duplicateDetection) {
+            ServiceBusEntityXml.DuplicateDetectionSettings duplicateDetection,
+            ServiceBusEntityXml.MessageLifetimeSettings lifetime) {
         String queueName = topicName + "/Subscriptions/" + subName;
         String deadLetterQueue = queueName + DEAD_LETTER_QUEUE_SUFFIX;
         String divertName = queueName + SUBSCRIPTION_DIVERT_SUFFIX;
@@ -410,6 +417,9 @@ public class ServiceBusNamespaceManager {
                     topicName + TOPIC_ADDRESS_SUFFIX, queueName, filter, false);
             configureDuplicateDetection(
                     http, baseUrl, auth, queueName, duplicateDetection);
+            configureExpiry(
+                    http, baseUrl, auth, queueName, lifetime.ttlMillis(),
+                    lifetime.deadLetterOnExpiration() ? deadLetterQueue : "");
         });
     }
 
@@ -456,9 +466,23 @@ public class ServiceBusNamespaceManager {
                     "removeAddressSettings(java.lang.String)",
                     jsonArr(queueName));
             removeDuplicateDetection(http, baseUrl, auth, queueName);
+            removeExpiry(http, baseUrl, auth, queueName);
         });
     }
 
+    private void configureExpiry(
+            HttpClient http, String baseUrl, String auth, String queueName, long ttlMillis,
+            String deadLetterAddress) {
+        jolokiaExec(http, baseUrl, auth, EXPIRY_MBEAN,
+                "configure(java.lang.String,long,java.lang.String)",
+                jsonArr(queueName, ttlMillis, deadLetterAddress));
+    }
+
+    private void removeExpiry(
+            HttpClient http, String baseUrl, String auth, String queueName) {
+        jolokiaExec(http, baseUrl, auth, EXPIRY_MBEAN,
+                "remove(java.lang.String)", jsonArr(queueName));
+    }
     // ── Private helpers ───────────────────────────────────────────────────────
 
     String containerName(String namespaceName) {

--- a/src/test/java/io/floci/az/services/ServiceBusServiceTest.java
+++ b/src/test/java/io/floci/az/services/ServiceBusServiceTest.java
@@ -115,6 +115,58 @@ public class ServiceBusServiceTest {
                 .body(containsString("between PT20S and P7D"));
     }
 
+    @Test
+    void queuePersistsMessageLifetimeSettings() {
+        String body = entry("<QueueDescription xmlns=\"" + SB_NS + "\">"
+                + "<DefaultMessageTimeToLive>PT2S</DefaultMessageTimeToLive>"
+                + "<DeadLetteringOnMessageExpiration>true</DeadLetteringOnMessageExpiration>"
+                + "</QueueDescription>");
+
+        given().body(body).when().put(BASE + "/ttl-queue")
+                .then().statusCode(201)
+                .body(containsString("<DefaultMessageTimeToLive>PT2S</DefaultMessageTimeToLive>"))
+                .body(containsString(
+                        "<DeadLetteringOnMessageExpiration>true</DeadLetteringOnMessageExpiration>"));
+
+        given().when().get(BASE + "/ttl-queue")
+                .then().statusCode(200)
+                .body(containsString("<DefaultMessageTimeToLive>PT2S</DefaultMessageTimeToLive>"))
+                .body(containsString(
+                        "<DeadLetteringOnMessageExpiration>true</DeadLetteringOnMessageExpiration>"));
+    }
+
+    @Test
+    void topicAndSubscriptionPersistIndependentMessageLifetimeSettings() {
+        given().body(entry("<TopicDescription xmlns=\"" + SB_NS + "\">"
+                        + "<DefaultMessageTimeToLive>PT3S</DefaultMessageTimeToLive>"
+                        + "</TopicDescription>"))
+                .when().put(BASE + "/ttl-topic")
+                .then().statusCode(201)
+                .body(containsString("<DefaultMessageTimeToLive>PT3S</DefaultMessageTimeToLive>"));
+
+        String subscriptionBody = entry("<SubscriptionDescription xmlns=\"" + SB_NS + "\">"
+                + "<DefaultMessageTimeToLive>PT4S</DefaultMessageTimeToLive>"
+                + "<DeadLetteringOnMessageExpiration>true</DeadLetteringOnMessageExpiration>"
+                + "</SubscriptionDescription>");
+        given().body(subscriptionBody)
+                .when().put(BASE + "/ttl-topic/subscriptions/ttl-subscription")
+                .then().statusCode(201)
+                .body(containsString("<DefaultMessageTimeToLive>PT4S</DefaultMessageTimeToLive>"))
+                .body(containsString(
+                        "<DeadLetteringOnMessageExpiration>true</DeadLetteringOnMessageExpiration>"));
+    }
+
+    @Test
+    void rejectsNonPositiveDefaultMessageTimeToLive() {
+        String body = entry("<QueueDescription xmlns=\"" + SB_NS + "\">"
+                + "<DefaultMessageTimeToLive>PT0S</DefaultMessageTimeToLive>"
+                + "</QueueDescription>");
+
+        given().body(body).when().put(BASE + "/invalid-ttl")
+                .then().statusCode(400)
+                .body(containsString("DefaultMessageTimeToLive must be positive"));
+    }
+
     private static String entry(String description) {
         return "<entry xmlns=\"http://www.w3.org/2005/Atom\"><content type=\"application/xml\">"
                 + description + "</content></entry>";

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusConfigGeneratorTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusConfigGeneratorTest.java
@@ -36,6 +36,8 @@ class ServiceBusConfigGeneratorTest {
         assertEquals(2, brokerXml.split("anycastPrefix=/", -1).length - 1);
         assertTrue(brokerXml.contains(
                 "class-name=\"io.floci.az.artemis.ServiceBusDuplicateDetectionPlugin\""));
+        assertTrue(brokerXml.contains(
+                "class-name=\"io.floci.az.artemis.ServiceBusExpiryPlugin\""));
     }
 
     @Test
@@ -77,6 +79,26 @@ class ServiceBusConfigGeneratorTest {
                     .get();
 
             assertTrue(factory instanceof org.apache.activemq.artemis.protocol.amqp.sasl.ServerSASLFactory);
+        }
+    }
+
+    @Test
+    void packagesMessageExpiryPluginForTheArtemisSidecar() throws Exception {
+        try (InputStream stream = getClass().getResourceAsStream(
+                ServiceBusNamespaceManager.ARTEMIS_EXTENSION_RESOURCE)) {
+            assertNotNull(stream, "Artemis extension JAR must be embedded in the application");
+            try (JarInputStream jar = new JarInputStream(stream)) {
+                Set<String> expectedClasses = Set.of(
+                        "io/floci/az/artemis/ServiceBusExpiryPlugin.class",
+                        "io/floci/az/artemis/ServiceBusExpiryPluginMBean.class");
+                Set<String> packagedClasses = new HashSet<>();
+                for (var entry = jar.getNextJarEntry(); entry != null; entry = jar.getNextJarEntry()) {
+                    if (expectedClasses.contains(entry.getName())) {
+                        packagedClasses.add(entry.getName());
+                    }
+                }
+                assertEquals(expectedClasses, packagedClasses);
+            }
         }
     }
 

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusEntityXmlTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusEntityXmlTest.java
@@ -1,0 +1,46 @@
+package io.floci.az.services.servicebus;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ServiceBusEntityXmlTest {
+
+    @Test
+    void defaultsToFourteenDaysWithoutDeadLettering() {
+        ServiceBusEntityXml.MessageLifetimeSettings settings =
+                ServiceBusEntityXml.parseMessageLifetime("");
+
+        assertEquals(Duration.ofDays(14).toMillis(), settings.ttlMillis());
+        assertFalse(settings.deadLetterOnExpiration());
+    }
+
+    @Test
+    void parsesFractionalDurationAndDeadLetterFlag() {
+        ServiceBusEntityXml.MessageLifetimeSettings settings =
+                ServiceBusEntityXml.parseMessageLifetime("""
+                        <QueueDescription>
+                          <DefaultMessageTimeToLive>PT1.5S</DefaultMessageTimeToLive>
+                          <DeadLetteringOnMessageExpiration>true</DeadLetteringOnMessageExpiration>
+                        </QueueDescription>
+                        """);
+
+        assertEquals(1_500, settings.ttlMillis());
+        assertTrue(settings.deadLetterOnExpiration());
+    }
+
+    @Test
+    void rejectsInvalidAndNonPositiveDurations() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ServiceBusEntityXml.parseMessageLifetime(
+                        "<DefaultMessageTimeToLive>soon</DefaultMessageTimeToLive>"));
+        assertThrows(IllegalArgumentException.class,
+                () -> ServiceBusEntityXml.parseMessageLifetime(
+                        "<DefaultMessageTimeToLive>-PT1S</DefaultMessageTimeToLive>"));
+    }
+}

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusModelsTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusModelsTest.java
@@ -37,4 +37,39 @@ class ServiceBusModelsTest {
 
         assertEquals(600, topic.duplicateDetectionHistorySeconds());
     }
+
+    @Test
+    void legacyEntitiesUseDefaultMessageTtl() throws Exception {
+        ServiceBusModels.QueueEntity queue = objectMapper.readValue("""
+                {
+                  "name": "legacy-queue",
+                  "maxDeliveryCount": 10,
+                  "lockDurationSeconds": 60,
+                  "maxSizeInMegabytes": 1024,
+                  "requiresSession": false
+                }
+                """, ServiceBusModels.QueueEntity.class);
+        ServiceBusModels.TopicEntity topic = objectMapper.readValue("""
+                {
+                  "name": "legacy-topic",
+                  "maxSizeInMegabytes": 1024
+                }
+                """, ServiceBusModels.TopicEntity.class);
+        ServiceBusModels.SubscriptionEntity subscription = objectMapper.readValue("""
+                {
+                  "topicName": "legacy-topic",
+                  "name": "legacy-subscription",
+                  "maxDeliveryCount": 10,
+                  "lockDurationSeconds": 60,
+                  "requiresSession": false
+                }
+                """, ServiceBusModels.SubscriptionEntity.class);
+
+        assertEquals(ServiceBusEntityXml.DEFAULT_MESSAGE_TTL_MILLIS,
+                queue.defaultMessageTtlMillis());
+        assertEquals(ServiceBusEntityXml.DEFAULT_MESSAGE_TTL_MILLIS,
+                topic.defaultMessageTtlMillis());
+        assertEquals(ServiceBusEntityXml.DEFAULT_MESSAGE_TTL_MILLIS,
+                subscription.defaultMessageTtlMillis());
+    }
 }


### PR DESCRIPTION
## Summary

- Parse, validate, persist, and echo per-entity `DefaultMessageTimeToLive` settings.
- Apply the shorter of entity TTL and message TTL independently to queues and topic subscriptions.
- Move expired messages to entity DLQs when `DeadLetteringOnMessageExpiration` is enabled.
- Cancel scheduled expiry work when messages settle, move, expire, or their entity is deleted.

## Validation

- Focused Service Bus unit suite: 17 tests passed.
- Azure.Messaging.ServiceBus 7.20.1 against a real Artemis sidecar: entity TTL, shorter message TTL, receiver exclusion, and DLQ delivery passed.
- Existing PR checks passed before the follow-up; checks rerun after this push.

Depends on #170.

Closes #165