### PR TITLE
refactor(core): converge runtime/util cluster on floci-aws baseline 0142dc4

### DIFF
--- a/src/main/java/io/floci/az/core/AdminController.java
+++ b/src/main/java/io/floci/az/core/AdminController.java
@@ -36,7 +36,7 @@ public class AdminController {
     /**
      * Wipes all emulator state across every service. Every state-holding
      * component self-registers by implementing {@link Resettable}; each
-     * {@code clearAll()} is self-contained (services with sidecar containers
+     * {@code clear()} is self-contained (services with sidecar containers
      * stop them themselves). The reset is best-effort: a failing handler is
      * logged and skipped so the remaining services still get cleared — CDI
      * iteration order is non-deterministic, so one failure must not decide
@@ -48,7 +48,7 @@ public class AdminController {
     public Response reset() {
         for (Resettable resettable : resettables) {
             try {
-                resettable.clearAll();
+                resettable.clear();
             } catch (Exception e) {
                 LOG.errorf(e, "Reset failed for %s — continuing with remaining services",
                         resettable.getClass().getSimpleName());

--- a/src/main/java/io/floci/az/core/HealthController.java
+++ b/src/main/java/io/floci/az/core/HealthController.java
@@ -5,20 +5,32 @@ import io.floci.az.core.tls.TlsConfigSource;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 @Path("/")
+@Produces(MediaType.APPLICATION_JSON)
 public class HealthController {
 
     @Inject EmulatorConfig config;
 
+    private static final String VERSION = resolveVersion();
+
+    static String resolveVersion() {
+        String env = System.getenv("FLOCI_AZ_VERSION");
+        if (env != null && !env.isBlank()) {
+            return env;
+        }
+        return "dev";
+    }
+
     @GET
     @Path("{path:(health|_floci/health)}")
     public Response health() {
-        String version = System.getenv("FLOCI_AZ_VERSION");
-        if (version == null) version = "dev";
+        String version = VERSION;
 
         return Response.ok(Map.of(
             "status", "UP",

--- a/src/main/java/io/floci/az/core/Resettable.java
+++ b/src/main/java/io/floci/az/core/Resettable.java
@@ -4,10 +4,10 @@ package io.floci.az.core;
  * A state-holding service component that can wipe all of its emulator state.
  * Implementations are discovered via CDI ({@code Instance<Resettable>}) and
  * invoked by {@code POST /_admin/reset} in no particular order, so
- * {@link #clearAll()} must be self-contained (a service that manages sidecar
+ * {@link #clear()} must be self-contained (a service that manages sidecar
  * containers stops them itself) and idempotent.
  */
 public interface Resettable {
 
-    void clearAll();
+    void clear();
 }

--- a/src/main/java/io/floci/az/core/XmlParser.java
+++ b/src/main/java/io/floci/az/core/XmlParser.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import org.jboss.logging.Logger;
 
 /**
  * Lightweight StAX-based helpers for parsing XML request bodies.
@@ -19,6 +20,8 @@ import java.util.Map;
  * All methods silently return empty collections on malformed input.
  */
 public final class XmlParser {
+
+    private static final Logger LOG = Logger.getLogger(XmlParser.class);
 
     private static final XMLInputFactory FACTORY;
 
@@ -84,7 +87,9 @@ public final class XmlParser {
                 }
             }
             r.close();
-        } catch (Exception ignored) {}
+        } catch (Exception e) {
+            LOG.debugv("Ignoring malformed XML during parse: {0}", e.getMessage());
+        }
         return result;
     }
 
@@ -139,7 +144,9 @@ public final class XmlParser {
                 }
             }
             r.close();
-        } catch (Exception ignored) {}
+        } catch (Exception e) {
+            LOG.debugv("Ignoring malformed XML during parse: {0}", e.getMessage());
+        }
         return result;
     }
 
@@ -181,7 +188,9 @@ public final class XmlParser {
                 }
             }
             r.close();
-        } catch (Exception ignored) {}
+        } catch (Exception e) {
+            LOG.debugv("Ignoring malformed XML during parse: {0}", e.getMessage());
+        }
         return result;
     }
 
