### PR TITLE
fix(core): omit Content-Type on bodyless error responses

### DIFF
--- a/src/main/java/io/floci/az/core/BodylessErrorContentTypeFilter.java
+++ b/src/main/java/io/floci/az/core/BodylessErrorContentTypeFilter.java
@@ -1,0 +1,37 @@
+package io.floci.az.core;
+
+import org.jboss.resteasy.reactive.server.ServerResponseFilter;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.core.HttpHeaders;
+
+/**
+ * Strips {@code Content-Type} from error responses that cannot carry a body.
+ *
+ * <p>A HEAD response never includes content (RFC 9110 §9.3.2), so JAX-RS discards the entity while
+ * keeping the content type set by {@link AzureErrorResponse}. That leaves
+ * {@code content-type: application/xml} on a zero-byte response - a combination the Azure SDK for C++
+ * cannot survive: {@code StorageException::CreateFromResponse} parses the body whenever the content
+ * type contains {@code "xml"} (or {@code "json"}) without checking that the buffer is non-empty, and
+ * the resulting {@code std::runtime_error} escapes the {@code RequestFailedException} constructor
+ * before any catch clause exists, calling {@code terminate()}.
+ *
+ * <p>Azurite gates both the content type and the body write on the request method for this reason,
+ * leaving the status code and the remaining headers untouched. This filter mirrors that behavior.
+ * {@code x-ms-error-code} is deliberately preserved: it is the SDK's documented fallback for
+ * recovering the error code once body parsing is skipped.
+ *
+ * <p>Restricted to error statuses: {@code Get Blob Properties} documents {@code Content-Type} among
+ * its 200 response headers, so a successful HEAD must keep it.
+ */
+public class BodylessErrorContentTypeFilter {
+
+    @ServerResponseFilter
+    public void stripContentTypeOnBodylessErrors(ContainerRequestContext request,
+                                                 ContainerResponseContext response) {
+        if (response.getStatus() >= 400 && "HEAD".equalsIgnoreCase(request.getMethod())) {
+            response.getHeaders().remove(HttpHeaders.CONTENT_TYPE);
+        }
+    }
+}

--- a/src/test/java/io/floci/az/services/BlobServiceTest.java
+++ b/src/test/java/io/floci/az/services/BlobServiceTest.java
@@ -720,6 +720,59 @@ public class BlobServiceTest {
             .header("Content-MD5", equalTo("XrY7u+Ae7tCTyyK7j1rNww=="));
     }
 
