### PR TITLE
perf(docker): stop duplicating the native binary into a second image layer

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Stage native binary for packaging
         run: |
           mkdir -p native/arm64
-          cp target/*-runner native/arm64/
+          cp target/*-runner native/arm64/application
           cp target/*.so native/arm64/ 2>/dev/null || true
 
       - uses: docker/setup-buildx-action@v4.2.0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -126,8 +126,11 @@ jobs:
           name: native-arm64
           path: native/arm64/
 
-      - name: Make binaries executable
-        run: chmod +x native/amd64/*-runner native/arm64/*-runner
+      - name: Stage binaries under a fixed name
+        run: |
+          for arch in amd64 arm64; do
+            mv native/$arch/*-runner native/$arch/application
+          done
 
       - name: Set created timestamp
         id: created

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,8 +115,11 @@ jobs:
           name: native-arm64
           path: native/arm64/
 
-      - name: Make binaries executable
-        run: chmod +x native/amd64/*-runner native/arm64/*-runner
+      - name: Stage binaries under a fixed name
+        run: |
+          for arch in amd64 arm64; do
+            mv native/$arch/*-runner native/$arch/application
+          done
 
       - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 

--- a/docker/Dockerfile.native
+++ b/docker/Dockerfile.native
@@ -67,8 +67,7 @@ ENV FLOCI_AZ_VERSION=${VERSION}
 ENV FLOCI_AZ_STORAGE_PERSISTENT_PATH=/app/data
 ENV FLOCI_AZ_SERVICES_FUNCTIONS_CODE_PATH=/app/data/functions
 
-COPY --from=build /app/target/*-runner /app/application
-RUN chmod +x /app/application
+COPY --chmod=755 --from=build /app/target/*-runner /app/application
 
 COPY --chmod=755 docker/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 

--- a/docker/Dockerfile.native-package
+++ b/docker/Dockerfile.native-package
@@ -36,8 +36,7 @@ RUN mkdir -p /app/data \
 
 VOLUME /app/data
 
-COPY --chown=1001:root native/${TARGETARCH}/ /app/
-RUN mv /app/*-runner /app/application && chmod +x /app/application
+COPY --chmod=755 --chown=1001:root native/${TARGETARCH}/ /app/
 
 COPY --chmod=755 docker/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 


### PR DESCRIPTION
## Summary

The native images carried two full copies of the ~196 MB binary: `COPY` wrote one layer, then `RUN mv/chmod` rewrote the whole file into a second. (Port of floci-aws `9e90e5cf`, where this cut the native image 521 → 325 MB uncompressed, 168 → 104 MB compressed.)

- `docker/Dockerfile.native` and `docker/Dockerfile.native-package`: set the executable bit at copy time (`COPY --chmod=755`) and drop the `RUN mv/chmod` layer
- `compatibility.yml` / `nightly.yml` / `release.yml`: stage the binary under the fixed name `native/<arch>/application` before the docker build, replacing the now-redundant `chmod +x` step

The workflow and Dockerfile changes must land together: `Dockerfile.native-package` no longer renames, so CI has to stage the fixed name in the same commit.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

`perf:` — patch bump (no matching checkbox in the template).

## Azure Compatibility

n/a — packaging only; no protocol or runtime behavior change.

## Checklist

- [ ] `./mvnw test` passes locally — not run; no Java touched (CI/docker files only)
- [ ] New or updated integration test added — n/a; verified by this PR's native-image build and native compat jobs
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
