### PR TITLE
feat(servicebus): support message sessions

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -79,6 +79,7 @@ jobs:
           - test: sdk-test-java
             emulator_env: >-
               -e FLOCI_AZ_SERVICES_SERVICE_BUS_MOCKED=false
+              -e FLOCI_AZ_SERVICES_SERVICE_BUS_LOCK_DURATION_SECONDS=5
             extra_env: >-
               -e SERVICEBUS_HOST=floci-az-servicebus-default
               -e SERVICEBUS_AMQPS_PORT=5671

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'src/**'
       - 'pom.xml'
+      - 'Makefile'
       - 'docker/Dockerfile.native-package'
       - 'docker/entrypoint.sh'
       - 'compatibility-tests/**'
@@ -76,6 +77,8 @@ jobs:
             extra_env: >-
               -e AZURE_POD_IDENTITY_AUTHORITY_HOST=http://floci-az:4577
           - test: sdk-test-java
+            emulator_env: >-
+              -e FLOCI_AZ_SERVICES_SERVICE_BUS_MOCKED=false
             extra_env: >-
               -e SERVICEBUS_HOST=floci-az-servicebus-default
               -e SERVICEBUS_AMQPS_PORT=5671

--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -81,6 +81,12 @@ jobs:
               -e SERVICEBUS_AMQPS_PORT=5671
               -e SERVICEBUS_NAMESPACE=default
               -e AZURE_POD_IDENTITY_AUTHORITY_HOST=http://floci-az:4577
+          - test: sdk-test-dotnet
+            emulator_env: >-
+              -e FLOCI_AZ_SERVICES_SERVICE_BUS_MOCKED=false
+            extra_env: >-
+              -e SERVICEBUS_HOST=floci-az-servicebus-default
+              -e SERVICEBUS_AMQP_PORT=5672
           - test: sdk-test-node
             extra_env: >-
               -e AZURE_POD_IDENTITY_AUTHORITY_HOST=http://floci-az:4577
@@ -109,6 +115,7 @@ jobs:
             -e FLOCI_AZ_SERVICES_DOCKER_NETWORK=compat-net \
             -e FLOCI_AZ_TLS_ENABLED=true \
             -e FLOCI_AZ_HOSTNAME=floci-az \
+            ${{ matrix.emulator_env }} \
             floci-az:test-native
 
       - name: Wait for floci-az to be ready

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ go.sum
 package-lock.json
 test-results.xml
 test-results/
+compatibility-tests/sdk-test-dotnet/bin/
+compatibility-tests/sdk-test-dotnet/obj/
 
 *.log
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -268,6 +268,8 @@ Current per-suite env vars that must stay in sync:
 | `sdk-test-java` | `-e SERVICEBUS_AMQPS_PORT=5671` | ✓ |
 | `sdk-test-java` | `-e SERVICEBUS_NAMESPACE=default` | ✓ |
 | `sdk-test-java` | `-e AZURE_POD_IDENTITY_AUTHORITY_HOST=http://floci-az:4577` | ✓ |
+| `sdk-test-dotnet` | `-e SERVICEBUS_HOST=floci-az-servicebus-default` | ✓ |
+| `sdk-test-dotnet` | `-e SERVICEBUS_AMQP_PORT=5672` | ✓ |
 | `sdk-test-python` | `-e AZURE_POD_IDENTITY_AUTHORITY_HOST=http://floci-az:4577` | ✓ |
 | `sdk-test-node` | `-e AZURE_POD_IDENTITY_AUTHORITY_HOST=http://floci-az:4577` | ✓ |
 

--- a/Makefile
+++ b/Makefile
@@ -75,11 +75,11 @@ docker run --rm --network $(COMPAT_NETWORK) \
 endef
 
 # Full session: build + start emulator, build suite image, run suite, always stop.
-# $(call COMPAT_SESSION,<suite>,<results-subdir>,<env args>,<late args>,<container cmd>)
+# $(call COMPAT_SESSION,<suite>,<results-subdir>,<suite env>,<late args>,<container cmd>,<emulator env>)
 define COMPAT_SESSION
 @mkdir -p $(COMPAT_RESULTS)/$(2)
 $(MAKE) compat-build
-$(MAKE) compat-run
+$(MAKE) compat-run FLOCI_AZ_COMPAT_EXTRA_ENV="$(6)"
 @EXIT=0; \
 $(MAKE) compat-$(1)-image || EXIT=$$?; \
 if [ $$EXIT -eq 0 ]; then \
@@ -270,7 +270,7 @@ test-blob:
 	@echo "==> Blob Storage SDK compatibility tests (Docker)"
 	@mkdir -p $(COMPAT_RESULTS)/blob-python $(COMPAT_RESULTS)/blob-node $(COMPAT_RESULTS)/blob-java
 	$(MAKE) compat-build
-	$(MAKE) compat-run FLOCI_AZ_COMPAT_EXTRA_ENV="$(6)"
+	$(MAKE) compat-run
 	@EXIT=0; \
 	$(MAKE) compat-python-image || EXIT=$$?; \
 	if [ $$EXIT -eq 0 ]; then $(MAKE) compat-node-image || EXIT=$$?; fi; \

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build run run-docker stop stop-docker require-emulator \
-        compat-network compat-build compat-run compat-stop compat-python-image compat-java-image compat-node-image compat-terraform-image compat-opentofu-image compat-azcli-image \
+        compat-network compat-build compat-run compat-stop compat-python-image compat-java-image compat-dotnet-image compat-node-image compat-terraform-image compat-opentofu-image compat-azcli-image \
         run-cosmos-mongo run-cosmos-postgresql run-cosmos-cassandra run-cosmos-gremlin run-cosmos-table run-cosmos-nosql run-sql \
-        test test-python-compat test-python-compat-local test-java-compat test-java-compat-local test-node-compat test-node-compat-local test-servicebus-compat \
+        test test-python-compat test-python-compat-local test-java-compat test-java-compat-local test-dotnet-compat test-node-compat test-node-compat-local test-servicebus-compat \
         test-blob test-blob-local test-blob-python test-blob-python-local test-blob-java test-blob-java-local test-blob-node test-blob-node-local \
         test-entra-node test-entra-node-local \
         test-apim-java \
@@ -14,6 +14,7 @@ PID_FILE       = emulator.pid
 PYTHON_DIR     = compatibility-tests/sdk-test-python
 JAVA_DIR       = compatibility-tests/sdk-test-java
 NODE_DIR       = compatibility-tests/sdk-test-node
+DOTNET_DIR     = compatibility-tests/sdk-test-dotnet
 TERRAFORM_DIR  = compatibility-tests/compat-terraform
 OPENTOFU_DIR   = compatibility-tests/compat-opentofu
 AZCLI_DIR      = compatibility-tests/compat-azcli
@@ -23,6 +24,7 @@ FLOCI_AZ_IMAGE = floci-az:test
 PYTHON_IMAGE   = compat-sdk-test-python
 JAVA_IMAGE     = compat-sdk-test-java
 NODE_IMAGE     = compat-sdk-test-node
+DOTNET_IMAGE   = compat-sdk-test-dotnet
 TERRAFORM_IMAGE = compat-terraform
 OPENTOFU_IMAGE  = compat-opentofu
 AZCLI_IMAGE     = compat-azcli
@@ -40,18 +42,22 @@ SUITE_ENV_JAVA   = $(POD_IDENTITY_ENV) \
 	-e SERVICEBUS_AMQPS_PORT=5671 \
 	-e SERVICEBUS_NAMESPACE=default
 SUITE_ENV_NODE   = $(POD_IDENTITY_ENV)
+SUITE_ENV_DOTNET = -e SERVICEBUS_HOST=floci-az-servicebus-default \
+	-e SERVICEBUS_AMQP_PORT=5672
 
 # Per-suite build context and image tag, keyed by suite name.
-SUITES = python java node terraform opentofu azcli
+SUITES = python java dotnet node terraform opentofu azcli
 SUITE_DIR_python    = $(PYTHON_DIR)
 SUITE_DIR_java      = $(JAVA_DIR)
 SUITE_DIR_node      = $(NODE_DIR)
+SUITE_DIR_dotnet    = $(DOTNET_DIR)
 SUITE_DIR_terraform = $(TERRAFORM_DIR)
 SUITE_DIR_opentofu  = $(OPENTOFU_DIR)
 SUITE_DIR_azcli     = $(AZCLI_DIR)
 SUITE_IMAGE_python    = $(PYTHON_IMAGE)
 SUITE_IMAGE_java      = $(JAVA_IMAGE)
 SUITE_IMAGE_node      = $(NODE_IMAGE)
+SUITE_IMAGE_dotnet    = $(DOTNET_IMAGE)
 SUITE_IMAGE_terraform = $(TERRAFORM_IMAGE)
 SUITE_IMAGE_opentofu  = $(OPENTOFU_IMAGE)
 SUITE_IMAGE_azcli     = $(AZCLI_IMAGE)
@@ -138,6 +144,7 @@ compat-run: compat-network
 		-e FLOCI_AZ_SERVICES_DOCKER_NETWORK=$(COMPAT_NETWORK) \
 		-e FLOCI_AZ_TLS_ENABLED=true \
 		-e FLOCI_AZ_HOSTNAME=floci-az \
+		$(FLOCI_AZ_COMPAT_EXTRA_ENV) \
 		$(FLOCI_AZ_IMAGE)
 	@echo "Waiting for floci-az Docker emulator to start on port $(PORT)..."
 	@until curl -sf http://127.0.0.1:$(PORT)/health > /dev/null; do sleep 1; done
@@ -212,6 +219,10 @@ test-node-compat:
 	@echo "==> Node.js SDK compatibility tests (Docker)"
 	$(call COMPAT_SESSION,node,node,$(SUITE_ENV_NODE),,)
 
+test-dotnet-compat:
+	@echo "==> .NET Service Bus SDK compatibility tests (Docker)"
+	$(call COMPAT_SESSION,dotnet,dotnet,$(SUITE_ENV_DOTNET),,,-e FLOCI_AZ_SERVICES_SERVICE_BUS_MOCKED=false)
+
 test-python-compat-local:
 	@echo "==> Python SDK compatibility tests (all services, local emulator)"
 	@cd $(PYTHON_DIR) && \
@@ -259,7 +270,7 @@ test-blob:
 	@echo "==> Blob Storage SDK compatibility tests (Docker)"
 	@mkdir -p $(COMPAT_RESULTS)/blob-python $(COMPAT_RESULTS)/blob-node $(COMPAT_RESULTS)/blob-java
 	$(MAKE) compat-build
-	$(MAKE) compat-run
+	$(MAKE) compat-run FLOCI_AZ_COMPAT_EXTRA_ENV="$(6)"
 	@EXIT=0; \
 	$(MAKE) compat-python-image || EXIT=$$?; \
 	if [ $$EXIT -eq 0 ]; then $(MAKE) compat-node-image || EXIT=$$?; fi; \
@@ -379,12 +390,13 @@ test-azcli:
 
 compat-docker:
 	$(MAKE) compat-build
-	$(MAKE) compat-run
-	@mkdir -p $(COMPAT_RESULTS)/python $(COMPAT_RESULTS)/node $(COMPAT_RESULTS)/java $(COMPAT_RESULTS)/terraform $(COMPAT_RESULTS)/opentofu $(COMPAT_RESULTS)/azcli
+	$(MAKE) compat-run FLOCI_AZ_COMPAT_EXTRA_ENV="-e FLOCI_AZ_SERVICES_SERVICE_BUS_MOCKED=false"
+	@mkdir -p $(COMPAT_RESULTS)/python $(COMPAT_RESULTS)/node $(COMPAT_RESULTS)/java $(COMPAT_RESULTS)/dotnet $(COMPAT_RESULTS)/terraform $(COMPAT_RESULTS)/opentofu $(COMPAT_RESULTS)/azcli
 	@EXIT=0; \
 	$(MAKE) compat-python-image || EXIT=$$?; \
 	if [ $$EXIT -eq 0 ]; then $(MAKE) compat-node-image || EXIT=$$?; fi; \
 	if [ $$EXIT -eq 0 ]; then $(MAKE) compat-java-image || EXIT=$$?; fi; \
+	if [ $$EXIT -eq 0 ]; then $(MAKE) compat-dotnet-image || EXIT=$$?; fi; \
 	if [ $$EXIT -eq 0 ]; then $(MAKE) compat-terraform-image || EXIT=$$?; fi; \
 	if [ $$EXIT -eq 0 ]; then $(MAKE) compat-opentofu-image || EXIT=$$?; fi; \
 	if [ $$EXIT -eq 0 ]; then $(MAKE) compat-azcli-image || EXIT=$$?; fi; \
@@ -401,6 +413,11 @@ compat-docker:
 	if [ $$EXIT -eq 0 ]; then \
 		echo "==> Java SDK tests"; \
 		$(call RUN_SUITE,java,java,$(SUITE_ENV_JAVA) -v /var/run/docker.sock:/var/run/docker.sock,,); \
+		EXIT=$$?; \
+	fi; \
+	if [ $$EXIT -eq 0 ]; then \
+		echo "==> .NET SDK tests"; \
+		$(call RUN_SUITE,dotnet,dotnet,$(SUITE_ENV_DOTNET),,); \
 		EXIT=$$?; \
 	fi; \
 	if [ $$EXIT -eq 0 ]; then \

--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,7 @@ test-python-compat:
 
 test-java-compat:
 	@echo "==> Java SDK compatibility tests (Docker)"
-	$(call COMPAT_SESSION,java,java,$(SUITE_ENV_JAVA) -v /var/run/docker.sock:/var/run/docker.sock,,)
+	$(call COMPAT_SESSION,java,java,$(SUITE_ENV_JAVA) -v /var/run/docker.sock:/var/run/docker.sock,,,-e FLOCI_AZ_SERVICES_SERVICE_BUS_MOCKED=false)
 
 test-node-compat:
 	@echo "==> Node.js SDK compatibility tests (Docker)"

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,9 @@ SUITE_ENV_JAVA   = $(POD_IDENTITY_ENV) \
 SUITE_ENV_NODE   = $(POD_IDENTITY_ENV)
 SUITE_ENV_DOTNET = -e SERVICEBUS_HOST=floci-az-servicebus-default \
 	-e SERVICEBUS_AMQP_PORT=5672
+SERVICEBUS_EMULATOR_ENV = -e FLOCI_AZ_SERVICES_SERVICE_BUS_MOCKED=false
+JAVA_SERVICEBUS_EMULATOR_ENV = $(SERVICEBUS_EMULATOR_ENV) \
+	-e FLOCI_AZ_SERVICES_SERVICE_BUS_LOCK_DURATION_SECONDS=5
 
 # Per-suite build context and image tag, keyed by suite name.
 SUITES = python java dotnet node terraform opentofu azcli
@@ -151,6 +154,8 @@ compat-run: compat-network
 	@echo "floci-az Docker emulator is up!"
 
 compat-stop:
+	@SIDECARS=$$(docker ps -aq --filter "network=$(COMPAT_NETWORK)" --filter "name=floci-az-servicebus-"); \
+	if [ -n "$$SIDECARS" ]; then docker rm -f $$SIDECARS >/dev/null 2>&1 || true; fi
 	@docker rm -f floci-az >/dev/null 2>&1 || true
 	@docker network rm $(COMPAT_NETWORK) >/dev/null 2>&1 || true
 
@@ -213,7 +218,7 @@ test-python-compat:
 
 test-java-compat:
 	@echo "==> Java SDK compatibility tests (Docker)"
-	$(call COMPAT_SESSION,java,java,$(SUITE_ENV_JAVA) -v /var/run/docker.sock:/var/run/docker.sock,,,-e FLOCI_AZ_SERVICES_SERVICE_BUS_MOCKED=false)
+	$(call COMPAT_SESSION,java,java,$(SUITE_ENV_JAVA) -v /var/run/docker.sock:/var/run/docker.sock,,,$(JAVA_SERVICEBUS_EMULATOR_ENV))
 
 test-node-compat:
 	@echo "==> Node.js SDK compatibility tests (Docker)"
@@ -221,7 +226,7 @@ test-node-compat:
 
 test-dotnet-compat:
 	@echo "==> .NET Service Bus SDK compatibility tests (Docker)"
-	$(call COMPAT_SESSION,dotnet,dotnet,$(SUITE_ENV_DOTNET),,,-e FLOCI_AZ_SERVICES_SERVICE_BUS_MOCKED=false)
+	$(call COMPAT_SESSION,dotnet,dotnet,$(SUITE_ENV_DOTNET),,,$(SERVICEBUS_EMULATOR_ENV))
 
 test-python-compat-local:
 	@echo "==> Python SDK compatibility tests (all services, local emulator)"
@@ -390,7 +395,7 @@ test-azcli:
 
 compat-docker:
 	$(MAKE) compat-build
-	$(MAKE) compat-run FLOCI_AZ_COMPAT_EXTRA_ENV="-e FLOCI_AZ_SERVICES_SERVICE_BUS_MOCKED=false"
+	$(MAKE) compat-run FLOCI_AZ_COMPAT_EXTRA_ENV="$(JAVA_SERVICEBUS_EMULATOR_ENV)"
 	@mkdir -p $(COMPAT_RESULTS)/python $(COMPAT_RESULTS)/node $(COMPAT_RESULTS)/java $(COMPAT_RESULTS)/dotnet $(COMPAT_RESULTS)/terraform $(COMPAT_RESULTS)/opentofu $(COMPAT_RESULTS)/azcli
 	@EXIT=0; \
 	$(MAKE) compat-python-image || EXIT=$$?; \