+    // HEAD carries no body (RFC 9110 9.3.2), so an error response must not advertise a content type
+    // either: the Azure SDK for C++ parses the body whenever content-type contains "xml", and an empty
+    // buffer throws std::runtime_error out of the RequestFailedException constructor -> terminate().
+    // Azurite gates both the content type and the body on the method for the same reason.
+    @Test
+    void headMissingBlobOmitsContentType() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+
+        given()
+            .when().head("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, "no-such-blob.txt")
+            .then()
+            .statusCode(404)
+            .header("Content-Type", nullValue())
+            .header("x-ms-error-code", "BlobNotFound");
+    }
+
+    @Test
+    void headMissingContainerOmitsContentType() {
+        given()
+            .when().head("/{account}/{container}?restype=container", ACCOUNT, "no-such-container")
+            .then()
+            .statusCode(404)
+            .header("Content-Type", nullValue())
+            .header("x-ms-error-code", "ContainerNotFound");
+    }
+
+    // Counterpart guard: GET is allowed a body, so the <Error> document and its content type must stay.
+    @Test
+    void getMissingBlobStillReturnsErrorBody() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+
+        given()
+            .when().get("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, "no-such-blob.txt")
+            .then()
+            .statusCode(404)
+            .contentType(containsString("xml"))
+            .header("x-ms-error-code", "BlobNotFound")
+            .body(containsString("<Code>BlobNotFound</Code>"));
+    }
+
+    // Get Blob Properties documents Content-Type among its 200 response headers, so a successful HEAD
+    // must keep it. Guards against the fix being applied to every bodyless response.
+    @Test
+    void headExistingBlobKeepsContentType() {
+        putTestBlob(BLOB_CONTENT);
+
+        given()
+            .when().head("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(200)
+            .header("Content-Type", not(emptyOrNullString()));
+    }
+
     private static void putTestBlob(String content) {
         given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
         given()

--- a/src/test/java/io/floci/az/services/QueueServiceTest.java
+++ b/src/test/java/io/floci/az/services/QueueServiceTest.java
@@ -323,4 +323,28 @@ public class QueueServiceTest {
             .statusCode(200)
             .body(containsString("delayed"));
     }
+
+    // A bodyless HEAD error must not advertise a content type: the Azure SDK for C++ parses the body
+    // whenever content-type contains "xml" without guarding against an empty buffer, and crashes.
+    @Test
+    void headMissingQueueOmitsContentType() {
+        given()
+            .when().head("/{account}/{queue}", ACCOUNT, "no-such-queue")
+            .then()
+            .statusCode(404)
+            .header("Content-Type", nullValue())
+            .header("x-ms-error-code", "QueueNotFound");
+    }
+
+    // GET is allowed a body, so the <Error> document and its content type must survive.
+    @Test
+    void getMissingQueueStillReturnsErrorBody() {
+        given()
+            .when().get("/{account}/{queue}", ACCOUNT, "no-such-queue")
+            .then()
+            .statusCode(404)
+            .contentType(containsString("xml"))
+            .header("x-ms-error-code", "QueueNotFound")
+            .body(containsString("<Code>QueueNotFound</Code>"));
+    }
 }

--- a/src/test/java/io/floci/az/services/TableServiceTest.java
+++ b/src/test/java/io/floci/az/services/TableServiceTest.java
@@ -8,6 +8,7 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 
 @QuarkusTest
@@ -66,5 +67,28 @@ public class TableServiceTest {
             .statusCode(200)
             .header("Content-Type", startsWith("application/json"))
             .body("value.TableName", hasItem("mytable"));
+    }
+
+    // The JSON error path carries the same crash class: the Azure SDK for C++ calls json::parse on the
+    // body whenever content-type contains "json", also without an empty-buffer guard.
+    @Test
+    void headOnUnsupportedTableOperationOmitsContentType() {
+        given()
+            .when().head("/{account}/Tables", ACCOUNT)
+            .then()
+            .statusCode(501)
+            .header("Content-Type", nullValue())
+            .header("x-ms-error-code", "NotImplemented");
+    }
+
+    // GET is allowed a body, so the JSON error document and its content type must survive.
+    @Test
+    void getMissingEntityStillReturnsErrorBody() {
+        given()
+            .when().get("/{account}/no-such-table(PartitionKey='p',RowKey='r')", ACCOUNT)
+            .then()
+            .statusCode(404)
+            .contentType(containsString("json"))
+            .body(containsString("ResourceNotFound"));
     }
 }


### PR DESCRIPTION
## Summary

Error responses to `HEAD` requests no longer advertise a `Content-Type`.

A HEAD response carries no body (RFC 9110 §9.3.2), but `AzureErrorResponse` set the content type unconditionally, so JAX-RS discarded the entity while keeping the header, leaving `content-type: application/xml` on a zero-byte response. That combination hard-crashes any caller using the Azure SDK for C++: `StorageException::CreateFromResponse` picks a parser by substring-matching the content type and hands the buffer to `XmlReader` without checking that it is non-empty, so the resulting `std::runtime_error` escapes the `RequestFailedException` constructor before any catch clause exists and calls `terminate()`. A `Get Blob Properties` on a missing blob crash-looped the consumer instead of surfacing a 404.

