### PR TITLE
feat(servicebus): support non-destructive message peeking

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -92,7 +92,12 @@ jobs:
               -e SERVICEBUS_HOST=floci-az-servicebus-default
               -e SERVICEBUS_AMQP_PORT=5672
           - test: sdk-test-node
+            emulator_env: >-
+              -e FLOCI_AZ_SERVICES_SERVICE_BUS_MOCKED=false
             extra_env: >-
+              -e SERVICEBUS_HOST=floci-az-servicebus-default
+              -e SERVICEBUS_AMQP_PORT=5672
+              -e SERVICEBUS_NAMESPACE=default
               -e AZURE_POD_IDENTITY_AUTHORITY_HOST=http://floci-az:4577
           - test: compat-terraform
           - test: compat-opentofu

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,7 +239,7 @@ compatibility-tests/
                           servicebus, eventgrid, apim, sql, postgres, vm, datalake,
                           managed identity
   sdk-test-node/        — Azure SDK for JS (jest): blob, queue, table, cosmos, appconfig,
-                          keyvault, eventhub, managed identity
+                          keyvault, eventhub, servicebus, managed identity
   compat-terraform/     — hashicorp/azurerm Terraform provider (BATS)
   compat-opentofu/      — OpenTofu with the azurerm provider (BATS)
   compat-azcli/         — real `az` CLI against a custom registered cloud (BATS)
@@ -272,6 +272,9 @@ Current per-suite env vars that must stay in sync:
 | `sdk-test-dotnet` | `-e SERVICEBUS_AMQP_PORT=5672` | ✓ |
 | `sdk-test-python` | `-e AZURE_POD_IDENTITY_AUTHORITY_HOST=http://floci-az:4577` | ✓ |
 | `sdk-test-node` | `-e AZURE_POD_IDENTITY_AUTHORITY_HOST=http://floci-az:4577` | ✓ |
+| `sdk-test-node` | `-e SERVICEBUS_HOST=floci-az-servicebus-default` | ✓ |
+| `sdk-test-node` | `-e SERVICEBUS_AMQP_PORT=5672` | ✓ |
+| `sdk-test-node` | `-e SERVICEBUS_NAMESPACE=default` | ✓ |
 
 The container name follows the pattern `floci-az-<service>-<namespace>` (e.g. `floci-az-servicebus-default`). If a new sidecar-based service is added, its container name and port must be added to both places.
 

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,10 @@ SUITE_ENV_JAVA   = $(POD_IDENTITY_ENV) \
 	-e SERVICEBUS_HOST=floci-az-servicebus-default \
 	-e SERVICEBUS_AMQPS_PORT=5671 \
 	-e SERVICEBUS_NAMESPACE=default
-SUITE_ENV_NODE   = $(POD_IDENTITY_ENV)
+SUITE_ENV_NODE   = $(POD_IDENTITY_ENV) \
+	-e SERVICEBUS_HOST=floci-az-servicebus-default \
+	-e SERVICEBUS_AMQP_PORT=5672 \
+	-e SERVICEBUS_NAMESPACE=default
 SUITE_ENV_DOTNET = -e SERVICEBUS_HOST=floci-az-servicebus-default \
 	-e SERVICEBUS_AMQP_PORT=5672
 SERVICEBUS_EMULATOR_ENV = -e FLOCI_AZ_SERVICES_SERVICE_BUS_MOCKED=false
@@ -222,7 +225,7 @@ test-java-compat:
 
 test-node-compat:
 	@echo "==> Node.js SDK compatibility tests (Docker)"
-	$(call COMPAT_SESSION,node,node,$(SUITE_ENV_NODE),,)
+	$(call COMPAT_SESSION,node,node,$(SUITE_ENV_NODE),,,$(SERVICEBUS_EMULATOR_ENV))
 
 test-dotnet-compat:
 	@echo "==> .NET Service Bus SDK compatibility tests (Docker)"
@@ -261,11 +264,11 @@ test-blob-java:
 
 test-blob-node:
 	@echo "==> Blob Storage Node.js SDK compatibility tests (Docker)"
-	$(call COMPAT_SESSION,node,blob-node,-e JEST_JUNIT_OUTPUT_DIR=/results -e JEST_JUNIT_OUTPUT_NAME=junit.xml,--entrypoint npm,test -- --runTestsByPath tests/blob.test.ts)
+	$(call COMPAT_SESSION,node,blob-node,$(SUITE_ENV_NODE) -e JEST_JUNIT_OUTPUT_DIR=/results -e JEST_JUNIT_OUTPUT_NAME=junit.xml,--entrypoint npm,test -- --runTestsByPath tests/blob.test.ts)
 
 test-entra-node:
 	@echo "==> Entra ID / Graph Node.js SDK compatibility tests (Docker)"
-	$(call COMPAT_SESSION,node,entra-node,-e JEST_JUNIT_OUTPUT_DIR=/results -e JEST_JUNIT_OUTPUT_NAME=junit.xml,--entrypoint npm,test -- --runTestsByPath tests/entra.test.ts)
+	$(call COMPAT_SESSION,node,entra-node,$(SUITE_ENV_NODE) -e JEST_JUNIT_OUTPUT_DIR=/results -e JEST_JUNIT_OUTPUT_NAME=junit.xml,--entrypoint npm,test -- --runTestsByPath tests/entra.test.ts)
 
 test-apim-java:
 	@echo "==> API Management Java compatibility tests (Docker)"
