### PR TITLE
fix(table): wrap error responses in the OData error envelope

### DIFF
--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/TableCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/TableCompatibilityTest.java
@@ -5,6 +5,7 @@ import com.azure.data.tables.TableServiceClient;
 import com.azure.data.tables.TableServiceClientBuilder;
 import com.azure.data.tables.models.ListEntitiesOptions;
 import com.azure.data.tables.models.TableEntity;
+import com.azure.data.tables.models.TableErrorCode;
 import com.azure.data.tables.models.TableEntityUpdateMode;
 import com.azure.data.tables.models.TableServiceException;
 import com.azure.data.tables.models.TableServiceProperties;
@@ -119,6 +120,20 @@ class TableCompatibilityTest {
         TableServiceException ex = assertThrows(TableServiceException.class,
             () -> client.createTable(name));
         assertEquals(409, ex.getResponse().getStatusCode());
+        assertEquals(TableErrorCode.TABLE_ALREADY_EXISTS, ex.getValue().getErrorCode());
+
+        client.deleteTable(name);
+    }
+
+    @Test
+    @DisplayName("createTableIfNotExists on existing table → silent no-op (odata.error envelope)")
+    void createTableIfNotExistsOnExistingTable() {
+        // The SDK only treats the 409 as "already exists" when the body carries
+        // the OData error envelope; a flat error body makes this throw instead.
+        String name = tableName();
+        client.createTable(name);
+
+        assertDoesNotThrow(() -> client.createTableIfNotExists(name));
 
         client.deleteTable(name);
     }

--- a/compatibility-tests/sdk-test-node/tests/table.test.ts
+++ b/compatibility-tests/sdk-test-node/tests/table.test.ts
@@ -79,11 +79,13 @@ test("get missing entity → 404", async () => {
   await client.deleteTable(name);
 });
 