--- a/compatibility-tests/sdk-test-dotnet/Dockerfile
+++ b/compatibility-tests/sdk-test-dotnet/Dockerfile
@@ -8,4 +8,4 @@ COPY ServiceBusCompatibilityTests.cs .
 RUN dotnet build --no-restore
 
 RUN mkdir -p /results
-ENTRYPOINT ["dotnet", "test", "--no-build", "--logger:junit;LogFilePath=/results/servicebus-dotnet.xml"]
+ENTRYPOINT ["dotnet", "run", "--no-build", "--", "--junit-output-path", "/results/servicebus-dotnet.xml"]

--- a/compatibility-tests/sdk-test-dotnet/Dockerfile
+++ b/compatibility-tests/sdk-test-dotnet/Dockerfile
@@ -1,0 +1,11 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0
+WORKDIR /app
+
+COPY SdkTestDotnet.csproj .
+RUN dotnet restore
+
+COPY ServiceBusCompatibilityTests.cs .
+RUN dotnet build --no-restore
+
+RUN mkdir -p /results
+ENTRYPOINT ["dotnet", "test", "--no-build", "--logger:junit;LogFilePath=/results/servicebus-dotnet.xml"]

--- a/compatibility-tests/sdk-test-dotnet/SdkTestDotnet.csproj
+++ b/compatibility-tests/sdk-test-dotnet/SdkTestDotnet.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -8,9 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
-    <PackageReference Include="JunitXml.TestLogger" Version="7.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="xunit.v3" Version="3.2.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageReference Include="TUnit" Version="1.63.0" />
   </ItemGroup>
 </Project>

--- a/compatibility-tests/sdk-test-dotnet/SdkTestDotnet.csproj
+++ b/compatibility-tests/sdk-test-dotnet/SdkTestDotnet.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
+    <PackageReference Include="JunitXml.TestLogger" Version="7.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
+  </ItemGroup>
+</Project>

--- a/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
+++ b/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
@@ -1,9 +1,11 @@
+using System.Collections.Concurrent;
 using System.Net.Http.Headers;
 using System.Text;
 using Azure.Messaging.ServiceBus;
 
 namespace FlociAz.Compatibility;
 
+[NotInParallel]
 public sealed class ServiceBusCompatibilityTests
 {
     private static readonly TimeSpan ReceiveTimeout = TimeSpan.FromSeconds(10);
@@ -80,6 +82,98 @@ public sealed class ServiceBusCompatibilityTests
             subscriptionDeadLetter, cancellationToken);
     }
 
+    [Test]
+    [Timeout(60_000)]
+    public async Task DotnetSdkSupportsSessionReceivers(CancellationToken cancellationToken)
+    {
+        const string serviceBusNamespace = "default";
+        string queue = $"dotnet-session-{Guid.NewGuid():N}";
+        await EnsureNamespace(serviceBusNamespace, cancellationToken);
+        await EnsureQueue(serviceBusNamespace, queue, cancellationToken, requiresSession: true);
+
+        string connectionString =
+            $"Endpoint=sb://{ServiceBusHost}:{ServiceBusPort};" +
+            "SharedAccessKeyName=RootManageSharedAccessKey;" +
+            "SharedAccessKey=devkey;UseDevelopmentEmulator=true;";
+
+        await using var client = new ServiceBusClient(connectionString, new ServiceBusClientOptions
+        {
+            RetryOptions = { TryTimeout = TimeSpan.FromSeconds(10) }
+        });
+        await using ServiceBusSender sender = client.CreateSender(queue);
+
+        string firstSession = $"session-a-{Guid.NewGuid():N}";
+        string secondSession = $"session-b-{Guid.NewGuid():N}";
+        await sender.SendMessageAsync(
+            new ServiceBusMessage("a-0") { SessionId = firstSession }, cancellationToken);
+        await sender.SendMessageAsync(
+            new ServiceBusMessage("a-1") { SessionId = firstSession }, cancellationToken);
+        await sender.SendMessageAsync(
+            new ServiceBusMessage("b-0") { SessionId = secondSession }, cancellationToken);
+
+        await using (ServiceBusSessionReceiver firstReceiver = await client.AcceptNextSessionAsync(
+            queue, new ServiceBusSessionReceiverOptions(), cancellationToken))
+        {
+            await Assert.That(firstReceiver.SessionId).IsEqualTo(firstSession);
+            IReadOnlyList<ServiceBusReceivedMessage> firstMessages = await firstReceiver.ReceiveMessagesAsync(
+                2, ReceiveTimeout, cancellationToken);
+            await Assert.That(firstMessages.Count).IsEqualTo(2);
+            await Assert.That(firstMessages[0].Body.ToString()).IsEqualTo("a-0");
+            await Assert.That(firstMessages[1].Body.ToString()).IsEqualTo("a-1");
+            foreach (ServiceBusReceivedMessage message in firstMessages)
+            {
+                await firstReceiver.CompleteMessageAsync(message, cancellationToken);
+            }
+        }
+
+        await using (ServiceBusSessionReceiver secondReceiver = await client.AcceptSessionAsync(
+            queue, secondSession, new ServiceBusSessionReceiverOptions(), cancellationToken))
+        {
+            ServiceBusReceivedMessage secondMessage = await Receive(secondReceiver, cancellationToken);
+            await Assert.That(secondMessage.SessionId).IsEqualTo(secondSession);
+            await Assert.That(secondMessage.Body.ToString()).IsEqualTo("b-0");
+            await secondReceiver.CompleteMessageAsync(secondMessage, cancellationToken);
+        }
+
+        string processorSessionA = $"session-processor-a-{Guid.NewGuid():N}";
+        string processorSessionB = $"session-processor-b-{Guid.NewGuid():N}";
+        await sender.SendMessageAsync(
+            new ServiceBusMessage("processor-a") { SessionId = processorSessionA }, cancellationToken);
+        await sender.SendMessageAsync(
+            new ServiceBusMessage("processor-b") { SessionId = processorSessionB }, cancellationToken);
+        var processedMessages = new ConcurrentDictionary<string, string>();
+        var processingComplete = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        await using ServiceBusSessionProcessor processor = client.CreateSessionProcessor(
+            queue,
+            new ServiceBusSessionProcessorOptions
+            {
+                AutoCompleteMessages = false,
+                MaxConcurrentSessions = 2,
+                MaxConcurrentCallsPerSession = 1
+            });
+        processor.ProcessMessageAsync += async args =>
+        {
+            await args.CompleteMessageAsync(args.Message, cancellationToken);
+            processedMessages[args.SessionId] = args.Message.Body.ToString();
+            if (processedMessages.Count == 2)
+            {
+                processingComplete.TrySetResult();
+            }
+        };
+        processor.ProcessErrorAsync += args =>
+        {
+            processingComplete.TrySetException(args.Exception);
+            return Task.CompletedTask;
+        };
+
+        await processor.StartProcessingAsync(cancellationToken);
+        await processingComplete.Task.WaitAsync(ReceiveTimeout, cancellationToken);
+        await processor.StopProcessingAsync(cancellationToken);
+        await Assert.That(processedMessages[processorSessionA]).IsEqualTo("processor-a");
+        await Assert.That(processedMessages[processorSessionB]).IsEqualTo("processor-b");
+    }
+
     private static async Task<ServiceBusReceivedMessage> Receive(
         ServiceBusReceiver receiver, CancellationToken cancellationToken)
     {
@@ -103,13 +197,19 @@ public sealed class ServiceBusCompatibilityTests
     }
 
     private static async Task EnsureQueue(
-        string serviceBusNamespace, string queue, CancellationToken cancellationToken)
+        string serviceBusNamespace, string queue, CancellationToken cancellationToken,
+        bool requiresSession = false)
     {
         using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
         using var request = new HttpRequestMessage(HttpMethod.Put,
             $"{EmulatorEndpoint}/devstoreaccount1-servicebus/{serviceBusNamespace}/queues/{queue}");
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/atom+xml"));
-        request.Content = new StringContent("", Encoding.UTF8, "application/atom+xml");
+        string body = requiresSession
+            ? "<entry xmlns=\"http://www.w3.org/2005/Atom\"><content type=\"application/xml\">" +
+              "<QueueDescription xmlns=\"http://schemas.microsoft.com/netservices/2010/10/servicebus/connect\">" +
+              "<RequiresSession>true</RequiresSession></QueueDescription></content></entry>"
+            : "";
+        request.Content = new StringContent(body, Encoding.UTF8, "application/atom+xml");
         HttpResponseMessage response = await http.SendAsync(request, cancellationToken);
         await Assert.That(response.IsSuccessStatusCode)
             .IsTrue()

--- a/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
+++ b/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
@@ -1,7 +1,6 @@
 using System.Net.Http.Headers;
 using System.Text;
 using Azure.Messaging.ServiceBus;
-using Xunit;
 
 namespace FlociAz.Compatibility;
 
@@ -15,13 +14,10 @@ public sealed class ServiceBusCompatibilityTests
     private static readonly int ServiceBusPort =
         int.Parse(Environment.GetEnvironmentVariable("SERVICEBUS_AMQP_PORT") ?? "5673");
 
-    [Fact]
-    public async Task DotnetSdkSupportsSettlementOperations()
+    [Test]
+    [Timeout(30_000)]
+    public async Task DotnetSdkSupportsSettlementOperations(CancellationToken cancellationToken)
     {
-        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(
-            TestContext.Current.CancellationToken);
-        timeout.CancelAfter(TimeSpan.FromSeconds(30));
-        CancellationToken cancellationToken = timeout.Token;
         const string serviceBusNamespace = "default";
         string queue = $"dotnet-{Guid.NewGuid():N}";
         await EnsureNamespace(serviceBusNamespace, cancellationToken);
@@ -41,15 +37,15 @@ public sealed class ServiceBusCompatibilityTests
 
         await sender.SendMessageAsync(new ServiceBusMessage("complete"), cancellationToken);
         ServiceBusReceivedMessage completed = await Receive(receiver, cancellationToken);
-        Assert.Equal("complete", completed.Body.ToString());
+        await Assert.That(completed.Body.ToString()).IsEqualTo("complete");
         await receiver.CompleteMessageAsync(completed, cancellationToken);
 
         await sender.SendMessageAsync(new ServiceBusMessage("abandon"), cancellationToken);
         ServiceBusReceivedMessage abandoned = await Receive(receiver, cancellationToken);
         await receiver.AbandonMessageAsync(abandoned, cancellationToken: cancellationToken);
         ServiceBusReceivedMessage redelivered = await Receive(receiver, cancellationToken);
-        Assert.Equal("abandon", redelivered.Body.ToString());
-        Assert.True(redelivered.DeliveryCount >= 1);
+        await Assert.That(redelivered.Body.ToString()).IsEqualTo("abandon");
+        await Assert.That(redelivered.DeliveryCount).IsGreaterThanOrEqualTo(1);
         await receiver.CompleteMessageAsync(redelivered, cancellationToken);
 
         await sender.SendMessageAsync(new ServiceBusMessage("dead-letter"), cancellationToken);
@@ -59,7 +55,7 @@ public sealed class ServiceBusCompatibilityTests
         await using ServiceBusReceiver deadLetterReceiver = client.CreateReceiver(
             queue, new ServiceBusReceiverOptions { SubQueue = SubQueue.DeadLetter });
         ServiceBusReceivedMessage fromDeadLetterQueue = await Receive(deadLetterReceiver, cancellationToken);
-        Assert.Equal("dead-letter", fromDeadLetterQueue.Body.ToString());
+        await Assert.That(fromDeadLetterQueue.Body.ToString()).IsEqualTo("dead-letter");
         await deadLetterReceiver.CompleteMessageAsync(fromDeadLetterQueue, cancellationToken);
     }
 
@@ -68,7 +64,8 @@ public sealed class ServiceBusCompatibilityTests
     {
         ServiceBusReceivedMessage? message =
             await receiver.ReceiveMessageAsync(ReceiveTimeout, cancellationToken);
-        return Assert.IsType<ServiceBusReceivedMessage>(message);
+        await Assert.That(message).IsNotNull();
+        return message!;
     }
 
     private static async Task EnsureNamespace(
@@ -79,8 +76,9 @@ public sealed class ServiceBusCompatibilityTests
         HttpResponseMessage response = await http.PutAsync(
             $"{EmulatorEndpoint}/devstoreaccount1-servicebus/namespaces/{serviceBusNamespace}",
             body, cancellationToken);
-        Assert.True(response.IsSuccessStatusCode,
-            $"Namespace creation failed: {(int)response.StatusCode} {await response.Content.ReadAsStringAsync()}");
+        await Assert.That(response.IsSuccessStatusCode)
+            .IsTrue()
+            .Because($"Namespace creation failed: {(int)response.StatusCode} {await response.Content.ReadAsStringAsync(cancellationToken)}");
     }
 
     private static async Task EnsureQueue(
@@ -92,7 +90,8 @@ public sealed class ServiceBusCompatibilityTests
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/atom+xml"));
         request.Content = new StringContent("", Encoding.UTF8, "application/atom+xml");
         HttpResponseMessage response = await http.SendAsync(request, cancellationToken);
-        Assert.True(response.IsSuccessStatusCode,
-            $"Queue creation failed: {(int)response.StatusCode} {await response.Content.ReadAsStringAsync()}");
+        await Assert.That(response.IsSuccessStatusCode)
+            .IsTrue()
+            .Because($"Queue creation failed: {(int)response.StatusCode} {await response.Content.ReadAsStringAsync(cancellationToken)}");
     }
 }

--- a/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
+++ b/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
@@ -15,7 +15,7 @@ public sealed class ServiceBusCompatibilityTests
         int.Parse(Environment.GetEnvironmentVariable("SERVICEBUS_AMQP_PORT") ?? "5673");
 
     [Test]
-    [Timeout(30_000)]
+    [Timeout(60_000)]
     public async Task DotnetSdkSupportsSettlementOperations(CancellationToken cancellationToken)
     {
         const string serviceBusNamespace = "default";
@@ -57,6 +57,27 @@ public sealed class ServiceBusCompatibilityTests
         ServiceBusReceivedMessage fromDeadLetterQueue = await Receive(deadLetterReceiver, cancellationToken);
         await Assert.That(fromDeadLetterQueue.Body.ToString()).IsEqualTo("dead-letter");
         await deadLetterReceiver.CompleteMessageAsync(fromDeadLetterQueue, cancellationToken);
+
+        string topic = $"dotnet-topic-{Guid.NewGuid():N}";
+        string subscription = $"dotnet-sub-{Guid.NewGuid():N}";
+        await EnsureTopic(serviceBusNamespace, topic, cancellationToken);
+        await EnsureSubscription(serviceBusNamespace, topic, subscription, cancellationToken);
+
+        await using ServiceBusSender topicSender = client.CreateSender(topic);
+        await using ServiceBusReceiver subscriptionReceiver = client.CreateReceiver(topic, subscription);
+        await topicSender.SendMessageAsync(new ServiceBusMessage("subscription-dead-letter"), cancellationToken);
+        ServiceBusReceivedMessage subscriptionMessage = await Receive(subscriptionReceiver, cancellationToken);
+        await subscriptionReceiver.DeadLetterMessageAsync(
+            subscriptionMessage, cancellationToken: cancellationToken);
+
+        await using ServiceBusReceiver subscriptionDeadLetterReceiver = client.CreateReceiver(
+            topic, subscription, new ServiceBusReceiverOptions { SubQueue = SubQueue.DeadLetter });
+        ServiceBusReceivedMessage subscriptionDeadLetter =
+            await Receive(subscriptionDeadLetterReceiver, cancellationToken);
+        await Assert.That(subscriptionDeadLetter.Body.ToString())
+            .IsEqualTo("subscription-dead-letter");
+        await subscriptionDeadLetterReceiver.CompleteMessageAsync(
+            subscriptionDeadLetter, cancellationToken);
     }
 
     private static async Task<ServiceBusReceivedMessage> Receive(
@@ -93,5 +114,35 @@ public sealed class ServiceBusCompatibilityTests
         await Assert.That(response.IsSuccessStatusCode)
             .IsTrue()
             .Because($"Queue creation failed: {(int)response.StatusCode} {await response.Content.ReadAsStringAsync(cancellationToken)}");
+    }
+
+    private static async Task EnsureTopic(
+        string serviceBusNamespace, string topic, CancellationToken cancellationToken)
+    {
+        await EnsureEntity(
+            $"{EmulatorEndpoint}/devstoreaccount1-servicebus/{serviceBusNamespace}/topics/{topic}",
+            "Topic", cancellationToken);
+    }
+
+    private static async Task EnsureSubscription(
+        string serviceBusNamespace, string topic, string subscription,
+        CancellationToken cancellationToken)
+    {
+        await EnsureEntity(
+            $"{EmulatorEndpoint}/devstoreaccount1-servicebus/{serviceBusNamespace}/topics/{topic}/subscriptions/{subscription}",
+            "Subscription", cancellationToken);
+    }
+
+    private static async Task EnsureEntity(
+        string url, string entityType, CancellationToken cancellationToken)
+    {
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+        using var request = new HttpRequestMessage(HttpMethod.Put, url);
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/atom+xml"));
+        request.Content = new StringContent("", Encoding.UTF8, "application/atom+xml");
+        HttpResponseMessage response = await http.SendAsync(request, cancellationToken);
+        await Assert.That(response.IsSuccessStatusCode)
+            .IsTrue()
+            .Because($"{entityType} creation failed: {(int)response.StatusCode} {await response.Content.ReadAsStringAsync(cancellationToken)}");
     }
 }

