### PR TITLE
feat: add ADLS list paths support

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ flowchart LR
 
 | Service                 | Routing                      | Notable operations                                                                                                                                                                                                    |
 |-------------------------|------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Blob Storage**        | `/{account}/`                | Create/delete containers, upload/download/delete blobs, list blobs; ADLS Gen2 DFS host alias, user delegation key vending, user delegation SAS enforcement                                                            |
+| **Blob Storage**        | `/{account}/`                | Create/delete containers, upload/download/delete blobs, list blobs; ADLS Gen2 DFS host alias, user delegation key vending, user delegation SAS enforcement, Path - List                                               |
 | **Queue Storage**       | `/{account}-queue/`          | Create/delete queues, send/receive/peek/delete messages, visibility timeout                                                                                                                                           |
 | **Table Storage**       | `/{account}-table/`          | Create/delete tables, insert/get/update/upsert/delete entities; OData `$filter` / `$select` / `$top`; server-side pagination (continuation tokens); ETag optimistic concurrency; Entity Group Transactions (`$batch`) |
 | **Azure Functions**     | `/{account}-functions/`      | Deploy & invoke HTTP-triggered functions (node, python, java, dotnet); warm-container pool                                                                                                                            |
@@ -421,7 +421,7 @@ Floci AZ uses path-style routing:
 | Service           | Endpoint                                              | Notes |
 |-------------------|-------------------------------------------------------|-------|
 | Blob              | `http://localhost:4577/{accountName}`                 | |
-| Data Lake Storage Gen2 | `http://localhost:4577/{accountName}`            | Use the `{accountName}.dfs.core.windows.net` Host header; maps to the Blob backend and supports Java DataLake SDK path flows |
+| Data Lake Storage Gen2 | `http://localhost:4577/{accountName}`            | Use the `{accountName}.dfs.core.windows.net` Host header; maps to the Blob backend and supports Java DataLake SDK path flows, including `listPaths` |
 | Queue             | `http://localhost:4577/{accountName}-queue`           | |
 | Table             | `http://localhost:4577/{accountName}-table`           | |
 | Functions         | `http://localhost:4577/{accountName}-functions`       | |

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/DataLakeCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/DataLakeCompatibilityTest.java
@@ -2,13 +2,17 @@ package io.floci.az.compat;
 
 import com.azure.core.credential.AccessToken;
 import com.azure.core.http.policy.HttpPipelinePolicy;
+import com.azure.core.http.rest.PagedResponse;
 import com.azure.core.util.Context;
 import com.azure.storage.common.StorageSharedKeyCredential;
+import com.azure.storage.file.datalake.DataLakeDirectoryClient;
 import com.azure.storage.file.datalake.DataLakeFileClient;
 import com.azure.storage.file.datalake.DataLakeFileSystemClient;
 import com.azure.storage.file.datalake.DataLakeServiceClient;
 import com.azure.storage.file.datalake.DataLakeServiceClientBuilder;
 import com.azure.storage.file.datalake.models.DataLakeStorageException;
+import com.azure.storage.file.datalake.models.ListPathsOptions;
+import com.azure.storage.file.datalake.models.PathItem;
 import com.azure.storage.file.datalake.models.UserDelegationKey;
 import com.azure.storage.file.datalake.sas.DataLakeServiceSasSignatureValues;
 import com.azure.storage.file.datalake.sas.FileSystemSasPermission;
@@ -20,6 +24,9 @@ import org.junit.jupiter.api.TestInstance;
 import reactor.core.publisher.Mono;
 
 import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -150,10 +157,190 @@ class DataLakeCompatibilityTest {
         }
     }
 