-test("create duplicate table → 409", async () => {
+test("create duplicate table: resolves (SDK swallows TableAlreadyExists)", async () => {
   const name = tableName();
   await client.createTable(name);
 
-  await expect(client.createTable(name)).rejects.toMatchObject({ statusCode: 409 });
+  // The SDK resolves rather than throws on a duplicate create, but only when it
+  // can parse TableAlreadyExists out of the OData error envelope on the 409.
+  await expect(client.createTable(name)).resolves.not.toThrow();
 
   await client.deleteTable(name);
 });

--- a/src/main/java/io/floci/az/core/AzureErrorResponse.java
+++ b/src/main/java/io/floci/az/core/AzureErrorResponse.java
@@ -5,6 +5,8 @@ import io.quarkus.runtime.annotations.RegisterForReflection;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
+import java.util.Map;
+
 @RegisterForReflection
 @JacksonXmlRootElement(localName = "Error")
 public record AzureErrorResponse(
@@ -24,6 +26,18 @@ public record AzureErrorResponse(
             .type(MediaType.APPLICATION_JSON)
             .header("x-ms-error-code", Code)
             .entity(this)
+            .build();
+    }
+
+    // The Table service wraps errors in the OData envelope; SDKs (notably .NET
+    // Azure.Data.Tables) parse the body, not just the x-ms-error-code header.
+    public Response toODataResponse(int httpStatus) {
+        return Response.status(httpStatus)
+            .type("application/json;odata=minimalmetadata")
+            .header("x-ms-error-code", Code)
+            .entity(Map.of("odata.error", Map.of(
+                "code", Code,
+                "message", Map.of("lang", "en-US", "value", Message))))
             .build();
     }
 }

--- a/src/main/java/io/floci/az/services/table/TableServiceHandler.java
+++ b/src/main/java/io/floci/az/services/table/TableServiceHandler.java
@@ -116,7 +116,7 @@ public class TableServiceHandler implements AzureServiceHandler, Resettable {
                 response = deleteTable(request, extractTableNameFromTablesPath(path));
             } else {
                 response = new AzureErrorResponse("NotImplemented", "The requested operation is not implemented.")
-                        .toJsonResponse(501);
+                        .toODataResponse(501);
             }
         } else {
             String tableName;
@@ -142,7 +142,7 @@ public class TableServiceHandler implements AzureServiceHandler, Resettable {
                 response = updateEntity(request, tableName, pkRkPart);
             } else {
                 response = new AzureErrorResponse("NotImplemented", "The requested operation is not implemented.")
-                        .toJsonResponse(501);
+                        .toODataResponse(501);
             }
         }
 
@@ -189,7 +189,7 @@ public class TableServiceHandler implements AzureServiceHandler, Resettable {
             String key = nsKey(request.accountName(), req.TableName());
             if (store.get(key).isPresent()) {
                 return new AzureErrorResponse("TableAlreadyExists", "The table specified already exists.")
-                        .toJsonResponse(Response.Status.CONFLICT.getStatusCode());
+                        .toODataResponse(Response.Status.CONFLICT.getStatusCode());
             }
             store.put(key, NS_SENTINEL);
             return Response.status(Response.Status.CREATED)
@@ -236,7 +236,7 @@ public class TableServiceHandler implements AzureServiceHandler, Resettable {
             if (pk == null || rk == null) {
                 return new AzureErrorResponse("PropertiesNeedValue",
                         "PartitionKey and RowKey are required.")
-                        .toJsonResponse(Response.Status.BAD_REQUEST.getStatusCode());
+                        .toODataResponse(Response.Status.BAD_REQUEST.getStatusCode());
             }
             String key = pk + "_" + rk;
             String etag = UUID.randomUUID().toString();
@@ -272,7 +272,7 @@ public class TableServiceHandler implements AzureServiceHandler, Resettable {
 
         if (object.isEmpty()) {
             return new AzureErrorResponse("ResourceNotFound", "The specified resource does not exist.")
-                    .toJsonResponse(Response.Status.NOT_FOUND.getStatusCode());
+                    .toODataResponse(Response.Status.NOT_FOUND.getStatusCode());
         }
 
         try {
@@ -448,7 +448,7 @@ public class TableServiceHandler implements AzureServiceHandler, Resettable {
         Optional<StoredObject> existing = store.get(storeKey);
         if (existing.isEmpty()) {
             return new AzureErrorResponse("ResourceNotFound", "The specified resource does not exist.")
-                    .toJsonResponse(Response.Status.NOT_FOUND.getStatusCode());
+                    .toODataResponse(Response.Status.NOT_FOUND.getStatusCode());
         }
 
         String ifMatch = request.headers().getHeaderString("If-Match");
@@ -478,7 +478,7 @@ public class TableServiceHandler implements AzureServiceHandler, Resettable {
             if (pk.isEmpty() || rk.isEmpty()) {
                 return new AzureErrorResponse("PropertiesNeedValue",
                         "PartitionKey and RowKey are required.")
-                        .toJsonResponse(Response.Status.BAD_REQUEST.getStatusCode());
+                        .toODataResponse(Response.Status.BAD_REQUEST.getStatusCode());
             }
             String key = pk + "_" + rk;
             String storeKey = objKey(request.accountName(), tableName, key);
@@ -533,7 +533,7 @@ public class TableServiceHandler implements AzureServiceHandler, Resettable {
             // Entity must exist
             if (stored == null) {
                 return new AzureErrorResponse("ResourceNotFound", "The specified resource does not exist.")
-                        .toJsonResponse(Response.Status.NOT_FOUND.getStatusCode());
+                        .toODataResponse(Response.Status.NOT_FOUND.getStatusCode());
             }
             return null; // exists, pass
         }
@@ -579,7 +579,7 @@ public class TableServiceHandler implements AzureServiceHandler, Resettable {
             String outerBoundary = extractBoundary(contentType);
             if (outerBoundary == null) {
                 return new AzureErrorResponse("InvalidInput", "Missing or invalid Content-Type boundary.")
-                        .toJsonResponse(400);
+                        .toODataResponse(400);
             }
 
             // Split on outer boundary
@@ -781,7 +781,7 @@ public class TableServiceHandler implements AzureServiceHandler, Resettable {
             return deleteEntityDirect(accountName, tableName, pkRkPart, ifMatch);
         } else {
             return new AzureErrorResponse("NotImplemented", "The requested operation is not implemented.")
-                    .toJsonResponse(501);
+                    .toODataResponse(501);
         }
     }
 
@@ -792,14 +792,14 @@ public class TableServiceHandler implements AzureServiceHandler, Resettable {
         try {
             if (entityBody == null) {
                 return new AzureErrorResponse("PropertiesNeedValue", "Entity body is required.")
-                        .toJsonResponse(400);
+                        .toODataResponse(400);
             }
             Map<String, Object> entity = new LinkedHashMap<>(entityBody);
             String pk = (String) entity.get("PartitionKey");
             String rk = (String) entity.get("RowKey");
             if (pk == null || rk == null) {
                 return new AzureErrorResponse("PropertiesNeedValue", "PartitionKey and RowKey are required.")
-                        .toJsonResponse(400);
+                        .toODataResponse(400);
             }
             String key = pk + "_" + rk;
             String etag = UUID.randomUUID().toString();
@@ -836,7 +836,7 @@ public class TableServiceHandler implements AzureServiceHandler, Resettable {
             }
             if (pk == null || pk.isEmpty() || rk == null || rk.isEmpty()) {
                 return new AzureErrorResponse("PropertiesNeedValue", "PartitionKey and RowKey are required.")
-                        .toJsonResponse(400);
+                        .toODataResponse(400);
             }
             String key = pk + "_" + rk;
             String storeKey = objKey(accountName, tableName, key);
@@ -883,7 +883,7 @@ public class TableServiceHandler implements AzureServiceHandler, Resettable {
         Optional<StoredObject> existing = store.get(storeKey);
         if (existing.isEmpty()) {
             return new AzureErrorResponse("ResourceNotFound", "The specified resource does not exist.")
-                    .toJsonResponse(404);
+                    .toODataResponse(404);
         }
 
         Response etagCheck = checkEtag(ifMatch, existing.get());

--- a/src/test/java/io/floci/az/services/TableServiceTest.java
+++ b/src/test/java/io/floci/az/services/TableServiceTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
@@ -90,5 +91,44 @@ public class TableServiceTest {
             .statusCode(404)
             .contentType(containsString("json"))
             .body(containsString("ResourceNotFound"));
+    }
+
+    @Test
+    void duplicateCreateTableReturnsODataErrorEnvelope() {
+        given()
+            .contentType("application/json")
+            .body("{\"TableName\":\"DupCreate\"}")
+            .when().post("/{account}/Tables", ACCOUNT)
+            .then().statusCode(201);
+
+        given()
+            .contentType("application/json")
+            .body("{\"TableName\":\"DupCreate\"}")
+            .when().post("/{account}/Tables", ACCOUNT)
+            .then()
+            .statusCode(409)
+            .header("x-ms-error-code", "TableAlreadyExists")
+            .contentType(containsString("odata=minimalmetadata"))
+            .body("'odata.error'.code", equalTo("TableAlreadyExists"))
+            .body("'odata.error'.message.lang", equalTo("en-US"))
+            .body("'odata.error'.message.value", containsString("already exists"));
+    }
+
+    @Test
+    void getMissingEntityReturnsODataErrorEnvelope() {
+        given()
+            .contentType("application/json")
+            .body("{\"TableName\":\"EnvelopeMiss\"}")
+            .when().post("/{account}/Tables", ACCOUNT)
+            .then().statusCode(201);
+
+        given()
+            .when().get("/{account}/EnvelopeMiss(PartitionKey='p',RowKey='absent')", ACCOUNT)
+            .then()
+            .statusCode(404)
+            .header("x-ms-error-code", "ResourceNotFound")
+            .contentType(containsString("odata=minimalmetadata"))
+            .body("'odata.error'.code", equalTo("ResourceNotFound"))
+            .body("'odata.error'.message.value", containsString("does not exist"));
     }
 }


### PR DESCRIPTION
Fixes #181

## Problem

The Table service returned flat `{"Code","Message"}` JSON error bodies (the shape shared with the XML-based storage services), but the Tables API wraps errors in the OData envelope. SDKs that parse the error *body* rather than the `x-ms-error-code` header couldn't recognize error codes:

- **.NET `Azure.Data.Tables`**: `CreateTableIfNotExistsAsync` threw `ArgumentNullException` on the 409 instead of no-opping — which permanently blocks Durable Functions task-hub bootstrap on any Functions-host restart against existing tables (fresh hubs work, restarts don't; full details in #181).
- **Java `azure-data-tables`**: `TableServiceException.getValue().getErrorCode()` was `null`.
- Python survives only because it falls back to the header.

## Change

- `AzureErrorResponse` gains `toODataResponse(int)` alongside `toJsonResponse(int)`: same `x-ms-error-code` header, body wrapped as `{"odata.error":{"code":...,"message":{"lang":"en-US","value":...}}}` with `Content-Type: application/json;odata=minimalmetadata` — matching what `CosmosTableApiHandler` already emits and what Azurite/real Azure return.
- All `TableServiceHandler` error sites (409/404/400/501) switch to it. `$batch` inner error bodies pick up the envelope automatically via the existing Jackson serialization, which is also what real Azure does inside changesets.
- No other service is touched: blob/queue keep their XML errors, and the flat JSON shape remains available via `toJsonResponse` for its other users.

## Tests

- **Unit** (`TableServiceTest`): duplicate create → 409 with `odata.error` envelope + odata content type; missing entity → 404 envelope. Both fail on `main` (flat body, plain `application/json`), pass with this change. Full suite: 555 tests green.
- **Compat** (`sdk-test-java/TableCompatibilityTest`):
  - `tableAlreadyExists` now also asserts `TableErrorCode.TABLE_ALREADY_EXISTS` is parsed — this fails against the released 0.10.0 image (`errorCode` is `null`) and passes against this branch.
  - New `createTableIfNotExistsOnExistingTable` locks in the silent no-op.

## Verification against real SDKs

Minimal .NET repro from #181, run against a container built from this branch:

```
first create: 201 OK
CreateTableIfNotExistsAsync: no-op OK          # main/0.10.0: ArgumentNullException
```

Raw wire shape after the change (matches Azurite 3.35.0 byte-for-byte modulo RequestId/Time suffix):

```
HTTP/1.1 409 Conflict
Content-Type: application/json;odata=minimalmetadata
x-ms-error-code: TableAlreadyExists

{"odata.error":{"message":{"value":"The table specified already exists.","lang":"en-US"},"code":"TableAlreadyExists"}}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
