### PR TITLE
feat(compat): add a C++ SDK compatibility suite

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -68,7 +68,9 @@ jobs:
     name: native / ${{ matrix.test }}
     needs: build-native
     runs-on: ubuntu-24.04-arm
-    timeout-minutes: 20
+    # sdk-test-cpp compiles OpenSSL, libxml2, libcurl and the SDK from source via vcpkg,
+    # so it needs more headroom than the suites that install prebuilt packages.
+    timeout-minutes: ${{ matrix.timeout_minutes || 20 }}
     strategy:
       fail-fast: false
       matrix:
@@ -94,6 +96,8 @@ jobs:
           - test: sdk-test-node
             extra_env: >-
               -e AZURE_POD_IDENTITY_AUTHORITY_HOST=http://floci-az:4577
+          - test: sdk-test-cpp
+            timeout_minutes: 45
           - test: compat-terraform
           - test: compat-opentofu
           - test: compat-azcli

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,6 +240,7 @@ compatibility-tests/
                           managed identity
   sdk-test-node/        — Azure SDK for JS (jest): blob, queue, table, cosmos, appconfig,
                           keyvault, eventhub, managed identity
+  sdk-test-cpp/         — Azure SDK for C++ (GoogleTest via vcpkg): blob, queue. Built from source, so ~6 min cold
   compat-terraform/     — hashicorp/azurerm Terraform provider (BATS)
   compat-opentofu/      — OpenTofu with the azurerm provider (BATS)
   compat-azcli/         — real `az` CLI against a custom registered cloud (BATS)
@@ -272,6 +273,7 @@ Current per-suite env vars that must stay in sync:
 | `sdk-test-dotnet` | `-e SERVICEBUS_AMQP_PORT=5672` | ✓ |
 | `sdk-test-python` | `-e AZURE_POD_IDENTITY_AUTHORITY_HOST=http://floci-az:4577` | ✓ |
 | `sdk-test-node` | `-e AZURE_POD_IDENTITY_AUTHORITY_HOST=http://floci-az:4577` | ✓ |
+| `sdk-test-cpp` | none — only the shared `FLOCI_AZ_ENDPOINT` | ✓ (no `extra_env`) |
 
 The container name follows the pattern `floci-az-<service>-<namespace>` (e.g. `floci-az-servicebus-default`). If a new sidecar-based service is added, its container name and port must be added to both places.
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build run run-docker stop stop-docker require-emulator \
-        compat-network compat-build compat-run compat-stop compat-python-image compat-java-image compat-dotnet-image compat-node-image compat-terraform-image compat-opentofu-image compat-azcli-image \
+        compat-network compat-build compat-run compat-stop compat-python-image compat-java-image compat-dotnet-image compat-node-image compat-cpp-image compat-terraform-image compat-opentofu-image compat-azcli-image \
         run-cosmos-mongo run-cosmos-postgresql run-cosmos-cassandra run-cosmos-gremlin run-cosmos-table run-cosmos-nosql run-sql \
-        test test-python-compat test-python-compat-local test-java-compat test-java-compat-local test-dotnet-compat test-node-compat test-node-compat-local test-servicebus-compat \
+        test test-python-compat test-python-compat-local test-java-compat test-java-compat-local test-dotnet-compat test-node-compat test-node-compat-local test-cpp-compat test-servicebus-compat \
         test-blob test-blob-local test-blob-python test-blob-python-local test-blob-java test-blob-java-local test-blob-node test-blob-node-local \
         test-entra-node test-entra-node-local \
         test-apim-java \
@@ -15,6 +15,7 @@ PYTHON_DIR     = compatibility-tests/sdk-test-python
 JAVA_DIR       = compatibility-tests/sdk-test-java
 NODE_DIR       = compatibility-tests/sdk-test-node
 DOTNET_DIR     = compatibility-tests/sdk-test-dotnet
+CPP_DIR        = compatibility-tests/sdk-test-cpp
 TERRAFORM_DIR  = compatibility-tests/compat-terraform
 OPENTOFU_DIR   = compatibility-tests/compat-opentofu
 AZCLI_DIR      = compatibility-tests/compat-azcli