@@ -222,7 +231,9 @@ public final class XmlParser {
                 }
             }
             r.close();
-        } catch (Exception ignored) {}
+        } catch (Exception e) {
+            LOG.debugv("Ignoring malformed XML during parse: {0}", e.getMessage());
+        }
         return result;
     }
 
@@ -271,7 +282,57 @@ public final class XmlParser {
                 }
             }
             r.close();
-        } catch (Exception ignored) {}
+        } catch (Exception e) {
+            LOG.debugv("Ignoring malformed XML during parse: {0}", e.getMessage());
+        }
+        return result;
+    }
+
+    /**
+     * Returns the local names of the direct child elements of the first
+     * {@code parentElement}, in document order, or an empty list when the
+     * parent is absent. Unlike {@link #extractGroups(String, String)}, children
+     * are reported whether they are leaves or containers.
+     *
+     * <pre>{@code
+     * List<String> children = XmlParser.childElementNames(body, "Filters");
+     * // <Filters><CorrelationFilter>...</CorrelationFilter></Filters> → [CorrelationFilter]
+     * }</pre>
+     */
+    public static List<String> childElementNames(String xml, String parentElement) {
+        List<String> result = new ArrayList<>();
+        if (xml == null || xml.isEmpty()) {
+            return result;
+        }
+        try {
+            XMLStreamReader r = FACTORY.createXMLStreamReader(new StringReader(xml));
+            boolean inParent = false;
+            int depth = 0;
+            while (r.hasNext()) {
+                int event = r.next();
+                if (event == XMLStreamConstants.START_ELEMENT) {
+                    if (!inParent) {
+                        if (parentElement.equals(r.getLocalName())) {
+                            inParent = true;
+                            depth = 1;
+                        }
+                    } else {
+                        if (depth == 1) {
+                            result.add(r.getLocalName());
+                        }
+                        depth++;
+                    }
+                } else if (event == XMLStreamConstants.END_ELEMENT && inParent) {
+                    depth--;
+                    if (depth == 0) {
+                        break;
+                    }
+                }
+            }
+            r.close();
+        } catch (Exception e) {
+            LOG.debugv("Ignoring malformed XML during parse: {0}", e.getMessage());
+        }
         return result;
     }
 }

--- a/src/main/java/io/floci/az/services/acr/AcrHandler.java
+++ b/src/main/java/io/floci/az/services/acr/AcrHandler.java
@@ -552,7 +552,7 @@ public class AcrHandler implements AzureServiceHandler, Resettable {
     }
 
     /** Wipes all ACR data — used by {@code POST /_admin/reset}. */
-    public void clearAll() {
+    public void clear() {
         storage.clear();
     }
 }

--- a/src/main/java/io/floci/az/services/aks/AksHandler.java
+++ b/src/main/java/io/floci/az/services/aks/AksHandler.java
@@ -637,7 +637,7 @@ public class AksHandler implements AzureServiceHandler, Resettable {
     }
 
     /** Wipes all AKS data — used by {@code POST /_admin/reset}. */
-    public void clearAll() {
+    public void clear() {
         storage.clear();
     }
 }

--- a/src/main/java/io/floci/az/services/apim/ApiManagementHandler.java
+++ b/src/main/java/io/floci/az/services/apim/ApiManagementHandler.java
@@ -79,7 +79,7 @@ public class ApiManagementHandler implements AzureServiceHandler, Resettable, Ar
     }
 
     @Override
-    public void clearAll() {
-        service.clearAll();
+    public void clear() {
+        service.clear();
     }
 }

--- a/src/main/java/io/floci/az/services/apim/ApiManagementService.java
+++ b/src/main/java/io/floci/az/services/apim/ApiManagementService.java
@@ -744,7 +744,7 @@ public class ApiManagementService {
                 .toString().replace("-", "");
     }
 