--- a/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
+++ b/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
@@ -1,0 +1,98 @@
+using System.Net.Http.Headers;
+using System.Text;
+using Azure.Messaging.ServiceBus;
+using Xunit;
+
+namespace FlociAz.Compatibility;
+
+public sealed class ServiceBusCompatibilityTests
+{
+    private static readonly TimeSpan ReceiveTimeout = TimeSpan.FromSeconds(10);
+    private static readonly string EmulatorEndpoint =
+        Environment.GetEnvironmentVariable("FLOCI_AZ_ENDPOINT") ?? "http://localhost:4577";
+    private static readonly string ServiceBusHost =
+        Environment.GetEnvironmentVariable("SERVICEBUS_HOST") ?? "localhost";
+    private static readonly int ServiceBusPort =
+        int.Parse(Environment.GetEnvironmentVariable("SERVICEBUS_AMQP_PORT") ?? "5673");
+
+    [Fact]
+    public async Task DotnetSdkSupportsSettlementOperations()
+    {
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(
+            TestContext.Current.CancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(30));
+        CancellationToken cancellationToken = timeout.Token;
+        const string serviceBusNamespace = "default";
+        string queue = $"dotnet-{Guid.NewGuid():N}";
+        await EnsureNamespace(serviceBusNamespace, cancellationToken);
+        await EnsureQueue(serviceBusNamespace, queue, cancellationToken);
+
+        string connectionString =
+            $"Endpoint=sb://{ServiceBusHost}:{ServiceBusPort};" +
+            "SharedAccessKeyName=RootManageSharedAccessKey;" +
+            "SharedAccessKey=devkey;UseDevelopmentEmulator=true;";
+
+        await using var client = new ServiceBusClient(connectionString, new ServiceBusClientOptions
+        {
+            RetryOptions = { TryTimeout = TimeSpan.FromSeconds(10) }
+        });
+        await using ServiceBusSender sender = client.CreateSender(queue);
+        await using ServiceBusReceiver receiver = client.CreateReceiver(queue);
+
+        await sender.SendMessageAsync(new ServiceBusMessage("complete"), cancellationToken);
+        ServiceBusReceivedMessage completed = await Receive(receiver, cancellationToken);
+        Assert.Equal("complete", completed.Body.ToString());
+        await receiver.CompleteMessageAsync(completed, cancellationToken);
+
+        await sender.SendMessageAsync(new ServiceBusMessage("abandon"), cancellationToken);
+        ServiceBusReceivedMessage abandoned = await Receive(receiver, cancellationToken);
+        await receiver.AbandonMessageAsync(abandoned, cancellationToken: cancellationToken);
+        ServiceBusReceivedMessage redelivered = await Receive(receiver, cancellationToken);
+        Assert.Equal("abandon", redelivered.Body.ToString());
+        Assert.True(redelivered.DeliveryCount >= 1);
+        await receiver.CompleteMessageAsync(redelivered, cancellationToken);
+
+        await sender.SendMessageAsync(new ServiceBusMessage("dead-letter"), cancellationToken);
+        ServiceBusReceivedMessage deadLettered = await Receive(receiver, cancellationToken);
+        await receiver.DeadLetterMessageAsync(deadLettered, cancellationToken: cancellationToken);
+
+        await using ServiceBusReceiver deadLetterReceiver = client.CreateReceiver(
+            queue, new ServiceBusReceiverOptions { SubQueue = SubQueue.DeadLetter });
+        ServiceBusReceivedMessage fromDeadLetterQueue = await Receive(deadLetterReceiver, cancellationToken);
+        Assert.Equal("dead-letter", fromDeadLetterQueue.Body.ToString());
+        await deadLetterReceiver.CompleteMessageAsync(fromDeadLetterQueue, cancellationToken);
+    }
+
+    private static async Task<ServiceBusReceivedMessage> Receive(
+        ServiceBusReceiver receiver, CancellationToken cancellationToken)
+    {
+        ServiceBusReceivedMessage? message =
+            await receiver.ReceiveMessageAsync(ReceiveTimeout, cancellationToken);
+        return Assert.IsType<ServiceBusReceivedMessage>(message);
+    }
+
+    private static async Task EnsureNamespace(
+        string serviceBusNamespace, CancellationToken cancellationToken)
+    {
+        using var http = new HttpClient { Timeout = TimeSpan.FromMinutes(2) };
+        using var body = new StringContent("{}", Encoding.UTF8, "application/json");
+        HttpResponseMessage response = await http.PutAsync(
+            $"{EmulatorEndpoint}/devstoreaccount1-servicebus/namespaces/{serviceBusNamespace}",
+            body, cancellationToken);
+        Assert.True(response.IsSuccessStatusCode,
+            $"Namespace creation failed: {(int)response.StatusCode} {await response.Content.ReadAsStringAsync()}");
+    }
+
+    private static async Task EnsureQueue(
+        string serviceBusNamespace, string queue, CancellationToken cancellationToken)
+    {
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+        using var request = new HttpRequestMessage(HttpMethod.Put,
+            $"{EmulatorEndpoint}/devstoreaccount1-servicebus/{serviceBusNamespace}/queues/{queue}");
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/atom+xml"));
+        request.Content = new StringContent("", Encoding.UTF8, "application/atom+xml");
+        HttpResponseMessage response = await http.SendAsync(request, cancellationToken);
+        Assert.True(response.IsSuccessStatusCode,
+            $"Queue creation failed: {(int)response.StatusCode} {await response.Content.ReadAsStringAsync()}");
+    }
+}

--- a/compatibility-tests/sdk-test-java/Dockerfile
+++ b/compatibility-tests/sdk-test-java/Dockerfile
@@ -17,6 +17,7 @@ RUN mvn surefire:test -Dsurefire.failIfNoSpecifiedTests=false -Dtest=nonexistent
 ENV FLOCI_AZ_ENDPOINT=http://floci-az:4577
 ENV EVENTHUB_HOST=floci-az-artemis-emulatorNs1
 ENV EVENTHUB_AMQP_PORT=5672