@@ -25,6 +26,7 @@ PYTHON_IMAGE   = compat-sdk-test-python
 JAVA_IMAGE     = compat-sdk-test-java
 NODE_IMAGE     = compat-sdk-test-node
 DOTNET_IMAGE   = compat-sdk-test-dotnet
+CPP_IMAGE      = compat-sdk-test-cpp
 TERRAFORM_IMAGE = compat-terraform
 OPENTOFU_IMAGE  = compat-opentofu
 AZCLI_IMAGE     = compat-azcli
@@ -49,11 +51,12 @@ JAVA_SERVICEBUS_EMULATOR_ENV = $(SERVICEBUS_EMULATOR_ENV) \
 	-e FLOCI_AZ_SERVICES_SERVICE_BUS_LOCK_DURATION_SECONDS=5
 
 # Per-suite build context and image tag, keyed by suite name.
-SUITES = python java dotnet node terraform opentofu azcli
+SUITES = python java dotnet node cpp terraform opentofu azcli
 SUITE_DIR_python    = $(PYTHON_DIR)
 SUITE_DIR_java      = $(JAVA_DIR)
 SUITE_DIR_node      = $(NODE_DIR)
 SUITE_DIR_dotnet    = $(DOTNET_DIR)
+SUITE_DIR_cpp       = $(CPP_DIR)
 SUITE_DIR_terraform = $(TERRAFORM_DIR)
 SUITE_DIR_opentofu  = $(OPENTOFU_DIR)
 SUITE_DIR_azcli     = $(AZCLI_DIR)
@@ -61,6 +64,7 @@ SUITE_IMAGE_python    = $(PYTHON_IMAGE)
 SUITE_IMAGE_java      = $(JAVA_IMAGE)
 SUITE_IMAGE_node      = $(NODE_IMAGE)
 SUITE_IMAGE_dotnet    = $(DOTNET_IMAGE)
+SUITE_IMAGE_cpp       = $(CPP_IMAGE)
 SUITE_IMAGE_terraform = $(TERRAFORM_IMAGE)
 SUITE_IMAGE_opentofu  = $(OPENTOFU_IMAGE)
 SUITE_IMAGE_azcli     = $(AZCLI_IMAGE)
@@ -227,6 +231,11 @@ test-node-compat:
 test-dotnet-compat:
 	@echo "==> .NET Service Bus SDK compatibility tests (Docker)"
 	$(call COMPAT_SESSION,dotnet,dotnet,$(SUITE_ENV_DOTNET),,,$(SERVICEBUS_EMULATOR_ENV))
+
+# No -local variant: the toolchain lives in the image, so this suite is Docker-only.
+test-cpp-compat:
+	@echo "==> C++ SDK compatibility tests (Docker)"
+	$(call COMPAT_SESSION,cpp,cpp,,,)
 
 test-python-compat-local:
 	@echo "==> Python SDK compatibility tests (all services, local emulator)"
@@ -396,12 +405,13 @@ test-azcli:
 compat-docker:
 	$(MAKE) compat-build
 	$(MAKE) compat-run FLOCI_AZ_COMPAT_EXTRA_ENV="$(JAVA_SERVICEBUS_EMULATOR_ENV)"
-	@mkdir -p $(COMPAT_RESULTS)/python $(COMPAT_RESULTS)/node $(COMPAT_RESULTS)/java $(COMPAT_RESULTS)/dotnet $(COMPAT_RESULTS)/terraform $(COMPAT_RESULTS)/opentofu $(COMPAT_RESULTS)/azcli
+	@mkdir -p $(COMPAT_RESULTS)/python $(COMPAT_RESULTS)/node $(COMPAT_RESULTS)/java $(COMPAT_RESULTS)/dotnet $(COMPAT_RESULTS)/cpp $(COMPAT_RESULTS)/terraform $(COMPAT_RESULTS)/opentofu $(COMPAT_RESULTS)/azcli
 	@EXIT=0; \
 	$(MAKE) compat-python-image || EXIT=$$?; \
 	if [ $$EXIT -eq 0 ]; then $(MAKE) compat-node-image || EXIT=$$?; fi; \
 	if [ $$EXIT -eq 0 ]; then $(MAKE) compat-java-image || EXIT=$$?; fi; \
 	if [ $$EXIT -eq 0 ]; then $(MAKE) compat-dotnet-image || EXIT=$$?; fi; \