+    @Test
+    @DisplayName("listPaths: recursive, non-recursive, directory, and continuation behavior")
+    void listPathsSupportsSdkOptionsAndContinuation() {
+        String name = "test-" + UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+        DataLakeFileSystemClient fileSystem = client.createFileSystem(name);
+        try {
+            createSdkPaths(fileSystem);
+
+            List<PathItem> nonRecursive = pathItems(fileSystem.listPaths(
+                    new ListPathsOptions().setRecursive(false), null));
+            assertEquals(List.of("dir", "root.txt"), names(nonRecursive));
+            assertTrue(nonRecursive.stream().filter(item -> item.getName().equals("dir")).findFirst().orElseThrow()
+                    .isDirectory());
+
+            List<PathItem> recursive = pathItems(fileSystem.listPaths(
+                    new ListPathsOptions().setRecursive(true), null));
+            assertEquals(List.of("dir/file.txt", "dir/sub/leaf.txt", "root.txt"), names(recursive));
+
+            List<PathItem> directory = pathItems(fileSystem.listPaths(
+                    new ListPathsOptions().setPath("dir").setRecursive(false), null));
+            assertEquals(List.of("dir/file.txt", "dir/sub"), names(directory));
+
+            List<String> firstPage = new ArrayList<>();
+            String continuation = null;
+            for (PagedResponse<PathItem> page : fileSystem.listPaths(
+                    new ListPathsOptions().setRecursive(true).setMaxResults(2), null).iterableByPage()) {
+                firstPage.addAll(names(page.getValue()));
+                continuation = page.getContinuationToken();
+                break;
+            }
+            assertEquals(List.of("dir/file.txt", "dir/sub/leaf.txt"), firstPage);
+            assertNotNull(continuation);
+        } finally {
+            client.deleteFileSystem(name);
+        }
+    }
+
+    @Test
+    @DisplayName("listPaths: user delegation SAS list scope is enforced")
+    void listPathsEnforcesSasListScope() {
+        OffsetDateTime start = OffsetDateTime.now().minusMinutes(5);
+        OffsetDateTime expiry = OffsetDateTime.now().plusHours(1);
+        DataLakeServiceClient bearerClient = bearerClient(expiry);
+        UserDelegationKey key = bearerClient.getUserDelegationKey(start, expiry);
+
+        String name = "test-" + UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+        DataLakeFileSystemClient fileSystem = bearerClient.createFileSystem(name);
+        try {
+            createSdkPaths(fileSystem);
+
+            String filesystemSas = fileSystem.generateUserDelegationSas(
+                    new DataLakeServiceSasSignatureValues(expiry,
+                            new FileSystemSasPermission().setListPermission(true)).setStartTime(start),
+                    key, EmulatorConfig.ACCOUNT, Context.NONE);
+            DataLakeFileSystemClient sasFileSystem = sasClient(filesystemSas).getFileSystemClient(name);
+            assertEquals(List.of("dir/file.txt", "dir/sub/leaf.txt", "root.txt"), names(pathItems(
+                    sasFileSystem.listPaths(new ListPathsOptions().setRecursive(true), null))));
+
+            String readOnlySas = fileSystem.generateUserDelegationSas(
+                    new DataLakeServiceSasSignatureValues(expiry,
+                            new FileSystemSasPermission().setReadPermission(true)).setStartTime(start),
+                    key, EmulatorConfig.ACCOUNT, Context.NONE);
+            DataLakeStorageException permissionFailure = assertThrows(DataLakeStorageException.class,
+                    () -> pathItems(sasClient(readOnlySas).getFileSystemClient(name)
+                            .listPaths(new ListPathsOptions().setRecursive(true), null)));
+            assertEquals(403, permissionFailure.getStatusCode());
+
+            DataLakeDirectoryClient directoryClient = fileSystem.getDirectoryClient("dir");
+            String directorySas = directoryClient.generateUserDelegationSas(
+                    new DataLakeServiceSasSignatureValues(expiry,
+                            new PathSasPermission().setListPermission(true)).setStartTime(start),
+                    key, EmulatorConfig.ACCOUNT, Context.NONE);
+            DataLakeFileSystemClient directorySasFileSystem = sasClient(directorySas).getFileSystemClient(name);
+            assertEquals(List.of("dir/file.txt", "dir/sub/leaf.txt"), names(pathItems(
+                    directorySasFileSystem.listPaths(
+                            new ListPathsOptions().setPath("dir").setRecursive(true), null))));
+            DataLakeStorageException outsideScope = assertThrows(DataLakeStorageException.class,
+                    () -> pathItems(directorySasFileSystem.listPaths(
+                            new ListPathsOptions().setRecursive(true), null)));
+            assertEquals(403, outsideScope.getStatusCode());
+        } finally {
+            client.deleteFileSystem(name);
+        }
+    }
+
+    @Test
+    @DisplayName("vended SAS property map: builds DataLake SDK client without SharedKey")
+    void vendedSasPropertyMapBuildsSdkClientWithoutSharedKey() {
+        OffsetDateTime start = OffsetDateTime.now().minusMinutes(5);
+        OffsetDateTime expiry = OffsetDateTime.now().plusHours(1);
+        DataLakeServiceClient bearerClient = bearerClient(expiry);
+        UserDelegationKey key = bearerClient.getUserDelegationKey(start, expiry);
+
+        String name = "test-" + UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+        DataLakeFileSystemClient fileSystem = bearerClient.createFileSystem(name);
+        try {
+            String sas = fileSystem.generateUserDelegationSas(
+                    new DataLakeServiceSasSignatureValues(expiry, new FileSystemSasPermission()
+                            .setCreatePermission(true)
+                            .setReadPermission(true)
+                            .setWritePermission(true)
+                            .setListPermission(true))
+                            .setStartTime(start),
+                    key, EmulatorConfig.ACCOUNT, Context.NONE);
+
+            Map<String, String> properties = Map.of(
+                    "adls.account-name", EmulatorConfig.ACCOUNT,
+                    "adls.sas-token." + EmulatorConfig.ACCOUNT + ".dfs.core.windows.net", "expired-token",
+                    "adls.sas-token-expires-at-ms." + EmulatorConfig.ACCOUNT + ".dfs.core.windows.net",
+                    Long.toString(System.currentTimeMillis() - 1),
+                    "adls.sas-token." + EmulatorConfig.ACCOUNT, sas,
+                    "adls.sas-token", "unused-fallback"
+            );
+
+            DataLakeServiceClient vendedClient = vendedClient(properties);
+            DataLakeFileSystemClient vendedFileSystem = vendedClient.getFileSystemClient(name);
+            vendedFileSystem.createFile("vended/file.txt");
+
+            assertTrue(vendedFileSystem.getFileClient("vended/file.txt").exists());
+            assertEquals(List.of("vended/file.txt"), names(pathItems(
+                    vendedFileSystem.listPaths(new ListPathsOptions().setRecursive(true), null))));
+        } finally {
+            client.deleteFileSystem(name);
+        }
+    }
+
     private static HttpPipelinePolicy dfsHostPolicy() {
         return (context, next) -> {
             context.getHttpRequest().setHeader("Host", EmulatorConfig.ACCOUNT + ".dfs.core.windows.net");
             return next.process();
         };
+    }
+
+    private static DataLakeServiceClient bearerClient(OffsetDateTime expiry) {
+        return new DataLakeServiceClientBuilder()
+                .endpoint(EmulatorConfig.httpBase().replaceFirst("^http://", "https://"))
+                .credential(request -> Mono.just(new AccessToken("fake-token", expiry)))
+                .addPolicy(dfsHostPolicy())
+                .buildClient();
+    }
+
+    private static DataLakeServiceClient sasClient(String sas) {
+        return new DataLakeServiceClientBuilder()
+                .endpoint(EmulatorConfig.httpBase())
+                .sasToken(sas)
+                .addPolicy(dfsHostPolicy())
+                .buildClient();
+    }
+
+    private static DataLakeServiceClient vendedClient(Map<String, String> properties) {
+        String account = properties.get("adls.account-name");
+        String host = account + ".dfs.core.windows.net";
+        String sas = resolveVendedSas(properties, account, host, System.currentTimeMillis());
+        return sasClient(sas);
+    }
+
+    private static String resolveVendedSas(Map<String, String> properties, String account, String host, long nowMs) {
+        for (String key : List.of("adls.sas-token." + host, "adls.sas-token." + account, "adls.sas-token")) {
+            String value = properties.get(key);
+            if (value != null && !isExpired(properties, key, nowMs)) {
+                return value;
+            }
+        }
+        throw new IllegalArgumentException("No unexpired ADLS SAS token property found");
+    }
+
+    private static boolean isExpired(Map<String, String> properties, String tokenKey, long nowMs) {
+        String expiresAt = properties.get(tokenKey.replace("adls.sas-token", "adls.sas-token-expires-at-ms"));
+        return expiresAt != null && Long.parseLong(expiresAt) <= nowMs;
+    }
+
+    private static void createSdkPaths(DataLakeFileSystemClient fileSystem) {
+        fileSystem.createFile("root.txt");
+        fileSystem.createFile("dir/file.txt");
+        fileSystem.createFile("dir/sub/leaf.txt");
+    }
+
+    private static List<PathItem> pathItems(Iterable<PathItem> items) {
+        List<PathItem> result = new ArrayList<>();
+        items.forEach(result::add);
+        return result;
+    }
+
+    private static List<String> names(List<PathItem> items) {
+        return items.stream().map(PathItem::getName).toList();
     }
 }

