### PR TITLE
docs(readme): fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -879,11 +879,11 @@ Join the Floci community on [Slack](https://join.slack.com/t/floci/shared_invite
 ## Star History
 
 <p align="center">
-  <a href="https://www.star-history.com/?repos=floci-io%2Ffloci-az&type=date&legend=top-left">
+  <a href="https://star-history.dera.page/#floci-io/floci-az&type=date&legend=top-left">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=floci-io/floci-az&type=date&theme=dark&legend=top-left" />
-      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=floci-io/floci-az&type=date&legend=top-left" />
-      <img width="600" alt="Star History Chart" src="https://api.star-history.com/chart?repos=floci-io/floci-az&type=date&legend=top-left" />
+      <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=floci-io/floci-az&type=date&theme=dark&legend=top-left" />
+      <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=floci-io/floci-az&type=date&legend=top-left" />
+      <img width="600" alt="Star History Chart" src="https://star-history.dera.page/svg?repos=floci-io/floci-az&type=date&legend=top-left" />
     </picture>
   </a>
 </p>


### PR DESCRIPTION
The star history chart in the README is currently broken because the upstream service can no longer fetch stargazer data due to GitHub API restrictions.

This change moves the chart to the maintained star-history.dera.page alternative, which uses a different data source that requires no API token, and updates the wrapping link to the new domain as well. No other references are affected.