### PR TITLE
fix(entra): make EntraStore participate in /_admin/reset

### DIFF
--- a/src/main/java/io/floci/az/services/entra/EntraStore.java
+++ b/src/main/java/io/floci/az/services/entra/EntraStore.java
@@ -3,6 +3,7 @@ package io.floci.az.services.entra;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.floci.az.config.EmulatorConfig;
+import io.floci.az.core.Resettable;
 import io.floci.az.core.StoredObject;
 import io.floci.az.core.storage.StorageBackend;
 import io.floci.az.core.storage.StorageFactory;
@@ -35,7 +36,7 @@ import java.util.Set;
  * <p>PR1 only reads the seed to populate token claims. Full admin CRUD is layered on in PR2.
  */
 @ApplicationScoped
-public class EntraStore {
+public class EntraStore implements Resettable {
 
     private static final Logger LOG = Logger.getLogger(EntraStore.class);
 
@@ -94,6 +95,13 @@ public class EntraStore {
             addMember(DEV_GROUP_OBJECT_ID, DEV_USER_OBJECT_ID);
             LOG.infov("Seeded Entra dev user/group (upn={0}, group={1})", DEV_USER_UPN, DEV_GROUP_NAME);
         }
+    }
+
+    /** Wipes all directory/authorization-code state, then reseeds the zero-setup dev fixtures. */
+    @Override
+    public void clear() {
+        store.clear();
+        seed();
     }
 
     public Optional<Tenant> getTenant(String id) {

--- a/src/test/java/io/floci/az/core/AdminResetTest.java
+++ b/src/test/java/io/floci/az/core/AdminResetTest.java
@@ -1,12 +1,16 @@
 package io.floci.az.core;
 
+import io.floci.az.services.entra.EntraModels.User;
+import io.floci.az.services.entra.EntraStore;
 import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasItem;
 
 @QuarkusTest
 @DisplayName("/_admin/reset — every state-holding service self-registers via Resettable")
@@ -15,6 +19,46 @@ class AdminResetTest {
     private static final String APIM_SERVICE =
             "/subscriptions/reset-sub/resourceGroups/reset-rg"
                     + "/providers/Microsoft.ApiManagement/service/reset-apim?api-version=2024-05-01";
+
+    @Inject EntraStore entraStore;
+
+    @Test
+    void resetClearsGraphMembershipWrittenThroughEntraStore() {
+        String userId = "reset-user-" + java.util.UUID.randomUUID();
+        entraStore.putUser(new User(userId, userId + "@floci-az.local", "reset test user", null, "reset-tenant"));
+
+        given()
+          .contentType("application/json")
+          .body("{\"@odata.id\": \"https://graph.microsoft.com/v1.0/directoryObjects/" + userId + "\"}")
+          .when().post("/v1.0/groups/{id}/members/$ref", EntraStore.DEV_GROUP_OBJECT_ID)
+          .then().statusCode(204);
+
+        given()
+          .contentType("application/json")
+          .body("{}")
+          .when().post("/v1.0/users/{id}/getMemberGroups", userId)
+          .then().statusCode(200)
+          .body("value", hasItem(EntraStore.DEV_GROUP_OBJECT_ID));
+
+        given().when().post("/_admin/reset")
+          .then().statusCode(204);
+
+        // EntraStore didn't self-register as Resettable before — this Graph-written
+        // membership (and the user backing it) used to survive a reset.
+        given()
+          .contentType("application/json")
+          .body("{}")
+          .when().post("/v1.0/users/{id}/getMemberGroups", userId)
+          .then().statusCode(404);
+
+        // the zero-setup dev fixtures must still work after a reset
+        given()
+          .contentType("application/json")
+          .body("{}")
+          .when().post("/v1.0/users/{id}/getMemberGroups", EntraStore.DEV_USER_OBJECT_ID)
+          .then().statusCode(200)
+          .body("value", hasItem(EntraStore.DEV_GROUP_OBJECT_ID));
+    }
 
     @Test
     void resetClearsApimEmailAndAppConfigState() {

--- a/src/test/java/io/floci/az/services/entra/EntraStoreTest.java
+++ b/src/test/java/io/floci/az/services/entra/EntraStoreTest.java
@@ -91,6 +91,27 @@ class EntraStoreTest {
     }
 
     @Test
+    void clearWipesMembershipStateAndReseedsDevFixtures() {
+        String userId = "user-" + java.util.UUID.randomUUID();
+        store.putUser(new User(userId, userId + "@floci-az.local", "test user", null, "tenant"));
+        store.addMember(EntraStore.DEV_GROUP_OBJECT_ID, userId);
+        assertTrue(store.memberGroups(userId).contains(EntraStore.DEV_GROUP_OBJECT_ID));
+
+        store.clear();
+
+        assertTrue(store.getUser(userId).isEmpty(), "clear() must drop state created after seeding");
+        assertTrue(store.memberGroups(userId).isEmpty(),
+            "clear() must drop membership rows created after seeding");
+        assertTrue(store.getUser(EntraStore.DEV_USER_OBJECT_ID).isPresent(),
+            "clear() must reseed the zero-setup dev user");
+        assertEquals(Set.of(EntraStore.DEV_GROUP_OBJECT_ID),
+            store.memberGroups(EntraStore.DEV_USER_OBJECT_ID),
+            "clear() must reseed the dev user's group membership, not just the bare records");
+        assertTrue(store.findAppByClientId(EntraStore.DEV_CLIENT_ID).isPresent(),
+            "clear() must reseed the zero-setup dev app registration");
+    }
+
+    @Test
     void concurrentMembershipMutationsAreNotLost() throws Exception {
         String groupId = "group-" + java.util.UUID.randomUUID();
         store.putGroup(new Group(groupId, "concurrent group", "tenant", true));


### PR DESCRIPTION
## Summary
- `EntraStore` held mutable directory and Graph membership state (users, groups, memberships, authorization codes) but never implemented `Resettable`, so state written through the Entra/Graph API survived `POST /_admin/reset` instead of being wiped like every other stateful service.
- `clear()` now wipes the backing store and reseeds the zero-setup dev fixtures (tenant/app/user/group) so SDK clients keep working with no setup immediately after a reset.

Follow-up from #143, per @hectorvent's approval comment:
> `EntraStore` now holds mutable membership state but does not implement `Resettable`, so `/_admin/reset` leaves Graph writes behind. Worth a small follow up rather than holding this up.

## Test plan
- [x] `EntraStoreTest#clearWipesMembershipStateAndReseedsDevFixtures` — unit-level: a custom user/membership added after seeding is wiped by `clear()`, while the dev user/group/app/membership are reseeded.
- [x] `AdminResetTest#resetClearsGraphMembershipWrittenThroughEntraStore` — HTTP-level: a membership written via `POST /v1.0/groups/{id}/members/$ref` is gone after `POST /_admin/reset`, and the dev fixtures still resolve via `getMemberGroups` afterward.
- [x] Verified both new tests fail against the pre-fix code (confirms they exercise the reported bug).
- [x] `./mvnw -DskipITs -Dtest=EntraServiceTest,EntraStoreTest,GraphServiceHandlerTest,AdminResetTest test` — 29/29 green.