@@ -285,7 +288,7 @@ test-blob:
 		EXIT=$$?; \
 	fi; \
 	if [ $$EXIT -eq 0 ]; then \
-		$(call RUN_SUITE,node,blob-node,-e JEST_JUNIT_OUTPUT_DIR=/results -e JEST_JUNIT_OUTPUT_NAME=junit.xml,--entrypoint npm,test -- --runTestsByPath tests/blob.test.ts); \
+		$(call RUN_SUITE,node,blob-node,$(SUITE_ENV_NODE) -e JEST_JUNIT_OUTPUT_DIR=/results -e JEST_JUNIT_OUTPUT_NAME=junit.xml,--entrypoint npm,test -- --runTestsByPath tests/blob.test.ts); \
 		EXIT=$$?; \
 	fi; \
 	if [ $$EXIT -eq 0 ]; then \

--- a/compatibility-tests/sdk-test-node/package.json
+++ b/compatibility-tests/sdk-test-node/package.json
@@ -13,6 +13,7 @@
     "@azure/identity": "^4.5.0",
     "@azure/keyvault-secrets": "^4.8.0",
     "@azure/msal-node": "^5.4.2",
+    "@azure/service-bus": "7.9.5",
     "@azure/storage-blob": "^12.23.0",
     "@azure/storage-queue": "^12.22.0",
     "@microsoft/microsoft-graph-client": "^3.0.7",

