### PR TITLE
fix(blob): preserve ADLS list directory identity

### DIFF
--- a/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
+++ b/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
@@ -603,7 +603,7 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
             return new AzureErrorResponse("FilesystemNotFound", "The specified filesystem does not exist.")
                     .toXmlResponse(Response.Status.NOT_FOUND.getStatusCode());
         }
-        if (directory != null && !directory.isBlank()
+        if (directory != null && !directory.isEmpty()
                 && !dataLakePathOperations.pathExists(request.accountName(), filesystem, directory)) {
             return new AzureErrorResponse("PathNotFound", "The specified path does not exist.")
                     .toXmlResponse(Response.Status.NOT_FOUND.getStatusCode());

--- a/src/main/java/io/floci/az/services/blob/DataLakePathOperations.java
+++ b/src/main/java/io/floci/az/services/blob/DataLakePathOperations.java
@@ -73,12 +73,13 @@ public class DataLakePathOperations {
 
     public boolean pathExists(String account, String filesystem, String path) {
         String normalizedPath = normalizeDirectory(path);
-        if (normalizedPath == null || normalizedPath.isBlank()) {
+        if (normalizedPath == null || normalizedPath.isEmpty()) {
             return true;
         }
         String exactKey = account + "/" + filesystem + "/" + normalizedPath;
-        if (store.get(exactKey).isPresent()) {
-            return true;
+        var exactPath = store.get(exactKey);
+        if (exactPath.isPresent()) {
+            return "directory".equals(exactPath.get().metadata().get(RESOURCE_TYPE));
         }
         String descendantPrefix = exactKey + "/";
         return store.keys().stream().anyMatch(key -> key.startsWith(descendantPrefix) && !isInternalKey(key));
@@ -115,7 +116,7 @@ public class DataLakePathOperations {
 
     private static String objectPrefix(String account, String filesystem, String directory) {
         String prefix = account + "/" + filesystem + "/";
-        if (directory == null || directory.isBlank()) {
+        if (directory == null || directory.isEmpty()) {
             return prefix;
         }
         return prefix + directory + "/";
@@ -126,18 +127,18 @@ public class DataLakePathOperations {
     }
 
     private static boolean isUnderDirectory(String name, String directory) {
-        return directory == null || directory.isBlank() || name.startsWith(directory + "/");
+        return directory == null || directory.isEmpty() || name.startsWith(directory + "/");
     }
 
     private static String relativeName(String name, String directory) {
-        if (directory == null || directory.isBlank()) {
+        if (directory == null || directory.isEmpty()) {
             return name;
         }
         return name.substring(directory.length() + 1);
     }
 
     private static String joinPath(String left, String right) {
-        if (left == null || left.isBlank()) {
+        if (left == null || left.isEmpty()) {
             return right;
         }
         return left + "/" + right;
@@ -147,14 +148,14 @@ public class DataLakePathOperations {
         if (directory == null) {
             return null;
         }
-        String normalized = directory.trim();
+        String normalized = directory;
         while (normalized.startsWith("/")) {
             normalized = normalized.substring(1);
         }
         while (normalized.endsWith("/")) {
             normalized = normalized.substring(0, normalized.length() - 1);
         }
-        return normalized.isBlank() ? null : normalized;
+        return normalized.isEmpty() ? null : normalized;
     }
 
     private static String quoteEtag(String etag) {

--- a/src/test/java/io/floci/az/services/BlobServiceTest.java
+++ b/src/test/java/io/floci/az/services/BlobServiceTest.java
@@ -675,6 +675,46 @@ public class BlobServiceTest {
     }
 
     @Test
+    void dataLakeDirectoryListingPreservesBoundarySpaces() {
+        String directory = " path with spaces ";
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().put("/{container}/{directory}?resource=directory", CONTAINER, directory)
+            .then()
+            .statusCode(201);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .queryParam("resource", "filesystem")
+            .queryParam("recursive", true)
+            .queryParam("directory", directory)
+            .when().get("/{container}", CONTAINER)
+            .then()
+            .statusCode(200)
+            .body("paths", hasSize(0));
+    }
+
+    @Test
+    void dataLakeDirectoryListingRejectsFilePath() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().put("/{container}/file?resource=file", CONTAINER)
+            .then()
+            .statusCode(201);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().get("/{container}?resource=filesystem&recursive=true&directory=file", CONTAINER)
+            .then()
+            .statusCode(404)
+            .header("x-ms-error-code", "PathNotFound");
+    }
+
+    @Test
     void dataLakeEmptyFilesystemListingReturnsEmptyPaths() {
         given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
 


### PR DESCRIPTION
Summary:
- Preserve boundary spaces when resolving the ADLS listPaths directory filter.
- Reject file paths supplied as listPaths directories with PathNotFound.

Type of change:
- [x] Bug fix (fix:)

Azure Compatibility:
- List Paths now preserves the requested directory identity and requires that the directory filter resolve to a directory.

Checklist:
- [ ] ./mvnw test passes locally (focused BlobServiceTest passes with JDK 25)
- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits
