### PR TITLE
fix(docker): converge docker cluster on floci-aws baseline 0142dc4

### DIFF
--- a/src/main/java/io/floci/az/core/docker/ContainerBuilder.java
+++ b/src/main/java/io/floci/az/core/docker/ContainerBuilder.java
@@ -18,7 +18,19 @@ import java.util.Map;
 import java.util.Optional;
 
 /**
- * Fluent builder for {@link ContainerSpec} instances.
+ * Fluent builder for constructing {@link ContainerSpec} instances.
+ * Provides sensible defaults and integrates with floci-az configuration.
+ *
+ * <p>Example usage:
+ * <pre>{@code
+ * ContainerSpec spec = containerBuilder.newContainer("nginx:latest")
+ *     .withName("floci-az-my-service")
+ *     .withEnv("MY_VAR", "value")
+ *     .withDynamicPort(8080)
+ *     .withDockerNetwork(config.services().myService().dockerNetwork())
+ *     .withLogRotation()
+ *     .build();
+ * }</pre>
  */
 @ApplicationScoped
 public class ContainerBuilder {
@@ -39,11 +51,57 @@ public class ContainerBuilder {
         this.currentContainerNetworkResolver = currentContainerNetworkResolver;
     }
 
+    /**
+     * Creates a new builder for a container with the specified image.
+     *
+     * @param image Docker image name (e.g., "nginx:latest")
+     * @return a new Builder instance
+     */
     public Builder newContainer(String image) {
-        return new Builder(image, config, dockerHostResolver, embeddedDnsServer,
+        return new Builder(resolveImage(image), config, dockerHostResolver, embeddedDnsServer,
                 currentContainerNetworkResolver);
     }
 
+    private String resolveImage(String image) {
+        return resolveImage(image, configuredImageRegistryBase(config));
+    }
+
+    /**
+     * Prefixes {@code image} with the configured registry base (mirror) unless the image
+     * already carries it. A missing/blank base leaves the image untouched.
+     */
+    static String resolveImage(String image, Optional<String> imageRegistryBase) {
+        if (image == null || image.isBlank()) {
+            return image;
+        }
+        return normalizeImageRegistryBase(imageRegistryBase)
+                .filter(base -> !image.startsWith(base + "/"))
+                .map(base -> base + "/" + image)
+                .orElse(image);
+    }
+
+    private static Optional<String> configuredImageRegistryBase(EmulatorConfig config) {
+        // floci-az's DockerConfig does not expose an image-registry-base property yet;
+        // once it does, read it here (config.docker().imageRegistryBase()) so every image
+        // funnelled through newContainer() is rewritten against the configured mirror.
+        return Optional.empty();
+    }
+
+    private static Optional<String> normalizeImageRegistryBase(Optional<String> imageRegistryBase) {
+        return imageRegistryBase
+                .map(String::trim)
+                .filter(value -> !value.isBlank())
+                .map(value -> {
+                    while (value.endsWith("/")) {
+                        value = value.substring(0, value.length() - 1);
+                    }
+                    return value;
+                });
+    }
+
+    /**
+     * Fluent builder for constructing ContainerSpec instances.
+     */
     public static class Builder {
         private final String image;
         private final EmulatorConfig config;
@@ -66,6 +124,9 @@ public class ContainerBuilder {
         private final Map<String, String> labels = new HashMap<>();
         private LogConfig logConfig;
         private boolean privileged;
+        private String cgroupnsMode;
+        private String user;
+        private final List<String> groupAdd = new ArrayList<>();
         private final List<String> dnsServers = new ArrayList<>();
 
         Builder(String image, EmulatorConfig config, DockerHostResolver dockerHostResolver,
@@ -78,66 +139,107 @@ public class ContainerBuilder {
             this.currentContainerNetworkResolver = currentContainerNetworkResolver;
         }
 
+        /**
+         * Sets the container name.
+         */
         public Builder withName(String name) {
             this.name = name;
             return this;
         }
 
+        /**
+         * Adds a single environment variable.
+         */
         public Builder withEnv(String key, String value) {
             this.env.add(key + "=" + value);
             return this;
         }
 
+        /**
+         * Adds multiple environment variables from a list of "KEY=value" strings.
+         */
         public Builder withEnv(List<String> env) {
             this.env.addAll(env);
             return this;
         }
 
+        /**
+         * Sets the container command (overrides image CMD).
+         */
         public Builder withCmd(List<String> cmd) {
             this.cmd = cmd;
             return this;
         }
 
+        /**
+         * Sets the container command from a single string (for simple commands).
+         */
         public Builder withCmd(String cmd) {
             this.cmd = List.of(cmd);
             return this;
         }
 
+        /**
+         * Sets the container entrypoint (overrides image ENTRYPOINT).
+         */
         public Builder withEntrypoint(List<String> entrypoint) {
             this.entrypoint = entrypoint;
             return this;
         }
 
+        /**
+         * Sets the working directory inside the container (overrides image WORKDIR).
+         */
         public Builder withWorkingDir(String workingDir) {
             this.workingDir = workingDir;
             return this;
         }
 
+        /**
+         * Sets the memory limit in megabytes.
+         */
         public Builder withMemoryMb(int memoryMb) {
             this.memoryBytes = (long) memoryMb * 1024 * 1024;
             return this;
         }
 
+        /**
+         * Sets the memory limit in bytes.
+         */
         public Builder withMemoryBytes(long memoryBytes) {
             this.memoryBytes = memoryBytes;
             return this;
         }
 
+        /**
+         * Adds a port binding from container port to a specific host port.
+         */
         public Builder withPortBinding(int containerPort, int hostPort) {
             this.portBindings.put(containerPort, hostPort);
             this.exposedPorts.add(containerPort);
             return this;
         }
 
+        /**
+         * Adds a port binding with dynamic host port allocation.
+         * Use this when you don't care which host port is used.
+         */
         public Builder withDynamicPort(int containerPort) {
             return withPortBinding(containerPort, 0);
         }
 
+        /**
+         * Exposes a port without creating a host binding.
+         * Useful when containers communicate via Docker network.
+         */
         public Builder withExposedPort(int port) {
             this.exposedPorts.add(port);
             return this;
         }
 
+        /**
+         * Sets the Docker network mode directly.
+         */
         public Builder withNetworkMode(String networkMode) {
             this.networkMode = networkMode;
             return this;
@@ -158,6 +260,9 @@ public class ContainerBuilder {
             return this;
         }
 
+        /**
+         * Adds a bind mount from host path to container path.
+         */
         public Builder withBind(String hostPath, String containerPath) {
             this.binds.add(new Bind(hostPath, new Volume(containerPath)));
             return this;
@@ -168,19 +273,38 @@ public class ContainerBuilder {
             return this;
         }
 
+        /**
+         * Adds a read-write named volume mount.
+         */
         public Builder withNamedVolume(String volumeName, String containerPath) {
+            return withNamedVolume(volumeName, containerPath, false);
+        }
+
+        /**
+         * Adds a named volume mount, read-only when {@code readOnly} is true.
+         */
+        public Builder withNamedVolume(String volumeName, String containerPath, boolean readOnly) {
             this.mounts.add(new Mount()
                     .withType(MountType.VOLUME)
                     .withSource(volumeName)
-                    .withTarget(containerPath));
+                    .withTarget(containerPath)
+                    .withReadOnly(readOnly));
             return this;
         }
 
+        /**
+         * Adds a mount (any type: volume, bind, tmpfs).
+         */
         public Builder withMount(Mount mount) {
             this.mounts.add(mount);
             return this;
         }
 
+        /**
+         * Adds the host.docker.internal extra host entry on Linux.
+         * This allows containers to reach the host via a consistent hostname
+         * across all platforms (already exists on Docker Desktop).
+         */
         public Builder withHostDockerInternalOnLinux() {
             if (dockerHostResolver.isLinuxHost()) {
                 this.extraHosts.add("host.docker.internal:host-gateway");
@@ -188,25 +312,44 @@ public class ContainerBuilder {
             return this;
         }
 
+        /**
+         * Adds a Docker label, merged over the default emulator labels at create time.
+         */
         public Builder withLabel(String key, String value) {
             this.labels.put(key, value);
             return this;
         }
 
+        /**
+         * Adds multiple Docker labels, merged over the default emulator labels at create time.
+         */
         public Builder withLabels(Map<String, String> labels) {
             this.labels.putAll(labels);
             return this;
         }
 
+        /**
+         * Adds a custom extra host entry.
+         */
         public Builder withExtraHost(String hostname, String ip) {
             this.extraHosts.add(hostname + ":" + ip);
             return this;
         }
 
+        /**
+         * Enables log rotation with default settings from configuration.
+         * Uses json-file driver with max-size and max-file from config.
+         */
         public Builder withLogRotation() {
             return withLogRotation(config.docker().logMaxSize(), config.docker().logMaxFile());
         }
 
+        /**
+         * Enables log rotation with custom settings.
+         *
+         * @param maxSize maximum log file size (e.g., "10m", "100k", "1g")
+         * @param maxFile maximum number of log files to retain
+         */
         public Builder withLogRotation(String maxSize, String maxFile) {
             this.logConfig = new LogConfig(
                     LogConfig.LoggingType.JSON_FILE,
@@ -214,21 +357,66 @@ public class ContainerBuilder {
             return this;
         }
 
+        /**
+         * Sets a custom log configuration.
+         */
         public Builder withLogConfig(LogConfig logConfig) {
             this.logConfig = logConfig;
             return this;
         }
 
+        /**
+         * Runs the container in privileged mode (required for k3s and similar containers
+         * that need full system access).
+         */
         public Builder withPrivileged(boolean privileged) {
             this.privileged = privileged;
             return this;
         }
 
+        /**
+         * Sets the Docker cgroup namespace mode (for example, "host").
+         */
+        public Builder withCgroupnsMode(String cgroupnsMode) {
+            this.cgroupnsMode = cgroupnsMode;
+            return this;
+        }
+
+        /**
+         * Sets the user the container process runs as, formatted {@code "uid[:gid]"}
+         * (Docker's top-level container user). Null or blank leaves the image {@code USER}
+         * in effect.
+         */
+        public Builder withUser(String user) {
+            this.user = user;
+            return this;
+        }
+
+        /**
+         * Adds a supplementary group id to the container process (Docker {@code --group-add}),
+         * so it can access group-owned resources without changing its primary uid/gid. Blank
+         * ids are ignored.
+         */
+        public Builder withGroupAdd(String groupId) {
+            if (groupId != null && !groupId.isBlank()) {
+                this.groupAdd.add(groupId);
+            }
+            return this;
+        }
+
+        /**
+         * Injects floci-az's embedded DNS server into the container so emulated hostnames
+         * resolve to floci-az's Docker network IP. No-op when the embedded DNS server is
+         * not running.
+         */
         public Builder withEmbeddedDns() {
             embeddedDnsServer.getServerIp().ifPresent(dnsServers::add);
             return this;
         }
 
+        /**
+         * Builds the immutable ContainerSpec.
+         */
         public ContainerSpec build() {
             return new ContainerSpec(
                     image,
@@ -246,8 +434,11 @@ public class ContainerBuilder {
                     Map.copyOf(labels),
                     logConfig,
                     privileged,
+                    cgroupnsMode,
                     List.copyOf(dnsServers),
-                    workingDir
+                    workingDir,
+                    user,
+                    List.copyOf(groupAdd)
             );
         }
     }

--- a/src/main/java/io/floci/az/core/docker/ContainerDetector.java
+++ b/src/main/java/io/floci/az/core/docker/ContainerDetector.java
@@ -10,18 +10,19 @@ import java.util.Locale;
 
 /**
  * Detects whether the application is running inside a container.
- *
+ * <p>
  * Supports detection for Docker, Moby, Docker Desktop, and Podman
  * on Linux, macOS, and Windows.
- *
+ * <p>
  * Detection heuristics (checked in order):
- *   1. Presence of {@code /.dockerenv} marker file (Docker / Moby / Docker Desktop)
- *   2. Presence of {@code /run/.containerenv} (Podman)
- *   3. The {@code container} environment variable set by some runtimes
- *   4. {@code /proc/1/cgroup} containing docker/kubepods/libpod (cgroup v1)
- *   5. {@code /proc/self/mountinfo} containing overlay paths (cgroup v2 / Podman)
- *   6. Windows: {@code CONTAINER} or {@code DOTNET_RUNNING_IN_CONTAINER} env var
- *
+ * <ol>
+ *   <li>Presence of the {@code /.dockerenv} marker file (Docker / Moby / Docker Desktop)</li>
+ *   <li>Presence of {@code /run/.containerenv} (Podman)</li>
+ *   <li>The {@code container} environment variable set by some runtimes (e.g. Podman sets it to {@code "podman"})</li>
+ *   <li>{@code /proc/1/cgroup} containing {@code docker}, {@code kubepods}, or {@code libpod} (cgroup v1)</li>
+ *   <li>{@code /proc/self/mountinfo} root mount containing {@code /docker/} or {@code /libpod-} overlay paths (cgroup v2 / Podman)</li>
+ *   <li>On Windows: the {@code CONTAINER} or {@code DOTNET_RUNNING_IN_CONTAINER} environment variable</li>
+ * </ol>
  */
 @ApplicationScoped
 public class ContainerDetector {
@@ -53,36 +54,49 @@ public class ContainerDetector {
     }
 
     private boolean detect() {
+        // 1. Docker / Moby / Docker Desktop marker file (Linux & macOS containers)
         if (fileExists(DOCKER_ENV_MARKER)) {
             LOG.debugv("Detected container via {0}", DOCKER_ENV_MARKER);
             return true;
         }
+
+        // 2. Podman marker file
         if (fileExists(PODMAN_ENV_MARKER)) {
             LOG.debugv("Detected container via {0}", PODMAN_ENV_MARKER);
             return true;
         }
+
+        // 3. Environment variable set by some container runtimes
         if (hasContainerEnvVariable()) {
             LOG.debugv("Detected container via environment variable");
             return true;
         }
+
+        // 4. cgroup v1 markers (Linux)
         if (hasCgroupV1Markers()) {
             LOG.debugv("Detected container via cgroup v1 markers in {0}", CGROUP_V1_FILE);
             return true;
         }
+
+        // 5. cgroup v2 / overlay mount markers (Linux)
         if (hasMountInfoMarkers()) {
             LOG.debugv("Detected container via mount markers in {0}", MOUNTINFO_FILE);
             return true;
         }
+
         return false;
     }
 
     private boolean hasContainerEnvVariable() {
+        // Podman sets "container=podman"; systemd-nspawn sets "container=systemd-nspawn"
         String containerEnv = getEnv("container");
         if (containerEnv != null && !containerEnv.isBlank()) return true;
 
+        // Docker Desktop on Windows sometimes exposes this (.NET convention reused by some images)
         String dotnetContainer = getEnv("DOTNET_RUNNING_IN_CONTAINER");
         if ("true".equalsIgnoreCase(dotnetContainer)) return true;
 
+        // Generic CONTAINER env var used in some Windows container images
         String genericContainer = getEnv("CONTAINER");
         return genericContainer != null && !genericContainer.isBlank();
     }

--- a/src/main/java/io/floci/az/core/docker/ContainerLifecycleManager.java
+++ b/src/main/java/io/floci/az/core/docker/ContainerLifecycleManager.java
@@ -14,7 +14,10 @@ import com.github.dockerjava.api.model.ContainerNetwork;
 import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.Frame;
 import com.github.dockerjava.api.model.HostConfig;
+import com.github.dockerjava.api.model.Mount;
+import com.github.dockerjava.api.model.MountType;
 import com.github.dockerjava.api.model.Ports;
+import com.github.dockerjava.core.command.WaitContainerResultCallback;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
@@ -30,9 +33,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 /**
- * Manages Docker container lifecycle: create, start, stop, remove, volume management.
+ * Manages Docker container lifecycle operations including create, start, stop, remove,
+ * and volume management. Consolidates common container management patterns used across
+ * floci-az services.
  */
 @ApplicationScoped
 public class ContainerLifecycleManager {
@@ -44,6 +52,9 @@ public class ContainerLifecycleManager {
     private final ContainerDetector containerDetector;
     private final PortAllocator portAllocator;
     private final EmulatorConfig config;
+
+    /** Volumes whose shared-ownership root has already been initialised this process (run-once guard). */
+    private final ConcurrentHashMap<String, Boolean> initializedSharedVolumes = new ConcurrentHashMap<>();
 
     @Inject
     public ContainerLifecycleManager(DockerClient dockerClient,
@@ -58,11 +69,35 @@ public class ContainerLifecycleManager {
         this.config = config;
     }
 
+    /**
+     * Creates and immediately starts a container. Delegates to
+     * {@link #create} and {@link #startCreated}. Suitable when no
+     * filesystem modifications are needed between creation and start.
+     *
+     * @param spec the container specification
+     * @return information about the created container including resolved endpoints
+     */
     public ContainerInfo createAndStart(ContainerSpec spec) {
         String containerId = create(spec);
-        return startCreated(containerId, spec);
+        try {
+            return startCreated(containerId, spec);
+        } catch (Exception e) {
+            // A failed start (e.g. host-port conflict) must not leak the created
+            // container: retrying callers would accumulate Created containers and
+            // fixed-name callers would hit name conflicts on the next attempt.
+            removeIfExists(containerId);
+            throw e;
+        }
     }
 
+    /**
+     * Creates a container without starting it. Use {@link #startCreated} to
+     * start it after any pre-start setup (e.g. copying files into the
+     * container filesystem).
+     *
+     * @param spec the container specification
+     * @return the container ID
+     */
     public String create(ContainerSpec spec) {
         LOG.debugv("Creating container: image={0}, name={1}", spec.image(), spec.name());
 
@@ -74,6 +109,7 @@ public class ContainerLifecycleManager {
                 .withHostConfig(hostConfig);
 
         if (spec.name() != null) createCmd.withName(spec.name());
+        if (spec.user() != null && !spec.user().isBlank()) createCmd.withUser(spec.user());
         if (spec.env() != null && !spec.env().isEmpty()) createCmd.withEnv(spec.env());
         if (spec.cmd() != null && !spec.cmd().isEmpty()) createCmd.withCmd(spec.cmd());
         if (spec.entrypoint() != null && !spec.entrypoint().isEmpty())
@@ -94,6 +130,13 @@ public class ContainerLifecycleManager {
         return containerId;
     }
 
+    /**
+     * Starts a previously created container and resolves its endpoints.
+     *
+     * @param containerId the container ID returned by {@link #create}
+     * @param spec the original spec (needed for network and endpoint resolution)
+     * @return information about the running container including resolved endpoints
+     */
     public ContainerInfo startCreated(String containerId, ContainerSpec spec) {
         dockerClient.startContainerCmd(containerId).exec();
         LOG.infov("Started container {0}", containerId);
@@ -116,6 +159,12 @@ public class ContainerLifecycleManager {
         return new ContainerInfo(containerId, endpoints);
     }
 
+    /**
+     * Stops and removes a container, closing any associated log stream.
+     *
+     * @param containerId the container ID to stop and remove
+     * @param logStream optional log stream to close (may be null)
+     */
     public void stopAndRemove(String containerId, Closeable logStream) {
         LOG.infov("Stopping container {0}", containerId);
 
@@ -159,6 +208,107 @@ public class ContainerLifecycleManager {
         }
     }
 
+    /**
+     * Ensures the named volume exists (see {@link #ensureVolume}) and, when POSIX ownership is
+     * requested, initialises the volume root once so shared-file-storage semantics hold. A Docker
+     * named volume is created {@code root:root 0755}, so a container whose image runs as a
+     * non-root {@code USER} cannot create files on it. This chowns/chmods the mount root inside a
+     * short-lived helper container. A 4-digit octal {@code rootPermissions} (e.g. {@code "2775"})
+     * carries the setgid bit, so subdirectories inherit the owner gid.
+     *
+     * <p>The initialisation runs at most once per volume name per process. When no ownership is
+     * configured (all of {@code ownerUid}/{@code ownerGid}/{@code rootPermissions} empty) this
+     * degrades to a plain {@link #ensureVolume}, so the default behaviour is unchanged.
+     *
+     * @param volumeName      the named volume
+     * @param ownerUid        owner uid for the volume root
+     * @param ownerGid        owner gid for the volume root
+     * @param rootPermissions octal permissions for the volume root (e.g. {@code "0777"}); empty skips init
+     * @param initImage       lightweight image used for the one-off chown/chmod helper
+     */
+    public void ensureSharedVolume(String volumeName, OptionalInt ownerUid, OptionalInt ownerGid,
+                                   Optional<String> rootPermissions, String initImage) {
+        ensureVolume(volumeName);
+        if (rootPermissions.isEmpty() && ownerUid.isEmpty() && ownerGid.isEmpty()) {
+            return;
+        }
+        // Owner uid and gid are only meaningful together; reject a partial ownership config
+        // rather than emitting a malformed `chown uid:` (whose trailing colon makes chown
+        // resolve the login group and fail in busybox for an unknown uid).
+        if (ownerUid.isPresent() != ownerGid.isPresent()) {
+            throw new IllegalArgumentException(
+                    "shared-volume owner-uid and owner-gid must be set together");
+        }
+        // Validate before splicing into the helper's `sh -c` (^[0-7]{3,4}$), so a typo can't
+        // produce a mangled script that soft-fails.
+        rootPermissions.ifPresent(p -> {
+            if (!p.matches("^[0-7]{3,4}$")) {
+                throw new IllegalArgumentException(
+                        "shared-volume root-permissions must be 3-4 octal digits (e.g. \"0777\","
+                                + " or \"2775\" for setgid): " + p);
+            }
+        });
+        // computeIfAbsent runs the one-off init under a per-volume lock, so a concurrent launch for
+        // the same volume waits for it to finish rather than mounting a still root:root 0755 root.
+        // Returning null on failure leaves the volume unmemoised, so the next launch retries.
+        initializedSharedVolumes.computeIfAbsent(volumeName, k -> {
+            try {
+                initSharedVolumeRoot(volumeName, ownerUid, ownerGid, rootPermissions, initImage);
+                return Boolean.TRUE;
+            } catch (RuntimeException e) {
+                LOG.warnv("Failed to initialise shared volume {0} ownership: {1}", volumeName, e.getMessage());
+                return null;
+            }
+        });
+    }
+
+    private void initSharedVolumeRoot(String volumeName, OptionalInt ownerUid, OptionalInt ownerGid,
+                                      Optional<String> rootPermissions, String initImage) {
+        String mount = "/floci-shared-volume";
+        StringBuilder script = new StringBuilder();
+        // ownerUid and ownerGid are validated to be present together by the caller, so the chown
+        // always has both operands (no trailing colon). setgid is expressed via a 4-digit octal
+        // rootPermissions (e.g. "2775").
+        if (ownerUid.isPresent() && ownerGid.isPresent()) {
+            script.append("chown ").append(ownerUid.getAsInt()).append(':').append(ownerGid.getAsInt())
+                    .append(' ').append(mount).append(" && ");
+        }
+        rootPermissions.ifPresent(p -> script.append("chmod ").append(p).append(' ').append(mount).append(" && "));
+        script.append("true");
+
+        String image = (initImage != null && !initImage.isBlank()) ? initImage : "busybox:stable";
+        imageCacheService.ensureImageExists(image);
+
+        HostConfig hostConfig = HostConfig.newHostConfig().withMounts(List.of(
+                new Mount().withType(MountType.VOLUME).withSource(volumeName).withTarget(mount)));
+        CreateContainerResponse created = dockerClient.createContainerCmd(image)
+                .withHostConfig(hostConfig)
+                .withCmd("sh", "-c", script.toString())
+                .withLabels(mergedLabels(null))
+                .exec();
+        String helperId = created.getId();
+        try {
+            dockerClient.startContainerCmd(helperId).exec();
+            Integer status = dockerClient.waitContainerCmd(helperId)
+                    .exec(new WaitContainerResultCallback())
+                    .awaitStatusCode(60, TimeUnit.SECONDS);
+            if (status == null || status != 0) {
+                // Throw so the caller leaves the volume unmemoised and retries on the next launch,
+                // rather than leaving it root:root 0755 with no further attempt.
+                throw new IllegalStateException("shared-volume init for " + volumeName
+                        + " exited with status " + status + " (cmd: " + script + ")");
+            }
+            LOG.infov("Initialised shared volume {0} root (cmd: {1})", volumeName, script);
+        } finally {
+            try {
+                dockerClient.removeContainerCmd(helperId).withForce(true).exec();
+            } catch (Exception e) {
+                // best-effort cleanup of the one-off helper
+                LOG.debugv("Could not remove shared-volume init helper {0}: {1}", helperId, e.getMessage());
+            }
+        }
+    }
+
     /** Default emulator labels merged with per-spec labels; spec labels win on collision. */
     private Map<String, String> mergedLabels(Map<String, String> specLabels) {
         Map<String, String> labels = ContainerStorageHelper.defaultLabels(config);
@@ -168,6 +318,9 @@ public class ContainerLifecycleManager {
         return labels;
     }
 
+    /**
+     * Removes a named Docker volume, ignoring errors if it does not exist or is still in use.
+     */
     public void removeVolume(String volumeName) {
         try {
             dockerClient.removeVolumeCmd(volumeName).exec();
@@ -178,6 +331,12 @@ public class ContainerLifecycleManager {
         }
     }
 
+    /**
+     * Finds an existing container by name.
+     *
+     * @param name the container name to search for
+     * @return the container if found
+     */
     public Optional<Container> findByName(String name) {
         try {
             List<Container> containers = dockerClient.listContainersCmd().withShowAll(true).exec();
@@ -185,6 +344,7 @@ public class ContainerLifecycleManager {
                 String[] names = c.getNames();
                 if (names == null) continue;
                 for (String n : names) {
+                    // Docker prefixes names with /
                     if (n.equals("/" + name) || n.equals(name)) return Optional.of(c);
                 }
             }
@@ -194,6 +354,67 @@ public class ContainerLifecycleManager {
         return Optional.empty();
     }
 
+    /**
+     * Adopts an existing container, starting it if stopped.
+     * Useful for services that reuse containers across restarts.
+     *
+     * @param containerId the container ID to adopt
+     * @param ports the container ports to resolve endpoints for
+     * @return information about the adopted container
+     */
+    public ContainerInfo adopt(String containerId, List<Integer> ports) {
+        LOG.infov("Adopting existing container {0}", containerId);
+
+        InspectContainerResponse inspect = dockerClient.inspectContainerCmd(containerId).exec();
+        boolean running = Boolean.TRUE.equals(inspect.getState().getRunning());
+
+        if (!running) {
+            dockerClient.startContainerCmd(containerId).exec();
+            LOG.infov("Started adopted container {0}", containerId);
+            inspect = dockerClient.inspectContainerCmd(containerId).exec();
+        }
+
+        Map<Integer, EndpointInfo> endpoints = new HashMap<>();
+        Map<Integer, Integer> publishedHostPorts = new HashMap<>();
+        for (int port : ports) {
+            endpoints.put(port, resolveEndpoint(inspect, port));
+            OptionalInt published = readPublishedHostPort(inspect, port);
+            if (published.isPresent()) {
+                publishedHostPorts.put(port, published.getAsInt());
+            }
+        }
+
+        return new ContainerInfo(containerId, endpoints, publishedHostPorts);
+    }
+
+    /**
+     * Reads the host port a container's internal port is published on, independent of
+     * whether floci-az itself runs inside a container. Unlike {@link #resolveEndpoint} —
+     * which switches to container-IP + internal port in container mode — this always
+     * reads the port binding, for URIs consumed by the host-side Docker daemon.
+     */
+    private static OptionalInt readPublishedHostPort(InspectContainerResponse inspect, int containerPort) {
+        Ports ports = inspect.getNetworkSettings().getPorts();
+        if (ports != null) {
+            Ports.Binding[] binding = ports.getBindings().get(ExposedPort.tcp(containerPort));
+            if (binding != null && binding.length > 0) {
+                try {
+                    return OptionalInt.of(Integer.parseInt(binding[0].getHostPortSpec()));
+                } catch (NumberFormatException e) {
+                    LOG.debugv("Unparseable host port binding for container port {0}: {1}",
+                            String.valueOf(containerPort), binding[0].getHostPortSpec());
+                }
+            }
+        }
+        return OptionalInt.empty();
+    }
+
+    /**
+     * Removes a container by name if it exists. Useful for cleaning up stale containers
+     * from previous runs before creating a new one.
+     *
+     * @param name the container name to remove
+     */
     public void removeIfExists(String name) {
         try {
             dockerClient.removeContainerCmd(name).withForce(true).exec();
@@ -240,6 +461,15 @@ public class ContainerLifecycleManager {
         }
     }
 
+    /**
+     * Returns whether the container is currently running. A missing container is treated as
+     * not-running; any other Docker error (e.g. an inspect timeout under daemon overload) is also
+     * treated as not-running, so a hung/dead container is not reused — a false negative merely
+     * triggers a clean cold-start, which is far cheaper than blocking until an invocation timeout.
+     *
+     * @param containerId the container ID to inspect
+     * @return true only if the container exists and is reported as running; false on any error
+     */
     public boolean isContainerRunning(String containerId) {
         try {
             InspectContainerResponse inspect = dockerClient.inspectContainerCmd(containerId).exec();
@@ -247,16 +477,32 @@ public class ContainerLifecycleManager {
         } catch (NotFoundException e) {
             return false;
         } catch (Exception e) {
-            LOG.warnv("Liveness check failed for container {0}: {1}", containerId, e.getMessage());
-            return true;
+            // Treat an inspect failure/timeout as NOT running. Under Docker-daemon overload,
+            // returning true here would let callers "reuse" dead/hung containers, so the
+            // invocation blocked until its timeout every time. A false negative merely
+            // triggers a clean cold-start, which is far cheaper than a hang.
+            LOG.warnv("Liveness check failed for container {0}; treating as not running: {1}",
+                    containerId, e.getMessage());
+            return false;
         }
     }
 
+    /**
+     * Resolves the endpoint (host and port) to connect to a specific container port.
+     *
+     * @param containerId the container ID
+     * @param containerPort the container port to resolve
+     * @return the endpoint information
+     */
     public EndpointInfo resolveEndpoint(String containerId, int containerPort) {
         InspectContainerResponse inspect = dockerClient.inspectContainerCmd(containerId).exec();
         return resolveEndpoint(inspect, containerPort, null);
     }
 
+    /**
+     * Returns the underlying DockerClient for operations not covered by this manager.
+     * Prefer using manager methods when available.
+     */
     public DockerClient getDockerClient() {
         return dockerClient;
     }
@@ -286,7 +532,7 @@ public class ContainerLifecycleManager {
                             output.append(new String(frame.getPayload(), StandardCharsets.UTF_8));
                         }
                     })
-                    .awaitCompletion(60, java.util.concurrent.TimeUnit.SECONDS);
+                    .awaitCompletion(60, TimeUnit.SECONDS);
 
             Long exitCode = dockerClient.inspectExecCmd(execId).exec().getExitCodeLong();
             return new ExecResult(exitCode == null ? -1 : exitCode.intValue(), output.toString());
@@ -329,9 +575,21 @@ public class ContainerLifecycleManager {
         }
     }
 
+    /**
+     * Returns {@code true} if the container runtime (Docker, Moby, or Podman) has a volume
+     * with the given name. The volume does not need to be attached to the current container.
+     * <p>
+     * This method uses the Docker Engine API ({@code /volumes/{name}}) which is supported
+     * by Docker, Moby, and Podman runtimes on all operating systems.
+     *
+     * @param name the volume name to look up
+     * @return {@code true} if the volume exists, {@code false} otherwise
+     */
     public boolean volumeExists(String name) {
         if (name == null || name.isBlank()) return false;
+        // Is a Unix absolute or relative path (e.g. "/var/lib/data", "./data", "../data")
         if (name.startsWith("/") || name.startsWith(".")) return false;
+        // Is a Windows absolute path (e.g. "C:\Users\data", "D:/sources/data")
         if (name.length() >= 3 && Character.isLetter(name.charAt(0))
                 && name.charAt(1) == ':' && (name.charAt(2) == '\\' || name.charAt(2) == '/'))
             return false;
@@ -352,6 +610,17 @@ public class ContainerLifecycleManager {
         HostConfig hostConfig = HostConfig.newHostConfig();
 
         if (spec.privileged()) hostConfig.withPrivileged(true);
+
+        if (spec.cgroupnsMode() != null && !spec.cgroupnsMode().isBlank()) {
+            hostConfig.withCgroupnsMode(spec.cgroupnsMode());
+        }
+
+        // Supplementary groups (Docker --group-add), e.g. to give a process access to a
+        // group-shared volume without changing its primary uid/gid.
+        if (spec.groupAdd() != null && !spec.groupAdd().isEmpty()) {
+            hostConfig.withGroupAdd(spec.groupAdd());
+        }
+
         if (spec.hasMemoryLimit()) hostConfig.withMemory(spec.memoryBytes());
 
         if (spec.hasPortBindings()) {
@@ -360,7 +629,8 @@ public class ContainerLifecycleManager {
                 int containerPort = entry.getKey();
                 int hostPort = entry.getValue() == 0 ? portAllocator.allocateAny() : entry.getValue();
                 ports.bind(ExposedPort.tcp(containerPort), Ports.Binding.bindPort(hostPort));
-                LOG.debugv("Port binding: {0} -> {1}", containerPort, hostPort);
+                LOG.debugv("Port binding: {0} -> {1}",
+                        String.valueOf(containerPort), String.valueOf(hostPort));
             }
             hostConfig.withPortBindings(ports);
         }
@@ -379,6 +649,8 @@ public class ContainerLifecycleManager {
         if (spec.extraHosts() != null && !spec.extraHosts().isEmpty())
             hostConfig.withExtraHosts(spec.extraHosts().toArray(new String[0]));
         if (spec.hasLogConfig()) hostConfig.withLogConfig(spec.logConfig());
+        // DNS servers — used to inject floci-az's embedded DNS so spawned containers
+        // can resolve emulated hostnames to floci-az's Docker network IP.
         if (spec.dnsServers() != null && !spec.dnsServers().isEmpty())
             hostConfig.withDns(spec.dnsServers().toArray(new String[0]));
 
@@ -402,14 +674,20 @@ public class ContainerLifecycleManager {
     private EndpointInfo resolveEndpoint(InspectContainerResponse inspect, int containerPort,
                                          String preferredNetwork) {
         if (!containerDetector.isRunningInContainer()) {
+            // Native mode: use localhost and the bound host port
             var bindings = inspect.getNetworkSettings().getPorts().getBindings();
             var binding = bindings.get(ExposedPort.tcp(containerPort));
             if (binding != null && binding.length > 0) {
                 int hostPort = Integer.parseInt(binding[0].getHostPortSpec());
                 return new EndpointInfo("localhost", hostPort);
             }
+            // Fallback to container port
             return new EndpointInfo("localhost", containerPort);
         } else {
+            // Container mode: use container IP on the docker network.
+            // Prefer the configured network's IP — the container may be on multiple
+            // networks (bridge + the configured network) when connectToNetworkCmd()
+            // is used instead of withNetworkMode() during creation.
             String containerIp = resolveContainerIp(inspect, preferredNetwork);
             return new EndpointInfo(containerIp, containerPort);
         }
@@ -418,24 +696,62 @@ public class ContainerLifecycleManager {
     private String resolveContainerIp(InspectContainerResponse inspect, String preferredNetwork) {
         var networks = inspect.getNetworkSettings().getNetworks();
         if (networks != null) {
+            // Prefer the configured network so that when the container is on both
+            // bridge (default) and the service network, we return the right IP.
             if (preferredNetwork != null && networks.containsKey(preferredNetwork)) {
                 String ip = networks.get(preferredNetwork).getIpAddress();
                 if (ip != null && !ip.isBlank()) return ip;
             }
+            // Fall back to any network
             for (Map.Entry<String, ContainerNetwork> entry : networks.entrySet()) {
                 String ip = entry.getValue().getIpAddress();
                 if (ip != null && !ip.isBlank()) return ip;
             }
         }
+        // Fallback to the global IP
         return inspect.getNetworkSettings().getIpAddress();
     }
 
-    public record ContainerInfo(String containerId, Map<Integer, EndpointInfo> endpoints) {
+    /**
+     * Information about a created or adopted container.
+     *
+     * @param containerId the Docker container ID
+     * @param endpoints map of container port to resolved endpoint (host:port for connection)
+     * @param publishedHostPorts map of container port to the host port it is published on;
+     *                           a port without a binding is absent
+     */
+    public record ContainerInfo(
+            String containerId,
+            Map<Integer, EndpointInfo> endpoints,
+            Map<Integer, Integer> publishedHostPorts
+    ) {
+        public ContainerInfo(String containerId, Map<Integer, EndpointInfo> endpoints) {
+            this(containerId, endpoints, Map.of());
+        }
+
+        /**
+         * Gets the endpoint for a specific container port.
+         */
         public EndpointInfo getEndpoint(int containerPort) {
             return endpoints.get(containerPort);
         }
+
+        /**
+         * Gets the host port a container port is published on, regardless of whether
+         * floci-az itself runs inside a container. Empty when the port has no binding.
+         */
+        public OptionalInt publishedHostPort(int containerPort) {
+            Integer published = publishedHostPorts.get(containerPort);
+            return published != null ? OptionalInt.of(published) : OptionalInt.empty();
+        }
     }
 
+    /**
+     * Network endpoint information for connecting to a container.
+     *
+     * @param host the host to connect to (localhost in native mode, container IP in Docker mode)
+     * @param port the port to connect to
+     */
     public record EndpointInfo(String host, int port) {
         @Override
         public String toString() {

--- a/src/main/java/io/floci/az/core/docker/ContainerSpec.java
+++ b/src/main/java/io/floci/az/core/docker/ContainerSpec.java
@@ -8,7 +8,29 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Immutable specification for a Docker container. Use {@link ContainerBuilder} to construct.
+ * Immutable specification for a Docker container to be created.
+ * Use {@link ContainerBuilder} to construct instances of this record.
+ *
+ * @param image Docker image name (required)
+ * @param name Container name (optional, Docker generates one if null)
+ * @param env Environment variables as "KEY=value" strings
+ * @param cmd Command to run (overrides image CMD)
+ * @param entrypoint Entrypoint to use (overrides image ENTRYPOINT)
+ * @param memoryBytes Memory limit in bytes (null = no limit)
+ * @param portBindings Map of container port to host port (0 = dynamic allocation)
+ * @param exposedPorts Ports to expose (required for port bindings)
+ * @param networkMode Docker network name or mode (null = default bridge)
+ * @param mounts Volume mounts (named volumes, bind mounts, tmpfs)
+ * @param binds Legacy bind mounts (prefer mounts for new code)
+ * @param extraHosts Extra /etc/hosts entries as "hostname:ip" strings
+ * @param labels Extra Docker labels merged over the default emulator labels
+ * @param logConfig Docker log driver configuration (null = daemon default)
+ * @param privileged Whether to run the container in privileged mode (required for k3s)
+ * @param cgroupnsMode Docker cgroup namespace mode (for example, "host")
+ * @param dnsServers DNS server IPs to inject into the container (e.g. floci-az's embedded DNS)
+ * @param workingDir Working directory inside the container (overrides image WORKDIR)
+ * @param user User the container process runs as, formatted "uid[:gid]" (null = image USER)
+ * @param groupAdd Supplementary group IDs added to the container process
  */
 public record ContainerSpec(
         String image,
@@ -26,22 +48,39 @@ public record ContainerSpec(
         Map<String, String> labels,
         LogConfig logConfig,
         boolean privileged,
+        String cgroupnsMode,
         List<String> dnsServers,
-        String workingDir
+        String workingDir,
+        String user,
+        List<String> groupAdd
 ) {
+    /**
+     * Creates a minimal spec with just the image name.
+     * All other fields will be null or empty collections.
+     */
     public ContainerSpec(String image) {
         this(image, null, List.of(), null, null, null, Map.of(), List.of(), null,
-                List.of(), List.of(), List.of(), Map.of(), null, false, List.of(), null);
+                List.of(), List.of(), List.of(), Map.of(), null, false, null, List.of(),
+                null, null, List.of());
     }
 
+    /**
+     * Returns true if this spec has any port bindings configured.
+     */
     public boolean hasPortBindings() {
         return portBindings != null && !portBindings.isEmpty();
     }
 
+    /**
+     * Returns true if this spec has a memory limit configured.
+     */
     public boolean hasMemoryLimit() {
         return memoryBytes != null && memoryBytes > 0;
     }
 
+    /**
+     * Returns true if log rotation is configured.
+     */
     public boolean hasLogConfig() {
         return logConfig != null;
     }

--- a/src/main/java/io/floci/az/core/docker/CurrentContainerNetworkResolver.java
+++ b/src/main/java/io/floci/az/core/docker/CurrentContainerNetworkResolver.java
@@ -59,32 +59,55 @@ public class CurrentContainerNetworkResolver {
             return Optional.empty();
         }
 
-        try {
-            String containerId = readContainerId();
-            if (containerId == null || containerId.isBlank()) {
-                LOG.debugv("Could not determine container ID from {0}", HOSTNAME_FILE);
-                return Optional.empty();
-            }
+        String containerId = currentContainerId();
+        if (containerId.isBlank()) {
+            LOG.debug("Could not determine current Docker container id");
+            return Optional.empty();
+        }
 
+        try {
             InspectContainerResponse inspect = dockerClient.inspectContainerCmd(containerId).exec();
             Map<String, ContainerNetwork> networks = inspect.getNetworkSettings().getNetworks();
             if (networks == null || networks.isEmpty()) {
                 return Optional.empty();
             }
 
-            Map.Entry<String, ContainerNetwork> first = networks.entrySet().iterator().next();
-            String networkName = first.getKey();
-            String ipAddress = first.getValue().getIpAddress();
-
-            LOG.infov("Detected current container network: {0}, IP: {1}", networkName, ipAddress);
-            return Optional.of(new CurrentContainerNetwork(networkName, ipAddress));
+            Optional<CurrentContainerNetwork> selected = selectNetwork(networks);
+            selected.ifPresent(network -> LOG.infov(
+                    "Detected current Docker network for spawned containers: {0} ({1})",
+                    network.name(), network.ipAddress()));
+            return selected;
         } catch (Exception e) {
-            LOG.debugv("Could not detect current container network: {0}", e.getMessage());
+            LOG.debugv("Could not inspect current Docker container {0}: {1}", containerId, e.getMessage());
             return Optional.empty();
         }
     }
 
-    private String readContainerId() {
+    /**
+     * Prefers a usable user-defined network over Docker's built-in bridge/host/none networks,
+     * so spawned sibling containers join a network where DNS-based service discovery works.
+     * Falls back to any network with a usable IP when no user-defined network is attached.
+     */
+    private Optional<CurrentContainerNetwork> selectNetwork(Map<String, ContainerNetwork> networks) {
+        return networks.entrySet().stream()
+                .filter(entry -> isUsable(entry.getValue()))
+                .filter(entry -> isUserDefinedNetwork(entry.getKey()))
+                .findFirst()
+                .or(() -> networks.entrySet().stream()
+                        .filter(entry -> isUsable(entry.getValue()))
+                        .findFirst())
+                .map(entry -> new CurrentContainerNetwork(entry.getKey(), entry.getValue().getIpAddress()));
+    }
+
+    private boolean isUsable(ContainerNetwork network) {
+        return network != null && network.getIpAddress() != null && !network.getIpAddress().isBlank();
+    }
+
+    private boolean isUserDefinedNetwork(String networkName) {
+        return !"bridge".equals(networkName) && !"host".equals(networkName) && !"none".equals(networkName);
+    }
+
+    String currentContainerId() {
         try {
             String hostname = System.getenv("HOSTNAME");
             if (hostname != null && !hostname.isBlank()) {
@@ -97,7 +120,7 @@ public class CurrentContainerNetworkResolver {
         } catch (Exception e) {
             LOG.debugv("Could not read container ID: {0}", e.getMessage());
         }
-        return null;
+        return "";
     }
 
     record CurrentContainerNetwork(String name, String ipAddress) {}

--- a/src/main/java/io/floci/az/core/docker/DockerClientProducer.java
+++ b/src/main/java/io/floci/az/core/docker/DockerClientProducer.java
@@ -30,6 +30,9 @@ public class DockerClientProducer {
     /**
      * Normalizes a Docker host value by prepending {@code tcp://} when no recognized
      * URI scheme ({@code tcp://}, {@code unix://}, {@code npipe://}) is present.
+     *
+     * @param dockerHost the raw Docker host configuration value
+     * @return the normalized Docker host value, or the original value if it already has a scheme
      */
     static String normalizeDockerHost(String dockerHost) {
         if (dockerHost == null) {
@@ -48,8 +51,14 @@ public class DockerClientProducer {
     }
 
     /**
-     * Resolves the effective Docker host. Prefers {@code DOCKER_HOST} env var over the
-     * configured default (unix socket), and normalizes bare host:port values to tcp://.
+     * Resolves the effective Docker host to use when creating the client.
+     *
+     * Priority:
+     * 1. If {@code floci-az.docker.docker-host} is explicitly configured (non-default), use it.
+     * 2. Otherwise fall back to the standard {@code DOCKER_HOST} env var (normalized).
+     * 3. Otherwise use the default unix socket.
+     *
+     * Both the configured value and the env var are normalized to ensure a valid URI scheme.
      */
     static String resolveEffectiveDockerHost(String configuredHost, String dockerHostEnv) {
         String normalizedEnvHost = normalizeDockerHost(dockerHostEnv);
@@ -81,6 +90,11 @@ public class DockerClientProducer {
                 config.docker().dockerHost(), System.getenv("DOCKER_HOST"));
         LOG.infov("Creating DockerClient for host: {0}", dockerHost);
 
+        // createDefaultConfigBuilder() reads DOCKER_HOST directly from System.getenv() and passes
+        // it to withDockerHost(), which calls URI.create() immediately. If DOCKER_HOST is set
+        // without a URI scheme (e.g. "10.37.124.101:2375" in Bitbucket Pipelines), the
+        // URI.create() call throws before floci-az's override takes effect. Fall back to a fresh
+        // builder in that case so we can supply the normalized host ourselves.
         DefaultDockerClientConfig.Builder builder = createDockerConfigBuilder();
         builder.withDockerHost(dockerHost);
         config.docker().dockerConfigPath().ifPresent(path -> {

--- a/src/main/java/io/floci/az/core/docker/DockerHostResolver.java
+++ b/src/main/java/io/floci/az/core/docker/DockerHostResolver.java
@@ -55,6 +55,8 @@ public class DockerHostResolver {
                 }
             }
 
+            // Use this container's own IP so function containers on the same network
+            // can reach servers bound to all interfaces inside this container.
             try {
                 String ip = InetAddress.getLocalHost().getHostAddress();
                 LOG.infov("Running in Docker — using container IP for function containers: {0}", ip);

--- a/src/main/java/io/floci/az/core/docker/ImageCacheService.java
+++ b/src/main/java/io/floci/az/core/docker/ImageCacheService.java
@@ -2,6 +2,8 @@ package io.floci.az.core.docker;
 
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.PullImageResultCallback;
+import com.github.dockerjava.api.exception.DockerClientException;
+import com.github.dockerjava.api.exception.InternalServerErrorException;
 import com.github.dockerjava.api.model.AuthConfig;
 import io.floci.az.config.EmulatorConfig;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -20,6 +22,9 @@ import java.util.concurrent.TimeUnit;
 public class ImageCacheService {
 
     private static final Logger LOG = Logger.getLogger(ImageCacheService.class);
+
+    static final int MAX_PULL_ATTEMPTS = 3;
+    static final long INITIAL_BACKOFF_MS = 500L;
 
     private final DockerClient dockerClient;
     private final List<EmulatorConfig.DockerConfig.RegistryCredential> registryCredentials;
@@ -48,10 +53,11 @@ public class ImageCacheService {
             }
             LOG.infov("Pulling image: {0}", imageUri);
             try {
-                dockerClient.pullImageCmd(imageUri)
-                        .withAuthConfig(resolveAuth(imageUri))
-                        .exec(new PullImageResultCallback())
-                        .awaitCompletion(5, TimeUnit.MINUTES);
+                runWithRetry(imageUri, MAX_PULL_ATTEMPTS, INITIAL_BACKOFF_MS,
+                        () -> dockerClient.pullImageCmd(imageUri)
+                                .withAuthConfig(resolveAuth(imageUri))
+                                .exec(new PullImageResultCallback())
+                                .awaitCompletion(5, TimeUnit.MINUTES));
                 pulledImages.add(imageUri);
                 LOG.infov("Image pulled successfully: {0}", imageUri);
             } catch (InterruptedException e) {
@@ -59,6 +65,56 @@ public class ImageCacheService {
                 throw new RuntimeException("Interrupted while pulling image: " + imageUri, e);
             }
         }
+    }
+
+    /**
+     * Runs the given pull attempt, retrying on transient registry failures with exponential
+     * backoff. A failure is considered transient when either:
+     * <ul>
+     *   <li>the docker daemon throws {@link InternalServerErrorException} directly (HTTP 500,
+     *       e.g. a registry's {@code "toomanyrequests: Rate exceeded"}), or</li>
+     *   <li>{@link PullImageResultCallback#awaitCompletion} rewraps a daemon error as
+     *       {@link DockerClientException} with a message starting with
+     *       {@code "Could not pull image: "} (the async-callback path; same root cause, just
+     *       a different exception class).</li>
+     * </ul>
+     * Permanent failures (auth, missing image, malformed request, or any other
+     * {@code DockerClientException} not coming from the pull wrapper) keep surfacing their
+     * original docker-java exception subclass on the first attempt and are not retried.
+     */
+    static void runWithRetry(String imageUri, int maxAttempts, long initialBackoffMs,
+                             PullAttempt attempt) throws InterruptedException {
+        long backoffMs = initialBackoffMs;
+        for (int i = 1; i <= maxAttempts; i++) {
+            try {
+                attempt.run();
+                return;
+            } catch (RuntimeException e) {
+                if (!isTransientPullFailure(e) || i == maxAttempts) {
+                    throw e;
+                }
+                LOG.warnv(e, "Transient image pull failure for {0} (attempt {1}/{2}). "
+                        + "Retrying in {3}ms.", imageUri, i, maxAttempts, backoffMs);
+                Thread.sleep(backoffMs);
+                backoffMs *= 2;
+            }
+        }
+    }
+
+    private static boolean isTransientPullFailure(RuntimeException e) {
+        if (e instanceof InternalServerErrorException) {
+            return true;
+        }
+        if (e instanceof DockerClientException && e.getMessage() != null
+                && e.getMessage().startsWith("Could not pull image: ")) {
+            return true;
+        }
+        return false;
+    }
+
+    @FunctionalInterface
+    interface PullAttempt {
+        void run() throws InterruptedException;
     }
 
     private boolean isLocalImagePresent(String imageUri) {

--- a/src/main/java/io/floci/az/core/docker/PortAllocator.java
+++ b/src/main/java/io/floci/az/core/docker/PortAllocator.java
@@ -16,36 +16,75 @@ public class PortAllocator {
 
     private static final Logger LOG = Logger.getLogger(PortAllocator.class);
 
+    // Ports reserved by this process but not yet bound by Docker.
+    // Prevents TOCTOU races when multiple containers are launched concurrently.
     private final Set<Integer> reserved = new ConcurrentSkipListSet<>();
 
+    /**
+     * Atomically finds and reserves a free TCP port within the specified range.
+     * The port is held in-memory until {@link #release(int)} is called, preventing
+     * concurrent callers from picking the same port before Docker binds it.
+     *
+     * @param basePort the lowest port number to try (inclusive)
+     * @param maxPort  the highest port number to try (inclusive)
+     * @return a reserved free port within the range
+     * @throws RuntimeException if no free port is available in the range
+     */
     public synchronized int allocate(int basePort, int maxPort) {
         for (int port = basePort; port <= maxPort; port++) {
             if (!reserved.contains(port) && isPortFree(port)) {
                 reserved.add(port);
-                LOG.debugv("Allocated port {0} from range {1}-{2}", port, basePort, maxPort);
+                LOG.debugv("Allocated port {0} from range {1}-{2}",
+                        String.valueOf(port), String.valueOf(basePort), String.valueOf(maxPort));
                 return port;
             }
         }
         throw new RuntimeException("No free port available in range " + basePort + "-" + maxPort);
     }
 
+    /**
+     * Marks a port as reserved without probing whether it is free. Used on restart to
+     * re-reserve host ports already held by surviving containers so the allocator does
+     * not hand them out again.
+     */
+    public synchronized void markReserved(int port) {
+        reserved.add(port);
+    }
+
+    /**
+     * Releases a previously allocated port back to the pool.
+     * Should be called when the Docker container that was using the port is removed.
+     */
     public void release(int port) {
         if (reserved.remove(port)) {
-            LOG.debugv("Released port {0}", port);
+            LOG.debugv("Released port {0}", String.valueOf(port));
         }
     }
 
+    /**
+     * Finds any free TCP port using ephemeral port allocation.
+     * This is the fastest method when any port will do.
+     *
+     * @return a free port
+     * @throws RuntimeException if no free port can be allocated
+     */
     public int allocateAny() {
         try (ServerSocket socket = new ServerSocket(0)) {
             socket.setReuseAddress(true);
             int port = socket.getLocalPort();
-            LOG.debugv("Allocated ephemeral port {0}", port);
+            LOG.debugv("Allocated ephemeral port {0}", String.valueOf(port));
             return port;
         } catch (IOException e) {
             throw new RuntimeException("Could not find a free port", e);
         }
     }
 
+    /**
+     * Checks if a specific port is currently free.
+     *
+     * @param port the port to check
+     * @return true if the port is available, false otherwise
+     */
     public boolean isPortFree(int port) {
         try (ServerSocket socket = new ServerSocket(port)) {
             socket.setReuseAddress(true);

--- a/src/test/java/io/floci/az/core/docker/ContainerLifecycleManagerLabelsTest.java
+++ b/src/test/java/io/floci/az/core/docker/ContainerLifecycleManagerLabelsTest.java
@@ -77,7 +77,7 @@ class ContainerLifecycleManagerLabelsTest {
         ContainerSpec spec = new ContainerSpec(
                 "busybox:stable", null, List.of(), null, null, null, Map.of(), List.of(), null,
                 List.of(), List.of(), List.of(), Map.of("floci_service", "functions"), null, false,
-                List.of(), null);
+                null, List.of(), null, null, List.of());
 
         manager().create(spec);
 

--- a/src/test/java/io/floci/az/core/docker/ContainerLifecycleManagerStartFailureTest.java
+++ b/src/test/java/io/floci/az/core/docker/ContainerLifecycleManagerStartFailureTest.java
@@ -1,0 +1,87 @@
+package io.floci.az.core.docker;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.RemoveContainerCmd;
+import io.floci.az.config.EmulatorConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link ContainerLifecycleManager#createAndStart} must not leak the created
+ * container when the start step fails (e.g. a host-port conflict):
+ * retrying callers would otherwise accumulate {@code Created} containers, and
+ * fixed-name callers would hit name conflicts on their next attempt.
+ */
+@ExtendWith(MockitoExtension.class)
+class ContainerLifecycleManagerStartFailureTest {
+
+    @Mock
+    private DockerClient dockerClient;
+
+    @Mock
+    private ImageCacheService imageCacheService;
+
+    @Mock
+    private ContainerDetector containerDetector;
+
+    @Mock
+    private PortAllocator portAllocator;
+
+    @Mock
+    private EmulatorConfig config;
+
+    private ContainerLifecycleManager manager;
+    private final ContainerSpec spec = new ContainerSpec("busybox:latest");
+
+    @BeforeEach
+    void setUp() {
+        manager = spy(new ContainerLifecycleManager(
+                dockerClient, imageCacheService, containerDetector, portAllocator, config));
+    }
+
+    @Test
+    void createAndStartRemovesCreatedContainerWhenStartFails() {
+        RuntimeException startFailure =
+                new RuntimeException("Bind for 0.0.0.0:80 failed: port is already allocated");
+        doReturn("container-id").when(manager).create(spec);
+        doThrow(startFailure).when(manager).startCreated("container-id", spec);
+
+        RemoveContainerCmd removeCmd = mock(RemoveContainerCmd.class);
+        when(dockerClient.removeContainerCmd("container-id")).thenReturn(removeCmd);
+        when(removeCmd.withForce(true)).thenReturn(removeCmd);
+
+        RuntimeException thrown = assertThrows(RuntimeException.class,
+                () -> manager.createAndStart(spec));
+
+        assertSame(startFailure, thrown, "original start failure must propagate");
+        verify(removeCmd).exec();
+    }
+
+    @Test
+    void createAndStartDoesNotRemoveContainerOnSuccess() {
+        ContainerLifecycleManager.ContainerInfo info =
+                new ContainerLifecycleManager.ContainerInfo("container-id", Map.of());
+        doReturn("container-id").when(manager).create(spec);
+        doReturn(info).when(manager).startCreated("container-id", spec);
+
+        assertSame(info, manager.createAndStart(spec));
+
+        verify(dockerClient, never()).removeContainerCmd(any(String.class));
+    }
+}

--- a/src/test/java/io/floci/az/core/docker/ImageCacheServiceTest.java
+++ b/src/test/java/io/floci/az/core/docker/ImageCacheServiceTest.java
@@ -1,0 +1,118 @@
+package io.floci.az.core.docker;
+
+import com.github.dockerjava.api.exception.DockerClientException;
+import com.github.dockerjava.api.exception.DockerException;
+import com.github.dockerjava.api.exception.InternalServerErrorException;
+import com.github.dockerjava.api.exception.NotFoundException;
+import com.github.dockerjava.api.exception.UnauthorizedException;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ImageCacheServiceTest {
+
+    private static final String IMAGE = "mcr.microsoft.com/azure-storage/azurite:latest";
+
+    @Test
+    void succeedsOnFirstAttempt() throws Exception {
+        AtomicInteger calls = new AtomicInteger();
+        ImageCacheService.runWithRetry(IMAGE, 3, 1L, calls::incrementAndGet);
+        assertEquals(1, calls.get());
+    }
+
+    @Test
+    void retriesOnTransient500AndSucceeds() throws Exception {
+        AtomicInteger calls = new AtomicInteger();
+        ImageCacheService.runWithRetry(IMAGE, 3, 1L, () -> {
+            int attempt = calls.incrementAndGet();
+            if (attempt < 3) {
+                throw new InternalServerErrorException(
+                        "Status 500: {\"message\":\"toomanyrequests: Rate exceeded\"}");
+            }
+        });
+        assertEquals(3, calls.get());
+    }
+
+    @Test
+    void exhaustsAttemptsAndRethrowsLast500() {
+        AtomicInteger calls = new AtomicInteger();
+        InternalServerErrorException ex = assertThrows(InternalServerErrorException.class,
+                () -> ImageCacheService.runWithRetry(IMAGE, 3, 1L, () -> {
+                    calls.incrementAndGet();
+                    throw new InternalServerErrorException("backend unavailable");
+                }));
+        assertEquals(3, calls.get());
+        assertTrue(ex.getMessage().contains("backend unavailable"));
+    }
+
+    @Test
+    void doesNotRetryOnNotFound() {
+        AtomicInteger calls = new AtomicInteger();
+        assertThrows(NotFoundException.class,
+                () -> ImageCacheService.runWithRetry(IMAGE, 3, 1L, () -> {
+                    calls.incrementAndGet();
+                    throw new NotFoundException("manifest unknown");
+                }));
+        assertEquals(1, calls.get());
+    }
+
+    @Test
+    void doesNotRetryOnUnauthorized() {
+        AtomicInteger calls = new AtomicInteger();
+        assertThrows(UnauthorizedException.class,
+                () -> ImageCacheService.runWithRetry(IMAGE, 3, 1L, () -> {
+                    calls.incrementAndGet();
+                    throw new UnauthorizedException("denied");
+                }));
+        assertEquals(1, calls.get());
+    }
+
+    @Test
+    void doesNotRetryOnGenericDockerException() {
+        AtomicInteger calls = new AtomicInteger();
+        assertThrows(DockerException.class,
+                () -> ImageCacheService.runWithRetry(IMAGE, 3, 1L, () -> {
+                    calls.incrementAndGet();
+                    throw new DockerException("connection refused", -1);
+                }));
+        assertEquals(1, calls.get());
+    }
+
+    @Test
+    void retriesOnPullWrapperDockerClientExceptionAndSucceeds() throws Exception {
+        AtomicInteger calls = new AtomicInteger();
+        ImageCacheService.runWithRetry(IMAGE, 3, 1L, () -> {
+            if (calls.incrementAndGet() < 2) {
+                throw new DockerClientException(
+                        "Could not pull image: toomanyrequests: Rate exceeded");
+            }
+        });
+        assertEquals(2, calls.get());
+    }
+
+    @Test
+    void doesNotRetryOnNonPullDockerClientException() {
+        AtomicInteger calls = new AtomicInteger();
+        assertThrows(DockerClientException.class,
+                () -> ImageCacheService.runWithRetry(IMAGE, 3, 1L, () -> {
+                    calls.incrementAndGet();
+                    throw new DockerClientException("container start failed: exit 137");
+                }));
+        assertEquals(1, calls.get());
+    }
+
+    @Test
+    void propagatesInterrupted() {
+        AtomicInteger calls = new AtomicInteger();
+        assertThrows(InterruptedException.class,
+                () -> ImageCacheService.runWithRetry(IMAGE, 3, 1L, () -> {
+                    calls.incrementAndGet();
+                    throw new InterruptedException("interrupted mid-pull");
+                }));
+        assertEquals(1, calls.get());
+    }
+}


### PR DESCRIPTION
## Summary

Converges the sidecar container infrastructure (`core/docker`) on floci-aws baseline `0142dc4`:

- `ContainerLifecycleManager`: treat a failed `docker inspect` as not-running so dead containers are never reused (floci-aws `47abda8e`); remove the created container when start fails (`3771c1e9`); wire user/cgroupnsMode/groupAdd; shared-volume POSIX init with run-once guard (`45ed00eb`); `adopt()` + published-host-port tracking with extended `ContainerInfo` (`6d1d892a`); locale-safe port logging (`0467eebf`)
- `PortAllocator`: `markReserved()` for surviving-container ports (`a27971c7`)
- `ImageCacheService`: retry transient registry failures with exponential backoff (`44da9da6`)
- `CurrentContainerNetworkResolver`: prefer usable user-defined networks over bridge/host/none (`ded329be`), keeping the HOSTNAME-env fallback
- `ContainerBuilder`/`ContainerSpec`: registry-base image normalization (`fef03c6b`), read-only named volumes (`56f84698`), cgroupns/user/groupAdd passthrough

Kept az-authored behavior: container/volume labeling (#157), sidecar network-at-creation (#95), start/stop/restart, centralized exec/copy. Deferred: embedded-DNS fallback wiring (lands with the dns/tls convergence), `docker.image-registry-base` config property.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

No wire-protocol change; fixes sidecar reliability. Previously a dead-but-present container could be adopted and never restarted, a failed start leaked the created container, and a transient registry error failed the pull outright.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
