### PR TITLE
fix(blob): honor user delegation SAS signing layouts by version

### DIFF
--- a/src/main/java/io/floci/az/core/auth/StorageSasAuthorization.java
+++ b/src/main/java/io/floci/az/core/auth/StorageSasAuthorization.java
@@ -149,11 +149,13 @@ public class StorageSasAuthorization {
                 value(token.signedKeyStart()),
                 value(token.signedKeyExpiry()),
                 value(token.signedKeyService()),
-                value(token.signedKeyVersion()),
-                value(token.preauthorizedAgentObjectId()),
-                value(token.agentObjectId()),
-                value(token.correlationId())
+                value(token.signedKeyVersion())
         ));
+        if (layout.includesAgentFields()) {
+            fields.add(value(token.preauthorizedAgentObjectId()));
+            fields.add(value(token.agentObjectId()));
+            fields.add(value(token.correlationId()));
+        }
         if (layout.includesDelegatedUser()) {
             fields.add(value(token.delegatedUserTenantId()));
             fields.add(value(token.delegatedUserObjectId()));
@@ -362,22 +364,25 @@ public class StorageSasAuthorization {
     }
 
     private enum SasLayout {
-        LEGACY(false, false, false),
-        SNAPSHOT(false, true, false),
-        ENCRYPTION_SCOPE(false, true, true),
-        DELEGATED_USER(true, true, true),
-        REQUEST_CONSTRAINTS(true, true, true);
+        LEGACY(false, false, true, false),
+        SNAPSHOT(true, false, true, false),
+        ENCRYPTION_SCOPE(true, false, true, true),
+        DELEGATED_USER(true, true, true, true),
+        REQUEST_CONSTRAINTS(true, true, true, true);
 
+        private final boolean agentFields;
         private final boolean delegatedUser;
         private final boolean snapshot;
         private final boolean encryptionScope;
 
-        SasLayout(boolean delegatedUser, boolean snapshot, boolean encryptionScope) {
+        SasLayout(boolean agentFields, boolean delegatedUser, boolean snapshot, boolean encryptionScope) {
+            this.agentFields = agentFields;
             this.delegatedUser = delegatedUser;
             this.snapshot = snapshot;
             this.encryptionScope = encryptionScope;
         }
 
+        boolean includesAgentFields() { return agentFields; }
         boolean includesDelegatedUser() { return delegatedUser; }
         boolean includesSnapshot() { return snapshot; }
         boolean includesEncryptionScope() { return encryptionScope; }

--- a/src/main/java/io/floci/az/core/auth/StorageSasAuthorization.java
+++ b/src/main/java/io/floci/az/core/auth/StorageSasAuthorization.java
@@ -1,6 +1,7 @@
 package io.floci.az.core.auth;
 
 import io.floci.az.core.AzureErrorResponse;
+import io.floci.az.core.AzureRequest;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
@@ -10,7 +11,9 @@ import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Optional;
@@ -27,32 +30,36 @@ public class StorageSasAuthorization {
         this.keyMaterial = keyMaterial;
     }
 
-    public Optional<Response> authorizeRead(String account, String container, String path, StorageSasToken token) {
-        return authorize(account, container, path, token, Operation.READ);
+    public Optional<Response> authorizeRead(AzureRequest request, String container, String path, StorageSasToken token) {
+        return authorize(request, container, path, token, Operation.READ);
     }
 
-    public Optional<Response> authorizeList(String account, String container, StorageSasToken token) {
-        return authorize(account, container, null, token, Operation.LIST);
+    public Optional<Response> authorizeList(AzureRequest request, String container, StorageSasToken token) {
+        return authorize(request, container, null, token, Operation.LIST);
     }
 
-    public Optional<Response> authorizeList(String account, String container, String path, StorageSasToken token) {
-        return authorize(account, container, path, token, Operation.LIST);
+    public Optional<Response> authorizeList(AzureRequest request, String container, String path, StorageSasToken token) {
+        return authorize(request, container, path, token, Operation.LIST);
     }
 
-    public Optional<Response> authorizeCreate(String account, String container, String path, StorageSasToken token) {
-        return authorize(account, container, path, token, Operation.CREATE);
+    public Optional<Response> authorizeCreate(AzureRequest request, String container, String path, StorageSasToken token) {
+        return authorize(request, container, path, token, Operation.CREATE);
     }
 
-    public Optional<Response> authorizeWrite(String account, String container, String path, StorageSasToken token) {
-        return authorize(account, container, path, token, Operation.WRITE);
+    public Optional<Response> authorizeWrite(AzureRequest request, String container, String path, StorageSasToken token) {
+        return authorize(request, container, path, token, Operation.WRITE);
     }
 
-    public Optional<Response> authorizeDelete(String account, String container, String path, StorageSasToken token) {
-        return authorize(account, container, path, token, Operation.DELETE);
+    public Optional<Response> authorizeDelete(AzureRequest request, String container, String path, StorageSasToken token) {
+        return authorize(request, container, path, token, Operation.DELETE);
+    }
+
+    public Optional<Response> authorizeAppend(AzureRequest request, String container, String path, StorageSasToken token) {
+        return authorize(request, container, path, token, Operation.APPEND);
     }
 
     private Optional<Response> authorize(
-            String account,
+            AzureRequest request,
             String container,
             String path,
             StorageSasToken token,
@@ -61,16 +68,17 @@ public class StorageSasAuthorization {
         if (token.resource() == null || token.permissions() == null || token.expiryTime() == null) {
             return Optional.of(authenticationFailed());
         }
-        if (!isSupportedResource(token.resource())) {
+        if (!isSupportedResource(token.resource()) || layoutFor(token.version()) == null
+                || token.delegatedUserTenantId() != null || token.delegatedUserObjectId() != null) {
             return Optional.of(authenticationFailed());
         }
         if (!delegationKeyValid(token)) {
             return Optional.of(authenticationFailed());
         }
-        if (!signatureMatches(account, container, path, token)) {
+        if (!signatureMatches(request, container, path, token)) {
             return Optional.of(authenticationFailed());
         }
-        if (!resourceCoversPath(token, path)) {
+        if (!resourceCoversPath(request, token, path)) {
             return Optional.of(authorizationPermissionMismatch());
         }
         if (!operation.allowedBy(token)) {
@@ -100,9 +108,9 @@ public class StorageSasAuthorization {
                 && !sasExpiry.get().isAfter(keyExpiry.get());
     }
 
-    private boolean signatureMatches(String account, String container, String path, StorageSasToken token) {
-        String canonicalName = canonicalName(account, container, signedPath(token, path));
-        String expected = hmac(keyMaterial.signingKeyForAccount(account), stringToSign(token, canonicalName));
+    private boolean signatureMatches(AzureRequest request, String container, String path, StorageSasToken token) {
+        String canonicalName = canonicalName(request.accountName(), container, signedPath(token, path));
+        String expected = hmac(keyMaterial.signingKeyForAccount(request.accountName()), stringToSign(request, token, canonicalName));
         return MessageDigest.isEqual(
                 expected.getBytes(StandardCharsets.UTF_8),
                 token.signature().getBytes(StandardCharsets.UTF_8)
@@ -126,8 +134,12 @@ public class StorageSasAuthorization {
         return "/blob/" + account + "/" + container + "/" + normalizePath(path);
     }
 
-    private static String stringToSign(StorageSasToken token, String canonicalName) {
-        return String.join("\n",
+    private static String stringToSign(AzureRequest request, StorageSasToken token, String canonicalName) {
+        SasLayout layout = layoutFor(token.version());
+        if (layout == null) {
+            throw new IllegalArgumentException("Unsupported SAS version");
+        }
+        var fields = new java.util.ArrayList<>(Arrays.asList(
                 value(token.permissions()),
                 value(token.startTime()),
                 value(token.expiryTime()),
@@ -140,19 +152,95 @@ public class StorageSasAuthorization {
                 value(token.signedKeyVersion()),
                 value(token.preauthorizedAgentObjectId()),
                 value(token.agentObjectId()),
-                value(token.correlationId()),
+                value(token.correlationId())
+        ));
+        if (layout.includesDelegatedUser()) {
+            fields.add(value(token.delegatedUserTenantId()));
+            fields.add(value(token.delegatedUserObjectId()));
+        }
+        fields.addAll(Arrays.asList(
                 value(token.ipRange()),
                 value(token.protocol()),
                 value(token.version()),
-                value(token.resource()),
-                "",
-                value(token.encryptionScope()),
+                value(token.resource())
+        ));
+        if (layout.includesSnapshot()) {
+            fields.add(value(token.snapshotTime()));
+        }
+        if (layout.includesEncryptionScope()) {
+            fields.add(value(token.encryptionScope()));
+        }
+        if (layout.includesRequestConstraints()) {
+            fields.add(canonicalizedHeaders(request, token.signedRequestHeaders()));
+            fields.add(canonicalizedQueryParameters(request, token.signedRequestQueryParameters()));
+        }
+        fields.addAll(Arrays.asList(
                 value(token.cacheControl()),
                 value(token.contentDisposition()),
                 value(token.contentEncoding()),
                 value(token.contentLanguage()),
                 value(token.contentType())
-        );
+        ));
+        return String.join("\n", fields);
+    }
+
+    private static String canonicalizedHeaders(AzureRequest request, String names) {
+        if (names == null) {
+            return "";
+        }
+        var result = new StringBuilder();
+        for (String name : names.split(",", -1)) {
+            String header = name.trim().toLowerCase(java.util.Locale.ROOT);
+            if (header.isEmpty()) {
+                return "__invalid__";
+            }
+            String value = request.headers().getHeaderString(header);
+            if (value == null) {
+                return "__missing__";
+            }
+            result.append(header).append(':').append(value).append('\n');
+        }
+        return result.toString();
+    }
+
+    private static String canonicalizedQueryParameters(AzureRequest request, String names) {
+        if (names == null) {
+            return "";
+        }
+        var result = new StringBuilder();
+        for (String name : names.split(",", -1)) {
+            String parameter = name.trim();
+            var values = request.queryParamsMulti().get(parameter);
+            if (parameter.isEmpty() || values == null || values.isEmpty()) {
+                return "__missing__";
+            }
+            result.append('\n').append(parameter).append('=').append(String.join(",", values));
+        }
+        return result.toString();
+    }
+
+    private static SasLayout layoutFor(String version) {
+        try {
+            LocalDate parsed = LocalDate.parse(version);
+            if (parsed.isBefore(LocalDate.parse("2018-11-09"))) {
+                return null;
+            }
+            if (!parsed.isBefore(LocalDate.parse("2026-04-06"))) {
+                return SasLayout.REQUEST_CONSTRAINTS;
+            }
+            if (!parsed.isBefore(LocalDate.parse("2025-07-05"))) {
+                return SasLayout.DELEGATED_USER;
+            }
+            if (!parsed.isBefore(LocalDate.parse("2020-12-06"))) {
+                return SasLayout.ENCRYPTION_SCOPE;
+            }
+            if (!parsed.isBefore(LocalDate.parse("2020-02-10"))) {
+                return SasLayout.SNAPSHOT;
+            }
+            return SasLayout.LEGACY;
+        } catch (DateTimeParseException e) {
+            return null;
+        }
     }
 
     private static String hmac(String base64Key, String stringToSign) {
@@ -165,12 +253,15 @@ public class StorageSasAuthorization {
         }
     }
 
-    private static boolean resourceCoversPath(StorageSasToken token, String path) {
+    private static boolean resourceCoversPath(AzureRequest request, StorageSasToken token, String path) {
         String normalizedPath = normalizePath(path);
         return switch (token.resource()) {
             case "c" -> true;
             case "b" -> normalizedPath != null && !normalizedPath.isBlank();
             case "d" -> signedDirectoryPath(token, normalizedPath) != null;
+            case "bs" -> normalizedPath != null && !normalizedPath.isBlank()
+                    && token.snapshotTime() != null
+                    && token.snapshotTime().equals(request.queryParams().get("snapshot"));
             default -> false;
         };
     }
@@ -199,7 +290,7 @@ public class StorageSasAuthorization {
     }
 
     private static boolean isSupportedResource(String resource) {
-        return "c".equals(resource) || "b".equals(resource) || "d".equals(resource);
+        return "c".equals(resource) || "b".equals(resource) || "d".equals(resource) || "bs".equals(resource);
     }
 
     private static String normalizePath(String path) {
@@ -259,8 +350,37 @@ public class StorageSasAuthorization {
             boolean allowedBy(StorageSasToken token) {
                 return token.hasPermission('d');
             }
+        },
+        APPEND {
+            @Override
+            boolean allowedBy(StorageSasToken token) {
+                return token.hasPermission('a');
+            }
         };
 
         abstract boolean allowedBy(StorageSasToken token);
+    }
+
+    private enum SasLayout {
+        LEGACY(false, false, false),
+        SNAPSHOT(false, true, false),
+        ENCRYPTION_SCOPE(false, true, true),
+        DELEGATED_USER(true, true, true),
+        REQUEST_CONSTRAINTS(true, true, true);
+
+        private final boolean delegatedUser;
+        private final boolean snapshot;
+        private final boolean encryptionScope;
+
+        SasLayout(boolean delegatedUser, boolean snapshot, boolean encryptionScope) {
+            this.delegatedUser = delegatedUser;
+            this.snapshot = snapshot;
+            this.encryptionScope = encryptionScope;
+        }
+
+        boolean includesDelegatedUser() { return delegatedUser; }
+        boolean includesSnapshot() { return snapshot; }
+        boolean includesEncryptionScope() { return encryptionScope; }
+        boolean includesRequestConstraints() { return this == REQUEST_CONSTRAINTS; }
     }
 }

--- a/src/main/java/io/floci/az/core/auth/StorageSasToken.java
+++ b/src/main/java/io/floci/az/core/auth/StorageSasToken.java
@@ -30,7 +30,12 @@ public record StorageSasToken(
         String contentEncoding,
         String contentLanguage,
         String contentType,
-        String encryptionScope
+        String encryptionScope,
+        String snapshotTime,
+        String delegatedUserTenantId,
+        String delegatedUserObjectId,
+        String signedRequestHeaders,
+        String signedRequestQueryParameters
 ) {
 
     public static Optional<StorageSasToken> from(Map<String, String> query) {
@@ -64,7 +69,12 @@ public record StorageSasToken(
                 blankToNull(query.get("rsce")),
                 blankToNull(query.get("rscl")),
                 blankToNull(query.get("rsct")),
-                blankToNull(query.get("ses"))
+                blankToNull(query.get("ses")),
+                blankToNull(query.get("snapshot")),
+                blankToNull(query.get("skdutid")),
+                blankToNull(query.get("sduoid")),
+                blankToNull(query.get("srh")),
+                blankToNull(query.get("srq"))
         ));
     }
 

--- a/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
+++ b/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
@@ -884,40 +884,46 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
     private Response authorizeRead(AzureRequest request, String containerName, String blobName) {
         return storageSas(request)
                 .flatMap(token -> sasAuthorization.authorizeRead(
-                        request.accountName(), containerName, blobName, token))
+                        request, containerName, blobName, token))
                 .orElse(null);
     }
 
     private Response authorizeList(AzureRequest request, String containerName) {
         return storageSas(request)
-                .flatMap(token -> sasAuthorization.authorizeList(request.accountName(), containerName, token))
+                .flatMap(token -> sasAuthorization.authorizeList(request, containerName, token))
                 .orElse(null);
     }
 
     private Response authorizeList(AzureRequest request, String containerName, String path) {
         return storageSas(request)
-                .flatMap(token -> sasAuthorization.authorizeList(request.accountName(), containerName, path, token))
+                .flatMap(token -> sasAuthorization.authorizeList(request, containerName, path, token))
                 .orElse(null);
     }
 
     private Response authorizeCreate(AzureRequest request, String containerName, String blobName) {
         return storageSas(request)
                 .flatMap(token -> sasAuthorization.authorizeCreate(
-                        request.accountName(), containerName, blobName, token))
+                        request, containerName, blobName, token))
                 .orElse(null);
     }
 
     private Response authorizeWrite(AzureRequest request, String containerName, String blobName) {
         return storageSas(request)
                 .flatMap(token -> sasAuthorization.authorizeWrite(
-                        request.accountName(), containerName, blobName, token))
+                        request, containerName, blobName, token))
                 .orElse(null);
     }
 
     private Response authorizeDelete(AzureRequest request, String containerName, String blobName) {
         return storageSas(request)
                 .flatMap(token -> sasAuthorization.authorizeDelete(
-                        request.accountName(), containerName, blobName, token))
+                        request, containerName, blobName, token))
+                .orElse(null);
+    }
+
+    private Response authorizeAppend(AzureRequest request, String containerName, String blobName) {
+        return storageSas(request)
+                .flatMap(token -> sasAuthorization.authorizeAppend(request, containerName, blobName, token))
                 .orElse(null);
     }
 

--- a/src/test/java/io/floci/az/core/auth/StorageSasTokenTest.java
+++ b/src/test/java/io/floci/az/core/auth/StorageSasTokenTest.java
@@ -26,7 +26,12 @@ class StorageSasTokenTest {
                 Map.entry("sks", "b"),
                 Map.entry("skv", "2024-11-04"),
                 Map.entry("sdd", "2"),
-                Map.entry("ses", "scope")
+                Map.entry("ses", "scope"),
+                Map.entry("snapshot", "2026-07-15T10:30:00Z"),
+                Map.entry("skdutid", "delegated-tenant"),
+                Map.entry("sduoid", "delegated-user"),
+                Map.entry("srh", "x-ms-client-request-id"),
+                Map.entry("srq", "operation")
         )).orElseThrow();
 
         assertThat(token.version(), equalTo("2024-11-04"));
@@ -36,6 +41,11 @@ class StorageSasTokenTest {
         assertThat(token.signedObjectId(), equalTo(UserDelegationKeyMaterial.SIGNED_OBJECT_ID));
         assertThat(token.directoryDepth(), equalTo("2"));
         assertThat(token.encryptionScope(), equalTo("scope"));
+        assertThat(token.snapshotTime(), equalTo("2026-07-15T10:30:00Z"));
+        assertThat(token.delegatedUserTenantId(), equalTo("delegated-tenant"));
+        assertThat(token.delegatedUserObjectId(), equalTo("delegated-user"));
+        assertThat(token.signedRequestHeaders(), equalTo("x-ms-client-request-id"));
+        assertThat(token.signedRequestQueryParameters(), equalTo("operation"));
         assertTrue(token.parsedStartTime().isPresent());
         assertTrue(token.parsedExpiryTime().isPresent());
         assertTrue(token.parsedSignedKeyStart().isPresent());

--- a/src/test/java/io/floci/az/services/BlobServiceTest.java
+++ b/src/test/java/io/floci/az/services/BlobServiceTest.java
@@ -324,6 +324,23 @@ public class BlobServiceTest {
     }
 
     @Test
+    void sasWithSignedRepeatedQueryValuesCanReadBlob() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        given()
+            .header("x-ms-blob-type", "BlockBlob")
+            .body(BLOB_CONTENT)
+            .put("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB);
+
+        given()
+            .queryParam("operation", "read", "metadata")
+            .when().get("/{account}/{container}/{blob}?{sas}",
+                    ACCOUNT, CONTAINER, BLOB, sasWithSignedRepeatedQueryValues(CONTAINER, BLOB))
+            .then()
+            .statusCode(200)
+            .body(equalTo(BLOB_CONTENT));
+    }
+
+    @Test
     void arbitraryNonExpiredSasReturnsAuthenticationFailed() {
         given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
         given()
@@ -1381,6 +1398,58 @@ public class BlobServiceTest {
         } catch (Exception e) {
             throw new IllegalStateException("Unable to derive legacy test key", e);
         }
+    }
+
+    private String sasWithSignedRepeatedQueryValues(String container, String blobName) {
+        OffsetDateTime start = OffsetDateTime.now(ZoneOffset.UTC).minusMinutes(5).withNano(0);
+        OffsetDateTime expiry = OffsetDateTime.now(ZoneOffset.UTC).plusHours(1).withNano(0);
+        String st = start.toString();
+        String se = expiry.toString();
+        String version = "2026-04-06";
+        String stringToSign = String.join("\n",
+                "r",
+                st,
+                se,
+                canonicalName(container, blobName),
+                UserDelegationKeyMaterial.SIGNED_OBJECT_ID,
+                UserDelegationKeyMaterial.SIGNED_TENANT_ID,
+                st,
+                se,
+                "b",
+                version,
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                "",
+                version,
+                "b",
+                "",
+                "",
+                "",
+                "\noperation=read,metadata",
+                "",
+                "",
+                "",
+                "",
+                ""
+        );
+        String signature = hmac(keyMaterial.signingKeyForAccount(ACCOUNT), stringToSign);
+        return "sv=" + version
+                + "&st=" + st
+                + "&se=" + se
+                + "&skoid=" + UserDelegationKeyMaterial.SIGNED_OBJECT_ID
+                + "&sktid=" + UserDelegationKeyMaterial.SIGNED_TENANT_ID
+                + "&skt=" + st
+                + "&ske=" + se
+                + "&sks=b"
+                + "&skv=" + version
+                + "&sr=b"
+                + "&sp=r"
+                + "&srq=operation"
+                + "&sig=" + signature;
     }
 
     private static String canonicalName(String container, String blobName) {

--- a/src/test/java/io/floci/az/services/BlobServiceTest.java
+++ b/src/test/java/io/floci/az/services/BlobServiceTest.java
@@ -324,6 +324,22 @@ public class BlobServiceTest {
     }
 
     @Test
+    void legacySasCanReadBlob() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        given()
+            .header("x-ms-blob-type", "BlockBlob")
+            .body(BLOB_CONTENT)
+            .put("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB);
+
+        given()
+            .when().get("/{account}/{container}/{blob}?{sas}", ACCOUNT, CONTAINER, BLOB,
+                    legacySas(CONTAINER, BLOB))
+            .then()
+            .statusCode(200)
+            .body(equalTo(BLOB_CONTENT));
+    }
+
+    @Test
     void sasWithSignedRepeatedQueryValuesCanReadBlob() {
         given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
         given()
@@ -1398,6 +1414,49 @@ public class BlobServiceTest {
         } catch (Exception e) {
             throw new IllegalStateException("Unable to derive legacy test key", e);
         }
+    }
+
+    private String legacySas(String container, String blobName) {
+        OffsetDateTime start = OffsetDateTime.now(ZoneOffset.UTC).minusMinutes(5).withNano(0);
+        OffsetDateTime expiry = OffsetDateTime.now(ZoneOffset.UTC).plusHours(1).withNano(0);
+        String st = start.toString();
+        String se = expiry.toString();
+        String version = "2019-12-12";
+        String stringToSign = String.join("\n",
+                "r",
+                st,
+                se,
+                canonicalName(container, blobName),
+                UserDelegationKeyMaterial.SIGNED_OBJECT_ID,
+                UserDelegationKeyMaterial.SIGNED_TENANT_ID,
+                st,
+                se,
+                "b",
+                version,
+                "",
+                "",
+                version,
+                "b",
+                "",
+                "",
+                "",
+                "",
+                "",
+                ""
+        );
+        String signature = hmac(keyMaterial.signingKeyForAccount(ACCOUNT), stringToSign);
+        return "sv=" + version
+                + "&st=" + st
+                + "&se=" + se
+                + "&skoid=" + UserDelegationKeyMaterial.SIGNED_OBJECT_ID
+                + "&sktid=" + UserDelegationKeyMaterial.SIGNED_TENANT_ID
+                + "&skt=" + st
+                + "&ske=" + se
+                + "&sks=b"
+                + "&skv=" + version
+                + "&sr=b"
+                + "&sp=r"
+                + "&sig=" + signature;
     }
 
     private String sasWithSignedRepeatedQueryValues(String container, String blobName) {


### PR DESCRIPTION
Summary:
- Select the user-delegation SAS string-to-sign layout from sv, including legacy, encryption-scope, delegated-user, and request-constraint fields.
- Parse the version-dependent SAS fields and fail closed for malformed versions or user-bound tokens that cannot yet be identity-validated.

Type of change:
- [x] Bug fix (fix:)

Azure Compatibility:
- Matches the documented Blob and Data Lake user-delegation SAS layouts from 2018-11-09 through 2026-04-06.

Checklist:
- [ ] ./mvnw test passes locally (blocked: available JDK is 21; project requires Java 25)
- [ ] New or updated integration test added (unit parser coverage added)
- [x] Commit messages follow Conventional Commits