--- a/docs/services/blob.md
+++ b/docs/services/blob.md
@@ -25,6 +25,9 @@ Blob XML responses, and the Data Lake Storage Gen2 DFS host alias.
 - **User delegation SAS enforcement** — validates SDK-generated user delegation SAS signatures,
   expiry, signed key validity, permissions, and container/blob/directory resource scope for Blob
   and ADLS path operations
+- **ADLS Path - List** — supports Java DataLake SDK `listPaths` over the DFS endpoint, including
+  recursive and non-recursive listing, directory filters, deterministic continuation tokens, and
+  user delegation SAS list-scope checks
 - **Range download** — `Range: bytes=…` returns `206 Partial Content`
 - **Conditional download** — `If-Match` / `If-None-Match` honored; a stale ETag is rejected
 - **Metadata** — `x-ms-meta-*` set on upload and returned on Get, round-tripped exactly
@@ -36,6 +39,7 @@ Blob XML responses, and the Data Lake Storage Gen2 DFS host alias.
 ```
 http://localhost:4577/{account}/{container}                  # container operations
 http://localhost:4577/{account}/{container}/{blob}           # blob operations
+http://localhost:4577/{account}/{filesystem}?resource=filesystem&recursive=true  # ADLS listPaths
 ```
 
 The account also answers at the host-style address `{account}.blob.core.windows.net` (and the Data

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -5,7 +5,7 @@ Floci-AZ provides emulation for several core Azure services.
 | Service | Endpoint | Implementation Status |
 |---|---|---|
 | **Azure Resource Manager** | `/subscriptions/...` + `/providers/...` | ✅ Subscriptions, resource groups, resource/provider listing; management-plane fallthrough for the `Microsoft.*` providers |
-| **Blob Storage** | `/{account}/` | ✅ Full CRUD; ADLS Gen2 DFS host alias, user delegation key vending, user delegation SAS enforcement |
+| **Blob Storage** | `/{account}/` | ✅ Full CRUD; ADLS Gen2 DFS host alias, user delegation key vending, user delegation SAS enforcement, Path - List |
 | **Queue Storage** | `/{account}-queue/` | ✅ Full CRUD |
 | **Table Storage** | `/{account}-table/` | ✅ Full CRUD |
 | **Azure Functions** | `/{account}-functions/` | ✅ HTTP Triggers, Docker runtimes |

--- a/src/main/java/io/floci/az/core/auth/StorageSasAuthorization.java
+++ b/src/main/java/io/floci/az/core/auth/StorageSasAuthorization.java
@@ -35,6 +35,10 @@ public class StorageSasAuthorization {
         return authorize(account, container, null, token, Operation.LIST);
     }
 
+    public Optional<Response> authorizeList(String account, String container, String path, StorageSasToken token) {
+        return authorize(account, container, path, token, Operation.LIST);
+    }
+
     public Optional<Response> authorizeCreate(String account, String container, String path, StorageSasToken token) {
         return authorize(account, container, path, token, Operation.CREATE);
     }

--- a/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
+++ b/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
@@ -65,6 +65,7 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
 
     private final UserDelegationKeyService userDelegationKeyService;
     private final StorageSasAuthorization sasAuthorization;
+    private final DataLakePathOperations dataLakePathOperations;
 
     @Inject
     public BlobServiceHandler(StorageFactory storageFactory, EmulatorConfig config,
@@ -74,6 +75,7 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
         this.userDelegationKeyService = userDelegationKeyService;
         this.sasAuthorization = sasAuthorization;
         this.store = storageFactory.create("blob");
+        this.dataLakePathOperations = new DataLakePathOperations(store);
     }
 
     @Override
@@ -141,7 +143,10 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
             String comp = query.get("comp");
 
             if (blobName.isEmpty()) {
-                if ("GET".equalsIgnoreCase(method) && "list".equals(comp)) {
+                if ("GET".equalsIgnoreCase(method) && comp == null
+                        && "filesystem".equals(query.get("resource"))) {
+                    response = listDataLakePaths(request, containerName);
+                } else if ("GET".equalsIgnoreCase(method) && "list".equals(comp)) {
                     response = listBlobs(request, containerName);
                 } else if (comp != null) {
                     // Container ops are multiplexed onto the same URL by `comp` (metadata, acl,
@@ -349,6 +354,10 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
             String blobType = request.headers().getHeaderString("x-ms-blob-type");
             metadata.put("BlobType", blobType != null ? blobType : "BlockBlob");
             addBlobHttpProperties(request, metadata);
+            String dataLakeResourceType = request.queryParams().get("resource");
+            if ("file".equals(dataLakeResourceType) || "directory".equals(dataLakeResourceType)) {
+                metadata.put("DataLakeResourceType", dataLakeResourceType);
+            }
             metadata.put("Name", blobName);
             metadata.put(CREATION_TIME_KEY, createdOn(existing).toString());
             metadata.putAll(readUserMetadata(request));
@@ -584,11 +593,77 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
         return Response.ok(XmlUtils.toXml(response)).type(MediaType.APPLICATION_XML).build();
     }
 
+    private Response listDataLakePaths(AzureRequest request, String filesystem) {
+        String directory = request.queryParams().get("directory");
+        Response authFailure = authorizeList(request, filesystem, directory);
+        if (authFailure != null) {
+            return authFailure;
+        }
+        if (store.get(nsKey(request.accountName(), filesystem)).isEmpty()) {
+            return new AzureErrorResponse("FilesystemNotFound", "The specified filesystem does not exist.")
+                    .toXmlResponse(Response.Status.NOT_FOUND.getStatusCode());
+        }
+        if (directory != null && !directory.isBlank()
+                && !dataLakePathOperations.pathExists(request.accountName(), filesystem, directory)) {
+            return new AzureErrorResponse("PathNotFound", "The specified path does not exist.")
+                    .toXmlResponse(Response.Status.NOT_FOUND.getStatusCode());
+        }
+
+        boolean recursive = Boolean.parseBoolean(request.queryParams().getOrDefault("recursive", "false"));
+        List<DataLakePathListResponse.PathEntry> entries =
+                dataLakePathOperations.list(request.accountName(), filesystem, directory, recursive);
+        int start = parseContinuation(request.queryParams().get("continuation"));
+        if (start < 0) {
+            return new AzureErrorResponse("InvalidQueryParameterValue",
+                    "Value for one of the query parameters specified in the request URI is invalid.")
+                    .toXmlResponse(Response.Status.BAD_REQUEST.getStatusCode());
+        }
+        int maxResults = parseDataLakeMaxResults(request.queryParams().get("maxResults"));
+        int end = Math.min(start + maxResults, entries.size());
+        List<DataLakePathListResponse.PathEntry> page = start >= entries.size()
+                ? List.of()
+                : entries.subList(start, end);
+
+        Response.ResponseBuilder builder = Response.ok(new DataLakePathListResponse(page))
+                .type(MediaType.APPLICATION_JSON_TYPE);
+        if (end < entries.size()) {
+            builder.header("x-ms-continuation", Integer.toString(end));
+        }
+        return builder.build();
+    }
+
     private static int parseMaxResults(String value) {
         if (value == null || value.isBlank()) {
             return 1000;
         }
         return Integer.parseInt(value);
+    }
+
+    private static int parseDataLakeMaxResults(String value) {
+        if (value == null || value.isBlank()) {
+            return 5000;
+        }
+        try {
+            int parsed = Integer.parseInt(value);
+            if (parsed < 1) {
+                return 5000;
+            }
+            return Math.min(parsed, 5000);
+        } catch (NumberFormatException e) {
+            return 5000;
+        }
+    }
+
+    private static int parseContinuation(String value) {
+        if (value == null || value.isBlank()) {
+            return 0;
+        }
+        try {
+            int parsed = Integer.parseInt(value);
+            return parsed < 0 ? -1 : parsed;
+        } catch (NumberFormatException e) {
+            return -1;
+        }
     }
 
     // ── Block Blob ────────────────────────────────────────────────────────────
@@ -816,6 +891,12 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
     private Response authorizeList(AzureRequest request, String containerName) {
         return storageSas(request)
                 .flatMap(token -> sasAuthorization.authorizeList(request.accountName(), containerName, token))
+                .orElse(null);
+    }
+
+    private Response authorizeList(AzureRequest request, String containerName, String path) {
+        return storageSas(request)
+                .flatMap(token -> sasAuthorization.authorizeList(request.accountName(), containerName, path, token))
                 .orElse(null);
     }
 

--- a/src/main/java/io/floci/az/services/blob/DataLakePathListResponse.java
+++ b/src/main/java/io/floci/az/services/blob/DataLakePathListResponse.java
@@ -1,0 +1,24 @@
+package io.floci.az.services.blob;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.List;
+
+@RegisterForReflection
+public record DataLakePathListResponse(
+        List<PathEntry> paths
+) {
+    @RegisterForReflection
+    public record PathEntry(
+            String name,
+            @JsonProperty("isDirectory") boolean directory,
+            String lastModified,
+            long contentLength,
+            String owner,
+            String group,
+            String permissions,
+            String etag
+    ) {
+    }
+}

--- a/src/main/java/io/floci/az/services/blob/DataLakePathOperations.java
+++ b/src/main/java/io/floci/az/services/blob/DataLakePathOperations.java
@@ -1,0 +1,169 @@
+package io.floci.az.services.blob;
+
+import io.floci.az.core.StoredObject;
+import io.floci.az.core.storage.StorageBackend;
+
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+public class DataLakePathOperations {
+
+    private static final DateTimeFormatter RFC1123_DATE_TIME = DateTimeFormatter
+            .ofPattern("EEE, dd MMM yyyy HH:mm:ss 'GMT'", Locale.US)
+            .withZone(ZoneId.of("GMT"));
+    private static final String OWNER = "00000000-0000-0000-0000-000000000000";
+    private static final String GROUP = "00000000-0000-0000-0000-000000000000";
+    private static final String FILE_PERMISSIONS = "rw-r-----";
+    private static final String DIRECTORY_PERMISSIONS = "rwxr-x---";
+    private static final String RESOURCE_TYPE = "DataLakeResourceType";
+    private static final String BLOCK_PREFIX = "__blk__:";
+    private static final String NAMESPACE_PREFIX = "__ns__:";
+
+    private final StorageBackend<String, StoredObject> store;
+
+    public DataLakePathOperations(StorageBackend<String, StoredObject> store) {
+        this.store = store;
+    }
+
+    public List<DataLakePathListResponse.PathEntry> list(
+            String account,
+            String filesystem,
+            String directory,
+            boolean recursive
+    ) {
+        String normalizedDirectory = normalizeDirectory(directory);
+        String objectPrefix = objectPrefix(account, filesystem, normalizedDirectory);
+        List<DataLakePathListResponse.PathEntry> entries = new ArrayList<>();
+        Set<String> emittedNames = new HashSet<>();
+
+        store.scan(key -> key.startsWith(objectPrefix) && !isInternalKey(key)).forEach(object -> {
+            String name = object.metadata().getOrDefault("Name", object.key());
+            if (!isUnderDirectory(name, normalizedDirectory)) {
+                return;
+            }
+
+            String relativeName = relativeName(name, normalizedDirectory);
+            if (relativeName.isBlank()) {
+                return;
+            }
+
+            int slash = relativeName.indexOf('/');
+            if (!recursive && slash >= 0) {
+                String directoryName = joinPath(normalizedDirectory, relativeName.substring(0, slash));
+                if (emittedNames.add(directoryName)) {
+                    entries.add(directoryEntry(directoryName, object));
+                }
+                return;
+            }
+
+            if (emittedNames.add(name)) {
+                entries.add(fileEntry(name, object));
+            }
+        });
+
+        entries.sort(Comparator.comparing(DataLakePathListResponse.PathEntry::name));
+        return entries;
+    }
+
+    public boolean pathExists(String account, String filesystem, String path) {
+        String normalizedPath = normalizeDirectory(path);
+        if (normalizedPath == null || normalizedPath.isBlank()) {
+            return true;
+        }
+        String exactKey = account + "/" + filesystem + "/" + normalizedPath;
+        if (store.get(exactKey).isPresent()) {
+            return true;
+        }
+        String descendantPrefix = exactKey + "/";
+        return store.keys().stream().anyMatch(key -> key.startsWith(descendantPrefix) && !isInternalKey(key));
+    }
+
+    private static DataLakePathListResponse.PathEntry fileEntry(String name, StoredObject object) {
+        if ("directory".equals(object.metadata().get(RESOURCE_TYPE))) {
+            return directoryEntry(name, object);
+        }
+        return new DataLakePathListResponse.PathEntry(
+                name,
+                false,
+                RFC1123_DATE_TIME.format(object.lastModified()),
+                object.data().length,
+                OWNER,
+                GROUP,
+                FILE_PERMISSIONS,
+                quoteEtag(object.etag())
+        );
+    }
+
+    private static DataLakePathListResponse.PathEntry directoryEntry(String name, StoredObject source) {
+        return new DataLakePathListResponse.PathEntry(
+                name,
+                true,
+                RFC1123_DATE_TIME.format(source.lastModified()),
+                0,
+                OWNER,
+                GROUP,
+                DIRECTORY_PERMISSIONS,
+                quoteEtag(source.etag())
+        );
+    }
+
+    private static String objectPrefix(String account, String filesystem, String directory) {
+        String prefix = account + "/" + filesystem + "/";
+        if (directory == null || directory.isBlank()) {
+            return prefix;
+        }
+        return prefix + directory + "/";
+    }
+
+    private static boolean isInternalKey(String key) {
+        return key.startsWith(BLOCK_PREFIX) || key.startsWith(NAMESPACE_PREFIX);
+    }
+
+    private static boolean isUnderDirectory(String name, String directory) {
+        return directory == null || directory.isBlank() || name.startsWith(directory + "/");
+    }
+
+    private static String relativeName(String name, String directory) {
+        if (directory == null || directory.isBlank()) {
+            return name;
+        }
+        return name.substring(directory.length() + 1);
+    }
+
+    private static String joinPath(String left, String right) {
+        if (left == null || left.isBlank()) {
+            return right;
+        }
+        return left + "/" + right;
+    }
+
+    private static String normalizeDirectory(String directory) {
+        if (directory == null) {
+            return null;
+        }
+        String normalized = directory.trim();
+        while (normalized.startsWith("/")) {
+            normalized = normalized.substring(1);
+        }
+        while (normalized.endsWith("/")) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+        return normalized.isBlank() ? null : normalized;
+    }
+
+    private static String quoteEtag(String etag) {
+        if (etag == null || etag.isBlank()) {
+            return "\"\"";
+        }
+        if (etag.startsWith("\"") && etag.endsWith("\"")) {
+            return etag;
+        }
+        return "\"" + etag + "\"";
+    }
+}

--- a/src/test/java/io/floci/az/services/BlobCompDispatchTest.java
+++ b/src/test/java/io/floci/az/services/BlobCompDispatchTest.java
@@ -122,6 +122,14 @@ public class BlobCompDispatchTest {
                 .then().statusCode(501);
     }
 
+    @Test
+    void dataLakeListPathsDoesNotClaimUnimplementedCompOperation() {
+        given()
+                .header("Host", ACCOUNT + ".dfs.core.windows.net")
+                .when().get("/{container}?resource=filesystem&recursive=true&comp=acl", CONTAINER)
+                .then().statusCode(501);
+    }
+
     // --- the operations that ARE implemented must keep working ---
 
     @Test

--- a/src/test/java/io/floci/az/services/BlobServiceTest.java
+++ b/src/test/java/io/floci/az/services/BlobServiceTest.java
@@ -597,6 +597,184 @@ public class BlobServiceTest {
     }
 
     @Test
+    void dataLakeRecursiveRootListingReturnsNestedFiles() {
+        createContainerWithDataLakePaths();
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().get("/{container}?resource=filesystem&recursive=true", CONTAINER)
+            .then()
+            .statusCode(200)
+            .contentType(containsString("json"))
+            .body("paths.name", containsInAnyOrder("dir/file.txt", "dir/sub/leaf.txt", "root.txt"))
+            .body("paths.find { it.name == 'dir/file.txt' }.isDirectory", equalTo(false));
+    }
+
+    @Test
+    void dataLakeNonRecursiveRootListingReturnsImmediateFilesAndDirectories() {
+        createContainerWithDataLakePaths();
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().get("/{container}?resource=filesystem&recursive=false", CONTAINER)
+            .then()
+            .statusCode(200)
+            .body("paths.name", containsInAnyOrder("dir", "root.txt"))
+            .body("paths.find { it.name == 'dir' }.isDirectory", equalTo(true))
+            .body("paths.find { it.name == 'root.txt' }.isDirectory", equalTo(false));
+    }
+
+    @Test
+    void dataLakeNonRecursiveDirectoryListingReturnsImmediateChildren() {
+        createContainerWithDataLakePaths();
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().get("/{container}?resource=filesystem&recursive=false&directory=dir", CONTAINER)
+            .then()
+            .statusCode(200)
+            .body("paths.name", containsInAnyOrder("dir/file.txt", "dir/sub"))
+            .body("paths.find { it.name == 'dir/sub' }.isDirectory", equalTo(true));
+    }
+
+    @Test
+    void dataLakeRecursiveDirectoryListingReturnsDescendants() {
+        createContainerWithDataLakePaths();
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().get("/{container}?resource=filesystem&recursive=true&directory=dir", CONTAINER)
+            .then()
+            .statusCode(200)
+            .body("paths.name", containsInAnyOrder("dir/file.txt", "dir/sub/leaf.txt"));
+    }
+
+    @Test
+    void dataLakeDirectoryListingRequiresExistingDirectory() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().get("/{container}?resource=filesystem&recursive=true&directory=missing", CONTAINER)
+            .then()
+            .statusCode(404)
+            .header("x-ms-error-code", "PathNotFound");
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().put("/{container}/empty?resource=directory", CONTAINER)
+            .then()
+            .statusCode(201);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().get("/{container}?resource=filesystem&recursive=true&directory=empty", CONTAINER)
+            .then()
+            .statusCode(200)
+            .body("paths", hasSize(0));
+    }
+
+    @Test
+    void dataLakeEmptyFilesystemListingReturnsEmptyPaths() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().get("/{container}?resource=filesystem&recursive=true", CONTAINER)
+            .then()
+            .statusCode(200)
+            .body("paths", hasSize(0));
+    }
+
+    @Test
+    void dataLakeListPathsPaginatesWithContinuation() {
+        createContainerWithDataLakePaths();
+
+        String continuation = given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().get("/{container}?resource=filesystem&recursive=true&maxResults=2", CONTAINER)
+            .then()
+            .statusCode(200)
+            .body("paths.name", contains("dir/file.txt", "dir/sub/leaf.txt"))
+            .header("x-ms-continuation", not(isEmptyOrNullString()))
+            .extract().header("x-ms-continuation");
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().get("/{container}?resource=filesystem&recursive=true&maxResults=2&continuation={continuation}",
+                    CONTAINER, continuation)
+            .then()
+            .statusCode(200)
+            .body("paths.name", contains("root.txt"))
+            .header("x-ms-continuation", nullValue());
+    }
+
+    @Test
+    void dataLakeMalformedContinuationReturnsBadRequest() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().get("/{container}?resource=filesystem&continuation=not-a-marker", CONTAINER)
+            .then()
+            .statusCode(400)
+            .header("x-ms-error-code", "InvalidQueryParameterValue");
+    }
+
+    @Test
+    void dataLakeListMissingFilesystemReturnsNotFound() {
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().get("/{container}?resource=filesystem&recursive=true", CONTAINER)
+            .then()
+            .statusCode(404)
+            .header("x-ms-error-code", "FilesystemNotFound");
+    }
+
+    @Test
+    void dataLakeListPathsRequiresListPermissionForSas() {
+        createContainerWithDataLakePaths();
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().get("/{container}?resource=filesystem&recursive=true&{sas}",
+                    CONTAINER, sas("r", "c", CONTAINER, null))
+            .then()
+            .statusCode(403)
+            .header("x-ms-error-code", "AuthorizationPermissionMismatch");
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().get("/{container}?resource=filesystem&recursive=true&{sas}",
+                    CONTAINER, sas("l", "c", CONTAINER, null))
+            .then()
+            .statusCode(200)
+            .body("paths.name", containsInAnyOrder("dir/file.txt", "dir/sub/leaf.txt", "root.txt"));
+    }
+
+    @Test
+    void directoryScopedSasCanListDirectoryButNotSibling() {
+        createContainerWithDataLakePaths();
+        String directorySas = sas("l", "d", CONTAINER, "dir");
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().get("/{container}?resource=filesystem&recursive=true&directory=dir&{sas}",
+                    CONTAINER, directorySas)
+            .then()
+            .statusCode(200)
+            .body("paths.name", containsInAnyOrder("dir/file.txt", "dir/sub/leaf.txt"));
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().get("/{container}?resource=filesystem&recursive=true&{sas}",
+                    CONTAINER, directorySas)
+            .then()
+            .statusCode(403)
+            .header("x-ms-error-code", "AuthenticationFailed");
+    }
+
+    @Test
     void setAndGetBlobMetadata() {
         given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
         given()
@@ -1100,6 +1278,17 @@ public class BlobServiceTest {
         return matcher.group(1);
     }
 
+    private static void createContainerWithDataLakePaths() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        for (String path : new String[] {"root.txt", "dir/file.txt", "dir/sub/leaf.txt"}) {
+            given()
+                .header("Host", ACCOUNT + ".dfs.core.windows.net")
+                .header("x-ms-version", "2023-11-03")
+                .when().put("/{container}/{path}?resource=file", CONTAINER, path)
+                .then().statusCode(201);
+        }
+    }
+
     private String sas(String permissions, String resource, String container, String blobName) {
         OffsetDateTime start = OffsetDateTime.now(ZoneOffset.UTC).minusMinutes(5).withNano(0);
         OffsetDateTime expiry = OffsetDateTime.now(ZoneOffset.UTC).plusHours(1).withNano(0);
@@ -1179,6 +1368,7 @@ public class BlobServiceTest {
                 + "&skv=" + version
                 + "&sr=" + resource
                 + "&sp=" + permissions
+                + ("d".equals(resource) ? "&sdd=1" : "")
                 + "&sig=" + signature;
     }
 


### PR DESCRIPTION
Summary:
- Add Blob-backed ADLS Path - List handling for DFS `listPaths` requests.
- Support recursive and non-recursive listing, directory filtering, deterministic continuation, and JSON path-list responses.
- Add SDK and HTTP coverage for `listPaths`, SAS list scope, and generic vended ADLS SAS property-map usage.

Type of change:
- [x] New feature (feat:)

Azure Compatibility:
- Implements the ADLS Path - List route used by Java Azure SDK DataLake clients: `GET /{filesystem}?resource=filesystem&recursive=...`
- SDK test source compile verified with repo-local Maven cache.

Checklist:
- [x] `./mvnw test` passes locally
- [x] New or updated integration test added.
- [x] Commit messages follow Conventional Commits.