--- a/compatibility-tests/sdk-test-node/tests/servicebus.test.ts
+++ b/compatibility-tests/sdk-test-node/tests/servicebus.test.ts
@@ -1,0 +1,191 @@
+import { ServiceBusClient, ServiceBusMessage } from "@azure/service-bus";
+
+const BASE = process.env.FLOCI_AZ_ENDPOINT ?? "http://localhost:4577";
+const ACCOUNT = process.env.FLOCI_AZ_ACCOUNT ?? "devstoreaccount1";
+const HOST = process.env.SERVICEBUS_HOST ?? "localhost";
+const PORT = parseInt(process.env.SERVICEBUS_AMQP_PORT ?? "5673", 10);
+const NAMESPACE = process.env.SERVICEBUS_NAMESPACE ?? "default";
+const CONNECTION_STRING =
+  `Endpoint=sb://${HOST}:${PORT};` +
+  "SharedAccessKeyName=RootManageSharedAccessKey;" +
+  "SharedAccessKey=devkey;UseDevelopmentEmulator=true;";
+
+beforeAll(async () => {
+  const response = await fetch(
+    `${BASE}/${ACCOUNT}-servicebus/namespaces/${NAMESPACE}`,
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+      signal: AbortSignal.timeout(120_000),
+    },
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to start Service Bus namespace: HTTP ${response.status}`);
+  }
+  const namespace = (await response.json()) as Record<string, unknown>;
+  if (namespace["mocked"] !== false) {
+    throw new Error("Service Bus compatibility tests require mocked=false");
+  }
+}, 130_000);
+
+function uniqueName(prefix: string): string {
+  return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+async function createEntity(path: string): Promise<void> {
+  const response = await fetch(
+    `${BASE}/${ACCOUNT}-servicebus/${NAMESPACE}/${path}`,
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/atom+xml;charset=utf-8" },
+      body: "",
+      signal: AbortSignal.timeout(30_000),
+    },
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to create Service Bus entity '${path}': HTTP ${response.status}`);
+  }
+}
+
+function testMessage(body: string, rank: number): ServiceBusMessage {
+  return {
+    body,
+    messageId: `id-${body}`,
+    correlationId: `correlation-${rank}`,
+    subject: "peek-subject",
+    applicationProperties: { rank, color: "blue" },
+  };
+}
+
+test("queue peek is bounded, repeatable, and non-destructive", async () => {
+  const queue = uniqueName("peek-queue");
+  await createEntity(`queues/${queue}`);
+  const client = new ServiceBusClient(CONNECTION_STRING);
+  const sender = client.createSender(queue);
+  const receiver = client.createReceiver(queue);
+
+  try {
+    const sent = [testMessage("first", 1), testMessage("second", 2), testMessage("third", 3)];
+    for (const message of sent) {
+      await sender.sendMessages(message);
+    }
+
+    const firstPeek = await receiver.peekMessages(2);
+    expect(firstPeek).toHaveLength(2);
+    expect(firstPeek.map((message) => message.body)).toEqual(["first", "second"]);
+    expect(firstPeek[0].messageId).toBe("id-first");
+    expect(firstPeek[0].correlationId).toBe("correlation-1");
+    expect(firstPeek[0].subject).toBe("peek-subject");
+    expect(firstPeek[0].applicationProperties).toEqual({ rank: 1, color: "blue" });
+    expect(firstPeek[0].sequenceNumber).toBeDefined();
+    expect(firstPeek[0].enqueuedTimeUtc).toBeInstanceOf(Date);
+    expect(firstPeek[0].deliveryCount).toBe(0);
+
+    const repeatedPeek = await receiver.peekMessages(2, {
+      fromSequenceNumber: firstPeek[0].sequenceNumber!,
+    });
+    expect(repeatedPeek.map((message) => message.body)).toEqual(["first", "second"]);
+    expect(repeatedPeek.map((message) => message.deliveryCount)).toEqual(
+      firstPeek.map((message) => message.deliveryCount),
+    );
+    expect(repeatedPeek.map((message) => message.enqueuedTimeUtc?.getTime())).toEqual(
+      firstPeek.map((message) => message.enqueuedTimeUtc?.getTime()),
+    );
+
+    const fromSecond = await receiver.peekMessages(2, {
+      fromSequenceNumber: firstPeek[1].sequenceNumber!,
+    });
+    expect(fromSecond.map((message) => message.body)).toEqual(["second", "third"]);
+
+    const received = await receiver.receiveMessages(3, { maxWaitTimeInMs: 5_000 });
+    expect(received.map((message) => message.body)).toEqual(["first", "second", "third"]);
+    await Promise.all(received.map((message) => receiver.completeMessage(message)));
+    expect(await receiver.peekMessages(1)).toEqual([]);
+  } finally {
+    await receiver.close();
+    await sender.close();
+    await client.close();
+  }
+}, 30_000);
+
+test("subscription peek leaves message available for receive", async () => {
+  const topic = uniqueName("peek-topic");
+  const subscription = "messages";
+  await createEntity(`topics/${topic}`);
+  await createEntity(`topics/${topic}/subscriptions/${subscription}`);
+  const client = new ServiceBusClient(CONNECTION_STRING);
+  const sender = client.createSender(topic);
+  const receiver = client.createReceiver(topic, subscription);
+
+  try {
+    await sender.sendMessages(testMessage("subscription-body", 7));
+    const peeked = await receiver.peekMessages(20);
+    expect(peeked).toHaveLength(1);
+    expect(peeked[0].body).toBe("subscription-body");
+    expect(peeked[0].applicationProperties).toEqual({ rank: 7, color: "blue" });
+
+    const received = await receiver.receiveMessages(1, { maxWaitTimeInMs: 5_000 });
+    expect(received).toHaveLength(1);
+    expect(received[0].body).toBe("subscription-body");
+    await receiver.completeMessage(received[0]);
+  } finally {
+    await receiver.close();
+    await sender.close();
+    await client.close();
+  }
+}, 30_000);
+
+test("empty queue peek returns no messages", async () => {
+  const queue = uniqueName("peek-empty");
+  await createEntity(`queues/${queue}`);
+  const client = new ServiceBusClient(CONNECTION_STRING);
+  const receiver = client.createReceiver(queue);
+  try {
+    expect(await receiver.peekMessages(20)).toEqual([]);
+  } finally {
+    await receiver.close();
+    await client.close();
+  }
+}, 30_000);
+
+test("concurrent clients receive their correlated peek responses", async () => {
+  const queue = uniqueName("peek-concurrent");
+  await createEntity(`queues/${queue}`);
+
+  const senderClient = new ServiceBusClient(CONNECTION_STRING);
+  const sender = senderClient.createSender(queue);
+  const receiverClients = Array.from(
+    { length: 4 },
+    () => new ServiceBusClient(CONNECTION_STRING),
+  );
+  const receivers = receiverClients.map((client) => client.createReceiver(queue));
+
+  try {
+    await sender.sendMessages(testMessage("shared", 1));
+    const [firstPeek] = await receivers[0].peekMessages(1);
+    expect(firstPeek?.body).toBe("shared");
+    const sequenceNumber = firstPeek.sequenceNumber!;
+    for (const receiver of receivers.slice(1)) {
+      const messages = await receiver.peekMessages(1, { fromSequenceNumber: sequenceNumber });
+      expect(messages[0]?.body).toBe("shared");
+    }
+
+    const results = await Promise.all(
+      receivers.map((receiver) =>
+        receiver.peekMessages(1, { fromSequenceNumber: sequenceNumber! }),
+      ),
+    );
+    expect(results.map((messages) => messages[0]?.body)).toEqual([
+      "shared",
+      "shared",
+      "shared",
+      "shared",
+    ]);
+  } finally {
+    await Promise.all(receivers.map((receiver) => receiver.close()));
+    await sender.close();
+    await Promise.all(receiverClients.map((client) => client.close()));
+    await senderClient.close();
+  }
+}, 30_000);

--- a/compatibility-tests/sdk-test-node/tests/servicebus.test.ts
+++ b/compatibility-tests/sdk-test-node/tests/servicebus.test.ts
@@ -149,6 +149,29 @@ test("empty queue peek returns no messages", async () => {
   }
 }, 30_000);
 