+	if [ $$EXIT -eq 0 ]; then $(MAKE) compat-cpp-image || EXIT=$$?; fi; \
 	if [ $$EXIT -eq 0 ]; then $(MAKE) compat-terraform-image || EXIT=$$?; fi; \
 	if [ $$EXIT -eq 0 ]; then $(MAKE) compat-opentofu-image || EXIT=$$?; fi; \
 	if [ $$EXIT -eq 0 ]; then $(MAKE) compat-azcli-image || EXIT=$$?; fi; \
@@ -423,6 +433,11 @@ compat-docker:
 	if [ $$EXIT -eq 0 ]; then \
 		echo "==> .NET SDK tests"; \
 		$(call RUN_SUITE,dotnet,dotnet,$(SUITE_ENV_DOTNET),,); \
+		EXIT=$$?; \
+	fi; \
+	if [ $$EXIT -eq 0 ]; then \
+		echo "==> C++ SDK tests"; \
+		$(call RUN_SUITE,cpp,cpp,,,); \
 		EXIT=$$?; \
 	fi; \
 	if [ $$EXIT -eq 0 ]; then \

--- a/README.md
+++ b/README.md
@@ -632,9 +632,12 @@ The [`compatibility-tests`](./compatibility-tests/) directory validates Floci AZ
 | `sdk-test-python`   | Python 3        | Blob, Queue, Table, Cosmos, App Configuration, Key Vault, ACR, Redis                                                            |   124 |
 | `sdk-test-java`     | Java 21         | Storage, Cosmos (+ Mongo/PostgreSQL/Cassandra/Gremlin/Table/NoSQL engines), App Config, Key Vault, Event Hubs, Service Bus, Functions, API Management, SQL, PostgreSQL (Flexible Server) | 252 |
 | `sdk-test-node`     | Node.js         | App Configuration, Blob, Cosmos, Event Hubs, Key Vault, Queue, Table                                                            |    72 |
+| `sdk-test-cpp` †    | C++ 17          | Blob, Queue: Lifecycle plus the bodyless-error path no other SDK reproduces                                                    |    10 |
 | `compat-terraform`  | Terraform       | `azurerm` provider apply/destroy (resource group, storage, key vault, VNet, VM, Redis, ACR)                                     |    12 |
 | `compat-opentofu`   | OpenTofu        | Same `azurerm` suite via `tofu`, plus PostgreSQL Flexible Server (server + database)                                            |    14 |
 | `compat-azcli` ‡    | Azure CLI       | `az` against a custom cloud with Entra service-principal login                                                                 |    13 |
