### PR TITLE
fix(storage): converge storage cluster on floci-aws baseline 0142dc4

### DIFF
--- a/src/main/java/io/floci/az/core/storage/InMemoryStorage.java
+++ b/src/main/java/io/floci/az/core/storage/InMemoryStorage.java
@@ -8,6 +8,10 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 
+/**
+ * Thread-safe in-memory storage backed by ConcurrentHashMap.
+ * No persistence — data is lost on shutdown unless explicitly flushed.
+ */
 public class InMemoryStorage<K, V> implements StorageBackend<K, V> {
 
     private final ConcurrentHashMap<K, V> store = new ConcurrentHashMap<>();

--- a/src/main/java/io/floci/az/core/storage/PersistentStorage.java
+++ b/src/main/java/io/floci/az/core/storage/PersistentStorage.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 /**
  * JSON file-backed persistent storage.
  * Write-through on every put/delete.
+ * Loads all data into memory on startup.
  * Uses atomic writes (temp file + rename) for safety.
  */
 public class PersistentStorage<K, V> implements StorageBackend<K, V> {
@@ -90,7 +91,25 @@ public class PersistentStorage<K, V> implements StorageBackend<K, V> {
             store.putAll(data);
             LOG.infov("Loaded {0} entries from {1}", store.size(), filePath);
         } catch (IOException e) {
-            LOG.errorv(e, "Failed to load data from {0}", filePath);
+            // Starting empty here silently drops all persisted state for this store, which can leave
+            // other services referencing resources that now appear missing. Quarantine the unreadable
+            // file and log loudly so the data loss is detectable rather than masquerading as an
+            // empty store.
+            quarantineUnreadableFile(e);
+        }
+    }
+
+    private void quarantineUnreadableFile(IOException cause) {
+        Path quarantine = filePath.resolveSibling(filePath.getFileName() + ".corrupt");
+        try {
+            Files.move(filePath, quarantine, StandardCopyOption.REPLACE_EXISTING);
+            LOG.errorv(cause, "Failed to load persisted data from {0}; moved the unreadable file to "
+                    + "{1} and started with an empty store. This store's state was lost.",
+                    filePath, quarantine);
+        } catch (IOException moveError) {
+            LOG.errorv(cause, "Failed to load persisted data from {0}; could not quarantine it ({1}). "
+                    + "Starting with an empty store. This store's state was lost.",
+                    filePath, moveError.getMessage());
         }
     }
 

--- a/src/main/java/io/floci/az/core/storage/StorageBackend.java
+++ b/src/main/java/io/floci/az/core/storage/StorageBackend.java
@@ -19,13 +19,21 @@ public interface StorageBackend<K, V> {
 
     void delete(K key);
 
+    /**
+     * Return a new mutable list of values whose keys pass the filter. Callers may sort,
+     * filter, or otherwise mutate the returned list without affecting the underlying store.
+     */
     List<V> scan(Predicate<K> keyFilter);
 
+    /** Return all keys in this store. */
     Set<K> keys();
 
+    /** Persist data to disk if applicable. */
     void flush();
 
+    /** Load data from disk on startup. */
     void load();
 
+    /** Clear all data. */
     void clear();
 }

--- a/src/main/java/io/floci/az/core/storage/StorageFactory.java
+++ b/src/main/java/io/floci/az/core/storage/StorageFactory.java
@@ -12,10 +12,15 @@ import org.jboss.logging.Logger;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+/**
+ * Factory that creates {@link StorageBackend} instances based on configuration.
+ * Tracks all created backends for lifecycle management.
+ */
 @ApplicationScoped
 public class StorageFactory {
 
@@ -24,6 +29,10 @@ public class StorageFactory {
     static final TypeReference<Map<String, StoredObject>> TYPE_REF = new TypeReference<>() {};
 
     private final EmulatorConfig config;
+    private final List<StorageBackend<?, ?>> allBackends = new ArrayList<>();
+    // A file path identifies one logical store: callers sharing a path are expected to agree on
+    // its value type and storage mode. The first create() wins; repeat calls reuse that backend.
+    private final Map<Path, StorageBackend<String, StoredObject>> backendsByPath = new HashMap<>();
     private final List<HybridStorage<?, ?>> hybridBackends = new ArrayList<>();
     private final List<WalStorage<?, ?>> walBackends = new ArrayList<>();
 
@@ -37,13 +46,22 @@ public class StorageFactory {
      * Resolves storage mode by checking the service-level override first,
      * falling back to the global persistence mode.
      */
-    public StorageBackend<String, StoredObject> create(String serviceName) {
+    public synchronized StorageBackend<String, StoredObject> create(String serviceName) {
         String mode           = resolveMode(serviceName);
         long flushIntervalMs  = resolveFlushInterval(serviceName);
         Path basePath         = Path.of(config.storage().persistentPath());
         Path filePath         = basePath.resolve(serviceName + ".json");
 
-        LOG.infov("Creating [{0}] storage backend: {1}", mode, serviceName);
+        // Reuse an existing backend for the same file. Handing out a second backend bound to the
+        // same path creates a duplicate in-memory store; on shutdown the stale duplicate flushes
+        // after the active instance and clobbers persisted state.
+        StorageBackend<String, StoredObject> existing = backendsByPath.get(filePath);
+        if (existing != null) {
+            LOG.debugv("Reusing existing [{0}] storage backend: {1} (file: {2})", mode, serviceName, filePath);
+            return existing;
+        }
+
+        LOG.debugv("Creating [{0}] storage backend: {1} (file: {2})", mode, serviceName, filePath);
 
         StorageBackend<String, StoredObject> backend = switch (mode) {
             case "memory"     -> new InMemoryStorage<>();
@@ -65,6 +83,8 @@ public class StorageFactory {
         };
 
         backend.load();
+        allBackends.add(backend);
+        backendsByPath.put(filePath, backend);
         return backend;
     }
 
@@ -72,9 +92,33 @@ public class StorageFactory {
         shutdownAll();
     }
 
-    public void shutdownAll() {
+    /** Load all storage backends from disk. */
+    public synchronized void loadAll() {
+        for (StorageBackend<?, ?> backend : allBackends) {
+            backend.load();
+        }
+    }
+
+    /** Flush all storage backends to disk. */
+    public synchronized void flushAll() {
+        for (StorageBackend<?, ?> backend : allBackends) {
+            backend.flush();
+        }
+    }
+
+    /** Clear all storage backends. */
+    public synchronized void clearAll() {
+        for (StorageBackend<?, ?> backend : allBackends) {
+            backend.clear();
+        }
+        flushAll();
+    }
+
+    /** Shutdown all managed backends (stop schedulers, flush final state). */
+    public synchronized void shutdownAll() {
         hybridBackends.forEach(HybridStorage::shutdown);
         walBackends.forEach(WalStorage::shutdown);
+        flushAll();
     }
 
     private String resolveMode(String serviceName) {

--- a/src/main/java/io/floci/az/core/storage/WalStorage.java
+++ b/src/main/java/io/floci/az/core/storage/WalStorage.java
@@ -251,12 +251,13 @@ public class WalStorage<K, V> implements StorageBackend<K, V> {
                     store.remove(key);
                     replayed++;
                 } else {
-                    LOG.errorv("Unknown WAL op: {0}, stopping replay", op);
+                    LOG.errorv("Unknown WAL op byte: {0}, stopping replay", op);
                     break;
                 }
             }
         } catch (IOException e) {
-            LOG.errorv(e, "Failed to replay WAL (replayed {0} entries before error)", replayed);
+            LOG.errorv(e, "Failed to replay WAL from {0} (replayed {1} entries before error)",
+                    walPath, replayed);
         }
         return replayed;
     }


### PR DESCRIPTION
## Summary

Converges the storage cluster on floci-aws baseline `0142dc4`:

- `PersistentStorage`: quarantine unreadable JSON files as `.corrupt` instead of silently starting empty (floci-aws `04e0f2dd`)
- `StorageFactory`: dedupe backends by resolved file path so two callers sharing a file cannot clobber persisted state on shutdown flush (floci-aws `551df637`); add `loadAll`/`flushAll`/`clearAll` lifecycle methods and flush on shutdown (floci-aws `f4c7a84d`); demote per-backend creation log to debug
- `StorageBackend`: document the mutable-list `scan()` contract (floci-aws `677bad0e`)
- `WalStorage`: restore `walPath` in the replay-failure log and op-byte wording

Deferred (recorded in the hub seam list): principal isolation and `ServiceConfigAccess` require RequestContext/catalog machinery floci-az does not have.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

No wire-protocol change; fixes silent data loss in persistent/hybrid/wal storage modes. Previously a corrupt persistence file wiped state without a trace, and two backends resolving to the same file could overwrite each other's flushed state on shutdown.

## Checklist

- [x] `./mvnw test` passes locally
- [ ] New or updated integration test added — no new tests for the quarantine/dedupe/shutdown-flush behavior; existing suite (567 tests) passes
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