+ENV SERVICEBUS_SESSION_LOCK_DURATION_SECONDS=5
 
 RUN mkdir -p /results
 ENTRYPOINT ["bash", "-c", \

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/EmulatorConfig.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/EmulatorConfig.java
@@ -484,16 +484,30 @@ public final class EmulatorConfig {
 
     /** Creates a subscription via the floci-az management API. */
     static void ensureServiceBusSubscription(String topicName, String subName) throws Exception {
+        ensureServiceBusSubscription(topicName, subName, false);
+    }
+
+    /** Creates a subscription via the floci-az management API. */
+    static void ensureServiceBusSubscription(String topicName, String subName,
+                                             boolean requiresSession) throws Exception {
         String url = BASE + "/" + ACCOUNT + "-servicebus/" + SERVICEBUS_NAMESPACE
                 + "/topics/" + topicName + "/subscriptions/" + subName;
+        String body = requiresSession
+                ? "<entry xmlns=\"http://www.w3.org/2005/Atom\"><content type=\"application/xml\">"
+                  + "<SubscriptionDescription xmlns=\"http://schemas.microsoft.com/netservices/2010/10/servicebus/connect\">"
+                  + "<RequiresSession>true</RequiresSession></SubscriptionDescription></content></entry>"
+                : "";
+        byte[] bodyBytes = body.getBytes(StandardCharsets.UTF_8);
         HttpURLConnection conn = (HttpURLConnection) URI.create(url).toURL().openConnection();
         conn.setRequestMethod("PUT");
         conn.setDoOutput(true);
         conn.setConnectTimeout(5_000);
         conn.setReadTimeout(30_000);
         conn.setRequestProperty("Content-Type", "application/atom+xml;charset=utf-8");
-        conn.setRequestProperty("Content-Length", "0");
-        conn.getOutputStream().close();
+        conn.setRequestProperty("Content-Length", String.valueOf(bodyBytes.length));
+        try (OutputStream os = conn.getOutputStream()) {
+            os.write(bodyBytes);
+        }
         int status = conn.getResponseCode();
         if (status != 200 && status != 201) {
             throw new RuntimeException(

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/ServiceBusCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/ServiceBusCompatibilityTest.java
@@ -7,6 +7,7 @@ import com.azure.messaging.servicebus.ServiceBusSenderClient;
 import com.azure.messaging.servicebus.ServiceBusSessionReceiverClient;
 import com.azure.messaging.servicebus.models.ServiceBusReceiveMode;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.function.Executable;
 
 import java.time.Duration;
 import java.time.OffsetDateTime;
@@ -420,6 +421,113 @@ class ServiceBusCompatibilityTest {
         }
     }
 
+    @Test
+    @DisplayName("session-enabled queues reject non-session receivers")
+    void sessionQueueRejectsNonSessionReceiver() throws Exception {
+        String queue = uniqueSessionQueue();
+
+        try (ServiceBusReceiverClient receiver = peekLockReceiver(queue)) {
+            assertReceiverRejected(
+                    () -> receiver.receiveMessages(1, Duration.ofSeconds(2)).stream().toList(),
+                    "A session receiver is required for this entity");
+        }
+    }
+
+    @Test
+    @DisplayName("non-session queues reject session receivers")
+    void nonSessionQueueRejectsSessionReceiver() throws Exception {
+        String queue = uniqueQueue();
+
+        try (ServiceBusSessionReceiverClient receiver = EmulatorConfig.serviceBusClientBuilder()
+                .sessionReceiver()
+                .queueName(queue)
+                .receiveMode(ServiceBusReceiveMode.PEEK_LOCK)
+                .buildClient()) {
+            assertReceiverRejected(receiver::acceptNextSession,
+                    "The entity is not configured to require sessions");
+        }
+    }
+
+    @Test
+    @DisplayName("session-enabled subscriptions require a session receiver")
+    void sessionSubscriptionRequiresSessionReceiver() throws Exception {
+        String topic = uniqueName("st");
+        String subscription = "session-sub";
+        String sessionId = "sub-session-" + UUID.randomUUID().toString().substring(0, 6);
+        EmulatorConfig.ensureServiceBusTopic(topic);
+        EmulatorConfig.ensureServiceBusSubscription(topic, subscription, true);
+
+        try (ServiceBusSenderClient sender = EmulatorConfig.serviceBusClientBuilder()
+                .sender().topicName(topic).buildClient()) {
+            ServiceBusMessage message = new ServiceBusMessage("subscription-session-message");
+            message.setSessionId(sessionId);
+            sender.sendMessage(message);
+        }
+
+        try (ServiceBusReceiverClient receiver = subscriptionReceiver(topic, subscription)) {
+            assertReceiverRejected(
+                    () -> receiver.receiveMessages(1, Duration.ofSeconds(2)).stream().toList(),
+                    "A session receiver is required for this entity");
+        }
+
+        try (ServiceBusSessionReceiverClient sessionReceiver = EmulatorConfig.serviceBusClientBuilder()
+                .sessionReceiver()
+                .topicName(topic)
+                .subscriptionName(subscription)
+                .receiveMode(ServiceBusReceiveMode.PEEK_LOCK)
+                .buildClient();
+             ServiceBusReceiverClient receiver = sessionReceiver.acceptSession(sessionId)) {
+            ServiceBusReceivedMessage message = receiver.receiveMessages(1, RECV_TIMEOUT)
+                    .stream().findFirst().orElse(null);
+            assertNotNull(message);
+            assertEquals(sessionId, message.getSessionId());
+            receiver.complete(message);
+        }
+    }
+
+    @Test
+    @DisplayName("session lock expires using configured duration and can be reacquired")
+    void sessionLockExpiresAndCanBeReacquired() throws Exception {
+        String configuredDuration = System.getenv("SERVICEBUS_SESSION_LOCK_DURATION_SECONDS");
+        Assumptions.assumeTrue(configuredDuration != null,
+                "Session expiry test requires the Docker compatibility environment");
+        long lockDurationSeconds = Long.parseLong(configuredDuration);
+        String queue = uniqueSessionQueue();
+        String sessionId = "expiring-" + UUID.randomUUID().toString().substring(0, 6);
+        ServiceBusMessage sent = new ServiceBusMessage("session-lock-expiry");
+        sent.setSessionId(sessionId);
+
+        try (ServiceBusSenderClient sender = EmulatorConfig.serviceBusClientBuilder()
+                .sender().queueName(queue).buildClient()) {
+            sender.sendMessage(sent);
+        }
+
+        try (ServiceBusSessionReceiverClient sessionReceiver = EmulatorConfig.serviceBusClientBuilder()
+                .sessionReceiver()
+                .queueName(queue)
+                .receiveMode(ServiceBusReceiveMode.PEEK_LOCK)
+                .maxAutoLockRenewDuration(Duration.ZERO)
+                .buildClient();
+            ServiceBusReceiverClient receiver = sessionReceiver.acceptSession(sessionId)) {
+            assertEquals(1, receiver.receiveMessages(1, RECV_TIMEOUT).stream().count());
+            Thread.sleep(Duration.ofSeconds(lockDurationSeconds + 1));
+        }
+
+        try (ServiceBusSessionReceiverClient sessionReceiver = EmulatorConfig.serviceBusClientBuilder()
+                .sessionReceiver()
+                .queueName(queue)
+                .receiveMode(ServiceBusReceiveMode.PEEK_LOCK)
+                .maxAutoLockRenewDuration(Duration.ZERO)
+                .buildClient();
+             ServiceBusReceiverClient receiver = sessionReceiver.acceptSession(sessionId)) {
+            ServiceBusReceivedMessage message = receiver.receiveMessages(1, RECV_TIMEOUT)
+                    .stream().findFirst().orElse(null);
+            assertNotNull(message, "Unsettled message should return after the session lock expires");
+            assertEquals(sessionId, message.getSessionId());
+            receiver.complete(message);
+        }
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private String uniqueQueue() throws Exception {
@@ -436,6 +544,16 @@ class ServiceBusCompatibilityTest {
 
     private static String uniqueName(String prefix) {
         return prefix + "-" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+    }
+
+    private static void assertReceiverRejected(Executable operation, String expectedMessage) {
+        RuntimeException error = assertThrows(RuntimeException.class, operation);
+        Throwable root = error;
+        while (root.getCause() != null) {
+            root = root.getCause();
+        }
+        assertInstanceOf(UnsupportedOperationException.class, root);
+        assertEquals(expectedMessage, root.getMessage());
     }
 
     private void send(String queue, String payload) {

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/ServiceBusCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/ServiceBusCompatibilityTest.java
@@ -372,6 +372,54 @@ class ServiceBusCompatibilityTest {
         }
     }
 
+    @Test
+    @DisplayName("accept-next-session preserves FIFO ordering and isolates sessions")
+    void acceptNextSessionPreservesOrder() throws Exception {
+        String queue = uniqueSessionQueue();
+        String sessionA = "next-a-" + UUID.randomUUID().toString().substring(0, 6);
+        String sessionB = "next-b-" + UUID.randomUUID().toString().substring(0, 6);
+
+        try (ServiceBusSenderClient sender = EmulatorConfig.serviceBusClientBuilder()
+                .sender().queueName(queue).buildClient()) {
+            for (int i = 0; i < 2; i++) {
+                ServiceBusMessage message = new ServiceBusMessage("a-" + i);
+                message.setSessionId(sessionA);
+                sender.sendMessage(message);
+            }
+            ServiceBusMessage message = new ServiceBusMessage("b-0");
+            message.setSessionId(sessionB);
+            sender.sendMessage(message);
+        }
+
+        try (ServiceBusSessionReceiverClient sessionReceiver = EmulatorConfig.serviceBusClientBuilder()
+                .sessionReceiver()
+                .queueName(queue)
+                .receiveMode(ServiceBusReceiveMode.PEEK_LOCK)
+                .buildClient();
+             ServiceBusReceiverClient receiver = sessionReceiver.acceptNextSession()) {
+            assertEquals(sessionA, receiver.getSessionId());
+            List<ServiceBusReceivedMessage> messages = receiver.receiveMessages(2, RECV_TIMEOUT)
+                    .stream().toList();
+            assertEquals(List.of("a-0", "a-1"), messages.stream()
+                    .map(message -> message.getBody().toString()).toList());
+            messages.forEach(receiver::complete);
+        }
+
+        try (ServiceBusSessionReceiverClient sessionReceiver = EmulatorConfig.serviceBusClientBuilder()
+                .sessionReceiver()
+                .queueName(queue)
+                .receiveMode(ServiceBusReceiveMode.PEEK_LOCK)
+                .buildClient();
+             ServiceBusReceiverClient receiver = sessionReceiver.acceptNextSession()) {
+            assertEquals(sessionB, receiver.getSessionId());
+            ServiceBusReceivedMessage message = receiver.receiveMessages(1, RECV_TIMEOUT)
+                    .stream().findFirst().orElse(null);
+            assertNotNull(message);
+            assertEquals("b-0", message.getBody().toString());
+            receiver.complete(message);
+        }
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private String uniqueQueue() throws Exception {

--- a/docs/services/service-bus.md
+++ b/docs/services/service-bus.md
@@ -67,6 +67,17 @@ dead-lettering).
 - Rule changes update the subscription's filter in place (messages already routed to the
   subscription stay, receivers stay attached) and, as on Azure, apply to future messages only.
 
+## Message sessions
+
+Queues and subscriptions created with `RequiresSession` support Azure SDK session receivers.
+Set `SessionId` on sent messages, then use a specific-session receiver, an accept-next-session
+receiver, or a session processor. The broker translates Azure's AMQP session filter into an
+Artemis `JMSXGroupID` selector, which keeps each session on one receiver and preserves FIFO order
+within that session. Attach responses include Azure's `com.microsoft:locked-until-utc` property.
+
+Session ownership lasts for the receiver link. Session state and explicit session-lock renewal are
+not currently emulated.
+
 ## Connection String
 
 ```
@@ -159,6 +170,7 @@ floci-az:
 
 ## Out of scope (future work)
 
-- Sessions, scheduled/deferred messages, and auto-forwarding
+- Session state and explicit session-lock renewal
+- Deferred messages and auto-forwarding
 - Duplicate detection and message transactions
 - Geo-disaster recovery and partitioned entities

--- a/docs/services/service-bus.md
+++ b/docs/services/service-bus.md
@@ -138,7 +138,7 @@ services:
 | `FLOCI_AZ_SERVICES_SERVICE_BUS_MOCKED` | `true` | Mocked mode (management plane only, no Artemis) |
 | `FLOCI_AZ_SERVICES_SERVICE_BUS_AMQP_PORT` | `5673` | Host port for AMQP (Artemis) |
 | `FLOCI_AZ_SERVICES_SERVICE_BUS_AMQP_TLS_PORT` | `5674` | Host port for AMQPS |
-| `FLOCI_AZ_SERVICES_SERVICE_BUS_ARTEMIS_IMAGE` | `apache/activemq-artemis:latest` | Artemis image |
+| `FLOCI_AZ_SERVICES_SERVICE_BUS_ARTEMIS_IMAGE` | `apache/activemq-artemis:2.44.0` | Artemis image; must match bundled protocol patches |
 | `FLOCI_AZ_SERVICES_SERVICE_BUS_MAX_DELIVERY_COUNT` | `10` | Max delivery attempts before dead-lettering |
 | `FLOCI_AZ_SERVICES_SERVICE_BUS_LOCK_DURATION_SECONDS` | `60` | Peek-lock duration |
 
@@ -152,7 +152,7 @@ floci-az:
       mocked: true              # true = management plane only, no Docker. false = real Artemis sidecar
       amqp-port: 5673
       amqp-tls-port: 5674
-      artemis-image: "apache/activemq-artemis:latest"
+      artemis-image: "apache/activemq-artemis:2.44.0"
       max-delivery-count: 10
       lock-duration-seconds: 60
 ```

--- a/docs/services/service-bus.md
+++ b/docs/services/service-bus.md
@@ -98,6 +98,19 @@ with ServiceBusClient.from_connection_string(CONN) as client:
             receiver.complete_message(msg)
 ```
 
+## .NET SDK
+
+```csharp
+await using var client = new ServiceBusClient(
+    "Endpoint=sb://localhost:5673;SharedAccessKeyName=RootManageSharedAccessKey;" +
+    "SharedAccessKey=devkey;UseDevelopmentEmulator=true;");
+ServiceBusSender sender = client.CreateSender("myqueue");
+await sender.SendMessageAsync(new ServiceBusMessage("hello world"));
+```
+
+The Artemis sidecar includes the `MSSBCBS` anonymous SASL mechanism expected by
+`Azure.Messaging.ServiceBus`; authorization continues through the standard CBS link.
+
 ## Configuration
 
 ### Docker Compose

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,8 @@
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
         <quarkus.platform.version>3.37.4</quarkus.platform.version>
+        <artemis.version>2.44.0</artemis.version>
+        <proton-j.version>0.34.1</proton-j.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.6</surefire-plugin.version>
     </properties>
@@ -107,7 +109,13 @@
         <dependency>
             <groupId>org.apache.qpid</groupId>
             <artifactId>proton-j</artifactId>
-            <version>0.34.1</version>
+            <version>${proton-j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.activemq</groupId>
+            <artifactId>artemis-amqp-protocol</artifactId>
+            <version>${artemis.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -145,11 +153,181 @@
                 </executions>
             </plugin>
             <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.8.1</version>
+                <executions>
+                    <execution>
+                        <id>unpack-servicebus-proton-j</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.apache.qpid</groupId>
+                                    <artifactId>proton-j</artifactId>
+                                    <version>${proton-j.version}</version>
+                                    <outputDirectory>${project.build.directory}/artemis-proton-classes</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>unpack-servicebus-artemis-amqp</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.apache.activemq</groupId>
+                                    <artifactId>artemis-amqp-protocol</artifactId>
+                                    <version>${artemis.version}</version>
+                                    <outputDirectory>${project.build.directory}/artemis-amqp-classes</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>unpack-servicebus-artemis-amqp-sources</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <overWriteReleases>true</overWriteReleases>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.apache.activemq</groupId>
+                                    <artifactId>artemis-amqp-protocol</artifactId>
+                                    <version>${artemis.version}</version>
+                                    <classifier>sources</classifier>
+                                    <outputDirectory>${project.build.directory}/artemis-amqp-patch-sources</outputDirectory>
+                                    <includes>
+                                        org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java,
+                                        org/apache/activemq/artemis/protocol/amqp/proton/DefaultSenderController.java,
+                                        org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java
+                                    </includes>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>patch-servicebus-artemis-amqp-sources</id>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <replace
+                                    file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java"
+                                    token="deliveryCount &gt; 1"
+                                    value="deliveryCount &gt; 0"
+                                    failOnNoReplacements="true" />
+                                <replace
+                                    file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/DefaultSenderController.java"
+                                    token="protonSender.setReceiverSettleMode(ReceiverSettleMode.FIRST);"
+                                    value="protonSender.setReceiverSettleMode(protonSender.getRemoteReceiverSettleMode());"
+                                    failOnNoReplacements="true" />
+                                <replace
+                                    file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java"
+                                    token="doAck(message);"
+                                    value="doAck(message); delivery.disposition(Accepted.getInstance());"
+                                    failOnNoReplacements="true" />
+                                <replace
+                                    file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java"
+                                    token="if (settleImmediate) {"
+                                    value="if (settleImmediate) { delivery.disposition(remoteState);"
+                                    failOnNoReplacements="true" />
+                            </target>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>package-servicebus-artemis-patches</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <copy todir="${project.build.directory}/artemis-plugin-classes">
+                                    <fileset dir="${project.basedir}/src/artemis-plugin/resources" />
+                                </copy>
+                                <mkdir dir="${project.build.directory}/classes/artemis" />
+                                <jar
+                                    destfile="${project.build.directory}/classes/artemis/servicebus-artemis-extension.jar"
+                                    basedir="${project.build.directory}/artemis-plugin-classes" />
+                                <jar
+                                    destfile="${project.build.directory}/classes/artemis/proton-j-${proton-j.version}-floci-az-proton-patch.jar"
+                                    basedir="${project.build.directory}/artemis-proton-classes" />
+                                <jar
+                                    destfile="${project.build.directory}/classes/artemis/artemis-amqp-protocol-${artemis.version}-floci-az-artemis-amqp-patch.jar"
+                                    basedir="${project.build.directory}/artemis-amqp-classes" />
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${compiler-plugin.version}</version>
                 <configuration>
                     <parameters>true</parameters>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>compile-servicebus-artemis-extension</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <release>21</release>
+                            <compileSourceRoots>
+                                <compileSourceRoot>${project.basedir}/src/artemis-plugin/java</compileSourceRoot>
+                            </compileSourceRoots>
+                            <outputDirectory>${project.build.directory}/artemis-plugin-classes</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>compile-servicebus-proton-patch</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <release>21</release>
+                            <compileSourceRoots>
+                                <compileSourceRoot>${project.basedir}/src/artemis-patch/java</compileSourceRoot>
+                            </compileSourceRoots>
+                            <outputDirectory>${project.build.directory}/artemis-proton-classes</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>compile-servicebus-artemis-amqp-patch</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <release>21</release>
+                            <compileSourceRoots>
+                                <compileSourceRoot>${project.basedir}/src/artemis-amqp-patch/java</compileSourceRoot>
+                                <compileSourceRoot>${project.build.directory}/artemis-amqp-patch-sources</compileSourceRoot>
+                            </compileSourceRoots>
+                            <outputDirectory>${project.build.directory}/artemis-amqp-classes</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -234,9 +234,49 @@
                                     value="deliveryCount &gt; 0"
                                     failOnNoReplacements="true" />
                                 <replace
+                                    file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java"
+                                    token="final int amqpDeliveryCount = deliveryCount - 1;"
+                                    value="final int amqpDeliveryCount = deliveryCount;"
+                                    failOnNoReplacements="true" />
+                                <replace
+                                    file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java"
+                                    token="AMQPMessageSupport.SCHEDULED_DELIVERY_TIME, AMQPMessageSupport.SCHEDULED_DELIVERY_DELAY};"
+                                    value="AMQPMessageSupport.SCHEDULED_DELIVERY_TIME, AMQPMessageSupport.SCHEDULED_DELIVERY_DELAY, Symbol.valueOf(&quot;x-opt-scheduled-enqueue-time&quot;)};"
+                                    failOnNoReplacements="true" />
+                                <replace
+                                    file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java"
+                                    token="AMQPMessageSymbolSearch.kmpNeedleOf(AMQPMessageSupport.SCHEDULED_DELIVERY_DELAY)};"
+                                    value="AMQPMessageSymbolSearch.kmpNeedleOf(AMQPMessageSupport.SCHEDULED_DELIVERY_DELAY), AMQPMessageSymbolSearch.kmpNeedleOf(Symbol.valueOf(&quot;x-opt-scheduled-enqueue-time&quot;))};"
+                                    failOnNoReplacements="true" />
+                                <replace
+                                    file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java"
+                                    token="Object objdelay = getMessageAnnotation(AMQPMessageSupport.SCHEDULED_DELIVERY_DELAY);"
+                                    value="Object objdelay = getMessageAnnotation(AMQPMessageSupport.SCHEDULED_DELIVERY_DELAY); Object objAzureScheduledTime = getMessageAnnotation(Symbol.valueOf(&quot;x-opt-scheduled-enqueue-time&quot;));"
+                                    failOnNoReplacements="true" />
+                                <replace
+                                    file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java"
+                                    token="if (objscheduledTime != null &amp;&amp; objscheduledTime instanceof Number number) {"
+                                    value="if (objAzureScheduledTime instanceof java.util.Date date) { this.scheduledTime = date.getTime(); } else if (objAzureScheduledTime instanceof Number number) { this.scheduledTime = number.longValue(); } else if (objscheduledTime != null &amp;&amp; objscheduledTime instanceof Number number) {"
+                                    failOnNoReplacements="true" />
+                                <replace
                                     file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/DefaultSenderController.java"
                                     token="protonSender.setReceiverSettleMode(ReceiverSettleMode.FIRST);"
                                     value="protonSender.setReceiverSettleMode(protonSender.getRemoteReceiverSettleMode());"
+                                    failOnNoReplacements="true" />
+                                <replace
+                                    file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/DefaultSenderController.java"
+                                    token="final String sourceAddress = ParameterisedAddress.extractAddress(source.getAddress());"
+                                    value="final String sourceAddress = ServiceBusSessionSupport.normalizeEntityPath(ParameterisedAddress.extractAddress(source.getAddress()));"
+                                    failOnNoReplacements="true" />
+                                <replace
+                                    file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/DefaultSenderController.java"
+                                    token="source.setFilter(supportedFilters.isEmpty() ? null : supportedFilters);"
+                                    value="selector = ServiceBusSessionSupport.configure(sessionSPI.getProtocolManager().getServer(), queue, source, supportedFilters, protonSender, selector); source.setFilter(supportedFilters.isEmpty() ? null : supportedFilters);"
+                                    failOnNoReplacements="true" />
+                                <replace
+                                    file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/DefaultSenderController.java"
+                                    token="public void close(boolean remoteClose) throws Exception {"
+                                    value="public void close(boolean remoteClose) throws Exception { ServiceBusSessionSupport.release(protonSender);"
                                     failOnNoReplacements="true" />
                                 <replace
                                     file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java"
@@ -247,6 +287,11 @@
                                     file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java"
                                     token="if (settleImmediate) {"
                                     value="if (settleImmediate) { delivery.disposition(remoteState);"
+                                    failOnNoReplacements="true" />
+                                <replace
+                                    file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java"
+                                    token="if (Boolean.TRUE.equals(modification.getDeliveryFailed())) {"
+                                    value="if (!Boolean.TRUE.equals(modification.getUndeliverableHere())) {"
                                     failOnNoReplacements="true" />
                             </target>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -271,7 +271,7 @@
                                 <replace
                                     file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/DefaultSenderController.java"
                                     token="source.setFilter(supportedFilters.isEmpty() ? null : supportedFilters);"
-                                    value="selector = ServiceBusSessionSupport.configure(sessionSPI.getProtocolManager().getServer(), queue, source, supportedFilters, protonSender, selector); source.setFilter(supportedFilters.isEmpty() ? null : supportedFilters);"
+                                    value="selector = ServiceBusSessionSupport.configure(sessionSPI.getProtocolManager().getServer(), queue, source, supportedFilters, protonSender, senderContext, selector); source.setFilter(supportedFilters.isEmpty() ? null : supportedFilters);"
                                     failOnNoReplacements="true" />
                                 <replace
                                     file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/DefaultSenderController.java"

--- a/src/artemis-amqp-patch/java/org/apache/activemq/artemis/protocol/amqp/proton/AmqpTransferTagGenerator.java
+++ b/src/artemis-amqp-patch/java/org/apache/activemq/artemis/protocol/amqp/proton/AmqpTransferTagGenerator.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor
+ * license agreements. See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership. The ASF licenses this
+ * file to you under the Apache License, Version 2.0.
+ */
+package org.apache.activemq.artemis.protocol.amqp.proton;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+
+/**
+ * Generates 16-byte delivery tags compatible with Azure Service Bus lock tokens.
+ */
+public final class AmqpTransferTagGenerator {
+
+   public static final int DEFAULT_TAG_POOL_SIZE = 1024;
+   private static final int AZURE_LOCK_TOKEN_SIZE = 16;
+
+   private final Deque<byte[]> tagPool;
+   private long nextTagId = 1;
+   private int maxPoolSize = DEFAULT_TAG_POOL_SIZE;
+
+   public AmqpTransferTagGenerator() {
+      this(true);
+   }
+
+   public AmqpTransferTagGenerator(boolean pool) {
+      tagPool = pool ? new ArrayDeque<>() : null;
+   }
+
+   public synchronized byte[] getNextTag() {
+      byte[] tagBytes = tagPool == null ? null : tagPool.pollFirst();
+      if (tagBytes == null) {
+         tagBytes = new byte[AZURE_LOCK_TOKEN_SIZE];
+         long tag = nextTagId++;
+         for (int i = 0; i < Long.BYTES; i++) {
+            tagBytes[AZURE_LOCK_TOKEN_SIZE - 1 - i] = (byte) (tag >>> (i * 8));
+         }
+      }
+      return tagBytes;
+   }
+
+   public synchronized void returnTag(byte[] data) {
+      if (tagPool != null && tagPool.size() < maxPoolSize) {
+         tagPool.offerLast(data);
+      }
+   }
+
+   public int getMaxPoolSize() {
+      return maxPoolSize;
+   }
+
+   public void setMaxPoolSize(int maxPoolSize) {
+      this.maxPoolSize = maxPoolSize;
+   }
+
+   public boolean isPooling() {
+      return tagPool != null;
+   }
+}

--- a/src/artemis-amqp-patch/java/org/apache/activemq/artemis/protocol/amqp/proton/ServiceBusSessionSupport.java
+++ b/src/artemis-amqp-patch/java/org/apache/activemq/artemis/protocol/amqp/proton/ServiceBusSessionSupport.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.proton;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.MessageReference;
+import org.apache.activemq.artemis.core.server.Queue;
+import org.apache.activemq.artemis.protocol.amqp.exceptions.ActiveMQAMQPException;
+import org.apache.activemq.artemis.utils.collections.LinkedListIterator;
+import org.apache.qpid.proton.amqp.Symbol;
+import org.apache.qpid.proton.amqp.messaging.Source;
+import org.apache.qpid.proton.engine.Sender;
+
+/** Azure Service Bus session-filter adaptation for Artemis sender links. */
+public final class ServiceBusSessionSupport {
+
+   private static final Symbol SESSION_FILTER = Symbol.valueOf("com.microsoft:session-filter");
+   private static final Symbol LOCKED_UNTIL_UTC = Symbol.valueOf("com.microsoft:locked-until-utc");
+   private static final Symbol TIMEOUT_ERROR = Symbol.valueOf("com.microsoft:timeout");
+   private static final Symbol SESSION_CANNOT_BE_LOCKED_ERROR =
+      Symbol.valueOf("com.microsoft:session-cannot-be-locked");
+
+   private static final long DOTNET_TICKS_AT_UNIX_EPOCH = 621_355_968_000_000_000L;
+   private static final long SESSION_LOCK_MILLIS = 60_000L;
+   private static final Map<SessionKey, Sender> SESSION_OWNERS = new ConcurrentHashMap<>();
+   private static final Map<Sender, SessionKey> SENDER_SESSIONS = new ConcurrentHashMap<>();
+
+   private ServiceBusSessionSupport() {
+   }
+
+   public static String configure(ActiveMQServer server,
+                                  SimpleString queueName,
+                                  Source source,
+                                  Map<Symbol, Object> supportedFilters,
+                                  Sender protonSender,
+                                  String existingSelector) throws Exception {
+      Map<Symbol, Object> requestedFilters = source.getFilter();
+      release(protonSender);
+      if (requestedFilters == null || !requestedFilters.containsKey(SESSION_FILTER)) {
+         return existingSelector;
+      }
+
+      SimpleString normalizedQueueName = normalizeQueueName(queueName);
+      Queue queue = server.locateQueue(normalizedQueueName);
+      Object requestedSession = requestedFilters.get(SESSION_FILTER);
+      String sessionId = requestedSession == null
+         ? reserveNextSession(queue, normalizedQueueName, protonSender)
+         : reserveSession(queue, normalizedQueueName, requestedSession.toString(), protonSender);
+      if (sessionId == null) {
+         throw new ActiveMQAMQPException(TIMEOUT_ERROR,
+                                         "No unlocked sessions are available",
+                                         ActiveMQExceptionType.TIMEOUT_EXCEPTION);
+      }
+
+      supportedFilters.put(SESSION_FILTER, sessionId);
+      setLockedUntil(protonSender);
+
+      String sessionSelector = "JMSXGroupID = '" + sessionId.replace("'", "''") + "'";
+      return existingSelector == null || existingSelector.isBlank()
+         ? sessionSelector
+         : "(" + existingSelector + ") AND " + sessionSelector;
+   }
+
+   public static void release(Sender protonSender) {
+      SessionKey session = SENDER_SESSIONS.remove(protonSender);
+      if (session != null) {
+         SESSION_OWNERS.remove(session, protonSender);
+      }
+   }
+
+   public static String normalizeEntityPath(String entityPath) {
+      if (entityPath == null) {
+         return null;
+      }
+
+      String normalized = entityPath;
+      String lowerCasePath = normalized.toLowerCase(Locale.ROOT);
+      String subscriptionSegment = "/subscriptions/";
+      int subscriptionIndex = lowerCasePath.indexOf(subscriptionSegment);
+      if (subscriptionIndex >= 0) {
+         normalized = normalized.substring(0, subscriptionIndex)
+            + "/Subscriptions/"
+            + normalized.substring(subscriptionIndex + subscriptionSegment.length());
+      }
+
+      String deadLetterQueueSuffix = "/$DeadLetterQueue";
+      int suffixIndex = normalized.length() - deadLetterQueueSuffix.length();
+      if (suffixIndex >= 0 && normalized.regionMatches(true,
+                                                       suffixIndex,
+                                                       deadLetterQueueSuffix,
+                                                       0,
+                                                       deadLetterQueueSuffix.length())) {
+         normalized = normalized.substring(0, suffixIndex) + deadLetterQueueSuffix;
+      }
+      return normalized;
+   }
+
+   private static String reserveNextSession(Queue queue, SimpleString queueName, Sender protonSender) {
+      if (queue == null) {
+         return null;
+      }
+
+      synchronized (queue) {
+         Map<SimpleString, ?> lockedGroups = queue.getGroups();
+         try (LinkedListIterator<MessageReference> iterator = queue.browserIterator()) {
+            while (iterator.hasNext()) {
+               SimpleString groupId = iterator.next().getMessage().getGroupID();
+               if (groupId != null
+                   && !lockedGroups.containsKey(groupId)
+                   && reserve(queueName, groupId.toString(), protonSender)) {
+                  return groupId.toString();
+               }
+            }
+         }
+      }
+
+      return null;
+   }
+
+   private static String reserveSession(Queue queue,
+                                        SimpleString queueName,
+                                        String sessionId,
+                                        Sender protonSender) throws ActiveMQAMQPException {
+      SimpleString groupId = SimpleString.of(sessionId);
+      if ((queue != null && queue.getGroups().containsKey(groupId))
+          || !reserve(queueName, sessionId, protonSender)) {
+         throw new ActiveMQAMQPException(SESSION_CANNOT_BE_LOCKED_ERROR,
+                                         "The requested session is already locked",
+                                         ActiveMQExceptionType.ILLEGAL_STATE);
+      }
+      return sessionId;
+   }
+
+   private static boolean reserve(SimpleString queueName, String sessionId, Sender protonSender) {
+      SessionKey session = new SessionKey(queueName, sessionId);
+      Sender owner = SESSION_OWNERS.putIfAbsent(session, protonSender);
+      if (owner == null || owner == protonSender) {
+         SENDER_SESSIONS.put(protonSender, session);
+         return true;
+      }
+      return false;
+   }
+
+   private static SimpleString normalizeQueueName(SimpleString queueName) {
+      String name = queueName.toString();
+      return name.startsWith("/") ? SimpleString.of(name.substring(1)) : queueName;
+   }
+
+   private static void setLockedUntil(Sender protonSender) {
+      Map<Symbol, Object> properties = protonSender.getProperties() == null
+         ? new HashMap<>()
+         : new HashMap<>(protonSender.getProperties());
+      long lockedUntilTicks = DOTNET_TICKS_AT_UNIX_EPOCH
+         + (System.currentTimeMillis() + SESSION_LOCK_MILLIS) * 10_000L;
+      properties.put(LOCKED_UNTIL_UTC, lockedUntilTicks);
+      protonSender.setProperties(properties);
+   }
+
+   private record SessionKey(SimpleString queueName, String sessionId) {
+   }
+}

--- a/src/artemis-amqp-patch/java/org/apache/activemq/artemis/protocol/amqp/proton/ServiceBusSessionSupport.java
+++ b/src/artemis-amqp-patch/java/org/apache/activemq/artemis/protocol/amqp/proton/ServiceBusSessionSupport.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
 import org.apache.activemq.artemis.api.core.SimpleString;
@@ -32,20 +33,27 @@ import org.apache.activemq.artemis.protocol.amqp.exceptions.ActiveMQAMQPExceptio
 import org.apache.activemq.artemis.utils.collections.LinkedListIterator;
 import org.apache.qpid.proton.amqp.Symbol;
 import org.apache.qpid.proton.amqp.messaging.Source;
+import org.apache.qpid.proton.amqp.transport.AmqpError;
+import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.apache.qpid.proton.engine.Sender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Azure Service Bus session-filter adaptation for Artemis sender links. */
 public final class ServiceBusSessionSupport {
 
+   private static final Logger LOGGER = LoggerFactory.getLogger(ServiceBusSessionSupport.class);
    private static final Symbol SESSION_FILTER = Symbol.valueOf("com.microsoft:session-filter");
    private static final Symbol LOCKED_UNTIL_UTC = Symbol.valueOf("com.microsoft:locked-until-utc");
    private static final Symbol TIMEOUT_ERROR = Symbol.valueOf("com.microsoft:timeout");
    private static final Symbol SESSION_CANNOT_BE_LOCKED_ERROR =
       Symbol.valueOf("com.microsoft:session-cannot-be-locked");
+   private static final Symbol SESSION_LOCK_LOST_ERROR =
+      Symbol.valueOf("com.microsoft:session-lock-lost");
 
    private static final long DOTNET_TICKS_AT_UNIX_EPOCH = 621_355_968_000_000_000L;
-   private static final long SESSION_LOCK_MILLIS = 60_000L;
-   private static final Map<SessionKey, Sender> SESSION_OWNERS = new ConcurrentHashMap<>();
+   private static final String SESSION_METADATA_PREFIX = "floci-az:servicebus-session:";
+   private static final Map<SessionKey, SessionOwner> SESSION_OWNERS = new ConcurrentHashMap<>();
    private static final Map<Sender, SessionKey> SENDER_SESSIONS = new ConcurrentHashMap<>();
 
    private ServiceBusSessionSupport() {
@@ -56,29 +64,44 @@ public final class ServiceBusSessionSupport {
                                   Source source,
                                   Map<Symbol, Object> supportedFilters,
                                   Sender protonSender,
+                                  ProtonServerSenderContext senderContext,
                                   String existingSelector) throws Exception {
       Map<Symbol, Object> requestedFilters = source.getFilter();
       release(protonSender);
-      if (requestedFilters == null || !requestedFilters.containsKey(SESSION_FILTER)) {
+      boolean sessionReceiver = requestedFilters != null && requestedFilters.containsKey(SESSION_FILTER);
+      SimpleString normalizedQueueName = normalizeQueueName(queueName);
+      Queue queue = server.locateQueue(normalizedQueueName);
+      SessionMetadata metadata = sessionMetadata(queue);
+
+      if (metadata == null && sessionReceiver) {
+         throw new ActiveMQAMQPException(AmqpError.NOT_ALLOWED,
+                                         "The entity is not configured to require sessions",
+                                         ActiveMQExceptionType.ILLEGAL_STATE);
+      }
+      if (metadata != null && !sessionReceiver) {
+         throw new ActiveMQAMQPException(AmqpError.NOT_ALLOWED,
+                                         "A session receiver is required for this entity",
+                                         ActiveMQExceptionType.ILLEGAL_STATE);
+      }
+      if (!sessionReceiver) {
          return existingSelector;
       }
 
-      SimpleString normalizedQueueName = normalizeQueueName(queueName);
-      Queue queue = server.locateQueue(normalizedQueueName);
       Object requestedSession = requestedFilters.get(SESSION_FILTER);
-      String sessionId = requestedSession == null
-         ? reserveNextSession(queue, normalizedQueueName, protonSender)
-         : reserveSession(queue, normalizedQueueName, requestedSession.toString(), protonSender);
-      if (sessionId == null) {
+      SessionReservation reservation = requestedSession == null
+         ? reserveNextSession(server, queue, normalizedQueueName, protonSender, senderContext, metadata.lockMillis())
+         : reserveSession(server, queue, normalizedQueueName, requestedSession.toString(), protonSender,
+                          senderContext, metadata.lockMillis());
+      if (reservation == null) {
          throw new ActiveMQAMQPException(TIMEOUT_ERROR,
                                          "No unlocked sessions are available",
                                          ActiveMQExceptionType.TIMEOUT_EXCEPTION);
       }
 
-      supportedFilters.put(SESSION_FILTER, sessionId);
-      setLockedUntil(protonSender);
+      supportedFilters.put(SESSION_FILTER, reservation.sessionId());
+      setLockedUntil(protonSender, reservation.owner().lockedUntilMillis());
 
-      String sessionSelector = "JMSXGroupID = '" + sessionId.replace("'", "''") + "'";
+      String sessionSelector = "JMSXGroupID = '" + reservation.sessionId().replace("'", "''") + "'";
       return existingSelector == null || existingSelector.isBlank()
          ? sessionSelector
          : "(" + existingSelector + ") AND " + sessionSelector;
@@ -87,7 +110,10 @@ public final class ServiceBusSessionSupport {
    public static void release(Sender protonSender) {
       SessionKey session = SENDER_SESSIONS.remove(protonSender);
       if (session != null) {
-         SESSION_OWNERS.remove(session, protonSender);
+         SessionOwner owner = SESSION_OWNERS.get(session);
+         if (owner != null && owner.sender() == protonSender) {
+            SESSION_OWNERS.remove(session, owner);
+         }
       }
    }
 
@@ -118,7 +144,12 @@ public final class ServiceBusSessionSupport {
       return normalized;
    }
 
-   private static String reserveNextSession(Queue queue, SimpleString queueName, Sender protonSender) {
+   private static SessionReservation reserveNextSession(ActiveMQServer server,
+                                                        Queue queue,
+                                                        SimpleString queueName,
+                                                        Sender protonSender,
+                                                        ProtonServerSenderContext senderContext,
+                                                        long lockMillis) {
       if (queue == null) {
          return null;
       }
@@ -128,10 +159,14 @@ public final class ServiceBusSessionSupport {
          try (LinkedListIterator<MessageReference> iterator = queue.browserIterator()) {
             while (iterator.hasNext()) {
                SimpleString groupId = iterator.next().getMessage().getGroupID();
-               if (groupId != null
-                   && !lockedGroups.containsKey(groupId)
-                   && reserve(queueName, groupId.toString(), protonSender)) {
-                  return groupId.toString();
+               if (groupId == null || lockedGroups.containsKey(groupId)) {
+                  continue;
+               }
+
+               SessionOwner owner = reserve(server, queue, queueName, groupId.toString(),
+                                            protonSender, senderContext, lockMillis);
+               if (owner != null) {
+                  return new SessionReservation(groupId.toString(), owner);
                }
             }
          }
@@ -140,28 +175,68 @@ public final class ServiceBusSessionSupport {
       return null;
    }
 
-   private static String reserveSession(Queue queue,
-                                        SimpleString queueName,
-                                        String sessionId,
-                                        Sender protonSender) throws ActiveMQAMQPException {
+   private static SessionReservation reserveSession(ActiveMQServer server,
+                                                    Queue queue,
+                                                    SimpleString queueName,
+                                                    String sessionId,
+                                                    Sender protonSender,
+                                                    ProtonServerSenderContext senderContext,
+                                                    long lockMillis) throws ActiveMQAMQPException {
       SimpleString groupId = SimpleString.of(sessionId);
-      if ((queue != null && queue.getGroups().containsKey(groupId))
-          || !reserve(queueName, sessionId, protonSender)) {
+      SessionOwner owner = queue == null || queue.getGroups().containsKey(groupId)
+         ? null
+         : reserve(server, queue, queueName, sessionId, protonSender, senderContext, lockMillis);
+      if (owner == null) {
          throw new ActiveMQAMQPException(SESSION_CANNOT_BE_LOCKED_ERROR,
                                          "The requested session is already locked",
                                          ActiveMQExceptionType.ILLEGAL_STATE);
       }
-      return sessionId;
+      return new SessionReservation(sessionId, owner);
    }
 
-   private static boolean reserve(SimpleString queueName, String sessionId, Sender protonSender) {
+   private static SessionOwner reserve(ActiveMQServer server,
+                                       Queue queue,
+                                       SimpleString queueName,
+                                       String sessionId,
+                                       Sender protonSender,
+                                       ProtonServerSenderContext senderContext,
+                                       long lockMillis) {
       SessionKey session = new SessionKey(queueName, sessionId);
-      Sender owner = SESSION_OWNERS.putIfAbsent(session, protonSender);
-      if (owner == null || owner == protonSender) {
+      SessionOwner candidate = new SessionOwner(
+         protonSender, senderContext, queue, System.currentTimeMillis() + lockMillis);
+      SessionOwner owner = SESSION_OWNERS.putIfAbsent(session, candidate);
+      if (owner == null || owner.sender() == protonSender) {
+         if (owner != null) {
+            candidate = owner;
+         } else {
+            scheduleExpiration(server, session, candidate, lockMillis);
+         }
          SENDER_SESSIONS.put(protonSender, session);
-         return true;
+         return candidate;
       }
-      return false;
+      return null;
+   }
+
+   private static void scheduleExpiration(ActiveMQServer server,
+                                          SessionKey session,
+                                          SessionOwner owner,
+                                          long lockMillis) {
+      server.getScheduledPool().schedule(() -> expire(session, owner), lockMillis, TimeUnit.MILLISECONDS);
+   }
+
+   private static void expire(SessionKey session, SessionOwner owner) {
+      if (!SESSION_OWNERS.remove(session, owner)) {
+         return;
+      }
+
+      SENDER_SESSIONS.remove(owner.sender(), session);
+      owner.queue().resetGroup(SimpleString.of(session.sessionId()));
+      try {
+         owner.senderContext().close(new ErrorCondition(
+            SESSION_LOCK_LOST_ERROR, "The session lock has expired"));
+      } catch (ActiveMQAMQPException e) {
+         LOGGER.warn("Failed to close an expired Service Bus session receiver", e);
+      }
    }
 
    private static SimpleString normalizeQueueName(SimpleString queueName) {
@@ -169,16 +244,50 @@ public final class ServiceBusSessionSupport {
       return name.startsWith("/") ? SimpleString.of(name.substring(1)) : queueName;
    }
 
-   private static void setLockedUntil(Sender protonSender) {
+   private static SessionMetadata sessionMetadata(Queue queue) {
+      if (queue == null || queue.getUser() == null) {
+         return null;
+      }
+
+      String value = queue.getUser().toString();
+      if (!value.startsWith(SESSION_METADATA_PREFIX)) {
+         return null;
+      }
+
+      try {
+         long lockSeconds = Long.parseLong(value.substring(SESSION_METADATA_PREFIX.length()));
+         if (lockSeconds <= 0) {
+            throw new NumberFormatException("Lock duration must be positive");
+         }
+         return new SessionMetadata(Math.multiplyExact(lockSeconds, 1_000L));
+      } catch (ArithmeticException | NumberFormatException e) {
+         LOGGER.warn("Ignoring invalid Service Bus session metadata: " + value, e);
+         return null;
+      }
+   }
+
+   private static void setLockedUntil(Sender protonSender, long lockedUntilMillis) {
       Map<Symbol, Object> properties = protonSender.getProperties() == null
          ? new HashMap<>()
          : new HashMap<>(protonSender.getProperties());
       long lockedUntilTicks = DOTNET_TICKS_AT_UNIX_EPOCH
-         + (System.currentTimeMillis() + SESSION_LOCK_MILLIS) * 10_000L;
+         + lockedUntilMillis * 10_000L;
       properties.put(LOCKED_UNTIL_UTC, lockedUntilTicks);
       protonSender.setProperties(properties);
    }
 
    private record SessionKey(SimpleString queueName, String sessionId) {
+   }
+
+   private record SessionMetadata(long lockMillis) {
+   }
+
+   private record SessionOwner(Sender sender,
+                               ProtonServerSenderContext senderContext,
+                               Queue queue,
+                               long lockedUntilMillis) {
+   }
+
+   private record SessionReservation(String sessionId, SessionOwner owner) {
    }
 }

--- a/src/artemis-patch/java/org/apache/qpid/proton/engine/impl/ReceiverImpl.java
+++ b/src/artemis-patch/java/org/apache/qpid/proton/engine/impl/ReceiverImpl.java
@@ -1,0 +1,189 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.apache.qpid.proton.engine.impl;
+
+import org.apache.qpid.proton.amqp.UnsignedInteger;
+import org.apache.qpid.proton.amqp.UnsignedLong;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+import org.apache.qpid.proton.codec.WritableBuffer;
+import org.apache.qpid.proton.engine.Receiver;
+
+public class ReceiverImpl extends LinkImpl implements Receiver
+{
+    private static final UnsignedLong DEFAULT_MAX_MESSAGE_SIZE = UnsignedLong.valueOf(1_048_576L);
+
+    private boolean _drainFlagMode = true;
+
+    @Override
+    public boolean advance()
+    {
+        DeliveryImpl current = current();
+        if(current != null)
+        {
+            current.setDone();
+        }
+        final boolean advance = super.advance();
+        if(advance)
+        {
+            decrementQueued();
+            decrementCredit();
+            getSession().incrementIncomingBytes(-current.pending());
+            getSession().incrementIncomingDeliveries(-1);
+            if (getSession().getTransportSession().getIncomingWindowSize().equals(UnsignedInteger.ZERO)) {
+                modified();
+            }
+        }
+        return advance;
+    }
+
+    private TransportReceiver _transportReceiver;
+    private int _unsentCredits;
+
+    ReceiverImpl(SessionImpl session, String name)
+    {
+        super(session, name);
+        // Proton's null encodes as AMQP's unlimited default. Azure's .NET SDK
+        // reads that uint64 value as signed -1 and rejects every message.
+        setMaxMessageSize(DEFAULT_MAX_MESSAGE_SIZE);
+    }
+
+    @Override
+    public void flow(final int credits)
+    {
+        addCredit(credits);
+        _unsentCredits += credits;
+        modified();
+        if (!_drainFlagMode)
+        {
+            setDrain(false);
+            _drainFlagMode = false;
+        }
+    }
+
+    int clearUnsentCredits()
+    {
+        int credits = _unsentCredits;
+        _unsentCredits = 0;
+        return credits;
+    }
+
+    @Override
+    public int recv(final byte[] bytes, int offset, int size)
+    {
+        if (_current == null) {
+            throw new IllegalStateException("no current delivery");
+        }
+
+        int consumed = _current.recv(bytes, offset, size);
+        if (consumed > 0) {
+            getSession().incrementIncomingBytes(-consumed);
+            if (getSession().getTransportSession().getIncomingWindowSize().equals(UnsignedInteger.ZERO)) {
+                modified();
+            }
+        }
+        return consumed;
+    }
+
+    @Override
+    public int recv(final WritableBuffer buffer)
+    {
+        if (_current == null) {
+            throw new IllegalStateException("no current delivery");
+        }
+
+        int consumed = _current.recv(buffer);
+        if (consumed > 0) {
+            getSession().incrementIncomingBytes(-consumed);
+            if (getSession().getTransportSession().getIncomingWindowSize().equals(UnsignedInteger.ZERO)) {
+                modified();
+            }
+        }
+        return consumed;
+    }
+
+    @Override
+    public ReadableBuffer recv()
+    {
+        if (_current == null) {
+            throw new IllegalStateException("no current delivery");
+        }
+
+        ReadableBuffer consumed = _current.recv();
+        if (consumed.remaining() > 0) {
+            getSession().incrementIncomingBytes(-consumed.remaining());
+            if (getSession().getTransportSession().getIncomingWindowSize().equals(UnsignedInteger.ZERO)) {
+                modified();
+            }
+        }
+        return consumed;
+    }
+
+    @Override
+    void doFree()
+    {
+        getSession().freeReceiver(this);
+        super.doFree();
+    }
+
+    boolean hasIncoming()
+    {
+        return false;
+    }
+
+    void setTransportLink(TransportReceiver transportReceiver)
+    {
+        _transportReceiver = transportReceiver;
+    }
+
+    @Override
+    TransportReceiver getTransportLink()
+    {
+        return _transportReceiver;
+    }
+
+    @Override
+    public void drain(int credit)
+    {
+        setDrain(true);
+        flow(credit);
+        _drainFlagMode = false;
+    }
+
+    @Override
+    public boolean draining()
+    {
+        return getDrain() && (getCredit() > getQueued());
+    }
+
+    @Override
+    public void setDrain(boolean drain)
+    {
+        super.setDrain(drain);
+        modified();
+        _drainFlagMode = true;
+    }
+
+    @Override
+    public int getRemoteCredit()
+    {
+        return getCredit() - getQueued();
+    }
+}

--- a/src/artemis-patch/java/org/apache/qpid/proton/engine/impl/TransportLink.java
+++ b/src/artemis-patch/java/org/apache/qpid/proton/engine/impl/TransportLink.java
@@ -1,0 +1,246 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+package org.apache.qpid.proton.engine.impl;
+
+import org.apache.qpid.proton.amqp.UnsignedInteger;
+import org.apache.qpid.proton.amqp.transport.Flow;
+import org.apache.qpid.proton.engine.Event;
+
+/**
+ * Proton-J 0.34.1 transport link with Azure Service Bus compatibility.
+ *
+ * Azure's pre-settled CBS sender omits the AMQP initial-delivery-count field.
+ * The stock class leaves the value null and crashes after the first transfer.
+ * AMQP delivery numbering starts at zero, so defaulting the missing field to
+ * zero is equivalent to the value used by Proton's normal sender path.
+ */
+class TransportLink<T extends LinkImpl>
+{
+    private UnsignedInteger _localHandle;
+    private String _name;
+    private UnsignedInteger _remoteHandle;
+    private UnsignedInteger _deliveryCount = UnsignedInteger.ZERO;
+    private UnsignedInteger _linkCredit = UnsignedInteger.ZERO;
+    private T _link;
+    private UnsignedInteger _remoteDeliveryCount;
+    private UnsignedInteger _remoteLinkCredit;
+    private boolean _detachReceived;
+    private boolean _attachSent;
+    private boolean _detachSent;
+
+    protected TransportLink(T link)
+    {
+        _link = link;
+        _name = link.getName();
+    }
+
+    static <L extends LinkImpl> TransportLink<L> createTransportLink(L link)
+    {
+        if (link instanceof ReceiverImpl)
+        {
+            ReceiverImpl r = (ReceiverImpl) link;
+            TransportReceiver tr = new TransportReceiver(r);
+            r.setTransportLink(tr);
+
+            return (TransportLink<L>) tr;
+        }
+        else
+        {
+            SenderImpl s = (SenderImpl) link;
+            TransportSender ts = new TransportSender(s);
+            s.setTransportLink(ts);
+
+            return (TransportLink<L>) ts;
+        }
+    }
+
+    void unbind()
+    {
+        clearLocalHandle();
+        clearRemoteHandle();
+    }
+
+    public UnsignedInteger getLocalHandle()
+    {
+        return _localHandle;
+    }
+
+    public void setLocalHandle(UnsignedInteger localHandle)
+    {
+        if (_localHandle == null) {
+            _link.incref();
+        }
+        _localHandle = localHandle;
+    }
+
+    public boolean isLocalHandleSet()
+    {
+        return _localHandle != null;
+    }
+
+    public String getName()
+    {
+        return _name;
+    }
+
+    public void setName(String name)
+    {
+        _name = name;
+    }
+
+    public void clearLocalHandle()
+    {
+        if (_localHandle != null) {
+            _link.decref();
+        }
+        _localHandle = null;
+    }
+
+    public UnsignedInteger getRemoteHandle()
+    {
+        return _remoteHandle;
+    }
+
+    public void setRemoteHandle(UnsignedInteger remoteHandle)
+    {
+        if (_remoteHandle == null) {
+            _link.incref();
+        }
+        _remoteHandle = remoteHandle;
+    }
+
+    public void clearRemoteHandle()
+    {
+        if (_remoteHandle != null) {
+            _link.decref();
+        }
+        _remoteHandle = null;
+    }
+
+    public UnsignedInteger getDeliveryCount()
+    {
+        return _deliveryCount;
+    }
+
+    public UnsignedInteger getLinkCredit()
+    {
+        return _linkCredit;
+    }
+
+    public void addCredit(int credits)
+    {
+        _linkCredit = UnsignedInteger.valueOf(_linkCredit.intValue() + credits);
+    }
+
+    public boolean hasCredit()
+    {
+        return getLinkCredit().compareTo(UnsignedInteger.ZERO) > 0;
+    }
+
+    public T getLink()
+    {
+        return _link;
+    }
+
+    void handleFlow(Flow flow)
+    {
+        _remoteDeliveryCount = flow.getDeliveryCount();
+        _remoteLinkCredit = flow.getLinkCredit();
+
+        _link.getConnectionImpl().put(Event.Type.LINK_FLOW, _link);
+    }
+
+    void setLinkCredit(UnsignedInteger linkCredit)
+    {
+        _linkCredit = linkCredit;
+    }
+
+    public void setDeliveryCount(UnsignedInteger deliveryCount)
+    {
+        _deliveryCount = deliveryCount == null ? UnsignedInteger.ZERO : deliveryCount;
+    }
+
+    public void settled(TransportDelivery transportDelivery)
+    {
+        getLink().getSession().getTransportSession().settled(transportDelivery);
+    }
+
+    UnsignedInteger getRemoteDeliveryCount()
+    {
+        return _remoteDeliveryCount;
+    }
+
+    UnsignedInteger getRemoteLinkCredit()
+    {
+        return _remoteLinkCredit;
+    }
+
+    public void setRemoteLinkCredit(UnsignedInteger remoteLinkCredit)
+    {
+        _remoteLinkCredit = remoteLinkCredit;
+    }
+
+    void decrementLinkCredit()
+    {
+        _linkCredit = _linkCredit.subtract(UnsignedInteger.ONE);
+    }
+
+    void incrementDeliveryCount()
+    {
+        _deliveryCount = _deliveryCount.add(UnsignedInteger.ONE);
+    }
+
+    public void receivedDetach()
+    {
+        _detachReceived = true;
+    }
+
+    public boolean detachReceived()
+    {
+        return _detachReceived;
+    }
+
+    public boolean attachSent()
+    {
+        return _attachSent;
+    }
+
+    public void sentAttach()
+    {
+        _attachSent = true;
+    }
+
+    public void setRemoteDeliveryCount(UnsignedInteger remoteDeliveryCount)
+    {
+        _remoteDeliveryCount = remoteDeliveryCount;
+    }
+
+    public boolean detachSent()
+    {
+        return _detachSent;
+    }
+
+    public void sentDetach()
+    {
+        _detachSent = true;
+    }
+}

--- a/src/artemis-plugin/java/io/floci/az/artemis/MssbcbsServerSasl.java
+++ b/src/artemis-plugin/java/io/floci/az/artemis/MssbcbsServerSasl.java
@@ -1,0 +1,29 @@
+package io.floci.az.artemis;
+
+import org.apache.activemq.artemis.protocol.amqp.sasl.PlainSASLResult;
+import org.apache.activemq.artemis.protocol.amqp.sasl.SASLResult;
+import org.apache.activemq.artemis.protocol.amqp.sasl.ServerSASL;
+
+final class MssbcbsServerSasl implements ServerSASL {
+
+    static final String MECHANISM = "MSSBCBS";
+
+    @Override
+    public String getName() {
+        return MECHANISM;
+    }
+
+    @Override
+    public byte[] processSASL(byte[] bytes) {
+        return null;
+    }
+
+    @Override
+    public SASLResult result() {
+        return new PlainSASLResult(true, null, null);
+    }
+
+    @Override
+    public void done() {
+    }
+}

--- a/src/artemis-plugin/java/io/floci/az/artemis/MssbcbsServerSaslFactory.java
+++ b/src/artemis-plugin/java/io/floci/az/artemis/MssbcbsServerSaslFactory.java
@@ -1,0 +1,37 @@
+package io.floci.az.artemis;
+
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.protocol.amqp.broker.AmqpInterceptor;
+import org.apache.activemq.artemis.protocol.amqp.proton.AMQPRoutingHandler;
+import org.apache.activemq.artemis.protocol.amqp.sasl.ServerSASL;
+import org.apache.activemq.artemis.protocol.amqp.sasl.ServerSASLFactory;
+import org.apache.activemq.artemis.spi.core.protocol.ProtocolManager;
+import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
+import org.apache.activemq.artemis.spi.core.remoting.Connection;
+
+public final class MssbcbsServerSaslFactory implements ServerSASLFactory {
+
+    @Override
+    public String getMechanism() {
+        return MssbcbsServerSasl.MECHANISM;
+    }
+
+    @Override
+    public ServerSASL create(
+            ActiveMQServer server,
+            ProtocolManager<AmqpInterceptor, AMQPRoutingHandler> manager,
+            Connection connection,
+            RemotingConnection remotingConnection) {
+        return new MssbcbsServerSasl();
+    }
+
+    @Override
+    public int getPrecedence() {
+        return Integer.MIN_VALUE;
+    }
+
+    @Override
+    public boolean isDefaultPermitted() {
+        return true;
+    }
+}

--- a/src/artemis-plugin/resources/META-INF/services/org.apache.activemq.artemis.protocol.amqp.sasl.ServerSASLFactory
+++ b/src/artemis-plugin/resources/META-INF/services/org.apache.activemq.artemis.protocol.amqp.sasl.ServerSASLFactory
@@ -1,0 +1,1 @@
+io.floci.az.artemis.MssbcbsServerSaslFactory

--- a/src/main/java/io/floci/az/config/EmulatorConfig.java
+++ b/src/main/java/io/floci/az/config/EmulatorConfig.java
@@ -362,7 +362,7 @@ public interface EmulatorConfig {
         @WithDefault("5674")
         int amqpTlsPort();
 
-        @WithDefault("apache/activemq-artemis:latest")
+        @WithDefault("apache/activemq-artemis:2.44.0")
         String artemisImage();
 
         @WithDefault("10")

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusCbsResponder.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusCbsResponder.java
@@ -25,7 +25,7 @@ import java.util.Map;
  *
  * The Azure Service Bus SDK always sends a PUT TOKEN request to the {@code $cbs} address
  * before opening any entity links. This responder receives those requests and replies with
- * status-code 200 on the {@code cbs-client-reply-to} address, unblocking the SDK.
+ * status-code 200 on the {@code $cbs} response link, unblocking the SDK.
  *
  * Uses proton-j directly since it is the same low-level AMQP library the SDK uses internally.
  */

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusConfigGenerator.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusConfigGenerator.java
@@ -35,16 +35,19 @@ public class ServiceBusConfigGenerator {
                 .elem("security-enabled", false)
                 .start("acceptors")
                   .startAttr("acceptor", "name", "amqp")
-                    .raw("tcp://0.0.0.0:" + AMQP_INTERNAL_PORT + "?protocols=AMQP;saslMechanisms=ANONYMOUS,PLAIN;maxMessageSize=1048576")
+                    .raw("tcp://0.0.0.0:" + AMQP_INTERNAL_PORT
+                        + "?protocols=AMQP;anycastPrefix=/"
+                        + ";saslMechanisms=MSSBCBS,ANONYMOUS,PLAIN;maxMessageSize=1048576")
                   .end("acceptor")
                   .startAttr("acceptor", "name", "amqps")
                     .raw("tcp://0.0.0.0:" + AMQPS_INTERNAL_PORT + "?protocols=AMQP"
+                        + ";anycastPrefix=/"
                         + ";sslEnabled=true"
                         + ";keyStorePath=/var/lib/artemis-instance/etc-override/artemis.p12"
                         + ";keyStorePassword=" + ArtemisTlsGenerator.KEYSTORE_PASSWORD
                         + ";keyStoreType=PKCS12"
                         + ";needClientAuth=false"
-                        + ";saslMechanisms=ANONYMOUS,PLAIN"
+                        + ";saslMechanisms=MSSBCBS,ANONYMOUS,PLAIN"
                         + ";maxMessageSize=1048576")
                   .end("acceptor")
                 .end("acceptors")
@@ -57,7 +60,7 @@ public class ServiceBusConfigGenerator {
                   .end("address-setting")
                 .end("address-settings")
                 .start("diverts")
-                  .startAttr("divert", "name", "cbs-put-token-intercept")
+                  .startAttr("divert", "name", "cbs-request-intercept")
                     .elem("address", "$cbs")
                     .elem("forwarding-address", "$cbs-intercept")
                     .selfClose("filter", "string", "operation = 'put-token'")
@@ -78,11 +81,6 @@ public class ServiceBusConfigGenerator {
                   .startAttr("address", "name", "$cbs-intercept")
                     .start("anycast")
                       .selfClose("queue", "name", "$cbs-intercept")
-                    .end("anycast")
-                  .end("address")
-                  .startAttr("address", "name", "cbs-client-reply-to")
-                    .start("anycast")
-                      .selfClose("queue", "name", "cbs-client-reply-to")
                     .end("anycast")
                   .end("address")
                 .end("addresses")

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
@@ -503,7 +503,8 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         store.put(key, toStoredObject(key, queue));
 
         try {
-            namespaceManager.jolokiaCreateQueue(namespace, queueName);
+            namespaceManager.jolokiaCreateQueue(
+                    namespace, queueName, queue.requiresSession(), queue.lockDurationSeconds());
         } catch (Exception e) {
             LOG.warnf(e, "Failed to provision queue '%s' in Artemis for namespace '%s'", queueName, namespace);
         }
@@ -681,7 +682,8 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         warnOnActionIgnored(initialRule);
 
         try {
-            namespaceManager.jolokiaCreateSubscription(namespace, topicName, subName, selector);
+            namespaceManager.jolokiaCreateSubscription(namespace, topicName, subName, selector,
+                    sub.requiresSession(), sub.lockDurationSeconds());
         } catch (Exception e) {
             LOG.warnf(e, "Failed to provision subscription '%s/%s' in Artemis for namespace '%s'",
                     topicName, subName, namespace);

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
@@ -23,6 +23,7 @@ import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -585,10 +586,19 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         }
 
         String subPrefix = subPrefix(account, namespace, topicName);
+        List<ServiceBusModels.SubscriptionEntity> subscriptions = scanDirectChildren(subPrefix)
+                .stream()
+                .map(obj -> fromBytes(obj.data(), ServiceBusModels.SubscriptionEntity.class))
+                .filter(Objects::nonNull)
+                .toList();
         store.scan(k -> k.startsWith(subPrefix)).forEach(obj -> store.delete(obj.key()));
         store.delete(topicKey);
 
         try {
+            for (ServiceBusModels.SubscriptionEntity subscription : subscriptions) {
+                namespaceManager.jolokiaDeleteSubscription(
+                        namespace, topicName, subscription.name());
+            }
             namespaceManager.jolokiaDeleteTopic(namespace, topicName);
         } catch (Exception e) {
             LOG.warnf(e, "Failed to remove topic '%s' from Artemis for namespace '%s'", topicName, namespace);

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -50,6 +50,7 @@ public class ServiceBusNamespaceManager {
     private static final int AMQPS_PORT = 5671;
     private static final int JOLOKIA_PORT = 8161;
     private static final String DEAD_LETTER_QUEUE_SUFFIX = "/$DeadLetterQueue";
+    private static final String SUBSCRIPTION_DIVERT_SUFFIX = "/$Divert";
 
     /**
      * Immutable snapshot of a running namespace.
@@ -267,8 +268,10 @@ public class ServiceBusNamespaceManager {
     }
 
     /**
-     * Provisions a durable MULTICAST queue (subscription) bound to the topic address.
-     * The queue name follows the Azure convention: {@code {topicName}/Subscriptions/{subName}}.
+     * Provisions a durable subscription queue with its own address and dead-letter queue.
+     * A divert copies matching messages from the MULTICAST topic address to the subscription's
+     * ANYCAST address. The queue name follows the Azure convention:
+     * {@code {topicName}/Subscriptions/{subName}}.
      *
      * @param filter Artemis core filter (SQL92 selector) applied to the queue — the compiled
      *               form of the subscription's rules; empty string matches everything
@@ -276,41 +279,75 @@ public class ServiceBusNamespaceManager {
     public void jolokiaCreateSubscription(String namespaceName, String topicName, String subName,
                                            String filter) {
         String queueName = topicName + "/Subscriptions/" + subName;
+        String deadLetterQueue = queueName + DEAD_LETTER_QUEUE_SUFFIX;
+        String divertName = queueName + SUBSCRIPTION_DIVERT_SUFFIX;
+        int maxDeliveryAttempts = config.services().serviceBus().maxDeliveryCount();
+        String addressSettings = "{\"deadLetterAddress\":" + jsonString(deadLetterQueue)
+                + ",\"maxDeliveryAttempts\":" + maxDeliveryAttempts
+                + ",\"autoCreateQueues\":false,\"autoCreateAddresses\":false}";
         withJolokia(namespaceName, (http, baseUrl, auth, mbean) -> {
-            // address=topicName (MULTICAST), queue name=topicName/Subscriptions/subName
+            jolokiaExec(http, baseUrl, auth, mbean,
+                    "createAddress(java.lang.String,java.lang.String)",
+                    jsonArr(queueName, "ANYCAST"));
             jolokiaExec(http, baseUrl, auth, mbean,
                     "createQueue(java.lang.String,java.lang.String,java.lang.String,java.lang.String,boolean,int,boolean,boolean)",
-                    jsonArr(topicName, "MULTICAST", queueName, filter, true, -1, false, false));
+                    jsonArr(queueName, "ANYCAST", queueName, "", true, -1, false, false));
+            jolokiaExec(http, baseUrl, auth, mbean,
+                    "createAddress(java.lang.String,java.lang.String)",
+                    jsonArr(deadLetterQueue, "ANYCAST"));
+            jolokiaExec(http, baseUrl, auth, mbean,
+                    "createQueue(java.lang.String,java.lang.String,java.lang.String,java.lang.String,boolean,int,boolean,boolean)",
+                    jsonArr(deadLetterQueue, "ANYCAST", deadLetterQueue, "", true, -1, false, false));
+            jolokiaExec(http, baseUrl, auth, mbean,
+                    "addAddressSettings(java.lang.String,java.lang.String)",
+                    jsonArr(queueName, addressSettings));
+            jolokiaCreateSubscriptionDivert(http, baseUrl, auth, mbean,
+                    divertName, topicName, queueName, filter);
         });
     }
 
     /**
-     * Replaces the filter of an existing subscription queue in place via
-     * {@code ActiveMQServerControl.updateQueue(String queueConfiguration)}. The broker applies
-     * the new filter to future routing only ({@code Queue.setFilter}), matching Azure's
-     * rule-change semantics: messages already routed to the subscription stay, attached
-     * receivers stay connected.
+     * Replaces the filter of an existing subscription divert. The broker applies the new filter
+     * to future routing only, matching Azure's rule-change semantics: messages already routed to
+     * the subscription stay, and attached receivers stay connected to the unchanged queue.
      */
     public void jolokiaUpdateSubscriptionFilter(String namespaceName, String topicName, String subName,
                                                  String filter) {
         String queueName = topicName + "/Subscriptions/" + subName;
-        // QueueConfiguration JSON uses kebab-case keys ("filter-string", not "filterString")
-        String queueConfigJson = "{\"name\":" + jsonString(queueName)
-                + ",\"filter-string\":" + jsonString(filter) + "}";
+        String divertName = queueName + SUBSCRIPTION_DIVERT_SUFFIX;
         withJolokia(namespaceName, (http, baseUrl, auth, mbean) -> {
             jolokiaExec(http, baseUrl, auth, mbean,
-                    "updateQueue(java.lang.String)",
-                    jsonArr(queueConfigJson));
+                    "destroyDivert(java.lang.String)",
+                    jsonArr(divertName));
+            jolokiaCreateSubscriptionDivert(http, baseUrl, auth, mbean,
+                    divertName, topicName, queueName, filter);
         });
     }
 
-    /** Removes a subscription queue from the running Artemis broker. */
+    /** Removes a subscription queue, divert, dead-letter queue, and address settings. */
     public void jolokiaDeleteSubscription(String namespaceName, String topicName, String subName) {
         String queueName = topicName + "/Subscriptions/" + subName;
+        String deadLetterQueue = queueName + DEAD_LETTER_QUEUE_SUFFIX;
+        String divertName = queueName + SUBSCRIPTION_DIVERT_SUFFIX;
         withJolokia(namespaceName, (http, baseUrl, auth, mbean) -> {
+            jolokiaExec(http, baseUrl, auth, mbean,
+                    "destroyDivert(java.lang.String)",
+                    jsonArr(divertName));
             jolokiaExec(http, baseUrl, auth, mbean,
                     "destroyQueue(java.lang.String,boolean,boolean)",
                     jsonArr(queueName, true, true));
+            jolokiaExec(http, baseUrl, auth, mbean,
+                    "deleteAddress(java.lang.String,boolean)",
+                    jsonArr(queueName, true));
+            jolokiaExec(http, baseUrl, auth, mbean,
+                    "destroyQueue(java.lang.String,boolean,boolean)",
+                    jsonArr(deadLetterQueue, true, true));
+            jolokiaExec(http, baseUrl, auth, mbean,
+                    "deleteAddress(java.lang.String,boolean)",
+                    jsonArr(deadLetterQueue, true));
+            jolokiaExec(http, baseUrl, auth, mbean,
+                    "removeAddressSettings(java.lang.String)",
+                    jsonArr(queueName));
         });
     }
 
@@ -348,6 +385,15 @@ public class ServiceBusNamespaceManager {
     @FunctionalInterface
     interface JolokiaAction {
         void run(HttpClient http, String baseUrl, String auth, String mbean) throws Exception;
+    }
+
+    private void jolokiaCreateSubscriptionDivert(HttpClient http, String baseUrl, String auth,
+                                                   String mbean, String divertName,
+                                                   String topicName, String queueName,
+                                                   String filter) {
+        jolokiaExec(http, baseUrl, auth, mbean,
+                "createDivert(java.lang.String,java.lang.String,java.lang.String,java.lang.String,boolean,java.lang.String,java.lang.String)",
+                jsonArr(divertName, divertName, topicName, queueName, false, filter, null));
     }
 
     private void withJolokia(String namespaceName, JolokiaAction action) {

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -12,6 +12,7 @@ import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.Socket;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -36,9 +37,19 @@ public class ServiceBusNamespaceManager {
 
     private static final Logger LOG = Logger.getLogger(ServiceBusNamespaceManager.class);
 
+    static final String ARTEMIS_EXTENSION_RESOURCE = "/artemis/servicebus-artemis-extension.jar";
+    static final String PROTON_PATCH_RESOURCE = "/artemis/proton-j-0.34.1-floci-az-proton-patch.jar";
+    static final String ARTEMIS_AMQP_PATCH_RESOURCE =
+            "/artemis/artemis-amqp-protocol-2.44.0-floci-az-artemis-amqp-patch.jar";
+    private static final String ARTEMIS_EXTENSION_PATH =
+            "/var/lib/artemis-instance/lib/floci-az-servicebus-extension.jar";
+    private static final String PROTON_J_PATH = "/opt/activemq-artemis/lib/proton-j-0.34.1.jar";
+    private static final String ARTEMIS_AMQP_PATH =
+            "/opt/activemq-artemis/lib/artemis-amqp-protocol-2.44.0.jar";
     private static final int AMQP_PORT = 5672;
     private static final int AMQPS_PORT = 5671;
     private static final int JOLOKIA_PORT = 8161;
+    private static final String DEAD_LETTER_QUEUE_SUFFIX = "/$DeadLetterQueue";
 
     /**
      * Immutable snapshot of a running namespace.
@@ -113,6 +124,12 @@ public class ServiceBusNamespaceManager {
                 "/var/lib/artemis-instance/etc-override/broker.xml");
         lifecycleManager.copyBytesToContainer(containerId, tls.pkcs12Bytes(),
                 "/var/lib/artemis-instance/etc-override/artemis.p12");
+        lifecycleManager.copyBytesToContainer(containerId, loadArtemisExtension(),
+                ARTEMIS_EXTENSION_PATH);
+        lifecycleManager.copyBytesToContainer(containerId, loadResource(PROTON_PATCH_RESOURCE),
+                PROTON_J_PATH);
+        lifecycleManager.copyBytesToContainer(containerId, loadResource(ARTEMIS_AMQP_PATCH_RESOURCE),
+                ARTEMIS_AMQP_PATH);
 
         ContainerLifecycleManager.ContainerInfo info = lifecycleManager.startCreated(containerId, spec);
 
@@ -188,6 +205,11 @@ public class ServiceBusNamespaceManager {
 
     /** Provisions an ANYCAST queue in the running Artemis broker. */
     public void jolokiaCreateQueue(String namespaceName, String queueName) {
+        String deadLetterQueue = queueName + DEAD_LETTER_QUEUE_SUFFIX;
+        int maxDeliveryAttempts = config.services().serviceBus().maxDeliveryCount();
+        String addressSettings = "{\"deadLetterAddress\":" + jsonString(deadLetterQueue)
+                + ",\"maxDeliveryAttempts\":" + maxDeliveryAttempts
+                + ",\"autoCreateQueues\":false,\"autoCreateAddresses\":false}";
         withJolokia(namespaceName, (http, baseUrl, auth, mbean) -> {
             jolokiaExec(http, baseUrl, auth, mbean,
                     "createAddress(java.lang.String,java.lang.String)",
@@ -195,15 +217,34 @@ public class ServiceBusNamespaceManager {
             jolokiaExec(http, baseUrl, auth, mbean,
                     "createQueue(java.lang.String,java.lang.String,java.lang.String,java.lang.String,boolean,int,boolean,boolean)",
                     jsonArr(queueName, "ANYCAST", queueName, "", true, -1, false, false));
+            jolokiaExec(http, baseUrl, auth, mbean,
+                    "createAddress(java.lang.String,java.lang.String)",
+                    jsonArr(deadLetterQueue, "ANYCAST"));
+            jolokiaExec(http, baseUrl, auth, mbean,
+                    "createQueue(java.lang.String,java.lang.String,java.lang.String,java.lang.String,boolean,int,boolean,boolean)",
+                    jsonArr(deadLetterQueue, "ANYCAST", deadLetterQueue, "", true, -1, false, false));
+            jolokiaExec(http, baseUrl, auth, mbean,
+                    "addAddressSettings(java.lang.String,java.lang.String)",
+                    jsonArr(queueName, addressSettings));
         });
     }
 
     /** Removes an ANYCAST queue from the running Artemis broker. */
     public void jolokiaDeleteQueue(String namespaceName, String queueName) {
+        String deadLetterQueue = queueName + DEAD_LETTER_QUEUE_SUFFIX;
         withJolokia(namespaceName, (http, baseUrl, auth, mbean) -> {
             jolokiaExec(http, baseUrl, auth, mbean,
                     "destroyQueue(java.lang.String,boolean,boolean)",
                     jsonArr(queueName, true, true));
+            jolokiaExec(http, baseUrl, auth, mbean,
+                    "destroyQueue(java.lang.String,boolean,boolean)",
+                    jsonArr(deadLetterQueue, true, true));
+            jolokiaExec(http, baseUrl, auth, mbean,
+                    "deleteAddress(java.lang.String,boolean)",
+                    jsonArr(deadLetterQueue, true));
+            jolokiaExec(http, baseUrl, auth, mbean,
+                    "removeAddressSettings(java.lang.String)",
+                    jsonArr(queueName));
         });
     }
 
@@ -277,6 +318,22 @@ public class ServiceBusNamespaceManager {
 
     String containerName(String namespaceName) {
         return ContainerStorageHelper.dockerName(config, "servicebus-" + namespaceName);
+    }
+
+    private static byte[] loadArtemisExtension() {
+        return loadResource(ARTEMIS_EXTENSION_RESOURCE);
+    }
+
+    private static byte[] loadResource(String resource) {
+        try (InputStream stream = ServiceBusNamespaceManager.class.getResourceAsStream(
+                resource)) {
+            if (stream == null) {
+                throw new IllegalStateException("Embedded Artemis resource not found: " + resource);
+            }
+            return stream.readAllBytes();
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to read embedded Artemis resource: " + resource, e);
+        }
     }
 
     private static String rootMessage(Throwable error) {

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -249,12 +249,15 @@ public class ServiceBusNamespaceManager {
         });
     }
 
-    /** Provisions a MULTICAST address for a topic in the running Artemis broker. */
+    /**
+     * Provisions a topic address that accepts the SDK's ANYCAST-prefixed sender link while
+     * subscription diverts fan each message out with topic semantics.
+     */
     public void jolokiaCreateTopic(String namespaceName, String topicName) {
         withJolokia(namespaceName, (http, baseUrl, auth, mbean) -> {
             jolokiaExec(http, baseUrl, auth, mbean,
                     "createAddress(java.lang.String,java.lang.String)",
-                    jsonArr(topicName, "MULTICAST"));
+                    jsonArr(topicName, "ANYCAST,MULTICAST"));
         });
     }
 

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -53,6 +53,7 @@ public class ServiceBusNamespaceManager {
     private static final String SUBSCRIPTION_DIVERT_SUFFIX = "/$Divert";
     private static final String TOPIC_ADDRESS_SUFFIX = "/$Topic";
     private static final String TOPIC_DIVERT_SUFFIX = "/$TopicDivert";
+    private static final String SESSION_METADATA_PREFIX = "floci-az:servicebus-session:";
 
     /**
      * Immutable snapshot of a running namespace.
@@ -207,7 +208,8 @@ public class ServiceBusNamespaceManager {
     // ── Jolokia entity management ─────────────────────────────────────────────
 
     /** Provisions an ANYCAST queue in the running Artemis broker. */
-    public void jolokiaCreateQueue(String namespaceName, String queueName) {
+    public void jolokiaCreateQueue(String namespaceName, String queueName,
+                                    boolean requiresSession, long lockDurationSeconds) {
         String deadLetterQueue = queueName + DEAD_LETTER_QUEUE_SUFFIX;
         int maxDeliveryAttempts = config.services().serviceBus().maxDeliveryCount();
         String addressSettings = "{\"deadLetterAddress\":" + jsonString(deadLetterQueue)
@@ -226,6 +228,10 @@ public class ServiceBusNamespaceManager {
             jolokiaExec(http, baseUrl, auth, mbean,
                     "createQueue(java.lang.String,java.lang.String,java.lang.String,java.lang.String,boolean,int,boolean,boolean)",
                     jsonArr(deadLetterQueue, "ANYCAST", deadLetterQueue, "", true, -1, false, false));
+            applySessionMetadata(http, baseUrl, auth, mbean, queueName,
+                    requiresSession, lockDurationSeconds);
+            applySessionMetadata(http, baseUrl, auth, mbean, deadLetterQueue,
+                    requiresSession, lockDurationSeconds);
             jolokiaExec(http, baseUrl, auth, mbean,
                     "addAddressSettings(java.lang.String,java.lang.String)",
                     jsonArr(queueName, addressSettings));
@@ -301,7 +307,8 @@ public class ServiceBusNamespaceManager {
      *               form of the subscription's rules; empty string matches everything
      */
     public void jolokiaCreateSubscription(String namespaceName, String topicName, String subName,
-                                           String filter) {
+                                           String filter, boolean requiresSession,
+                                           long lockDurationSeconds) {
         String queueName = topicName + "/Subscriptions/" + subName;
         String deadLetterQueue = queueName + DEAD_LETTER_QUEUE_SUFFIX;
         String divertName = queueName + SUBSCRIPTION_DIVERT_SUFFIX;
@@ -322,6 +329,10 @@ public class ServiceBusNamespaceManager {
             jolokiaExec(http, baseUrl, auth, mbean,
                     "createQueue(java.lang.String,java.lang.String,java.lang.String,java.lang.String,boolean,int,boolean,boolean)",
                     jsonArr(deadLetterQueue, "ANYCAST", deadLetterQueue, "", true, -1, false, false));
+            applySessionMetadata(http, baseUrl, auth, mbean, queueName,
+                    requiresSession, lockDurationSeconds);
+            applySessionMetadata(http, baseUrl, auth, mbean, deadLetterQueue,
+                    requiresSession, lockDurationSeconds);
             jolokiaExec(http, baseUrl, auth, mbean,
                     "addAddressSettings(java.lang.String,java.lang.String)",
                     jsonArr(queueName, addressSettings));
@@ -418,6 +429,22 @@ public class ServiceBusNamespaceManager {
                 "createDivert(java.lang.String,java.lang.String,java.lang.String,java.lang.String,boolean,java.lang.String,java.lang.String)",
                 jsonArr(divertName, divertName, sourceAddress, forwardingAddress,
                         exclusive, filter, null));
+    }
+
+    private void applySessionMetadata(HttpClient http, String baseUrl, String auth,
+                                      String mbean, String queueName,
+                                      boolean requiresSession, long lockDurationSeconds) {
+        if (!requiresSession) {
+            return;
+        }
+
+        // Artemis security is disabled in this sidecar, so QueueConfiguration.user can carry
+        // internal metadata that the patched AMQP protocol handler reads during link attach.
+        String metadata = SESSION_METADATA_PREFIX + lockDurationSeconds;
+        String queueConfiguration = "{\"name\":" + jsonString(queueName)
+                + ",\"user\":" + jsonString(metadata) + "}";
+        jolokiaExec(http, baseUrl, auth, mbean,
+                "updateQueue(java.lang.String)", jsonArr(queueConfiguration));
     }
 
     private void withJolokia(String namespaceName, JolokiaAction action) {

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -51,6 +51,8 @@ public class ServiceBusNamespaceManager {
     private static final int JOLOKIA_PORT = 8161;
     private static final String DEAD_LETTER_QUEUE_SUFFIX = "/$DeadLetterQueue";
     private static final String SUBSCRIPTION_DIVERT_SUFFIX = "/$Divert";
+    private static final String TOPIC_ADDRESS_SUFFIX = "/$Topic";
+    private static final String TOPIC_DIVERT_SUFFIX = "/$TopicDivert";
 
     /**
      * Immutable snapshot of a running namespace.
@@ -250,23 +252,42 @@ public class ServiceBusNamespaceManager {
     }
 
     /**
-     * Provisions a topic address that accepts the SDK's ANYCAST-prefixed sender link while
-     * subscription diverts fan each message out with topic semantics.
+     * Provisions an ANYCAST ingress accepted by SDK sender links and diverts it exclusively to a
+     * hidden MULTICAST address. Subscription diverts fan messages out from that hidden address.
      */
     public void jolokiaCreateTopic(String namespaceName, String topicName) {
+        String topicAddress = topicName + TOPIC_ADDRESS_SUFFIX;
         withJolokia(namespaceName, (http, baseUrl, auth, mbean) -> {
             jolokiaExec(http, baseUrl, auth, mbean,
                     "createAddress(java.lang.String,java.lang.String)",
-                    jsonArr(topicName, "ANYCAST,MULTICAST"));
+                    jsonArr(topicName, "ANYCAST"));
+            jolokiaExec(http, baseUrl, auth, mbean,
+                    "createQueue(java.lang.String,java.lang.String,java.lang.String,java.lang.String,boolean,int,boolean,boolean)",
+                    jsonArr(topicName, "ANYCAST", topicName, "", true, -1, false, false));
+            jolokiaExec(http, baseUrl, auth, mbean,
+                    "createAddress(java.lang.String,java.lang.String)",
+                    jsonArr(topicAddress, "MULTICAST"));
+            jolokiaCreateDivert(http, baseUrl, auth, mbean,
+                    topicName + TOPIC_DIVERT_SUFFIX, topicName, topicAddress, "", true);
         });
     }
 
     /** Removes a MULTICAST address and all its subscription queues from the running Artemis broker. */
     public void jolokiaDeleteTopic(String namespaceName, String topicName) {
+        String topicAddress = topicName + TOPIC_ADDRESS_SUFFIX;
         withJolokia(namespaceName, (http, baseUrl, auth, mbean) -> {
+            jolokiaExec(http, baseUrl, auth, mbean,
+                    "destroyDivert(java.lang.String)",
+                    jsonArr(topicName + TOPIC_DIVERT_SUFFIX));
+            jolokiaExec(http, baseUrl, auth, mbean,
+                    "destroyQueue(java.lang.String,boolean,boolean)",
+                    jsonArr(topicName, true, true));
             jolokiaExec(http, baseUrl, auth, mbean,
                     "deleteAddress(java.lang.String,boolean)",
                     jsonArr(topicName, true));
+            jolokiaExec(http, baseUrl, auth, mbean,
+                    "deleteAddress(java.lang.String,boolean)",
+                    jsonArr(topicAddress, true));
         });
     }
 
@@ -304,8 +325,8 @@ public class ServiceBusNamespaceManager {
             jolokiaExec(http, baseUrl, auth, mbean,
                     "addAddressSettings(java.lang.String,java.lang.String)",
                     jsonArr(queueName, addressSettings));
-            jolokiaCreateSubscriptionDivert(http, baseUrl, auth, mbean,
-                    divertName, topicName, queueName, filter);
+            jolokiaCreateDivert(http, baseUrl, auth, mbean, divertName,
+                    topicName + TOPIC_ADDRESS_SUFFIX, queueName, filter, false);
         });
     }
 
@@ -322,8 +343,8 @@ public class ServiceBusNamespaceManager {
             jolokiaExec(http, baseUrl, auth, mbean,
                     "destroyDivert(java.lang.String)",
                     jsonArr(divertName));
-            jolokiaCreateSubscriptionDivert(http, baseUrl, auth, mbean,
-                    divertName, topicName, queueName, filter);
+            jolokiaCreateDivert(http, baseUrl, auth, mbean, divertName,
+                    topicName + TOPIC_ADDRESS_SUFFIX, queueName, filter, false);
         });
     }
 
@@ -390,13 +411,13 @@ public class ServiceBusNamespaceManager {
         void run(HttpClient http, String baseUrl, String auth, String mbean) throws Exception;
     }
 
-    private void jolokiaCreateSubscriptionDivert(HttpClient http, String baseUrl, String auth,
-                                                   String mbean, String divertName,
-                                                   String topicName, String queueName,
-                                                   String filter) {
+    private void jolokiaCreateDivert(HttpClient http, String baseUrl, String auth,
+                                      String mbean, String divertName, String sourceAddress,
+                                      String forwardingAddress, String filter, boolean exclusive) {
         jolokiaExec(http, baseUrl, auth, mbean,
                 "createDivert(java.lang.String,java.lang.String,java.lang.String,java.lang.String,boolean,java.lang.String,java.lang.String)",
-                jsonArr(divertName, divertName, topicName, queueName, false, filter, null));
+                jsonArr(divertName, divertName, sourceAddress, forwardingAddress,
+                        exclusive, filter, null));
     }
 
     private void withJolokia(String namespaceName, JolokiaAction action) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -168,11 +168,7 @@ floci-az:
       default-port: 0        # 0 = OS picks a free port per server (recommended)
     service-bus:
       enabled: true
-      # Deliberately mocked: the Artemis sidecar starts fine, but every SDK send fails with
-      # "payload exceeded maximum message size: 0 kb" -- Artemis attaches the link with
-      # max-message-size=0 ("no limit" per AMQP 1.0) and azure-core-amqp reads it literally
-      # (ReactorSender.getLinkSize). The maxMessageSize=... on the acceptor below is NOT a real
-      # Artemis parameter and is silently ignored. See local/full-parity.md (C1) before flipping.
+      # Keep the broker opt-in because each namespace owns an Artemis sidecar.
       mocked: true
       amqp-port: 5673
       amqp-tls-port: 5674

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -174,7 +174,7 @@ floci-az:
       mocked: true
       amqp-port: 5673
       amqp-tls-port: 5674
-      artemis-image: "apache/activemq-artemis:latest"
+      artemis-image: "apache/activemq-artemis:2.44.0"
       max-delivery-count: 10
       lock-duration-seconds: 60
     monitor:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,8 @@ quarkus:
       enabled: true
       origins: /.*/
   native:
+    resources:
+      includes: artemis/**
     additional-build-args: >-
       --initialize-at-run-time=org.apache.hc.client5.http.impl.auth.NTLMEngineImpl,
       --initialize-at-run-time=com.github.dockerjava.transport.NamedPipeSocket$Kernel32,

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusConfigGeneratorTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusConfigGeneratorTest.java
@@ -1,0 +1,125 @@
+package io.floci.az.services.servicebus;
+
+import io.floci.az.config.EmulatorConfig;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.ServiceLoader;
+import java.util.Set;
+import java.util.jar.JarInputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ServiceBusConfigGeneratorTest {
+
+    @Test
+    void advertisesMssbcbsOnBothAmqpAcceptors() {
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
+        EmulatorConfig.ServiceBusConfig serviceBus = mock(EmulatorConfig.ServiceBusConfig.class);
+        when(config.services()).thenReturn(services);
+        when(services.serviceBus()).thenReturn(serviceBus);
+        when(serviceBus.maxDeliveryCount()).thenReturn(10);
+
+        String brokerXml = new ServiceBusConfigGenerator(config).generate("default");
+
+        assertEquals(2, brokerXml.split("saslMechanisms=MSSBCBS,ANONYMOUS,PLAIN", -1).length - 1);
+        assertEquals(2, brokerXml.split("anycastPrefix=/", -1).length - 1);
+    }
+
+    @Test
+    void routesAllCbsRequestsExclusivelyToTheResponder() {
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
+        EmulatorConfig.ServiceBusConfig serviceBus = mock(EmulatorConfig.ServiceBusConfig.class);
+        when(config.services()).thenReturn(services);
+        when(services.serviceBus()).thenReturn(serviceBus);
+        when(serviceBus.maxDeliveryCount()).thenReturn(10);
+
+        String brokerXml = new ServiceBusConfigGenerator(config).generate("default");
+
+        assertTrue(brokerXml.contains("<address>$cbs</address>"));
+        assertTrue(brokerXml.contains("<forwarding-address>$cbs-intercept</forwarding-address>"));
+        assertTrue(brokerXml.contains("<filter string=\"operation = &apos;put-token&apos;\"/>"));
+        assertTrue(brokerXml.contains("<exclusive>true</exclusive>"));
+        assertTrue(brokerXml.contains("<queue name=\"$cbs-intercept\"/>"));
+    }
+
+    @Test
+    void packagesMssbcbsFactoryForTheArtemisSidecar() throws Exception {
+        URL extensionJar;
+        try (InputStream stream = getClass().getResourceAsStream(
+                ServiceBusNamespaceManager.ARTEMIS_EXTENSION_RESOURCE)) {
+            assertNotNull(stream, "Artemis extension JAR must be embedded in the application");
+            Path jar = Files.createTempFile("floci-az-servicebus-artemis-", ".jar");
+            Files.copy(stream, jar, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+            extensionJar = jar.toUri().toURL();
+        }
+
+        try (URLClassLoader loader = new URLClassLoader(new URL[]{extensionJar}, getClass().getClassLoader())) {
+            Object factory = ServiceLoader.load(
+                            org.apache.activemq.artemis.protocol.amqp.sasl.ServerSASLFactory.class, loader)
+                    .stream()
+                    .filter(provider -> provider.get().getMechanism().equals("MSSBCBS"))
+                    .findFirst()
+                    .orElseThrow()
+                    .get();
+
+            assertTrue(factory instanceof org.apache.activemq.artemis.protocol.amqp.sasl.ServerSASLFactory);
+        }
+    }
+
+    @Test
+    void packagesProtonPatchForAzureCbsTransfers() throws Exception {
+        try (InputStream stream = getClass().getResourceAsStream(
+                ServiceBusNamespaceManager.PROTON_PATCH_RESOURCE)) {
+            assertNotNull(stream, "Patched proton-j JAR must be embedded in the application");
+            try (JarInputStream jar = new JarInputStream(stream)) {
+                boolean containsTransportPatch = false;
+                boolean containsReceiverPatch = false;
+                for (var entry = jar.getNextJarEntry(); entry != null; entry = jar.getNextJarEntry()) {
+                    if (entry.getName().equals(
+                            "org/apache/qpid/proton/engine/impl/TransportLink.class")) {
+                        containsTransportPatch = true;
+                    } else if (entry.getName().equals(
+                            "org/apache/qpid/proton/engine/impl/ReceiverImpl.class")) {
+                        containsReceiverPatch = true;
+                    }
+                }
+                assertTrue(containsTransportPatch);
+                assertTrue(containsReceiverPatch);
+            }
+        }
+    }
+
+    @Test
+    void packagesArtemisPatchesForAzureSdkSemantics() throws Exception {
+        Set<String> expectedClasses = Set.of(
+                "org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.class",
+                "org/apache/activemq/artemis/protocol/amqp/proton/AmqpTransferTagGenerator.class",
+                "org/apache/activemq/artemis/protocol/amqp/proton/DefaultSenderController.class",
+                "org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.class");
+        try (InputStream stream = getClass().getResourceAsStream(
+                ServiceBusNamespaceManager.ARTEMIS_AMQP_PATCH_RESOURCE)) {
+            assertNotNull(stream, "Patched Artemis AMQP JAR must be embedded in the application");
+            try (JarInputStream jar = new JarInputStream(stream)) {
+                Set<String> packagedClasses = new HashSet<>();
+                for (var entry = jar.getNextJarEntry(); entry != null; entry = jar.getNextJarEntry()) {
+                    if (expectedClasses.contains(entry.getName())) {
+                        packagedClasses.add(entry.getName());
+                    }
+                }
+                assertEquals(expectedClasses, packagedClasses);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- translate Azure AMQP session filters into Artemis message-group selectors with session ownership, FIFO ordering, accept-next-session, and lock metadata
- cover Java session receivers and .NET session receivers/processors against a real Artemis sidecar
- fix real-broker Java SDK compatibility for delivery counts, abandon, dead-letter/subscription path casing, and scheduled enqueue annotations
- run the Java Service Bus compatibility tests with mocked mode disabled in CI and the Makefile
- document supported session behavior and current limitations

## Validation

- `./mvnw test` — 601 passed
- Java `ServiceBusCompatibilityTest` — 12 passed against real Artemis
- .NET compatibility suite — 2 passed against real Artemis
- patched Artemis package build succeeded
- compatibility workflow YAML parsed successfully

Depends on #170.
Closes #123.