+test("peek caps responses at the Azure 250-message limit", async () => {
+  const queue = uniqueName("peek-limit");
+  await createEntity(`queues/${queue}`);
+  const client = new ServiceBusClient(CONNECTION_STRING);
+  const sender = client.createSender(queue);
+  const receiver = client.createReceiver(queue);
+
+  try {
+    for (let index = 0; index <= 250; index++) {
+      await sender.sendMessages({ body: `message-${index}` });
+    }
+
+    const peeked = await receiver.peekMessages(1_000);
+    expect(peeked).toHaveLength(250);
+    expect(peeked[0].body).toBe("message-0");
+    expect(peeked[249].body).toBe("message-249");
+  } finally {
+    await receiver.close();
+    await sender.close();
+    await client.close();
+  }
+}, 60_000);
+
 test("concurrent clients receive their correlated peek responses", async () => {
   const queue = uniqueName("peek-concurrent");
   await createEntity(`queues/${queue}`);

--- a/docs/services/service-bus.md
+++ b/docs/services/service-bus.md
@@ -78,6 +78,13 @@ within that session. Attach responses include Azure's `com.microsoft:locked-unti
 Session ownership lasts for the receiver link. Session state and explicit session-lock renewal are
 not currently emulated.
 
+## Message peeking
+
+Queue and subscription receivers support Azure SDK `peekMessages()` calls through each entity's
+AMQP `$management` node. Peeking preserves message bodies, system properties, and application
+properties; supports `maxMessages` and `fromSequenceNumber`; and does not lock, remove, or change
+delivery count. Empty entities return an empty result.
+
 ## Connection String
 
 ```

--- a/docs/services/service-bus.md
+++ b/docs/services/service-bus.md
@@ -83,7 +83,8 @@ not currently emulated.
 Queue and subscription receivers support Azure SDK `peekMessages()` calls through each entity's
 AMQP `$management` node. Peeking preserves message bodies, system properties, and application
 properties; supports `maxMessages` and `fromSequenceNumber`; and does not lock, remove, or change
-delivery count. Empty entities return an empty result.
+delivery count. Each call returns at most Azure's 250-message limit and may return fewer messages
+when needed to keep the AMQP response bounded. Empty entities return an empty result.
 
 ## Connection String
 

--- a/src/artemis-plugin/java/io/floci/az/artemis/ServiceBusPeekPlugin.java
+++ b/src/artemis-plugin/java/io/floci/az/artemis/ServiceBusPeekPlugin.java
@@ -44,6 +44,8 @@ public final class ServiceBusPeekPlugin implements ActiveMQServerPlugin {
     private static final String MESSAGE = "message";
     private static final String STATUS_CODE = "statusCode";
     private static final String STATUS_DESCRIPTION = "statusDescription";
+    private static final int MAX_MESSAGE_COUNT = 250;
+    private static final int MAX_RESPONSE_PAYLOAD_BYTES = 1_048_576;
     private static final Symbol SEQUENCE_NUMBER = Symbol.valueOf("x-opt-sequence-number");
     private static final Symbol ENQUEUED_TIME = Symbol.valueOf("x-opt-enqueued-time");
 
@@ -102,11 +104,12 @@ public final class ServiceBusPeekPlugin implements ActiveMQServerPlugin {
     private void sendPeekResponse(AMQPMessage request) throws Exception {
         Map<?, ?> body = requestBody(request);
         long fromSequenceNumber = number(body, FROM_SEQUENCE_NUMBER).longValue();
-        int messageCount = number(body, MESSAGE_COUNT).intValue();
-        if (fromSequenceNumber < 0 || messageCount <= 0) {
+        int requestedMessageCount = number(body, MESSAGE_COUNT).intValue();
+        if (fromSequenceNumber < 0 || requestedMessageCount <= 0) {
             sendResponse(request, 400, "Bad Request", Map.of());
             return;
         }
+        int messageCount = Math.min(requestedMessageCount, MAX_MESSAGE_COUNT);
 
         String entityPath = normalizeEntityPath(
                 request.getAddress().substring(0,
@@ -150,7 +153,8 @@ public final class ServiceBusPeekPlugin implements ActiveMQServerPlugin {
             int messageCount,
             String sessionId,
             boolean omitMessageBody) {
-        List<Map<String, Object>> messages = new ArrayList<>(Math.min(messageCount, 256));
+        List<Map<String, Object>> messages = new ArrayList<>(messageCount);
+        int responsePayloadBytes = 0;
         try (LinkedListIterator<MessageReference> iterator = queue.browserIterator()) {
             while (iterator.hasNext() && messages.size() < messageCount) {
                 MessageReference reference = iterator.next();
@@ -159,8 +163,13 @@ public final class ServiceBusPeekPlugin implements ActiveMQServerPlugin {
                         || !matchesSession(source, sessionId)) {
                     continue;
                 }
-                messages.add(Map.of(MESSAGE,
-                        new Binary(encodePeekedMessage(source, reference, omitMessageBody))));
+                byte[] encodedMessage = encodePeekedMessage(source, reference, omitMessageBody);
+                if (!messages.isEmpty()
+                        && encodedMessage.length > MAX_RESPONSE_PAYLOAD_BYTES - responsePayloadBytes) {
+                    break;
+                }
+                messages.add(Map.of(MESSAGE, new Binary(encodedMessage)));
+                responsePayloadBytes += encodedMessage.length;
             }
         }
         return messages;

--- a/src/artemis-plugin/java/io/floci/az/artemis/ServiceBusPeekPlugin.java
+++ b/src/artemis-plugin/java/io/floci/az/artemis/ServiceBusPeekPlugin.java
@@ -1,0 +1,282 @@
+package io.floci.az.artemis;
+
+import org.apache.activemq.artemis.api.core.Message;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.MessageReference;
+import org.apache.activemq.artemis.core.server.Queue;
+import org.apache.activemq.artemis.core.server.RoutingContext;
+import org.apache.activemq.artemis.core.server.plugin.ActiveMQServerPlugin;
+import org.apache.activemq.artemis.protocol.amqp.broker.AMQPMessage;
+import org.apache.activemq.artemis.protocol.amqp.broker.AMQPStandardMessage;
+import org.apache.activemq.artemis.utils.collections.LinkedListIterator;
+import org.apache.qpid.proton.Proton;
+import org.apache.qpid.proton.amqp.Binary;
+import org.apache.qpid.proton.amqp.Symbol;
+import org.apache.qpid.proton.amqp.UnsignedInteger;
+import org.apache.qpid.proton.amqp.messaging.AmqpValue;
+import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
+import org.apache.qpid.proton.amqp.messaging.Header;
+import org.apache.qpid.proton.amqp.messaging.MessageAnnotations;
+import org.apache.qpid.proton.amqp.messaging.Properties;
+
+import java.nio.BufferOverflowException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/** Implements Azure Service Bus non-destructive peek requests on entity management nodes. */
+public final class ServiceBusPeekPlugin implements ActiveMQServerPlugin {
+
+    private static final System.Logger LOG =
+            System.getLogger(ServiceBusPeekPlugin.class.getName());
+    private static final String MANAGEMENT_SUFFIX = "/$management";
+    private static final String PEEK_OPERATION = "com.microsoft:peek-message";
+    private static final String OPERATION = "operation";
+    private static final String FROM_SEQUENCE_NUMBER = "from-sequence-number";
+    private static final String MESSAGE_COUNT = "message-count";
+    private static final String SESSION_ID = "session-id";
+    private static final String OMIT_MESSAGE_BODY = "omit-message-body";
+    private static final String MESSAGES = "messages";
+    private static final String MESSAGE = "message";
+    private static final String STATUS_CODE = "statusCode";
+    private static final String STATUS_DESCRIPTION = "statusDescription";
+    private static final Symbol SEQUENCE_NUMBER = Symbol.valueOf("x-opt-sequence-number");
+    private static final Symbol ENQUEUED_TIME = Symbol.valueOf("x-opt-enqueued-time");
+
+    private volatile ActiveMQServer server;
+
+    @Override
+    public void registered(ActiveMQServer registeredServer) {
+        server = registeredServer;
+    }
+
+    @Override
+    public void unregistered(ActiveMQServer unregisteredServer) {
+        server = null;
+    }
+
+    @Override
+    public void beforeMessageRoute(
+            Message message, RoutingContext context, boolean direct, boolean rejectDuplicates) {
+        if (!(message instanceof AMQPMessage request) || !isPeekRequest(request)) {
+            return;
+        }
+
+        // The multicast management address lets Artemis create one response subscription per
+        // client. Peek requests are handled here and must never reach those subscriptions.
+        context.clear();
+        try {
+            sendPeekResponse(request);
+        } catch (IllegalArgumentException e) {
+            LOG.log(System.Logger.Level.WARNING, "Invalid Service Bus peek request", e);
+            sendErrorResponse(request, 400, "Bad Request");
+        } catch (Exception e) {
+            LOG.log(System.Logger.Level.ERROR, "Could not process Service Bus peek request", e);
+            sendErrorResponse(request, 500, "Internal Server Error");
+        }
+    }
+
+    private void sendErrorResponse(AMQPMessage request, int statusCode, String description) {
+        try {
+            sendResponse(request, statusCode, description, Map.of());
+        } catch (Exception responseError) {
+            LOG.log(System.Logger.Level.ERROR,
+                    "Could not send Service Bus peek error response", responseError);
+        }
+    }
+
+    private static boolean isPeekRequest(AMQPMessage request) {
+        String address = request.getAddress();
+        if (address == null || !address.endsWith(MANAGEMENT_SUFFIX)) {
+            return false;
+        }
+        ApplicationProperties applicationProperties = request.getApplicationProperties();
+        return applicationProperties != null
+                && PEEK_OPERATION.equals(applicationProperties.getValue().get(OPERATION));
+    }
+
+    private void sendPeekResponse(AMQPMessage request) throws Exception {
+        Map<?, ?> body = requestBody(request);
+        long fromSequenceNumber = number(body, FROM_SEQUENCE_NUMBER).longValue();
+        int messageCount = number(body, MESSAGE_COUNT).intValue();
+        if (fromSequenceNumber < 0 || messageCount <= 0) {
+            sendResponse(request, 400, "Bad Request", Map.of());
+            return;
+        }
+
+        String entityPath = normalizeEntityPath(
+                request.getAddress().substring(0,
+                        request.getAddress().length() - MANAGEMENT_SUFFIX.length()));
+        ActiveMQServer activeServer = requireServer();
+        Queue queue = activeServer.locateQueue(SimpleString.of(entityPath));
+        if (queue == null) {
+            sendResponse(request, 404, "Not Found", Map.of());
+            return;
+        }
+
+        String sessionId = body.get(SESSION_ID) instanceof String value ? value : null;
+        boolean omitMessageBody = Boolean.TRUE.equals(body.get(OMIT_MESSAGE_BODY));
+        List<Map<String, Object>> messages = browse(
+                queue, fromSequenceNumber, messageCount, sessionId, omitMessageBody);
+        if (messages.isEmpty()) {
+            sendResponse(request, 204, "No Content", Map.of());
+            return;
+        }
+        sendResponse(request, 200, "OK", Map.of(MESSAGES, messages));
+    }
+
+    private static Map<?, ?> requestBody(AMQPMessage request) {
+        if (request.getBody() instanceof AmqpValue value && value.getValue() instanceof Map<?, ?> map) {
+            return map;
+        }
+        throw new IllegalArgumentException("Peek request body must be an AMQP map");
+    }
+
+    private static Number number(Map<?, ?> body, String key) {
+        Object value = body.get(key);
+        if (value instanceof Number number) {
+            return number;
+        }
+        throw new IllegalArgumentException("Peek request is missing numeric '" + key + "'");
+    }
+
+    private static List<Map<String, Object>> browse(
+            Queue queue,
+            long fromSequenceNumber,
+            int messageCount,
+            String sessionId,
+            boolean omitMessageBody) {
+        List<Map<String, Object>> messages = new ArrayList<>(Math.min(messageCount, 256));
+        try (LinkedListIterator<MessageReference> iterator = queue.browserIterator()) {
+            while (iterator.hasNext() && messages.size() < messageCount) {
+                MessageReference reference = iterator.next();
+                if (reference.getMessageID() < fromSequenceNumber
+                        || !(reference.getMessage() instanceof AMQPMessage source)
+                        || !matchesSession(source, sessionId)) {
+                    continue;
+                }
+                messages.add(Map.of(MESSAGE,
+                        new Binary(encodePeekedMessage(source, reference, omitMessageBody))));
+            }
+        }
+        return messages;
+    }
+
+    private static boolean matchesSession(AMQPMessage source, String sessionId) {
+        if (sessionId == null) {
+            return true;
+        }
+        Properties properties = source.getProperties();
+        return properties != null && sessionId.equals(properties.getGroupId());
+    }
+
+    private static byte[] encodePeekedMessage(
+            AMQPMessage source, MessageReference reference, boolean omitMessageBody) {
+        org.apache.qpid.proton.message.Message peeked = Proton.message();
+        peeked.setHeader(peekHeader(source, reference));
+        peeked.setProperties(source.getProperties());
+        peeked.setApplicationProperties(source.getApplicationProperties());
+        peeked.setFooter(source.getFooter());
+        if (!omitMessageBody) {
+            peeked.setBody(source.getBody());
+        }
+
+        MessageAnnotations sourceAnnotations = source.getMessageAnnotations();
+        Map<Symbol, Object> annotations = sourceAnnotations == null
+                ? new HashMap<>()
+                : new HashMap<>(sourceAnnotations.getValue());
+        annotations.put(SEQUENCE_NUMBER, reference.getMessageID());
+        annotations.put(ENQUEUED_TIME, new Date(enqueuedTime(source)));
+        peeked.setMessageAnnotations(new MessageAnnotations(annotations));
+
+        int capacity = Math.max(1_024, source.getEncodeSize() + 256);
+        while (true) {
+            byte[] encoded = new byte[capacity];
+            try {
+                int length = peeked.encode(encoded, 0, encoded.length);
+                if (length == encoded.length) {
+                    return encoded;
+                }
+                byte[] exact = new byte[length];
+                System.arraycopy(encoded, 0, exact, 0, length);
+                return exact;
+            } catch (BufferOverflowException e) {
+                capacity = Math.multiplyExact(capacity, 2);
+            }
+        }
+    }
+
+    private static Header peekHeader(AMQPMessage source, MessageReference reference) {
+        Header sourceHeader = source.getHeader();
+        Header header = sourceHeader == null ? new Header() : new Header(sourceHeader);
+        header.setDeliveryCount(UnsignedInteger.valueOf(reference.getDeliveryCount()));
+        return header;
+    }
+
+    private static long enqueuedTime(AMQPMessage source) {
+        Long ingressTimestamp = source.getIngressTimestamp();
+        if (ingressTimestamp != null) {
+            return ingressTimestamp;
+        }
+        long creationTime = source.getTimestamp();
+        if (creationTime > 0) {
+            return creationTime;
+        }
+        throw new IllegalStateException("Service Bus message is missing an ingress timestamp");
+    }
+
+    private void sendResponse(
+            AMQPMessage request, int statusCode, String description, Map<String, Object> body)
+            throws Exception {
+        Properties requestProperties = request.getProperties();
+        if (requestProperties == null || requestProperties.getMessageId() == null) {
+            throw new IllegalArgumentException("Peek request is missing message-id");
+        }
+
+        Properties responseProperties = new Properties();
+        responseProperties.setCorrelationId(requestProperties.getMessageId());
+        Map<String, Object> applicationProperties = new HashMap<>();
+        applicationProperties.put(STATUS_CODE, statusCode);
+        applicationProperties.put(STATUS_DESCRIPTION, description);
+
+        ActiveMQServer activeServer = requireServer();
+        AMQPStandardMessage response = AMQPStandardMessage.createMessage(
+                activeServer.getStorageManager().generateID(),
+                0,
+                null,
+                null,
+                responseProperties,
+                null,
+                null,
+                applicationProperties,
+                null,
+                body.isEmpty() ? null : new AmqpValue(body));
+        // Every client receives the response; correlation-id selects the requesting client.
+        response.setAddress(request.getAddress());
+        activeServer.getPostOffice().route(response, false);
+    }
+
+    private ActiveMQServer requireServer() {
+        ActiveMQServer activeServer = server;
+        if (activeServer == null) {
+            throw new IllegalStateException("Service Bus peek plugin is not registered");
+        }
+        return activeServer;
+    }
+
+    private static String normalizeEntityPath(String entityPath) {
+        String lowerCasePath = entityPath.toLowerCase(Locale.ROOT);
+        String subscriptionSegment = "/subscriptions/";
+        int subscriptionIndex = lowerCasePath.indexOf(subscriptionSegment);
+        if (subscriptionIndex < 0) {
+            return entityPath;
+        }
+        return entityPath.substring(0, subscriptionIndex)
+                + "/Subscriptions/"
+                + entityPath.substring(subscriptionIndex + subscriptionSegment.length());
+    }
+}

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusConfigGenerator.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusConfigGenerator.java
@@ -58,6 +58,9 @@ public class ServiceBusConfigGenerator {
                   .startAttr("broker-plugin", "class-name",
                           "io.floci.az.artemis.ServiceBusExpiryPlugin")
                   .end("broker-plugin")
+                  .startAttr("broker-plugin", "class-name",
+                          "io.floci.az.artemis.ServiceBusPeekPlugin")
+                  .end("broker-plugin")
                 .end("broker-plugins")
                 .start("address-settings")
                   .startAttr("address-setting", "match", "#")
@@ -65,6 +68,7 @@ public class ServiceBusConfigGenerator {
                     .elem("dead-letter-address", "DLQ")
                     .elem("auto-create-queues", false)
                     .elem("auto-create-addresses", false)
+                    .elem("enable-ingress-timestamp", true)
                   .end("address-setting")
                 .end("address-settings")
                 .start("diverts")
@@ -82,9 +86,7 @@ public class ServiceBusConfigGenerator {
                     .end("anycast")
                   .end("address")
                   .startAttr("address", "name", "$cbs")
-                    .start("anycast")
-                      .selfClose("queue", "name", "$cbs")
-                    .end("anycast")
+                    .selfClose("multicast")
                   .end("address")
                   .startAttr("address", "name", "$cbs-intercept")
                     .start("anycast")

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -72,6 +72,7 @@ public class ServiceBusNamespaceManager {
     private static final int AMQP_PORT = 5672;
     private static final int AMQPS_PORT = 5671;
     private static final int JOLOKIA_PORT = 8161;
+    private static final String MANAGEMENT_SUFFIX = "/$management";
     private static final String DEAD_LETTER_QUEUE_SUFFIX = "/$DeadLetterQueue";
     private static final String SUBSCRIPTION_DIVERT_SUFFIX = "/$Divert";
     private static final String TOPIC_ADDRESS_SUFFIX = "/$Topic";
@@ -266,6 +267,8 @@ public class ServiceBusNamespaceManager {
             jolokiaExec(http, baseUrl, auth, mbean,
                     "createQueue(java.lang.String,java.lang.String,java.lang.String,java.lang.String,boolean,int,boolean,boolean)",
                     jsonArr(deadLetterQueue, "ANYCAST", deadLetterQueue, "", true, -1, false, false));
+            createManagementAddress(http, baseUrl, auth, mbean, queueName);
+            createManagementAddress(http, baseUrl, auth, mbean, deadLetterQueue);
             applySessionMetadata(http, baseUrl, auth, mbean, queueName,
                     requiresSession, lockDurationSeconds);
             applySessionMetadata(http, baseUrl, auth, mbean, deadLetterQueue,
@@ -285,6 +288,8 @@ public class ServiceBusNamespaceManager {
     public void jolokiaDeleteQueue(String namespaceName, String queueName) {
         String deadLetterQueue = queueName + DEAD_LETTER_QUEUE_SUFFIX;
         withJolokia(namespaceName, (http, baseUrl, auth, mbean) -> {
+            deleteManagementAddress(http, baseUrl, auth, mbean, queueName);
+            deleteManagementAddress(http, baseUrl, auth, mbean, deadLetterQueue);
             jolokiaExec(http, baseUrl, auth, mbean,
                     "destroyQueue(java.lang.String,boolean,boolean)",
                     jsonArr(queueName, true, true));
@@ -412,6 +417,8 @@ public class ServiceBusNamespaceManager {
             jolokiaExec(http, baseUrl, auth, mbean,
                     "createQueue(java.lang.String,java.lang.String,java.lang.String,java.lang.String,boolean,int,boolean,boolean)",
                     jsonArr(deadLetterQueue, "ANYCAST", deadLetterQueue, "", true, -1, false, false));
+            createManagementAddress(http, baseUrl, auth, mbean, queueName);
+            createManagementAddress(http, baseUrl, auth, mbean, deadLetterQueue);
             applySessionMetadata(http, baseUrl, auth, mbean, queueName,
                     requiresSession, lockDurationSeconds);
             applySessionMetadata(http, baseUrl, auth, mbean, deadLetterQueue,
@@ -453,6 +460,8 @@ public class ServiceBusNamespaceManager {
         String deadLetterQueue = queueName + DEAD_LETTER_QUEUE_SUFFIX;
         String divertName = queueName + SUBSCRIPTION_DIVERT_SUFFIX;
         withJolokia(namespaceName, (http, baseUrl, auth, mbean) -> {
+            deleteManagementAddress(http, baseUrl, auth, mbean, queueName);
+            deleteManagementAddress(http, baseUrl, auth, mbean, deadLetterQueue);
             jolokiaExec(http, baseUrl, auth, mbean,
                     "destroyDivert(java.lang.String)",
                     jsonArr(divertName));
@@ -482,6 +491,22 @@ public class ServiceBusNamespaceManager {
         jolokiaExec(http, baseUrl, auth, EXPIRY_MBEAN,
                 "configure(java.lang.String,long,java.lang.String)",
                 jsonArr(queueName, ttlMillis, deadLetterAddress));
+    }
+
+    private void createManagementAddress(
+            HttpClient http, String baseUrl, String auth, String mbean, String entityPath) {
+        String managementAddress = entityPath + MANAGEMENT_SUFFIX;
+        jolokiaExec(http, baseUrl, auth, mbean,
+                "createAddress(java.lang.String,java.lang.String)",
+                jsonArr(managementAddress, "MULTICAST"));
+    }
+
+    private void deleteManagementAddress(
+            HttpClient http, String baseUrl, String auth, String mbean, String entityPath) {
+        String managementAddress = entityPath + MANAGEMENT_SUFFIX;
+        jolokiaExec(http, baseUrl, auth, mbean,
+                "deleteAddress(java.lang.String,boolean)",
+                jsonArr(managementAddress, true));
     }
 
     private void removeExpiry(

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusConfigGeneratorTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusConfigGeneratorTest.java
@@ -38,6 +38,9 @@ class ServiceBusConfigGeneratorTest {
                 "class-name=\"io.floci.az.artemis.ServiceBusDuplicateDetectionPlugin\""));
         assertTrue(brokerXml.contains(
                 "class-name=\"io.floci.az.artemis.ServiceBusExpiryPlugin\""));
+        assertTrue(brokerXml.contains(
+                "class-name=\"io.floci.az.artemis.ServiceBusPeekPlugin\""));
+        assertTrue(brokerXml.contains("<enable-ingress-timestamp>true</enable-ingress-timestamp>"));
     }
 
     @Test
@@ -55,6 +58,7 @@ class ServiceBusConfigGeneratorTest {
         assertTrue(brokerXml.contains("<forwarding-address>$cbs-intercept</forwarding-address>"));
         assertTrue(brokerXml.contains("<filter string=\"operation = &apos;put-token&apos;\"/>"));
         assertTrue(brokerXml.contains("<exclusive>true</exclusive>"));
+        assertTrue(brokerXml.contains("<address name=\"$cbs\"><multicast/></address>"));
         assertTrue(brokerXml.contains("<queue name=\"$cbs-intercept\"/>"));
     }
 
@@ -83,14 +87,15 @@ class ServiceBusConfigGeneratorTest {
     }
 
     @Test
-    void packagesMessageExpiryPluginForTheArtemisSidecar() throws Exception {
+    void packagesServiceBusPluginsForTheArtemisSidecar() throws Exception {
         try (InputStream stream = getClass().getResourceAsStream(
                 ServiceBusNamespaceManager.ARTEMIS_EXTENSION_RESOURCE)) {
             assertNotNull(stream, "Artemis extension JAR must be embedded in the application");
             try (JarInputStream jar = new JarInputStream(stream)) {
                 Set<String> expectedClasses = Set.of(
                         "io/floci/az/artemis/ServiceBusExpiryPlugin.class",
-                        "io/floci/az/artemis/ServiceBusExpiryPluginMBean.class");
+                        "io/floci/az/artemis/ServiceBusExpiryPluginMBean.class",
+                        "io/floci/az/artemis/ServiceBusPeekPlugin.class");
                 Set<String> packagedClasses = new HashSet<>();
                 for (var entry = jar.getNextJarEntry(); entry != null; entry = jar.getNextJarEntry()) {
                     if (expectedClasses.contains(entry.getName())) {


### PR DESCRIPTION
## Summary

- implement Azure Service Bus queue and subscription `peekMessages()` through Artemis `$management` nodes
- preserve message bodies, system/application properties, sequence filtering, enqueue timestamps, and delivery counts without locking or consuming messages
- isolate management and CBS responses across concurrent clients with per-client multicast subscriptions
- add Azure JavaScript SDK 7.9.5 compatibility coverage and synchronize mocked=false CI/Makefile configuration
- document message peeking support

## Testing

- `./mvnw test` — 748 passed
- `npx tsc --noEmit` — passed
- real Artemis with `@azure/service-bus` 7.9.5 — 4 tests passed, including four concurrent clients
- `git diff --check` — passed

Closes #137