### PR TITLE
fix(functions): accept deployment packages larger than 20 MB

### DIFF
--- a/src/main/java/io/floci/az/core/JacksonConfig.java
+++ b/src/main/java/io/floci/az/core/JacksonConfig.java
@@ -14,6 +14,17 @@ public class JacksonConfig implements ObjectMapperCustomizer {
 
     @Override
     public void customize(ObjectMapper mapper) {
+        applyLargePayloadConstraints(mapper);
+    }
+
+    /**
+     * Apply the large-payload stream-read constraints to a mapper.
+     *
+     * <p>The customizer above only reaches the CDI-managed {@link ObjectMapper}. Handlers that
+     * construct their own mapper keep Jackson's 20 MB default string limit unless they call this,
+     * which would reject payloads real Azure accepts.
+     */
+    public static void applyLargePayloadConstraints(ObjectMapper mapper) {
         mapper.getFactory().setStreamReadConstraints(
                 StreamReadConstraints.builder()
                         .maxStringLength(MAX_STRING_LENGTH)

--- a/src/main/java/io/floci/az/services/functions/FunctionsServiceHandler.java
+++ b/src/main/java/io/floci/az/services/functions/FunctionsServiceHandler.java
@@ -1,6 +1,7 @@
 package io.floci.az.services.functions;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.floci.az.core.JacksonConfig;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.floci.az.config.EmulatorConfig;
@@ -58,6 +59,10 @@ public class FunctionsServiceHandler implements AzureServiceHandler, Resettable 
         this.mapper    = new ObjectMapper()
                 .registerModule(new JavaTimeModule())
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        // This mapper is built here rather than injected, so the ObjectMapperCustomizer that
+        // raises Jackson's string-length limit does not reach it — without this a function ZIP
+        // over 20 MB is rejected, which real Azure Functions accepts.
+        JacksonConfig.applyLargePayloadConstraints(this.mapper);
     }
 
     @Override public String getServiceType() { return "functions"; }

--- a/src/test/java/io/floci/az/services/functions/FunctionsServiceHandlerMockedTest.java
+++ b/src/test/java/io/floci/az/services/functions/FunctionsServiceHandlerMockedTest.java
@@ -65,6 +65,32 @@ class FunctionsServiceHandlerMockedTest {
     }
 
     @Test
+    @DisplayName("a function ZIP larger than Jackson's 20 MB string default is accepted")
+    void deployAcceptsZipBeyondJacksonStringDefault() {
+        // Real Azure Functions puts no ~20 MB cap on the deployment package; a Python function
+        // bundling a few SDKs easily exceeds it. Jackson's default maxStringLength is 20,000,000
+        // characters, so the base64 field has to be longer than that to cover the regression.
+        String zipBase64 = "A".repeat(24_000_000);
+
+        given()
+            .contentType("application/json")
+            .body("{\"runtime\":\"python\",\"linuxFxVersion\":\"Python|3.12\"}")
+            .when().put(FN + "/admin/apps/bigapp")
+            .then().statusCode(201);
+
+        given()
+            .contentType("application/json")
+            .body("{\"handler\":\"function_app.handler\",\"zipBase64\":\"" + zipBase64 + "\"}")
+            .when().put(FN + "/admin/apps/bigapp/functions/big")
+            .then().statusCode(201);
+
+        given()
+            .when().get(FN + "/admin/apps/bigapp/functions")
+            .then().statusCode(200)
+            .body("value", hasSize(1));
+    }
+
+    @Test
     @DisplayName("invoking an unknown function still returns 404 in mocked mode")
     void unknownFunctionStill404() {
         given()


### PR DESCRIPTION
## Summary

Closes #192

The `ObjectMapperCustomizer` added in #41 ("fix(blob): support large blob uploads beyond 20 MB") raises Jackson's string-length limit on the **CDI-managed** `ObjectMapper`. `FunctionsServiceHandler` constructs its own mapper in its constructor, so the customizer never reached it and it kept Jackson's default `maxStringLength` of 20,000,000 characters.

Any deploy whose `zipBase64` exceeded that was rejected outright:

```
{"Code":"InvalidInput","Message":"Invalid request body: String value length (58721234) exceeds the maximum allowed (20000000, from `StreamReadConstraints.getMaxStringLength()`) ... DeployFunctionRequest[\"zipBase64\"]"}
```

That is exactly the failure #192 reports, and it makes any function bundling a realistic dependency set (the reporter hit it with `pandas`+`numpy` at ~96 MB) undeployable.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

Incorrect behavior: a zip deployment package over ~20 MB was rejected with `InvalidInput`. Real Azure Functions applies no such cap to the deployment package, so a function that deploys fine against Azure could not be deployed against the emulator at all.

The fix extracts the constraint setup from `JacksonConfig` into a reusable static helper and applies it to the Functions handler's mapper, so both paths share one definition of the limit (512 MB) rather than duplicating the constant.

Scope note: the decoded ZIP is written to disk by `FunctionCodeStore` and only its **path** is persisted in `FunctionDefinition`, so the base64 string is never re-serialised through the storage layer — this one mapper was the only remaining place the limit applied.

## Checklist

- [x] `./mvnw test` passes locally — **full suite: 633 tests, 0 failures, 0 errors**
- [x] New or updated integration test added — `FunctionsServiceHandlerMockedTest.deployAcceptsZipBeyondJacksonStringDefault` deploys a function with a 24,000,000-character `zipBase64` and asserts 201 + listability. Verified it is a genuine regression test: with the one-line fix reverted it fails with the exact `StreamReadConstraints.getMaxStringLength()` error from the issue.
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)