-    public void clearAll() {
+    public void clear() {
         services.clear();
         apis.clear();
         operations.clear();

--- a/src/main/java/io/floci/az/services/appconfig/AppConfigHandler.java
+++ b/src/main/java/io/floci/az/services/appconfig/AppConfigHandler.java
@@ -919,7 +919,7 @@ public class AppConfigHandler implements AzureServiceHandler, Resettable {
     // Public API
     // -------------------------------------------------------------------------
 
-    public void clearAll() {
+    public void clear() {
         store.clear();
         syncTokens.clear();
     }

--- a/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
+++ b/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
@@ -736,7 +736,7 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
         return ids;
     }
 
-    public void clearAll() {
+    public void clear() {
         store.clear();
     }
 

--- a/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
@@ -1265,5 +1265,5 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
 
     private String quoted(String s) { return "\"" + s + "\""; }
 
-    public void clearAll() { store.clear(); }
+    public void clear() { store.clear(); }
 }

--- a/src/main/java/io/floci/az/services/email/EmailHandler.java
+++ b/src/main/java/io/floci/az/services/email/EmailHandler.java
@@ -483,7 +483,7 @@ public class EmailHandler implements AzureServiceHandler, Resettable {
     }
 
     /** Wipes all email data — used by {@code POST /_admin/reset}. */
-    public void clearAll() {
+    public void clear() {
         emailStorage.clear();
         communicationServices.clear();
         emailServices.clear();

--- a/src/main/java/io/floci/az/services/eventgrid/EventGridHandler.java
+++ b/src/main/java/io/floci/az/services/eventgrid/EventGridHandler.java
@@ -98,8 +98,8 @@ public class EventGridHandler implements AzureServiceHandler, Resettable, ArmPro
                 + path + "\"}}").type("application/json").build();
     }
 
-    public void clearAll() {
-        service.clearAll();
+    public void clear() {
+        service.clear();
     }
 
     private static String stripQuery(String path) {

--- a/src/main/java/io/floci/az/services/eventgrid/EventGridService.java
+++ b/src/main/java/io/floci/az/services/eventgrid/EventGridService.java
@@ -253,7 +253,7 @@ public class EventGridService {
                 .toList();
     }
 
-    public void clearAll() {
+    public void clear() {
         store.clear();
     }
 

--- a/src/main/java/io/floci/az/services/eventhub/EventHubHandler.java
+++ b/src/main/java/io/floci/az/services/eventhub/EventHubHandler.java
@@ -349,7 +349,7 @@ public class EventHubHandler implements AzureServiceHandler, Resettable {
      * Stops all Event Hubs sidecar containers (Artemis, Redpanda) and clears namespace state.
      * Used by {@code POST /_admin/reset} for test isolation.
      */
-    public void clearAll() {
+    public void clear() {
         namespaceManager.shutdownAll();
         kafkaManager.stop();
     }

--- a/src/main/java/io/floci/az/services/functions/FunctionsServiceHandler.java
+++ b/src/main/java/io/floci/az/services/functions/FunctionsServiceHandler.java
@@ -350,7 +350,7 @@ public class FunctionsServiceHandler implements AzureServiceHandler, Resettable 
 
     // ── Helpers ───────────────────────────────────────────────────────────────
 
-    public void clearAll() {
+    public void clear() {
         store.clear();
     }
 

--- a/src/main/java/io/floci/az/services/keyvault/KeyVaultHandler.java
+++ b/src/main/java/io/floci/az/services/keyvault/KeyVaultHandler.java
@@ -660,7 +660,7 @@ public class KeyVaultHandler implements AzureServiceHandler, Resettable {
     }
 
     /** Wipes all Key Vault data — used by {@code POST /_admin/reset}. */
-    public void clearAll() {
+    public void clear() {
         store.clear();
     }
 }

--- a/src/main/java/io/floci/az/services/managedidentity/ManagedIdentityHandler.java
+++ b/src/main/java/io/floci/az/services/managedidentity/ManagedIdentityHandler.java
@@ -133,8 +133,8 @@ public class ManagedIdentityHandler implements AzureServiceHandler, Resettable {
     }
 
     @Override
-    public void clearAll() {
-        store.clearAll();
+    public void clear() {
+        store.clear();
     }
 
     /** ARM-shaped identities in a resource group, for ArmHandler's RG resource listing. */

--- a/src/main/java/io/floci/az/services/managedidentity/ManagedIdentityStore.java
+++ b/src/main/java/io/floci/az/services/managedidentity/ManagedIdentityStore.java
@@ -95,7 +95,7 @@ public class ManagedIdentityStore {
                 .findFirst();
     }
 
-    public void clearAll() {
+    public void clear() {
         identities.clear();
         federatedCredentials.clear();
     }

--- a/src/main/java/io/floci/az/services/mariadb/MariaDbHandler.java
+++ b/src/main/java/io/floci/az/services/mariadb/MariaDbHandler.java
@@ -631,13 +631,13 @@ public class MariaDbHandler implements AzureServiceHandler, Resettable {
                 "message", "Azure Database for MariaDB service is disabled on this emulator."))).build();
     }
 
-    public void clearAll() {
+    public void clear() {
         state.listServers().forEach(entry -> {
             try { serverManager.stopServer(entry); } catch (Exception e) {
                 LOG.warnf(e, "Error stopping MariaDB container during reset: server=%s", entry.serverName());
             }
         });
-        state.clearAll();
+        state.clear();
         startLocks.clear();
     }
 }

--- a/src/main/java/io/floci/az/services/mariadb/MariaDbState.java
+++ b/src/main/java/io/floci/az/services/mariadb/MariaDbState.java
@@ -171,7 +171,7 @@ public class MariaDbState {
 
     // ── Reset ─────────────────────────────────────────────────────────────────
 
-    public synchronized void clearAll() {
+    public synchronized void clear() {
         servers.clear();
         store.clear();
     }

--- a/src/main/java/io/floci/az/services/monitor/MonitorHandler.java
+++ b/src/main/java/io/floci/az/services/monitor/MonitorHandler.java
@@ -679,7 +679,7 @@ public class MonitorHandler implements AzureServiceHandler, Resettable, ArmProvi
             .toList();
     }
 
-    public void clearAll() {
+    public void clear() {
         store.clear();
     }
 }

--- a/src/main/java/io/floci/az/services/mysql/MySqlHandler.java
+++ b/src/main/java/io/floci/az/services/mysql/MySqlHandler.java
@@ -637,13 +637,13 @@ public class MySqlHandler implements AzureServiceHandler, Resettable {
                 "message", "Azure Database for MySQL service is disabled on this emulator."))).build();
     }
 
-    public void clearAll() {
+    public void clear() {
         state.listServers().forEach(entry -> {
             try { serverManager.stopServer(entry); } catch (Exception e) {
                 LOG.warnf(e, "Error stopping MySQL container during reset: server=%s", entry.serverName());
             }
         });
-        state.clearAll();
+        state.clear();
         startLocks.clear();
     }
 }

--- a/src/main/java/io/floci/az/services/mysql/MySqlState.java
+++ b/src/main/java/io/floci/az/services/mysql/MySqlState.java
@@ -170,7 +170,7 @@ public class MySqlState {
 
     // ── Reset ─────────────────────────────────────────────────────────────────
 
-    public synchronized void clearAll() {
+    public synchronized void clear() {
         servers.clear();
         store.clear();
     }

--- a/src/main/java/io/floci/az/services/network/NetworkHandler.java
+++ b/src/main/java/io/floci/az/services/network/NetworkHandler.java
@@ -35,7 +35,7 @@ public class NetworkHandler implements Resettable {
     }
 
     @Override
-    public void clearAll() {
-        service.clearAll();
+    public void clear() {
+        service.clear();
     }
 }

--- a/src/main/java/io/floci/az/services/network/NetworkService.java
+++ b/src/main/java/io/floci/az/services/network/NetworkService.java
@@ -108,7 +108,7 @@ public class NetworkService {
                 .toList();
     }
 
-    public void clearAll() {
+    public void clear() {
         resources.clear();
     }
 

--- a/src/main/java/io/floci/az/services/postgres/PostgresHandler.java
+++ b/src/main/java/io/floci/az/services/postgres/PostgresHandler.java
@@ -587,13 +587,13 @@ public class PostgresHandler implements AzureServiceHandler, Resettable {
      * Stops all running PostgreSQL containers and wipes state.
      * Used by {@code POST /_admin/reset} for test isolation.
      */
-    public void clearAll() {
+    public void clear() {
         state.listServers().forEach(entry -> {
             try { serverManager.stopServer(entry); } catch (Exception e) {
                 LOG.warnf(e, "Error stopping PostgreSQL container during reset: server=%s", entry.serverName());
             }
         });
-        state.clearAll();
+        state.clear();
         startLocks.clear();
     }
 }

--- a/src/main/java/io/floci/az/services/postgres/PostgresState.java
+++ b/src/main/java/io/floci/az/services/postgres/PostgresState.java
@@ -187,7 +187,7 @@ public class PostgresState {
      * cache and the persistence backend.
      * Callers are responsible for stopping running containers beforehand.
      */
-    public synchronized void clearAll() {
+    public synchronized void clear() {
         servers.clear();
         store.clear();
     }

--- a/src/main/java/io/floci/az/services/queue/QueueServiceHandler.java
+++ b/src/main/java/io/floci/az/services/queue/QueueServiceHandler.java
@@ -580,7 +580,7 @@ public class QueueServiceHandler implements AzureServiceHandler, Resettable {
         }
     }
 
-    public void clearAll() {
+    public void clear() {
         store.clear();
     }
 

--- a/src/main/java/io/floci/az/services/redis/RedisHandler.java
+++ b/src/main/java/io/floci/az/services/redis/RedisHandler.java
@@ -504,7 +504,7 @@ public class RedisHandler implements AzureServiceHandler, Resettable {
     }
 
     /** Wipes all Redis data — used by {@code POST /_admin/reset}. */
-    public void clearAll() {
+    public void clear() {
         storage.clear();
     }
 }

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
@@ -1170,7 +1170,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
     }
 
     /** Wipes all Service Bus data — used by {@code POST /_admin/reset}. */
-    public void clearAll() {
+    public void clear() {
         store.clear();
     }
 }

--- a/src/main/java/io/floci/az/services/sql/SqlHandler.java
+++ b/src/main/java/io/floci/az/services/sql/SqlHandler.java
@@ -606,13 +606,13 @@ public class SqlHandler implements AzureServiceHandler, Resettable {
      * Stops all running SQL Server containers and wipes state.
      * Used by {@code POST /_admin/reset} for test isolation.
      */
-    public void clearAll() {
+    public void clear() {
         state.listServers().forEach(entry -> {
             try { serverManager.stopServer(entry); } catch (Exception e) {
                 LOG.warnf(e, "Error stopping SQL container during reset: server=%s", entry.serverName());
             }
         });
-        state.clearAll();
+        state.clear();
         startLocks.clear();
     }
 }

--- a/src/main/java/io/floci/az/services/sql/SqlState.java
+++ b/src/main/java/io/floci/az/services/sql/SqlState.java
@@ -169,7 +169,7 @@ public class SqlState {
      * cache and the persistence backend.
      * Callers are responsible for stopping running containers beforehand.
      */
-    public synchronized void clearAll() {
+    public synchronized void clear() {
         servers.clear();
         store.clear();
     }

--- a/src/main/java/io/floci/az/services/table/TableServiceHandler.java
+++ b/src/main/java/io/floci/az/services/table/TableServiceHandler.java
@@ -1091,7 +1091,7 @@ public class TableServiceHandler implements AzureServiceHandler, Resettable {
     // Utility helpers
     // -------------------------------------------------------------------------
 
-    public void clearAll() {
+    public void clear() {
         store.clear();
     }
 

--- a/src/main/java/io/floci/az/services/vm/VmHandler.java
+++ b/src/main/java/io/floci/az/services/vm/VmHandler.java
@@ -546,7 +546,7 @@ public class VmHandler implements AzureServiceHandler, Resettable {
     }
 
     /** Wipes all VM data — used by {@code POST /_admin/reset}. */
-    public void clearAll() {
+    public void clear() {
         storage.clear();
     }
 }

--- a/src/test/java/io/floci/az/services/mariadb/MariaDbStateTest.java
+++ b/src/test/java/io/floci/az/services/mariadb/MariaDbStateTest.java
@@ -139,10 +139,10 @@ class MariaDbStateTest {
     }
 
     @Test
-    @DisplayName("clearAll empties state")
-    void clearAll() {
+    @DisplayName("clear empties state")
+    void clear() {
         state.putServer(server("x"));
-        state.clearAll();
+        state.clear();
         assertEquals(0, state.listServers().size());
     }
 }

--- a/src/test/java/io/floci/az/services/mysql/MySqlStateTest.java
+++ b/src/test/java/io/floci/az/services/mysql/MySqlStateTest.java
@@ -147,10 +147,10 @@ class MySqlStateTest {
     }
 
     @Test
-    @DisplayName("clearAll empties state")
-    void clearAll() {
+    @DisplayName("clear empties state")
+    void clear() {
         state.putServer(server("x"));
-        state.clearAll();
+        state.clear();
         assertEquals(0, state.listServers().size());
     }
 }

--- a/src/test/java/io/floci/az/services/postgres/PostgresStateTest.java
+++ b/src/test/java/io/floci/az/services/postgres/PostgresStateTest.java
@@ -238,8 +238,8 @@ class PostgresStateTest {
     }
 
     @Test
-    @DisplayName("clearAll removes entries from both in-memory cache and backend")
-    void clearAllPurgesBackend() {
+    @DisplayName("clear removes entries from both in-memory cache and backend")
+    void clearPurgesBackend() {
         InMemoryStorage<String, StoredObject> sharedBackend = new InMemoryStorage<>();
         PostgresState s = new PostgresState(sharedBackend);
 
@@ -247,7 +247,7 @@ class PostgresStateTest {
         s.putServer(server("s2"));
         assertEquals(2, s.listServers().size());
 
-        s.clearAll();
+        s.clear();
         assertEquals(0, s.listServers().size(), "in-memory cache cleared");
 
         PostgresState reloaded = new PostgresState(sharedBackend);

--- a/src/test/java/io/floci/az/services/sql/SqlStateTest.java
+++ b/src/test/java/io/floci/az/services/sql/SqlStateTest.java
@@ -304,8 +304,8 @@ class SqlStateTest {
     }
 
     @Test
-    @DisplayName("clearAll removes entries from both in-memory cache and backend")
-    void clearAllPurgesBackend() {
+    @DisplayName("clear removes entries from both in-memory cache and backend")
+    void clearPurgesBackend() {
         InMemoryStorage<String, StoredObject> sharedBackend = new InMemoryStorage<>();
         SqlState s = new SqlState(sharedBackend);
 
@@ -313,7 +313,7 @@ class SqlStateTest {
         s.putServer(server("s2"));
         assertEquals(2, s.listServers().size());
 
-        s.clearAll();
+        s.clear();
         assertEquals(0, s.listServers().size(), "in-memory cache cleared");
 
         // A fresh load from the same backend must also be empty


### PR DESCRIPTION
## Summary

Converges the runtime/util cluster on floci-aws baseline `0142dc4`:

- `Resettable`: rename `clearAll()` → `clear()` to match the baseline contract (mechanical rename across all implementors and call sites; no collisions)
- `HealthController`: resolve the version once with a blank-env guard so `FLOCI_AZ_VERSION=""` no longer yields an empty version string (pattern from floci-aws `fb420876`); produce JSON at class level
- `XmlParser`: log swallowed malformed-XML parse errors at debug instead of silently ignoring them, and add `childElementNames()` for container-aware child listing (floci-aws `959eb167`)

az-authored `XmlParser`/`XmlBuilder` additions (`newStreamReader`, `readLeafText`, `startAttr`/`selfClose`, `toString`) are untouched; they were folded back into floci-aws separately.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## Azure Compatibility

No wire-protocol change; internal contract alignment with the floci-aws baseline. The health endpoint response is unchanged except that a blank `FLOCI_AZ_VERSION` env var no longer produces an empty version string.

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added — test changes are the mechanical `clearAll()` → `clear()` rename only; the health-version guard and `childElementNames()` have no direct new coverage
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
