### PR TITLE
fix(functions): support Python v2 app-root packages

### DIFF
--- a/docs/services/functions.md
+++ b/docs/services/functions.md
@@ -73,12 +73,24 @@ paths accept the same setting under `properties.siteConfig.linuxFxVersion` and
 }
 ```
 
-The ZIP must contain your function code in the Azure Functions v4 layout:
+For the Node.js and Python v1 model, the ZIP must contain your function code in
+the Azure Functions v4 layout:
 ```
 host.json
 {funcName}/function.json
 {funcName}/index.js   (or handler file for the runtime)
 ```
+
+Python v2 model packages are also supported. A Python v2 ZIP is identified by
+`function_app.py` at its root and is extracted to the application root:
+```
+host.json
+function_app.py
+.python_packages/lib/site-packages/   (optional)
+```
+The package's `host.json` is preserved. Its `extensions.http.routePrefix`
+controls the internal worker route; when omitted, the default is `/api`.
+The emulator's public invocation URL remains `/api/{appName}/{funcName}`.
 
 ### Invocation
 

--- a/src/main/java/io/floci/az/services/functions/ContainerLauncher.java
+++ b/src/main/java/io/floci/az/services/functions/ContainerLauncher.java
@@ -115,15 +115,21 @@ public class ContainerLauncher {
         String containerId = lifecycleManager.create(spec);
         LOG.infov("Created container {0} ({1})", containerName, containerId.substring(0, 12));
 
-        // Inject a shared host.json at the wwwroot root so the Functions host starts
-        // correctly when each function's code is in its own subdirectory.
-        injectHostJson(containerId);
+        boolean hasRootLayout = appDefs.stream().anyMatch(FunctionDefinition::packageRootLayout);
+        if (!hasRootLayout) {
+            // The v1 layout has no app-level host.json in the stored package.
+            injectHostJson(containerId);
+        }
 
-        // Inject code for every function in the app before starting so the Functions
-        // host finds them all at /home/site/wwwroot/{funcName}/ on startup.
+        // v1 functions are isolated by name; Python v2 packages are app roots.
         for (FunctionDefinition fn : appDefs) {
             if (fn.codeLocalPath() != null && Files.exists(Path.of(fn.codeLocalPath()))) {
-                copyCodeToContainer(containerId, Path.of(fn.codeLocalPath()), fn.funcName());
+                Path codePath = Path.of(fn.codeLocalPath());
+                if (fn.packageRootLayout()) {
+                    copyCodeRootToContainer(containerId, codePath);
+                } else {
+                    copyCodeToContainer(containerId, codePath, fn.funcName());
+                }
             }
         }
 
@@ -179,6 +185,11 @@ public class ContainerLauncher {
         env.add("WEBSITE_HOSTNAME=localhost");
         env.add("AzureWebJobsSecretStorageType=files");
         env.add("AZURE_FUNCTIONS_ENVIRONMENT=Development");
+
+        if (def.packageRootLayout()) {
+            env.add("AzureWebJobsScriptRoot=" + WWWROOT);
+            env.add("PYTHONPATH=" + WWWROOT + "/.python_packages/lib/site-packages:" + WWWROOT);
+        }
 
         if (def.environment() != null) {
             def.environment().forEach((k, v) -> env.add(k + "=" + v));
@@ -242,6 +253,29 @@ public class ContainerLauncher {
             LOG.debugv("Injected code for {0} into {1}", funcName, WWWROOT);
         } catch (Exception e) {
             LOG.warnv("Failed to copy code for {0}: {1}", funcName, e.getMessage());
+        }
+    }
+
+    private void copyCodeRootToContainer(String containerId, Path codeDir) {
+        try (PipedOutputStream pos = new PipedOutputStream();
+             PipedInputStream pis = new PipedInputStream(pos, 256 * 1024)) {
+            Thread tarThread = new Thread(() -> {
+                try (pos) {
+                    createTarWithPrefix(codeDir, pos, "home/site/wwwroot/");
+                } catch (IOException e) {
+                    LOG.errorv("Failed to stream root-layout TAR: {0}", e.getMessage());
+                }
+            }, "tar-function-app");
+            tarThread.setDaemon(true);
+            tarThread.start();
+
+            dockerClient.copyArchiveToContainerCmd(containerId)
+                    .withRemotePath("/")
+                    .withTarInputStream(pis)
+                    .exec();
+            LOG.debugv("Injected root-layout code into {0}", WWWROOT);
+        } catch (Exception e) {
+            LOG.warnv("Failed to copy root-layout code: {0}", e.getMessage());
         }
     }
 

--- a/src/main/java/io/floci/az/services/functions/FunctionCodeStore.java
+++ b/src/main/java/io/floci/az/services/functions/FunctionCodeStore.java
@@ -29,8 +29,10 @@ public class FunctionCodeStore {
     private static final Pattern ROUTE_DECORATOR = Pattern.compile(
             "@app\\.route\\s*\\((.*?)\\)\\s*(?:\\r?\\n\\s*@[^\\r\\n]+)*\\s*def\\s+([A-Za-z_][A-Za-z0-9_]*)\\s*\\(",
             Pattern.DOTALL);
-    private static final Pattern ROUTE_VALUE = Pattern.compile(
-            "(?:\\broute\\s*=\\s*)?[\\\"']([^\\\"']*)[\\\"']");
+        private static final Pattern NAMED_ROUTE = Pattern.compile(
+            "\\broute\\s*=\\s*[\\\"']([^\\\"']*)[\\\"']");
+        private static final Pattern POSITIONAL_ROUTE = Pattern.compile(
+            "^\\s*[\\\"']([^\\\"']*)[\\\"']");
 
     private final EmulatorConfig config;
     private final FunctionZipExtractor extractor;
@@ -82,8 +84,13 @@ public class FunctionCodeStore {
             if (!methodName.equals(decorator.group(2))) {
                 continue;
             }
-            Matcher route = ROUTE_VALUE.matcher(decorator.group(1));
-            return route.find() ? route.group(1) : methodName;
+            String arguments = decorator.group(1);
+            Matcher namedRoute = NAMED_ROUTE.matcher(arguments);
+            if (namedRoute.find()) {
+                return namedRoute.group(1);
+            }
+            Matcher positionalRoute = POSITIONAL_ROUTE.matcher(arguments);
+            return positionalRoute.find() ? positionalRoute.group(1) : methodName;
         }
         return null;
     }

--- a/src/main/java/io/floci/az/services/functions/FunctionCodeStore.java
+++ b/src/main/java/io/floci/az/services/functions/FunctionCodeStore.java
@@ -30,7 +30,7 @@ public class FunctionCodeStore {
             "@app\\.route\\s*\\((.*?)\\)\\s*(?:\\r?\\n\\s*@[^\\r\\n]+)*\\s*def\\s+([A-Za-z_][A-Za-z0-9_]*)\\s*\\(",
             Pattern.DOTALL);
     private static final Pattern ROUTE_VALUE = Pattern.compile(
-            "\\broute\\s*=\\s*[\\\"']([^\\\"']*)[\\\"']");
+            "(?:\\broute\\s*=\\s*)?[\\\"']([^\\\"']*)[\\\"']");
 
     private final EmulatorConfig config;
     private final FunctionZipExtractor extractor;

--- a/src/main/java/io/floci/az/services/functions/FunctionCodeStore.java
+++ b/src/main/java/io/floci/az/services/functions/FunctionCodeStore.java
@@ -1,5 +1,7 @@
 package io.floci.az.services.functions;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.floci.az.config.EmulatorConfig;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -9,6 +11,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Manages function code packages on disk.
@@ -18,6 +21,7 @@ import java.util.Comparator;
 public class FunctionCodeStore {
 
     private static final Logger LOG = Logger.getLogger(FunctionCodeStore.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     private final EmulatorConfig config;
     private final FunctionZipExtractor extractor;
@@ -42,6 +46,20 @@ public class FunctionCodeStore {
 
     public Path getCodePath(String account, String appName, String funcName) {
         return codeDir(account, appName, funcName);
+    }
+
+    public boolean isPackageRootLayout(Path codePath) {
+        return Files.isRegularFile(codePath.resolve("function_app.py"));
+    }
+
+    public String routePrefix(Path codePath) throws IOException {
+        Path hostJson = codePath.resolve("host.json");
+        if (!Files.isRegularFile(hostJson)) {
+            return null;
+        }
+        JsonNode root = MAPPER.readTree(Files.readString(hostJson, StandardCharsets.UTF_8));
+        JsonNode routePrefix = root.path("extensions").path("http").get("routePrefix");
+        return routePrefix != null && routePrefix.isTextual() ? routePrefix.asText() : null;
     }
 
     public void deleteCode(String account, String appName, String funcName) {

--- a/src/main/java/io/floci/az/services/functions/FunctionCodeStore.java
+++ b/src/main/java/io/floci/az/services/functions/FunctionCodeStore.java
@@ -3,6 +3,7 @@ package io.floci.az.services.functions;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.floci.az.config.EmulatorConfig;
+import io.floci.az.services.functions.FunctionModels.FunctionDefinition;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
@@ -11,7 +12,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.Objects;
 import java.nio.charset.StandardCharsets;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Manages function code packages on disk.
@@ -22,6 +26,11 @@ public class FunctionCodeStore {
 
     private static final Logger LOG = Logger.getLogger(FunctionCodeStore.class);
     private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final Pattern ROUTE_DECORATOR = Pattern.compile(
+            "@app\\.route\\s*\\((.*?)\\)\\s*(?:\\r?\\n\\s*@[^\\r\\n]+)*\\s*def\\s+([A-Za-z_][A-Za-z0-9_]*)\\s*\\(",
+            Pattern.DOTALL);
+    private static final Pattern ROUTE_VALUE = Pattern.compile(
+            "\\broute\\s*=\\s*[\\\"']([^\\\"']*)[\\\"']");
 
     private final EmulatorConfig config;
     private final FunctionZipExtractor extractor;
@@ -60,6 +69,46 @@ public class FunctionCodeStore {
         JsonNode root = MAPPER.readTree(Files.readString(hostJson, StandardCharsets.UTF_8));
         JsonNode routePrefix = root.path("extensions").path("http").get("routePrefix");
         return routePrefix != null && routePrefix.isTextual() ? routePrefix.asText() : null;
+    }
+
+    public String functionRoute(Path codePath, String handler) throws IOException {
+        if (!isPackageRootLayout(codePath) || handler == null || handler.isBlank()) {
+            return null;
+        }
+        String methodName = handler.substring(handler.lastIndexOf('.') + 1);
+        String source = Files.readString(codePath.resolve("function_app.py"), StandardCharsets.UTF_8);
+        Matcher decorator = ROUTE_DECORATOR.matcher(source);
+        while (decorator.find()) {
+            if (!methodName.equals(decorator.group(2))) {
+                continue;
+            }
+            Matcher route = ROUTE_VALUE.matcher(decorator.group(1));
+            return route.find() ? route.group(1) : methodName;
+        }
+        return null;
+    }
+
+    public FunctionDefinition normalize(FunctionDefinition definition) throws IOException {
+        if (definition.codeLocalPath() == null) {
+            return definition;
+        }
+        Path codePath = Path.of(definition.codeLocalPath());
+        if (!isPackageRootLayout(codePath)) {
+            return definition;
+        }
+        String prefix = definition.routePrefix() == null
+                ? routePrefix(codePath) : definition.routePrefix();
+        String route = definition.functionRoute() == null
+                ? functionRoute(codePath, definition.handler()) : definition.functionRoute();
+        if (definition.packageRootLayout() && Objects.equals(prefix, definition.routePrefix())
+                && Objects.equals(route, definition.functionRoute())) {
+            return definition;
+        }
+        return new FunctionDefinition(
+                definition.appName(), definition.funcName(), definition.accountName(),
+                definition.runtime(), definition.linuxFxVersion(), definition.handler(),
+                definition.timeoutSeconds(), definition.environment(), definition.codeLocalPath(),
+                definition.createdAt(), true, prefix, route);
     }
 
     public void deleteCode(String account, String appName, String funcName) {

--- a/src/main/java/io/floci/az/services/functions/FunctionModels.java
+++ b/src/main/java/io/floci/az/services/functions/FunctionModels.java
@@ -32,7 +32,9 @@ public class FunctionModels {
             int timeoutSeconds,
             @JsonInclude(JsonInclude.Include.NON_NULL) Map<String, String> environment,
             @JsonInclude(JsonInclude.Include.NON_NULL) String codeLocalPath,
-            Instant createdAt
+            Instant createdAt,
+            boolean packageRootLayout,
+            @JsonInclude(JsonInclude.Include.NON_NULL) String routePrefix
     ) {
         /** Pool key — all functions in one app share one container. */
         public String appKey() {
@@ -41,6 +43,10 @@ public class FunctionModels {
 
         public String functionKey() {
             return accountName + "/" + appName + "/" + funcName;
+        }
+
+        public String effectiveRoutePrefix() {
+            return routePrefix == null ? "/api" : routePrefix;
         }
     }
 

--- a/src/main/java/io/floci/az/services/functions/FunctionModels.java
+++ b/src/main/java/io/floci/az/services/functions/FunctionModels.java
@@ -34,7 +34,8 @@ public class FunctionModels {
             @JsonInclude(JsonInclude.Include.NON_NULL) String codeLocalPath,
             Instant createdAt,
             boolean packageRootLayout,
-            @JsonInclude(JsonInclude.Include.NON_NULL) String routePrefix
+            @JsonInclude(JsonInclude.Include.NON_NULL) String routePrefix,
+            @JsonInclude(JsonInclude.Include.NON_NULL) String functionRoute
     ) {
         /** Pool key — all functions in one app share one container. */
         public String appKey() {
@@ -48,6 +49,10 @@ public class FunctionModels {
         public String effectiveRoutePrefix() {
             return routePrefix == null ? "/api" : routePrefix;
         }
+
+                public String effectiveFunctionRoute() {
+                        return functionRoute == null || functionRoute.isBlank() ? funcName : functionRoute;
+                }
     }
 
     // ── Request bodies ────────────────────────────────────────────────────────

--- a/src/main/java/io/floci/az/services/functions/FunctionsExecutorService.java
+++ b/src/main/java/io/floci/az/services/functions/FunctionsExecutorService.java
@@ -80,7 +80,7 @@ public class FunctionsExecutorService {
         String routePrefix = def.effectiveRoutePrefix();
         String targetPath = routePrefix.isBlank() ? "" : "/" + routePrefix.strip().replaceAll("^/+|/+$", "");
         String targetUrl = "http://" + handle.host() + ":" + handle.port()
-            + targetPath + "/" + def.funcName();
+            + targetPath + "/" + def.effectiveFunctionRoute().replaceAll("^/+|/+$", "");
 
         // Append query string
         if (!request.queryParams().isEmpty()) {

--- a/src/main/java/io/floci/az/services/functions/FunctionsExecutorService.java
+++ b/src/main/java/io/floci/az/services/functions/FunctionsExecutorService.java
@@ -57,7 +57,7 @@ public class FunctionsExecutorService {
         ContainerHandle handle = null;
         try {
             handle = warmPool.acquire(def, appDefs);
-            return proxy(handle, request, def.funcName(), def.timeoutSeconds());
+            return proxy(handle, request, def, def.timeoutSeconds());
         } catch (Exception e) {
             LOG.errorv("Invocation failed for {0}: {1}", def.appKey(), e.getMessage());
             if (handle != null) {
@@ -76,8 +76,11 @@ public class FunctionsExecutorService {
     // ── Private helpers ───────────────────────────────────────────────────────
 
     private Response proxy(ContainerHandle handle, AzureRequest request,
-                           String funcName, int timeoutSeconds) throws IOException, InterruptedException {
-        String targetUrl = "http://" + handle.host() + ":" + handle.port() + "/api/" + funcName;
+                   FunctionDefinition def, int timeoutSeconds) throws IOException, InterruptedException {
+        String routePrefix = def.effectiveRoutePrefix();
+        String targetPath = routePrefix.isBlank() ? "" : "/" + routePrefix.strip().replaceAll("^/+|/+$", "");
+        String targetUrl = "http://" + handle.host() + ":" + handle.port()
+            + targetPath + "/" + def.funcName();
 
         // Append query string
         if (!request.queryParams().isEmpty()) {
@@ -112,7 +115,7 @@ public class FunctionsExecutorService {
             }
         });
 
-        LOG.debugv("Proxying {0} {1} → {2}", request.method(), funcName, targetUrl);
+        LOG.debugv("Proxying {0} {1} → {2}", request.method(), def.funcName(), targetUrl);
 
         HttpResponse<byte[]> resp = httpClient.send(reqBuilder.build(),
                 HttpResponse.BodyHandlers.ofByteArray());

--- a/src/main/java/io/floci/az/services/functions/FunctionsServiceHandler.java
+++ b/src/main/java/io/floci/az/services/functions/FunctionsServiceHandler.java
@@ -21,6 +21,7 @@ import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.time.Instant;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -239,6 +240,16 @@ public class FunctionsServiceHandler implements AzureServiceHandler, Resettable 
                         request.accountName(), appName, funcName, zipBytes).toString();
             }
 
+            boolean packageRootLayout = false;
+            String routePrefix = null;
+            if (codePath != null) {
+                Path storedCode = Path.of(codePath);
+                packageRootLayout = codeStore.isPackageRootLayout(storedCode);
+                if (packageRootLayout) {
+                    routePrefix = codeStore.routePrefix(storedCode);
+                }
+            }
+
             // Merge environment: app-level + function-level
             Map<String, String> env = new LinkedHashMap<>();
             if (app.environment() != null) env.putAll(app.environment());
@@ -252,7 +263,9 @@ public class FunctionsServiceHandler implements AzureServiceHandler, Resettable 
                     body.timeoutSeconds() > 0 ? body.timeoutSeconds() : 230,
                     env.isEmpty() ? null : env,
                     codePath,
-                    Instant.now());
+                    Instant.now(),
+                    packageRootLayout,
+                    routePrefix);
 
             // Drain the app container on redeploy — container must restart with updated code.
             warmPool.drain(def.appKey());

--- a/src/main/java/io/floci/az/services/functions/FunctionsServiceHandler.java
+++ b/src/main/java/io/floci/az/services/functions/FunctionsServiceHandler.java
@@ -216,7 +216,7 @@ public class FunctionsServiceHandler implements AzureServiceHandler, Resettable 
         return Response.noContent().build();
     }
 
-    private Response deployFunction(AzureRequest request, String appName, String funcName) {
+    private synchronized Response deployFunction(AzureRequest request, String appName, String funcName) {
         // Verify app exists and get runtime
         Optional<StoredObject> appSo = store.get(appKey(request.accountName(), appName));
         if (appSo.isEmpty()) {

--- a/src/main/java/io/floci/az/services/functions/FunctionsServiceHandler.java
+++ b/src/main/java/io/floci/az/services/functions/FunctionsServiceHandler.java
@@ -242,12 +242,22 @@ public class FunctionsServiceHandler implements AzureServiceHandler, Resettable 
 
             boolean packageRootLayout = false;
             String routePrefix = null;
+            String functionRoute = null;
             if (codePath != null) {
                 Path storedCode = Path.of(codePath);
                 packageRootLayout = codeStore.isPackageRootLayout(storedCode);
                 if (packageRootLayout) {
                     routePrefix = codeStore.routePrefix(storedCode);
+                    functionRoute = codeStore.functionRoute(storedCode,
+                            body.handler() != null ? body.handler() : "index.handler");
                 }
+            }
+
+            if (hasIncompatibleLayout(request.accountName(), appName, funcName, packageRootLayout)) {
+                codeStore.deleteCode(request.accountName(), appName, funcName);
+                return error("IncompatibleFunctionLayout",
+                        "Function app '" + appName + "' cannot mix Python v2 app-root packages "
+                                + "with v1 function directories or multiple app-root packages", 409);
             }
 
             // Merge environment: app-level + function-level
@@ -265,7 +275,8 @@ public class FunctionsServiceHandler implements AzureServiceHandler, Resettable 
                     codePath,
                     Instant.now(),
                     packageRootLayout,
-                    routePrefix);
+                    routePrefix,
+                    functionRoute);
 
             // Drain the app container on redeploy — container must restart with updated code.
             warmPool.drain(def.appKey());
@@ -282,7 +293,7 @@ public class FunctionsServiceHandler implements AzureServiceHandler, Resettable 
         return store.get(fnKey(request.accountName(), appName, funcName))
                 .map(so -> {
                     try {
-                        FunctionDefinition def = mapper.readValue(so.data(), FunctionDefinition.class);
+                        FunctionDefinition def = readDefinition(so);
                         return Response.ok(toFunctionResponse(def, request.accountName()))
                                 .type(MediaType.APPLICATION_JSON).build();
                     } catch (IOException e) {
@@ -298,7 +309,7 @@ public class FunctionsServiceHandler implements AzureServiceHandler, Resettable 
         List<FunctionResponse> fns = store.scan(k -> k.startsWith(prefix)).stream()
                 .map(so -> {
                     try { return toFunctionResponse(
-                            mapper.readValue(so.data(), FunctionDefinition.class), request.accountName()); }
+                            readDefinition(so), request.accountName()); }
                     catch (IOException e) { return null; }
                 })
                 .filter(Objects::nonNull)
@@ -347,14 +358,14 @@ public class FunctionsServiceHandler implements AzureServiceHandler, Resettable 
         }
 
         try {
-            FunctionDefinition def = mapper.readValue(fnSo.get().data(), FunctionDefinition.class);
+            FunctionDefinition def = readDefinition(fnSo.get());
 
             // All functions in the app share one container — collect them all so the
             // launcher can inject every function's code before starting the host.
             String fnPrefix = fnScanPrefix(request.accountName(), appName);
             List<FunctionModels.FunctionDefinition> appDefs = store.scan(k -> k.startsWith(fnPrefix)).stream()
                     .map(so -> {
-                        try { return mapper.readValue(so.data(), FunctionDefinition.class); }
+                        try { return readDefinition(so); }
                         catch (IOException e) { return null; }
                     })
                     .filter(Objects::nonNull)
@@ -370,6 +381,24 @@ public class FunctionsServiceHandler implements AzureServiceHandler, Resettable 
 
     public void clear() {
         store.clear();
+    }
+
+    private FunctionDefinition readDefinition(StoredObject stored) throws IOException {
+        return codeStore.normalize(mapper.readValue(stored.data(), FunctionDefinition.class));
+    }
+
+    private boolean hasIncompatibleLayout(String accountName, String appName,
+                                          String funcName, boolean packageRootLayout) {
+        String prefix = fnScanPrefix(accountName, appName);
+        return store.scan(key -> key.startsWith(prefix)).stream()
+                .filter(stored -> !stored.key().equals(fnKey(accountName, appName, funcName)))
+                .map(stored -> {
+                    try { return readDefinition(stored); }
+                    catch (IOException e) { return null; }
+                })
+                .filter(Objects::nonNull)
+                .filter(definition -> definition.codeLocalPath() != null)
+                .anyMatch(definition -> packageRootLayout || definition.packageRootLayout());
     }
 
     private StoredObject toStoredObject(Object obj) {

--- a/src/test/java/io/floci/az/services/functions/FunctionCodeStoreTest.java
+++ b/src/test/java/io/floci/az/services/functions/FunctionCodeStoreTest.java
@@ -102,6 +102,19 @@ class FunctionCodeStoreTest {
         }
     }
 
+    @Test
+    void namedRouteWinsOverQuotedDecoratorArguments() throws Exception {
+        Path basePath = Files.createTempDirectory("function-store-");
+        try {
+            FunctionCodeStore store = newStore(basePath);
+            Path stored = store.storeCode("account", "app", "hello", namedRouteWithMethodsZip());
+
+            assertEquals("welcome", store.functionRoute(stored, "function_app.greet"));
+        } finally {
+            deleteRecursively(basePath);
+        }
+    }
+
     private static byte[] pythonV2Zip() throws Exception {
         ByteArrayOutputStream bytes = new ByteArrayOutputStream();
         try (ZipOutputStream zip = new ZipOutputStream(bytes)) {
@@ -136,6 +149,20 @@ class FunctionCodeStoreTest {
                     import azure.functions as func
                     app = func.FunctionApp()
                     @app.route("welcome")
+                    def greet(req: func.HttpRequest) -> func.HttpResponse:
+                        return func.HttpResponse("ok")
+                    """);
+        }
+        return bytes.toByteArray();
+    }
+
+    private static byte[] namedRouteWithMethodsZip() throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ZipOutputStream zip = new ZipOutputStream(bytes)) {
+            addEntry(zip, "function_app.py", """
+                    import azure.functions as func
+                    app = func.FunctionApp()
+                    @app.route(methods=["GET"], route="welcome")
                     def greet(req: func.HttpRequest) -> func.HttpResponse:
                         return func.HttpResponse("ok")
                     """);

--- a/src/test/java/io/floci/az/services/functions/FunctionCodeStoreTest.java
+++ b/src/test/java/io/floci/az/services/functions/FunctionCodeStoreTest.java
@@ -69,6 +69,26 @@ class FunctionCodeStoreTest {
         }
     }
 
+    @Test
+    void detectsDecoratedRouteAndNormalizesLegacyDefinition() throws Exception {
+        Path basePath = Files.createTempDirectory("function-store-");
+        try {
+            FunctionCodeStore store = newStore(basePath);
+            Path stored = store.storeCode("account", "app", "hello", decoratedPythonV2Zip());
+            FunctionModels.FunctionDefinition legacy = new FunctionModels.FunctionDefinition(
+                    "app", "hello", "account", "python", "Python|3.12", "function_app.greet",
+                    60, null, stored.toString(), java.time.Instant.now(), false, null, null);
+
+            FunctionModels.FunctionDefinition normalized = store.normalize(legacy);
+
+            assertTrue(normalized.packageRootLayout());
+            assertEquals("", normalized.routePrefix());
+            assertEquals("welcome", normalized.functionRoute());
+        } finally {
+            deleteRecursively(basePath);
+        }
+    }
+
     private static byte[] pythonV2Zip() throws Exception {
         ByteArrayOutputStream bytes = new ByteArrayOutputStream();
         try (ZipOutputStream zip = new ZipOutputStream(bytes)) {
@@ -76,6 +96,22 @@ class FunctionCodeStoreTest {
             addEntry(zip, "host.json",
                     "{\"version\":\"2.0\",\"extensions\":{\"http\":{\"routePrefix\":\"\"}}}");
             addEntry(zip, ".python_packages/lib/site-packages/example.py", "VALUE = 1\n");
+        }
+        return bytes.toByteArray();
+    }
+
+    private static byte[] decoratedPythonV2Zip() throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ZipOutputStream zip = new ZipOutputStream(bytes)) {
+            addEntry(zip, "function_app.py", """
+                    import azure.functions as func
+                    app = func.FunctionApp()
+                    @app.route(route="welcome")
+                    def greet(req: func.HttpRequest) -> func.HttpResponse:
+                        return func.HttpResponse("ok")
+                    """);
+            addEntry(zip, "host.json",
+                    "{\"version\":\"2.0\",\"extensions\":{\"http\":{\"routePrefix\":\"\"}}}");
         }
         return bytes.toByteArray();
     }

--- a/src/test/java/io/floci/az/services/functions/FunctionCodeStoreTest.java
+++ b/src/test/java/io/floci/az/services/functions/FunctionCodeStoreTest.java
@@ -89,6 +89,19 @@ class FunctionCodeStoreTest {
         }
     }
 
+    @Test
+    void detectsPositionalDecoratedRoute() throws Exception {
+        Path basePath = Files.createTempDirectory("function-store-");
+        try {
+            FunctionCodeStore store = newStore(basePath);
+            Path stored = store.storeCode("account", "app", "hello", positionalRouteZip());
+
+            assertEquals("welcome", store.functionRoute(stored, "function_app.greet"));
+        } finally {
+            deleteRecursively(basePath);
+        }
+    }
+
     private static byte[] pythonV2Zip() throws Exception {
         ByteArrayOutputStream bytes = new ByteArrayOutputStream();
         try (ZipOutputStream zip = new ZipOutputStream(bytes)) {
@@ -112,6 +125,20 @@ class FunctionCodeStoreTest {
                     """);
             addEntry(zip, "host.json",
                     "{\"version\":\"2.0\",\"extensions\":{\"http\":{\"routePrefix\":\"\"}}}");
+        }
+        return bytes.toByteArray();
+    }
+
+    private static byte[] positionalRouteZip() throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ZipOutputStream zip = new ZipOutputStream(bytes)) {
+            addEntry(zip, "function_app.py", """
+                    import azure.functions as func
+                    app = func.FunctionApp()
+                    @app.route("welcome")
+                    def greet(req: func.HttpRequest) -> func.HttpResponse:
+                        return func.HttpResponse("ok")
+                    """);
         }
         return bytes.toByteArray();
     }

--- a/src/test/java/io/floci/az/services/functions/FunctionCodeStoreTest.java
+++ b/src/test/java/io/floci/az/services/functions/FunctionCodeStoreTest.java
@@ -1,0 +1,110 @@
+package io.floci.az.services.functions;
+
+import io.floci.az.config.EmulatorConfig;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import java.io.ByteArrayOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class FunctionCodeStoreTest {
+
+    @Test
+    void detectsPythonV2RootLayoutAndEmptyRoutePrefix() throws Exception {
+        Path root = Files.createTempDirectory("function-code-");
+        try {
+            Files.writeString(root.resolve("function_app.py"), "import azure.functions");
+            Files.writeString(root.resolve("host.json"), """
+                    {"version":"2.0","extensions":{"http":{"routePrefix":""}}}
+                    """);
+
+            FunctionCodeStore store = newStore(root);
+
+            assertTrue(store.isPackageRootLayout(root));
+            assertEquals("", store.routePrefix(root));
+        } finally {
+            deleteRecursively(root);
+        }
+    }
+
+    @Test
+    void defaultsToV1LayoutWhenFunctionAppIsAbsent() throws Exception {
+        Path root = Files.createTempDirectory("function-code-");
+        try {
+            Files.writeString(root.resolve("function.json"), "{}");
+
+            FunctionCodeStore store = newStore(root);
+
+            assertFalse(store.isPackageRootLayout(root));
+            assertNull(store.routePrefix(root));
+        } finally {
+            deleteRecursively(root);
+        }
+    }
+
+    @Test
+    void storesPythonV2ZipWithRootFilesAndPackagesIntact() throws Exception {
+        Path basePath = Files.createTempDirectory("function-store-");
+        try {
+            FunctionCodeStore store = newStore(basePath);
+            Path stored = store.storeCode("account", "app", "hello", pythonV2Zip());
+
+            assertTrue(Files.isRegularFile(stored.resolve("function_app.py")));
+            assertTrue(Files.isRegularFile(stored.resolve("host.json")));
+            assertTrue(Files.isRegularFile(stored.resolve(
+                    ".python_packages/lib/site-packages/example.py")));
+            assertTrue(store.isPackageRootLayout(stored));
+            assertEquals("", store.routePrefix(stored));
+        } finally {
+            deleteRecursively(basePath);
+        }
+    }
+
+    private static byte[] pythonV2Zip() throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ZipOutputStream zip = new ZipOutputStream(bytes)) {
+            addEntry(zip, "function_app.py", "import azure.functions\n");
+            addEntry(zip, "host.json",
+                    "{\"version\":\"2.0\",\"extensions\":{\"http\":{\"routePrefix\":\"\"}}}");
+            addEntry(zip, ".python_packages/lib/site-packages/example.py", "VALUE = 1\n");
+        }
+        return bytes.toByteArray();
+    }
+
+    private static void addEntry(ZipOutputStream zip, String name, String content) throws Exception {
+        zip.putNextEntry(new ZipEntry(name));
+        zip.write(content.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        zip.closeEntry();
+    }
+
+    private static FunctionCodeStore newStore(Path codePath) {
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
+        EmulatorConfig.FunctionsConfig functions = mock(EmulatorConfig.FunctionsConfig.class);
+        when(config.services()).thenReturn(services);
+        when(services.functions()).thenReturn(functions);
+        when(functions.codePath()).thenReturn(codePath.toString());
+        return new FunctionCodeStore(config, new FunctionZipExtractor());
+    }
+
+    private static void deleteRecursively(Path root) throws Exception {
+        try (var paths = Files.walk(root)) {
+            paths.sorted(java.util.Comparator.reverseOrder()).forEach(path -> {
+                try {
+                    Files.delete(path);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+    }
+}

--- a/src/test/java/io/floci/az/services/functions/FunctionDefinitionTest.java
+++ b/src/test/java/io/floci/az/services/functions/FunctionDefinitionTest.java
@@ -33,6 +33,6 @@ class FunctionDefinitionTest {
     private static FunctionDefinition definition(String routePrefix) {
         return new FunctionDefinition(
                 "app", "hello", "account", "python", "Python|3.12", "function_app.hello",
-                60, null, "/tmp/functions/hello", Instant.now(), true, routePrefix);
+                60, null, "/tmp/functions/hello", Instant.now(), true, routePrefix, null);
     }
 }

--- a/src/test/java/io/floci/az/services/functions/FunctionDefinitionTest.java
+++ b/src/test/java/io/floci/az/services/functions/FunctionDefinitionTest.java
@@ -1,0 +1,38 @@
+package io.floci.az.services.functions;
+
+import io.floci.az.services.functions.FunctionModels.FunctionDefinition;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class FunctionDefinitionTest {
+
+    @Test
+    void emptyRoutePrefixRemainsUnprefixed() {
+        FunctionDefinition definition = definition("");
+
+        assertEquals("", definition.effectiveRoutePrefix());
+    }
+
+    @Test
+    void customRoutePrefixIsPreserved() {
+        FunctionDefinition definition = definition("functions");
+
+        assertEquals("functions", definition.effectiveRoutePrefix());
+    }
+
+    @Test
+    void missingRoutePrefixDefaultsToApi() {
+        FunctionDefinition definition = definition(null);
+
+        assertEquals("/api", definition.effectiveRoutePrefix());
+    }
+
+    private static FunctionDefinition definition(String routePrefix) {
+        return new FunctionDefinition(
+                "app", "hello", "account", "python", "Python|3.12", "function_app.hello",
+                60, null, "/tmp/functions/hello", Instant.now(), true, routePrefix);
+    }
+}

--- a/src/test/java/io/floci/az/services/functions/FunctionsExecutorServiceTest.java
+++ b/src/test/java/io/floci/az/services/functions/FunctionsExecutorServiceTest.java
@@ -1,0 +1,73 @@
+package io.floci.az.services.functions;
+
+import com.sun.net.httpserver.HttpServer;
+import io.floci.az.core.AzureRequest;
+import io.floci.az.services.functions.FunctionModels.FunctionDefinition;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class FunctionsExecutorServiceTest {
+
+    @Test
+    void emptyRoutePrefixProxiesDirectlyToFunctionRoute() throws Exception {
+        assertProxiedPath("", "/hello");
+    }
+
+    @Test
+    void missingRoutePrefixKeepsAzureApiDefault() throws Exception {
+        assertProxiedPath(null, "/api/hello");
+    }
+
+    private static void assertProxiedPath(String routePrefix, String expectedPath) throws Exception {
+        AtomicReference<String> receivedPath = new AtomicReference<>();
+        HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        server.createContext("/", exchange -> {
+            receivedPath.set(exchange.getRequestURI().getPath());
+            byte[] body = "ok".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, body.length);
+            try (var output = exchange.getResponseBody()) {
+                output.write(body);
+            }
+        });
+        server.start();
+
+        try {
+            FunctionDefinition definition = new FunctionDefinition(
+                    "app", "hello", "account", "python", "Python|3.12", "function_app.hello",
+                    10, null, "/tmp/functions/hello", Instant.now(), true, routePrefix);
+            WarmPool pool = mock(WarmPool.class);
+            ContainerHandle handle = new ContainerHandle(
+                    "container", definition.appKey(), "127.0.0.1", server.getAddress().getPort());
+            when(pool.acquire(eq(definition), eq(List.of(definition)))).thenReturn(handle);
+
+            FunctionsExecutorService executor = new FunctionsExecutorService(pool);
+            Response response = executor.invoke(definition, List.of(definition), request());
+
+            assertEquals(200, response.getStatus());
+            assertEquals(expectedPath, receivedPath.get());
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    private static AzureRequest request() {
+        HttpHeaders headers = mock(HttpHeaders.class);
+        when(headers.getRequestHeaders()).thenReturn(new MultivaluedHashMap<>());
+        return new AzureRequest("GET", "account", "functions", "api/app/hello",
+                headers, null, Map.of(), null, false);
+    }
+}

--- a/src/test/java/io/floci/az/services/functions/FunctionsExecutorServiceTest.java
+++ b/src/test/java/io/floci/az/services/functions/FunctionsExecutorServiceTest.java
@@ -32,7 +32,17 @@ class FunctionsExecutorServiceTest {
         assertProxiedPath(null, "/api/hello");
     }
 
+    @Test
+    void decoratedRouteIsUsedInsteadOfDeploymentName() throws Exception {
+        assertProxiedPath("", "/welcome", "welcome");
+    }
+
     private static void assertProxiedPath(String routePrefix, String expectedPath) throws Exception {
+        assertProxiedPath(routePrefix, expectedPath, null);
+    }
+
+    private static void assertProxiedPath(String routePrefix, String expectedPath,
+                                          String functionRoute) throws Exception {
         AtomicReference<String> receivedPath = new AtomicReference<>();
         HttpServer server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
         server.createContext("/", exchange -> {
@@ -48,7 +58,7 @@ class FunctionsExecutorServiceTest {
         try {
             FunctionDefinition definition = new FunctionDefinition(
                     "app", "hello", "account", "python", "Python|3.12", "function_app.hello",
-                    10, null, "/tmp/functions/hello", Instant.now(), true, routePrefix);
+                    10, null, "/tmp/functions/hello", Instant.now(), true, routePrefix, functionRoute);
             WarmPool pool = mock(WarmPool.class);
             ContainerHandle handle = new ContainerHandle(
                     "container", definition.appKey(), "127.0.0.1", server.getAddress().getPort());

--- a/src/test/java/io/floci/az/services/functions/FunctionsServiceHandlerMockedTest.java
+++ b/src/test/java/io/floci/az/services/functions/FunctionsServiceHandlerMockedTest.java
@@ -6,7 +6,13 @@ import io.quarkus.test.junit.TestProfile;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Map;
+import java.util.UUID;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
@@ -98,5 +104,69 @@ class FunctionsServiceHandlerMockedTest {
             .body("{}")
             .when().post(FN + "/api/ghostapp/ghostfn")
             .then().statusCode(404);
+    }
+
+    @Test
+    @DisplayName("incompatible root and v1 layouts are rejected in one app")
+    void incompatibleLayoutsAreRejected() throws Exception {
+        String app = "layout-" + UUID.randomUUID().toString().substring(0, 8);
+
+        given()
+            .contentType("application/json")
+            .body("{\"runtime\":\"python\",\"linuxFxVersion\":\"Python|3.12\"}")
+            .when().put(FN + "/admin/apps/" + app)
+            .then().statusCode(201);
+
+        given()
+            .contentType("application/json")
+            .body(deployBody("function_app.hello", rootLayoutZip()))
+            .when().put(FN + "/admin/apps/" + app + "/functions/hello")
+            .then().statusCode(201);
+
+        given()
+            .contentType("application/json")
+            .body(deployBody("function_app.goodbye", rootLayoutZip()))
+            .when().put(FN + "/admin/apps/" + app + "/functions/goodbye")
+            .then().statusCode(409)
+            .body("Code", equalTo("IncompatibleFunctionLayout"));
+
+        given()
+            .contentType("application/json")
+            .body(deployBody("index.handler", v1LayoutZip()))
+            .when().put(FN + "/admin/apps/" + app + "/functions/legacy")
+            .then().statusCode(409)
+            .body("Code", equalTo("IncompatibleFunctionLayout"));
+    }
+
+    private static String deployBody(String handler, String zipBase64) {
+        return "{\"handler\":\"" + handler + "\",\"zipBase64\":\"" + zipBase64 + "\"}";
+    }
+
+    private static String rootLayoutZip() throws Exception {
+        return zipBase64(Map.of(
+                "function_app.py", "import azure.functions\n",
+                "host.json", "{\"version\":\"2.0\"}"));
+    }
+
+    private static String v1LayoutZip() throws Exception {
+        return zipBase64(Map.of(
+                "function.json", "{}",
+                "index.js", "module.exports = async function() {};\n"));
+    }
+
+    private static String zipBase64(Map<String, String> entries) throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ZipOutputStream zip = new ZipOutputStream(bytes)) {
+            entries.forEach((name, content) -> {
+                try {
+                    zip.putNextEntry(new ZipEntry(name));
+                    zip.write(content.getBytes(StandardCharsets.UTF_8));
+                    zip.closeEntry();
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+        return Base64.getEncoder().encodeToString(bytes.toByteArray());
     }
 }


### PR DESCRIPTION
## Summary

Fixes #193.

Python v2 deployments with `function_app.py` at the ZIP root were extracted into a per-function directory, causing the root `host.json` to be ignored and preventing `routePrefix` from being honored.

This PR:

- Detects Python v2 packages by their root-level `function_app.py`.
- Extracts app-root packages to `/home/site/wwwroot` while preserving `host.json` and `.python_packages`.
- Sets the Python worker script root and package path.
- Proxies invocations using the effective `host.json` `routePrefix`, including an empty prefix.
- Preserves the existing v1 per-function layout and shared app container behavior.
- Documents both supported deployment layouts.

## Tests

- `./mvnw test -Dtest=FunctionCodeStoreTest,FunctionDefinitionTest,FunctionsExecutorServiceTest,FunctionsServiceHandlerMockedTest,FunctionRuntimeTest`
- Result: 15 tests, 0 failures, 0 errors.
- `git diff --check`

The full Maven suite previously reported 723 tests with 0 failures and one unrelated `PostgresDockerTest.createServer` Docker socket timeout.