+
+† Built from source via vcpkg, so the image takes ~6 min cold (seconds if warm).
 
 ‡ Ships with the Entra ID feature ([#23](https://github.com/floci-io/floci-az/issues/23)).
 
@@ -644,6 +647,7 @@ Run the suites against a running container:
 make test-python-compat
 make test-java-compat
 make test-node-compat
+make test-cpp-compat
 make test-cosmos-all    # Cosmos engine tests: MongoDB · PostgreSQL · Cassandra · Gremlin · Table · NoSQL (requires Docker)
 make test-iac-compat    # Terraform + OpenTofu
 make compat-docker      # full matrix

--- a/compatibility-tests/sdk-test-cpp/CMakeLists.txt
+++ b/compatibility-tests/sdk-test-cpp/CMakeLists.txt
@@ -1,0 +1,25 @@
+cmake_minimum_required(VERSION 3.22)
+project(floci-sdk-test-cpp CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(azure-storage-blobs-cpp CONFIG REQUIRED)
+find_package(azure-storage-queues-cpp CONFIG REQUIRED)
+find_package(GTest CONFIG REQUIRED)
+
+enable_testing()
+
+add_executable(compat_tests
+  tests/blob_test.cpp
+  tests/queue_test.cpp
+)
+
+target_include_directories(compat_tests PRIVATE tests)
+
+target_link_libraries(compat_tests PRIVATE
+  Azure::azure-storage-blobs
+  Azure::azure-storage-queues
+  GTest::gtest
+  GTest::gtest_main
+)

--- a/compatibility-tests/sdk-test-cpp/Dockerfile
+++ b/compatibility-tests/sdk-test-cpp/Dockerfile
@@ -1,0 +1,63 @@
+# Azure SDK for C++ compatibility tests.
+#
+# Unlike the Python/Node/Java suites, there is no prebuilt package to install: vcpkg
+# compiles OpenSSL, libxml2, libcurl and the SDK from source, so the build stage takes
+# roughly 6 minutes cold (seconds if warm, since only the final COPY layers change when tests
+# are edited). The runtime stage keeps that cost out of the shipped image.
+FROM debian:bookworm-slim AS build
+
+# vcpkg is pinned to a release tag for reproducibility. Its SPDX manifest generation
+# uses string(JSON ... STRING_ENCODE), which requires CMake 4.3+, so install the
+# upstream CMake binary rather than bookworm's 3.25.
+ARG CMAKE_VERSION=4.4.2
+ARG VCPKG_TAG=2026.07.29
+
+# make + perl are required by vcpkg's openssl port; linux-libc-dev provides the kernel
+# headers it checks for.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates \
+      curl \
+      g++ \
+      git \
+      linux-libc-dev \
+      make \
+      ninja-build \
+      perl \
+      pkg-config \
+      python3 \
+      tar \
+      unzip \
+      zip \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-$(uname -m).tar.gz" \
+      | tar -xz --strip-components=1 -C /usr/local
+
+ENV VCPKG_ROOT=/opt/vcpkg
+ENV VCPKG_FORCE_SYSTEM_BINARIES=1
+RUN git clone --depth 1 --branch "${VCPKG_TAG}" https://github.com/microsoft/vcpkg.git "${VCPKG_ROOT}" \
+    && "${VCPKG_ROOT}/bootstrap-vcpkg.sh" -disableMetrics
+
+WORKDIR /app
+
+# Dependencies first, so editing a test does not rebuild the SDK.
+COPY vcpkg.json .
+RUN "${VCPKG_ROOT}/vcpkg" install
+
+COPY CMakeLists.txt .
+COPY tests/ tests/
+RUN cmake -B build -G Ninja \
+      -DCMAKE_TOOLCHAIN_FILE="${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" \
+      -DCMAKE_BUILD_TYPE=Release \
+    && cmake --build build
+
+# The SDK and its dependencies are static-linked, so the runtime stage needs only
+# libstdc++. This keeps the image around 130 MB instead of the ~2.7 GB build stage.
+FROM debian:bookworm-slim
+
+COPY --from=build /app/build/compat_tests /usr/local/bin/compat_tests
+
+ENV FLOCI_AZ_ENDPOINT=http://floci-az:4577
+
+RUN mkdir -p /results
+ENTRYPOINT ["/usr/local/bin/compat_tests", "--gtest_output=xml:/results/junit.xml"]

--- a/compatibility-tests/sdk-test-cpp/README.md
+++ b/compatibility-tests/sdk-test-cpp/README.md
@@ -1,0 +1,58 @@
+# sdk-test-cpp
+
+Compatibility tests for [Floci AZ](https://github.com/floci-io/floci-az) using the **Azure SDK for C++**.
+
+Tests are [GoogleTest](https://github.com/google/googletest) cases driving the real SDK clients, mirroring the Python/Java/Node suites. Dependencies come from [vcpkg](https://vcpkg.io) in manifest mode (`vcpkg.json`).
+
+## Services Covered
+
+| Suite           | Coverage                                                                    |
+| --------------- | --------------------------------------------------------------------------- |
+| `blob_test`     | Blob lifecycle, `Get Blob Properties`, error codes (404 / 409), XML error body |
+| `queue_test`    | Queue lifecycle, enqueue/receive/delete, queue properties, error codes        |
+
+## Why this suite exists
+
+The Azure SDK for C++ fails on bodyless error responses in a way no other SDK does. `StorageException::CreateFromResponse` picks a parser by substring-matching the `content-type` header and hands the body to `XmlReader` without checking that the buffer is non-empty. On a `HEAD` error response advertising `application/xml` with zero bytes, the resulting `std::runtime_error` is thrown from *inside* the `RequestFailedException` constructor, so the exception object is never built, no catch clause can run, and the process calls `terminate()`.
+
+## Requirements
+
+- Docker (the image builds its own toolchain)
+
+Building outside Docker additionally needs CMake 4.3+, a C++17 compiler, Ninja, and vcpkg.
+
+## Running
+
+```bash
+# Build the emulator + run this suite (from repo root)
+make test-cpp-compat
+
+# As part of the full compatibility matrix
+make compat-docker
+```
+
+## Configuration
+
+| Variable            | Default                   | Description                |
+| ------------------- | ------------------------- | -------------------------- |
+| `FLOCI_AZ_ENDPOINT` | `http://floci-az:4577`    | Floci AZ emulator endpoint |
+
+## Build cost
+
+vcpkg compiles OpenSSL, libxml2, libcurl and the SDK from source, so the **cold build takes roughly 6 minutes**. Dependencies are installed before the test sources are copied, so editing a test rebuilds in seconds.
+
+The build stage is ~2.7 GB, but the SDK is static-linked and the runtime stage copies only the test binary — the final image is ~130 MB.
+
+## Docker
+
+```bash
+docker build -t compat-sdk-test-cpp .
+docker run --rm --network compat-net \
+  -e FLOCI_AZ_ENDPOINT=http://floci-az:4577 \
+  -v "$PWD/results:/results" compat-sdk-test-cpp
+
+# Run a subset (GoogleTest filters)
+docker run --rm --network compat-net compat-sdk-test-cpp --gtest_filter='BlobErrors.*'
+```
+
+Results are written as JUnit XML to `/results/junit.xml`.

--- a/compatibility-tests/sdk-test-cpp/tests/blob_test.cpp
+++ b/compatibility-tests/sdk-test-cpp/tests/blob_test.cpp
@@ -1,0 +1,145 @@
+#include "emulator_config.hpp"
+
+#include <azure/storage/blobs.hpp>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+using namespace Azure::Storage::Blobs;
+
+namespace {
+
+BlobServiceClient Service()
+{
+  return BlobServiceClient::CreateFromConnectionString(floci::BlobConnectionString());
+}
+
+BlobContainerClient Container(const std::string& name)
+{
+  auto container = Service().GetBlobContainerClient(name);
+  container.CreateIfNotExists();
+  return container;
+}
+
+} // namespace
+
+// --- Golden path ---
+
+TEST(BlobLifecycle, UploadDownloadDelete)
+{
+  auto container = Container("cpp-lifecycle");
+  auto blob = container.GetBlockBlobClient("hello.txt");
+
+  const std::string content = "Hello from Azure SDK C++!";
+  blob.UploadFrom(reinterpret_cast<const uint8_t*>(content.data()), content.size());
+
+  std::vector<uint8_t> buffer(content.size());
+  blob.DownloadTo(buffer.data(), buffer.size());
+  EXPECT_EQ(std::string(buffer.begin(), buffer.end()), content);
+
+  blob.Delete();
+}
+
+TEST(BlobLifecycle, GetPropertiesOnExistingBlobSucceeds)
+{
+  auto container = Container("cpp-lifecycle");
+  auto blob = container.GetBlockBlobClient("props.txt");
+
+  const std::string content = "properties";
+  blob.UploadFrom(reinterpret_cast<const uint8_t*>(content.data()), content.size());
+
+  // Get Blob Properties is a HEAD request. On success it must still carry a
+  // Content-Type, which the SDK surfaces as HttpHeaders.ContentType.
+  auto properties = blob.GetProperties().Value;
+  EXPECT_EQ(properties.BlobSize, static_cast<int64_t>(content.size()));
+  EXPECT_FALSE(properties.HttpHeaders.ContentType.empty());
+
+  blob.Delete();
+}
+
+// --- Error paths ---
+
+// The regression this suite was added for (floci-io/floci-az#184).
+//
+// GetProperties is a HEAD request, so its error response cannot carry a body. If the
+// emulator still advertises content-type: application/xml on that zero-byte response,
+// StorageException::CreateFromResponse hands an empty buffer to XmlReader, which throws
+// std::runtime_error("Failed to parse xml.") from inside the RequestFailedException
+// constructor, so the exception is never constructed and no catch clause can run.
+//
+// No other SDK in compatibility-tests/ reproduces this: Python, Java and Node all
+// tolerate the bodyless response. In a plain consumer the throw reaches terminate();
+// here gtest's handler catches it and reports a failure instead.
+TEST(BlobErrors, GetPropertiesOnMissingBlobThrowsNotFound)
+{
+  auto blob = Container("cpp-errors").GetBlobClient("does-not-exist");
+
+  try
+  {
+    blob.GetProperties();
+    FAIL() << "expected StorageException for a missing blob";
+  }
+  catch (const Azure::Storage::StorageException& e)
+  {
+    EXPECT_EQ(static_cast<int>(e.StatusCode), 404);
+    // Recovered from the x-ms-error-code header, which must survive even when the
+    // body and its content type do not.
+    EXPECT_EQ(e.ErrorCode, "BlobNotFound");
+  }
+}
+
+// Container GetProperties is a GET in the C++ SDK (unlike the blob one above), so this
+// covers the container error code and its parsed XML body rather than the HEAD path.
+TEST(BlobErrors, GetPropertiesOnMissingContainerThrowsNotFound)
+{
+  auto container = Service().GetBlobContainerClient("cpp-no-such-container");
+
+  try
+  {
+    container.GetProperties();
+    FAIL() << "expected StorageException for a missing container";
+  }
+  catch (const Azure::Storage::StorageException& e)
+  {
+    EXPECT_EQ(static_cast<int>(e.StatusCode), 404);
+    EXPECT_EQ(e.ErrorCode, "ContainerNotFound");
+  }
+}
+
+// The counterpart guard: GET is allowed a body, so the <Error> document and its
+// content type must still be sent and parsed. This is what catches an over-broad
+// fix that strips Content-Type from every error response.
+TEST(BlobErrors, DownloadMissingBlobParsesXmlErrorBody)
+{
+  auto blob = Container("cpp-errors").GetBlobClient("does-not-exist");
+
+  try
+  {
+    blob.Download();
+    FAIL() << "expected StorageException for a missing blob";
+  }
+  catch (const Azure::Storage::StorageException& e)
+  {
+    EXPECT_EQ(static_cast<int>(e.StatusCode), 404);
+    EXPECT_EQ(e.ErrorCode, "BlobNotFound");
+  }
+}
+
+TEST(BlobErrors, CreateExistingContainerThrowsAlreadyExists)
+{
+  const std::string name = "cpp-already-exists";
+  auto container = Container(name);
+
+  try
+  {
+    container.Create();
+    FAIL() << "expected StorageException for an existing container";
+  }
+  catch (const Azure::Storage::StorageException& e)
+  {
+    EXPECT_EQ(static_cast<int>(e.StatusCode), 409);
+    EXPECT_EQ(e.ErrorCode, "ContainerAlreadyExists");
+  }
+}

--- a/compatibility-tests/sdk-test-cpp/tests/emulator_config.hpp
+++ b/compatibility-tests/sdk-test-cpp/tests/emulator_config.hpp
@@ -1,0 +1,37 @@
+// Shared emulator configuration
+#pragma once
+
+#include <cstdlib>
+#include <string>
+
+namespace floci {
+
+// The well-known Azurite/devstore development key, same as every other suite.
+inline const char* DevKey()
+{
+  return "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/"
+         "K1SZFPTOtr/KBHBeksoGMh0==";
+}
+
+inline const char* AccountName() { return "devstoreaccount1"; }
+
+inline std::string Endpoint()
+{
+  const char* env = std::getenv("FLOCI_AZ_ENDPOINT");
+  return env != nullptr ? std::string(env) : std::string("http://localhost:4577");
+}
+
+inline std::string BlobConnectionString()
+{
+  return std::string("DefaultEndpointsProtocol=http;AccountName=") + AccountName()
+      + ";AccountKey=" + DevKey() + ";BlobEndpoint=" + Endpoint() + "/" + AccountName() + ";";
+}
+
+inline std::string QueueConnectionString()
+{
+  return std::string("DefaultEndpointsProtocol=http;AccountName=") + AccountName()
+      + ";AccountKey=" + DevKey() + ";QueueEndpoint=" + Endpoint() + "/" + AccountName()
+      + "-queue;";
+}
+
+} // namespace floci

--- a/compatibility-tests/sdk-test-cpp/tests/queue_test.cpp
+++ b/compatibility-tests/sdk-test-cpp/tests/queue_test.cpp
@@ -1,0 +1,86 @@
+#include "emulator_config.hpp"
+
+#include <azure/storage/queues.hpp>
+#include <gtest/gtest.h>
+
+#include <string>
+
+using namespace Azure::Storage::Queues;
+
+namespace {
+
+QueueClient Queue(const std::string& name)
+{
+  return QueueClient::CreateFromConnectionString(floci::QueueConnectionString(), name);
+}
+
+} // namespace
+
+// --- Golden path ---
+
+TEST(QueueLifecycle, EnqueueReceiveDelete)
+{
+  auto queue = Queue("cpp-lifecycle");
+  queue.Create();
+
+  queue.EnqueueMessage("hello from C++");
+
+  auto received = queue.ReceiveMessages().Value;
+  ASSERT_EQ(received.Messages.size(), 1u);
+  EXPECT_EQ(received.Messages[0].MessageText, "hello from C++");
+
+  const auto& message = received.Messages[0];
+  queue.DeleteMessage(message.MessageId, message.PopReceipt);
+
+  queue.Delete();
+}
+
+TEST(QueueLifecycle, GetPropertiesOnExistingQueueSucceeds)
+{
+  auto queue = Queue("cpp-properties");
+  queue.Create();
+
+  queue.EnqueueMessage("counted");
+
+  auto properties = queue.GetProperties().Value;
+  EXPECT_EQ(properties.ApproximateMessageCount, 1);
+
+  queue.Delete();
+}
+
+// --- Error paths ---
+
+// Queue error responses are built by a separate cluster of toXmlResponse call sites
+// from blob, so these cover that cluster's error codes and XML error bodies.
+TEST(QueueErrors, GetPropertiesOnMissingQueueThrowsNotFound)
+{
+  auto queue = Queue("cpp-no-such-queue");
+
+  try
+  {
+    queue.GetProperties();
+    FAIL() << "expected StorageException for a missing queue";
+  }
+  catch (const Azure::Storage::StorageException& e)
+  {
+    EXPECT_EQ(static_cast<int>(e.StatusCode), 404);
+    EXPECT_EQ(e.ErrorCode, "QueueNotFound");
+  }
+}
+
+// GET is allowed a body, so the <Error> document must still be sent and parsed.
+TEST(QueueErrors, ReceiveFromMissingQueueParsesXmlErrorBody)
+{
+  auto queue = Queue("cpp-no-such-queue");
+
+  try
+  {
+    queue.ReceiveMessages();
+    FAIL() << "expected StorageException for a missing queue";
+  }
+  catch (const Azure::Storage::StorageException& e)
+  {
+    EXPECT_EQ(static_cast<int>(e.StatusCode), 404);
+    EXPECT_EQ(e.ErrorCode, "QueueNotFound");
+  }
+}

--- a/compatibility-tests/sdk-test-cpp/vcpkg.json
+++ b/compatibility-tests/sdk-test-cpp/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "floci-sdk-test-cpp",
+  "version-string": "0.1.0",
+  "description": "Azure SDK for C++ compatibility tests for Floci AZ",
+  "dependencies": [
+    "azure-storage-blobs-cpp",
+    "azure-storage-queues-cpp",
+    "gtest"
+  ]
+}

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -25,6 +25,7 @@ src/main/java/io/floci/az/
     └── functions/   # FunctionsServiceHandler, ContainerLauncher, WarmPool, FunctionCodeStore
 
 compatibility-tests/
+├── sdk-test-cpp/    # Azure C++ SDK tests (GoogleTest, vcpkg)
 ├── sdk-test-java/   # Azure Java SDK tests (JUnit 5)
 ├── sdk-test-node/   # Azure Node.js SDK tests (Jest)
 └── sdk-test-python/ # Azure Python SDK tests (pytest)
@@ -50,6 +51,7 @@ Then run via Make:
 make test-python-compat # Python SDK (virtualenv)
 make test-java-compat   # Java SDK (Maven)
 make test-node-compat   # Node.js SDK (npm)
+make test-cpp-compat    # C++ SDK (Docker only: the toolchain lives in the image)
 ```
 
 ### Compatibility tests — Docker (matches CI)


### PR DESCRIPTION
## Summary

Adds `sdk-test-cpp`, an Azure SDK for C++ compatibility suite. GoogleTest cases driving the real SDK clients, dependencies resolved by vcpkg in manifest mode, mirroring the Python/Java/Node suites.

The C++ SDK is uniquely sensitive to bodyless error responses. `StorageException::CreateFromResponse` picks a parser by substring-matching the `content-type` header and hands the body to `XmlReader` without checking that the buffer is non-empty. On a `HEAD` error response advertising `application/xml` with zero bytes, the resulting `std::runtime_error` is thrown from *inside* the `RequestFailedException` constructor — the exception object is never built, no catch clause can run, and the process calls `terminate()`.

Python, Java and Node all tolerate that response. This suite closes that blind spot.

> Depends on #185 (`fix/bodyless-error-content-type`). This branch is stacked on it so CI is green; `BlobErrors.GetPropertiesOnMissingBlobThrowsNotFound` fails without that fix.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Testing

**10 tests**, all passing against the emulator:

| Test | Covers |
|---|---|
| `BlobLifecycle.UploadDownloadDelete` | upload, download, delete round-trip |
| `BlobLifecycle.GetPropertiesOnExistingBlobSucceeds` | HEAD 200 keeps `Content-Type` |
| `BlobErrors.GetPropertiesOnMissingBlobThrowsNotFound` | 404  `BlobNotFound` |
| `BlobErrors.GetPropertiesOnMissingContainerThrowsNotFound` | 404  `ContainerNotFound` |
| `BlobErrors.DownloadMissingBlobParsesXmlErrorBody` | GET error keeps the parsable `<Error>` body |
| `BlobErrors.CreateExistingContainerThrowsAlreadyExists` | 409 `ContainerAlreadyExists` |
| `QueueLifecycle.EnqueueReceiveDelete` | enqueue, receive, delete |
| `QueueLifecycle.GetPropertiesOnExistingQueueSucceeds` | `ApproximateMessageCount` |
| `QueueErrors.GetPropertiesOnMissingQueueThrowsNotFound` | 404 `QueueNotFound` |
| `QueueErrors.ReceiveFromMissingQueueParsesXmlErrorBody` | queue XML error body |

**The regression test was verified in both directions.** Against an emulator image built with the
`BodylessErrorContentTypeFilter` removed, it fails with the reported symptom and the container exits
1:

```
[ RUN      ] BlobErrors.GetPropertiesOnMissingBlobThrowsNotFound
Entity: line 1: parser error : Document is empty
C++ exception with description "Failed to parse xml." thrown in the test body.
[  FAILED  ] BlobErrors.GetPropertiesOnMissingBlobThrowsNotFound
```

With the fix in place, 10/10 pass. So this is a test that demonstrably catches the bug rather than
one that merely passes.

## Build cost

Unlike the other suites there is no prebuilt package to install, so vcpkg compiles OpenSSL, libxml2, libcurl and the SDK from source.

| | Measured |
|---|---|
| Cold build | ~6 min |
| Warm rebuild (test edit) | 8s |
| Shipped image | 132 MB |
| Build stage | ~2.7 GB (discarded) |
| Test run | ~0.3s |

## CI

The matrix gains a per-suite timeout override:

```yaml
timeout-minutes: ${{ matrix.timeout_minutes || 20 }}
```

`sdk-test-cpp` gets 45; every other suite keeps the existing 20. The shared 20 min budget assumed
prebuilt dependencies, and the CI runners have fewer cores than my local machine, so a cold build
could possibly exceed it.

## Verification caveat

Everything above was measured on **x86_64**. CI runs on `ubuntu-24.04-arm`, and this machine has no arm64 emulation available, so I could not verify the arm64 build locally. Nothing is architecture-pinned: the CMake asset comes from `uname -m` and vcpkg auto-detects its triplet, but the arm64 build is genuinely first exercised by CI on this PR.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

No emulator source is touched. This PR is additive test infrastructure, so the existing unit suite is unaffected.