Fixed centrally in a `@ServerResponseFilter`, so it covers all 66 `toXmlResponse`/`toJsonResponse` call sites across blob, queue, table and functions. The JSON path needs it too: the SDK's JSON branch calls `json::parse(bodyBuffer)` equally unguarded.

Closes #184

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

**Incorrect behavior:** `HEAD /{account}/{container}/{missing-blob}` returned `Content-Type: application/xml` with a 0-byte body.

**Reference implementation:** Azurite gates *both* the content type and the body write on the request method, in `src/blob/generated/middleware/error.middleware.ts`:

```ts
if (err.contentType && req.getMethod() !== "HEAD") { res.setContentType(err.contentType); }
if (err.body && req.getMethod() !== "HEAD") { res.getBodyStream().write(err.body); }
```

Note the asymmetry: status code and the header loop run regardless of method. This PR mirrors that exactly, so the behavior is copied from Microsoft's own emulator rather than invented.

**Spec basis:**

- RFC 9110 §9.3.2: "The server SHOULD send the same header fields in response to a HEAD request as it would have sent if the request method had been GET. However, a server MAY omit header fields forwhich a value is determined only while generating the content." §15.3 adds that HEAD responses "never include content". A `SHOULD` with an explicit MAY-omit carve-out — omitting a content type that describes content we are forbidden to send is within spec.
- [Status and error codes](https://learn.microsoft.com/en-us/rest/api/storageservices/status-and-error-codes2) documents the `<Error><Code/><Message/></Error>` body and the `x-ms-error-code` header, but does **not** require `Content-Type` on error responses. `x-ms-error-code` is preserved - it is the SDK's documented fallback once body parsing is skipped, and is what lets the C++ SDK still map 404 not-found.
- [Get Blob Properties](https://learn.microsoft.com/en-us/rest/api/storageservices/get-blob-properties) lists `Content-Type` among its **200** response headers, which is why the fix is scoped to  `status >= 400`. A successful HEAD keeps its content type.
**Scope.** Errors only, and only where a body cannot be sent. `GET` error responses are unchanged and still return the full `<Error>` document with `application/xml`.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

572 tests pass (Docker-backed suites excluded locally: `AksDockerTest`, `PostgresDockerTest`, `VmDockerTest` hang in `@AfterAll` container teardown on this machine, unrelated to this change; CI runs them).

The two HEAD-error tests were confirmed to **fail before the fix** with exactly the reported symptom:

```
Expected header "Content-Type" was not null, was "application/xml". Headers are:
Content-Type=application/xml
x-ms-error-code=BlobNotFound
```

Eight tests, covering both directions so the fix cannot be over- or under-applied:

| Test | Asserts |
|---|---|
| `BlobServiceTest.headMissingBlobOmitsContentType` | 404, no `Content-Type`, `x-ms-error-code: BlobNotFound` |
| `BlobServiceTest.headMissingContainerOmitsContentType` | 404, no `Content-Type`, `x-ms-error-code: ContainerNotFound` |
| `BlobServiceTest.getMissingBlobStillReturnsErrorBody` | GET 404 **keeps** xml + `<Code>BlobNotFound</Code>` |
| `BlobServiceTest.headExistingBlobKeepsContentType` | HEAD 200 **keeps** `Content-Type` |
| `QueueServiceTest.headMissingQueueOmitsContentType` | 404, no `Content-Type`, `x-ms-error-code: QueueNotFound` |
| `QueueServiceTest.getMissingQueueStillReturnsErrorBody` | GET 404 keeps xml + `<Code>QueueNotFound</Code>` |
| `TableServiceTest.headOnUnsupportedTableOperationOmitsContentType` | 501, no `Content-Type` (the JSON path) |
| `TableServiceTest.getMissingEntityStillReturnsErrorBody` | GET 404 keeps json + `ResourceNotFound` |

No C++ compatibility suite exists in this repo and adding one is out of scope, so coverage is via the unit/integration tests above plus the cited SDK source and spec pages (`CONTRIBUTING.md` asks authors to explain test choices).