### PR TITLE
feat(sql): add data-plane providers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,6 +206,7 @@ $(foreach e,$(COSMOS_ENGINES),$(eval $(call COSMOS_RULES,$(e))))
 
 run-sql:
 	$(MVN) quarkus:dev -Dno-color \
+		"-Dfloci-az.services.sql.data-plane.provider=managed" \
 		"-Dfloci-az.services.sql.accept-eula=Y" > emulator.log 2>&1 & echo $$! > $(PID_FILE)
 	@until curl -s http://localhost:$(PORT)/health > /dev/null; do sleep 1; done
 	@echo "Emulator is up! (SQL service — EULA accepted)"

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ flowchart LR
 | **Key Vault**           | `/{account}-keyvault/`       | Secrets CRUD, versioning, soft-delete, properties update                                                                                                                                                              |
 | **Event Hubs**          | AMQP `:5672` / Kafka `:9093` | AMQP 1.0 (Artemis sidecar), Kafka-compatible (Redpanda, opt-in)                                                                                                                                                       |
 | **Service Bus**         | `/{account}-servicebus/` + AMQP `:5673` | Queues, topics, subscriptions (created dynamically); AMQP 1.0 data plane via Artemis sidecar, or mocked (management plane only)                                                                             |
-| **Azure SQL Database**  | ARM path + `/{account}-sql/` | Servers, databases, firewall rules; Docker-backed SQL Server 2025 containers; dynamic port allocation                                                                                                                |
+| **Azure SQL Database**  | ARM path + `/{account}-sql/` | Servers, databases, firewall rules; ARM-only by default, optional managed SQL Server 2025 containers                                                                                                                 |
 | **Azure Database for PostgreSQL** | ARM path (`Microsoft.DBforPostgreSQL`) + `/{account}-postgres/` | Flexible servers, databases, firewall rules, configurations; Docker-backed `postgres:17-alpine` containers (no EULA), dynamic port allocation, or mocked |
 | **Azure Kubernetes Service** | ARM path (`Microsoft.ContainerService`) | CreateOrUpdate, Get, Delete, List, agent pools, kubeconfig (`listClusterAdminCredential`); real k3s containers or mocked |
 | **API Management**      | ARM path (`Microsoft.ApiManagement`) + `/{account}-apim/{service}/` | In-process APIM emulator for ARM resources, gateway routing, products/subscriptions, named values, backends, OpenAPI import, and a focused policy subset |
@@ -381,7 +381,7 @@ Floci AZ uses real Docker containers when in-process emulation would reduce fide
 | Cosmos DB PostgreSQL | `citusdata/citus` | Citus — the exact engine Azure runs |
 | Cosmos DB Cassandra | `scylladb/scylla:6.2` | CQL-compatible drop-in |
 | Cosmos DB Gremlin | `tinkerpop/gremlin-server` | Apache TinkerPop — standard Gremlin traversals |
-| Azure SQL Database | `mcr.microsoft.com/mssql/server:2025-latest` | SQL Server engine (per server) |
+| Azure SQL Database | `mcr.microsoft.com/mssql/server:2025-latest` | Optional managed SQL Server engine (per server) |
 | Azure Database for PostgreSQL | `postgres:17-alpine` | PostgreSQL engine (per flexible server) |
 | AKS | `rancher/k3s:latest` | Kubernetes API server via k3s |
 | Azure Cache for Redis | `valkey/valkey:8-alpine` | Redis / Valkey protocol (per cache) |

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/SqlCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/SqlCompatibilityTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  * <ul>
  *   <li>floci-az emulator running (default: http://localhost:4577)</li>
  *   <li>Docker available so floci-az can start SQL Server containers</li>
+ *   <li>Managed provider: {@code FLOCI_AZ_SERVICES_SQL_DATA_PLANE_PROVIDER=managed}</li>
  *   <li>EULA accepted: {@code FLOCI_AZ_SERVICES_SQL_ACCEPT_EULA=Y} set in the emulator</li>
  * </ul>
  *
@@ -94,6 +95,9 @@ class SqlCompatibilityTest {
         // Fetch connection info for the master database
         HttpResponse<String> connectResp = send("GET",
             BASE + "/devstoreaccount1-sql/servers/" + SERVER + "/connect", null);
+        assumeTrue(connectResp.statusCode() != 409,
+            "SQL data plane is disabled — set FLOCI_AZ_SERVICES_SQL_DATA_PLANE_PROVIDER=managed "
+                + "and restart emulator");
         assertEquals(200, connectResp.statusCode(),
             "/connect failed: " + connectResp.body());
 

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/SqlCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/SqlCompatibilityTest.java
@@ -95,7 +95,9 @@ class SqlCompatibilityTest {
         // Fetch connection info for the master database
         HttpResponse<String> connectResp = send("GET",
             BASE + "/devstoreaccount1-sql/servers/" + SERVER + "/connect", null);
-        assumeTrue(connectResp.statusCode() != 409,
+        boolean dataPlaneDisabled = connectResp.statusCode() == 409
+            && connectResp.body().contains("\"code\":\"DataPlaneNotEnabled\"");
+        assumeTrue(!dataPlaneDisabled,
             "SQL data plane is disabled — set FLOCI_AZ_SERVICES_SQL_DATA_PLANE_PROVIDER=managed "
                 + "and restart emulator");
         assertEquals(200, connectResp.statusCode(),

--- a/docs/configuration/docker-compose.md
+++ b/docs/configuration/docker-compose.md
@@ -54,8 +54,8 @@ services:
 
 ### With Azure SQL Database
 
-SQL Server containers are started on-demand when a server is created via the management API.
-The Docker socket mount is required:
+SQL defaults to control-plane-only mode and needs no Docker socket. To opt into managed SQL Server
+containers, set the provider to `managed`, accept the EULA, and mount the Docker socket:
 
 ```yaml
 services:
@@ -66,6 +66,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
+      FLOCI_AZ_SERVICES_SQL_DATA_PLANE_PROVIDER: managed
       FLOCI_AZ_SERVICES_SQL_ACCEPT_EULA: "Y"   # accept the Microsoft SQL Server EULA
       # FLOCI_AZ_SERVICES_SQL_IMAGE: "mcr.microsoft.com/mssql/server:2025-latest"
 ```
@@ -236,7 +237,9 @@ All variables are optional; the default applies when unset.
 
 | Variable | Default | Description |
 |---|---|---|
-| `FLOCI_AZ_SERVICES_SQL_ACCEPT_EULA` | _(empty)_ | Set to `Y` to accept the Microsoft SQL Server EULA (required) |
+| `FLOCI_AZ_SERVICES_SQL_DATA_PLANE_PROVIDER` | `none` | `none` for ARM state only; `managed` for a real SQL Server container; `external` is reserved |
+| `FLOCI_AZ_SERVICES_SQL_MOCKED` | _(unset)_ | Deprecated provider alias: `true` = `none`, `false` = `managed` |
+| `FLOCI_AZ_SERVICES_SQL_ACCEPT_EULA` | `N` | Set to `Y` to accept the Microsoft SQL Server EULA (managed mode only) |
 | `FLOCI_AZ_SERVICES_SQL_IMAGE` | `mcr.microsoft.com/mssql/server:2025-latest` | Docker image for SQL Server containers |
 | `FLOCI_AZ_SERVICES_SQL_STARTUP_TIMEOUT_SECONDS` | `60` | Seconds to wait for SQL Server to become ready |
 

--- a/docs/configuration/ports.md
+++ b/docs/configuration/ports.md
@@ -39,7 +39,7 @@ These ports are resolved at runtime via the Docker daemon — you never configur
 
 | Service | Sidecar container | Protocol | How to discover port |
 |---|---|---|---|
-| Azure SQL Database | `mssql/server` | TDS (SQL Server) | `GET /{account}-sql/servers/{name}/connect` → `port` field |
+| Azure SQL Database (`managed`) | `mssql/server` | TDS (SQL Server) | `GET /{account}-sql/servers/{name}/connect` → `port` field |
 | Azure Kubernetes Service | `rancher/k3s` | HTTPS (Kubernetes API) | `POST .../listClusterAdminCredential` → `kubeconfigs[0].value` → `server:` in kubeconfig |
 | Cosmos MongoDB | `mongo` | MongoDB wire | `GET /{account}-cosmosmongo/connect` → `port` field |
 | Cosmos PostgreSQL | `postgres` | PostgreSQL | `GET /{account}-cosmospostgresql/connect` → `port` field |

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -15,7 +15,7 @@ Floci-AZ provides emulation for several core Azure services.
 | **Key Vault** | `/{account}-keyvault/` | ✅ Secrets CRUD, versioning, soft-delete, properties update |
 | **Event Hubs** | AMQP `:5672` / Kafka `:9093` | ✅ AMQP 1.0 (Artemis), Kafka-compatible (Redpanda, opt-in) |
 | **Service Bus** | `/{account}-servicebus/` + AMQP `:5673` | ✅ Queues, topics, subscriptions (dynamic); AMQP 1.0 via Artemis sidecar or mocked |
-| **Azure SQL Database** | ARM path + `/{account}-sql/` | ✅ Servers, databases, firewall rules; Docker-backed SQL Server containers |
+| **Azure SQL Database** | ARM path + `/{account}-sql/` | ✅ Servers, databases, firewall rules; ARM-only by default, managed SQL Server opt-in |
 | **Azure Kubernetes Service** | ARM path (`Microsoft.ContainerService`) | ✅ Clusters, agent pools, credentials; real k3s containers or mocked |
 | **API Management** | ARM path (`Microsoft.ApiManagement`) + `/{account}-apim/` | ✅ APIs, operations, products, subscriptions, named values, backends, OpenAPI import; gateway routing + policy subset |
 | **Virtual Network** | ARM path (`Microsoft.Network`) | ✅ VNets, subnets, NICs, public IPs, NSGs, private DNS zones (+ virtual network links, record sets), private endpoints (+ private DNS zone groups), private link services; in-process ARM state for Terraform/OpenTofu and VM dependencies |
@@ -40,7 +40,7 @@ The following services spin up Docker containers on demand and require the Docke
 | Service | Docker image | Data plane |
 |---|---|---|
 | **Azure Functions** | User-provided image | HTTP to container |
-| **Azure SQL Database** | `mcr.microsoft.com/mssql/server:2025-latest` | TDS direct to container port |
+| **Azure SQL Database** | `mcr.microsoft.com/mssql/server:2025-latest` | Optional managed mode; TDS direct to container port |
 | **Cosmos DB engines** | Various (mongo, postgres, cassandra, …) | Protocol direct to container port |
 | **Azure Kubernetes Service** | `rancher/k3s:latest` | kubectl direct to k3s API server port |
 

--- a/docs/services/sql.md
+++ b/docs/services/sql.md
@@ -1,26 +1,41 @@
 # Azure SQL Database
 
-Compatible with the `mssql-jdbc`, `pyodbc`, `System.Data.SqlClient`, and any TDS-speaking client.
-
-> **Requires Docker** — each logical SQL Server maps to one SQL Server 2025 container.
-> The data plane (TDS/port 1433) goes **directly** to the container; floci-az only handles
-> the management plane (ARM REST API).
+Management-plane operations work without Docker by default. Set the data-plane provider to
+`managed` to use `mssql-jdbc`, `pyodbc`, `System.Data.SqlClient`, or another TDS-speaking client
+against a real SQL Server 2025 container.
 
 ---
 
 ## Features
 
-- **Servers** — create, get, list, delete; one Docker container per logical server
+- **Servers** — create, get, list, delete; immediate ARM state by default
 - **Databases** — create (with optional collation), get, list, delete; guarded against dropping `master`
 - **Firewall rules** — full CRUD; metadata-only (no actual IP filtering in dev mode)
 - **Connection policy** — GET returns `Default` (read-only)
 - **Name availability check** — `POST .../checkNameAvailability`
-- **Connection strings** — convenience endpoint returns JDBC, ADO.NET, pyodbc, and EF Core strings ready to use
-- **EULA guard** — server creation returns `503` until `FLOCI_AZ_SERVICES_SQL_ACCEPT_EULA=Y` is set
+- **Data-plane providers** — `none` (default), `managed`, and reserved `external`
+- **Connection strings** — managed mode returns JDBC, ADO.NET, pyodbc, and EF Core strings
+- **EULA guard** — managed server creation requires `FLOCI_AZ_SERVICES_SQL_ACCEPT_EULA=Y`
 
 ---
 
-## EULA Requirement
+## Data-plane providers
+
+| Provider | Behavior |
+|---|---|
+| `none` | Default. Azure-compatible ARM state only; no Docker access, image pull, EULA, or TDS endpoint. |
+| `managed` | Starts one real SQL Server container per logical server. Requires Docker and EULA acceptance. |
+| `external` | Reserved for a later release. Requests currently return `DataPlaneProviderUnavailable`. |
+
+When `none` is selected, `/connect` returns `409 DataPlaneNotEnabled`. ARM responses still expose
+the Azure-shaped `{server}.database.windows.net` hostname and never include emulator-only port data.
+
+The deprecated `mocked` setting remains a compatibility alias when `data-plane.provider` is absent:
+`true` maps to `none`; `false` maps to `managed`.
+
+---
+
+## EULA Requirement (managed provider only)
 
 SQL Server is covered by the [Microsoft SQL Server EULA](https://go.microsoft.com/fwlink/?linkid=857698).
 You must explicitly accept it before the emulator will start any container:
@@ -33,10 +48,10 @@ FLOCI_AZ_SERVICES_SQL_ACCEPT_EULA=Y
 -Dfloci-az.services.sql.accept-eula=Y
 ```
 
-Without it, `PUT /servers/{name}` returns:
+Without it, managed `PUT /servers/{name}` returns:
 
 ```json
-{ "error": "EulaNotAccepted", "message": "..." }
+{ "error": { "code": "EulaNotAccepted", "message": "..." } }
 ```
 
 ---
@@ -65,6 +80,9 @@ The `/connect` endpoints are a **floci-az addition** — they return all connect
 
 ## Quickstart
 
+This data-plane quickstart assumes `data-plane.provider: managed`, Docker access, and accepted EULA.
+For ARM-only use, keep the default `none` provider and stop after creating management resources.
+
 ### 1 — Create a server
 
 ```bash
@@ -80,7 +98,7 @@ curl -s -X PUT \
   }'
 ```
 
-> First call starts the container and waits for the SQL Server engine to become ready (~30 s with
+> In managed mode, first call starts the container and waits for SQL Server to become ready (~30 s with
 > a cached image, longer on the first pull of the SQL Server image).
 
 ### 2 — Get connection strings
@@ -235,12 +253,8 @@ PORT=$(curl -s "http://localhost:4577/devstoreaccount1-sql/servers/myserver/conn
        | python3 -c "import sys,json; print(json.load(sys.stdin)['port'])")
 ```
 
-**The server GET response (`localPort` property):**
-
-```bash
-curl -s "http://localhost:4577/subscriptions/my-sub/resourceGroups/my-rg/providers/Microsoft.Sql/servers/myserver?api-version=2021-11-01" \
-  | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['properties']['localPort'])"
-```
+ARM resources intentionally omit the emulator-specific port. Use `/connect` for reachable endpoint
+details in data-plane modes.
 
 ---
 
@@ -296,7 +310,8 @@ floci-az:
   services:
     sql:
       enabled: true
-      mocked: false                                 # false (default) = real SQL Server container (needs accept-eula=Y). true = management plane only, no Docker, no EULA
+      data-plane:
+        provider: managed                           # none (default) | managed | external (reserved)
       accept-eula: "Y"                              # Required to start containers
       image: "mcr.microsoft.com/mssql/server:2025-latest"
       startup-timeout-seconds: 60
@@ -305,16 +320,12 @@ floci-az:
 Microsoft supports SQL Server Linux container images only on Intel and AMD x86-64 hosts.
 ARM64 hosts require an explicitly configured alternative image or unsupported CPU emulation.
 
-In **mocked** mode (`mocked: true`) servers are created in state and report
-`state=Ready` with no SQL Server container and no EULA required — useful for
-management-plane testing without Docker. The data plane is unavailable (no live
-JDBC endpoint), so the `/connect` endpoints return no usable port.
-
 | Environment Variable | Default | Description |
 |---|---|---|
 | `FLOCI_AZ_SERVICES_SQL_ENABLED` | `true` | Enable or disable the SQL service |
-| `FLOCI_AZ_SERVICES_SQL_MOCKED` | `false` | Mocked mode (management plane only, no Docker, no EULA) |
-| `FLOCI_AZ_SERVICES_SQL_ACCEPT_EULA` | _(empty)_ | Set to `Y` to accept the Microsoft SQL Server EULA |
+| `FLOCI_AZ_SERVICES_SQL_DATA_PLANE_PROVIDER` | `none` | Data-plane provider: `none`, `managed`, or reserved `external` |
+| `FLOCI_AZ_SERVICES_SQL_MOCKED` | _(unset)_ | Deprecated alias used only when provider is unset: `true` = `none`, `false` = `managed` |
+| `FLOCI_AZ_SERVICES_SQL_ACCEPT_EULA` | `N` | Set to `Y` to accept the Microsoft SQL Server EULA in managed mode |
 | `FLOCI_AZ_SERVICES_SQL_IMAGE` | `mcr.microsoft.com/mssql/server:2025-latest` | Docker image to use for SQL Server containers |
 | `FLOCI_AZ_SERVICES_SQL_STARTUP_TIMEOUT_SECONDS` | `60` | Seconds to wait for the SQL Server engine to become ready |
 
@@ -332,6 +343,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock   # required for SQL + Functions
     environment:
+      FLOCI_AZ_SERVICES_SQL_DATA_PLANE_PROVIDER: managed
       FLOCI_AZ_SERVICES_SQL_ACCEPT_EULA: "Y"
       # SQL Server containers bind a random port directly to the host.
       # Do NOT add those ports here — floci-az manages them via Docker socket.
@@ -359,5 +371,6 @@ services:
 └──────────────────────────────────────────────────────────────┘
 ```
 
-The management plane (ARM API) goes through floci-az on port 4577.
-The data plane (TDS protocol) connects **directly** to the SQL Server container on its dynamic port — floci-az is not in the data path.
+The management plane (ARM API) always goes through floci-az on port 4577. With `provider=managed`,
+the data plane connects **directly** to the SQL Server container on its dynamic port. With
+`provider=none`, no data-plane container or port exists.

--- a/docs/services/sql.md
+++ b/docs/services/sql.md
@@ -33,6 +33,10 @@ the Azure-shaped `{server}.database.windows.net` hostname and never include emul
 The deprecated `mocked` setting remains a compatibility alias when `data-plane.provider` is absent:
 `true` maps to `none`; `false` maps to `managed`.
 
+For upgrade compatibility, `accept-eula: "Y"` also selects `managed` when neither
+`data-plane.provider` nor `mocked` is configured. An explicit provider or legacy `mocked` value
+always takes precedence.
+
 ---
 
 ## EULA Requirement (managed provider only)

--- a/src/main/java/io/floci/az/config/EmulatorConfig.java
+++ b/src/main/java/io/floci/az/config/EmulatorConfig.java
@@ -542,13 +542,24 @@ public interface EmulatorConfig {
         SqlDataPlaneConfig dataPlane();
 
         /**
-         * Resolves the explicit provider, then the legacy {@code mocked} alias, then the
-         * control-plane-only default.
+         * Resolves the explicit provider, then the legacy {@code mocked} alias. When neither is
+         * configured, an accepted EULA preserves the legacy managed data plane; otherwise the
+         * service defaults to control-plane-only behavior.
          */
         default SqlDataPlaneProvider dataPlaneProvider() {
-            return dataPlane().provider().orElseGet(() -> mocked()
-                .map(value -> value ? SqlDataPlaneProvider.NONE : SqlDataPlaneProvider.MANAGED)
-                .orElse(SqlDataPlaneProvider.NONE));
+            Optional<SqlDataPlaneProvider> provider = dataPlane().provider();
+            if (provider.isPresent()) {
+                return provider.get();
+            }
+
+            Optional<Boolean> legacyMocked = mocked();
+            if (legacyMocked.isPresent()) {
+                return legacyMocked.get() ? SqlDataPlaneProvider.NONE : SqlDataPlaneProvider.MANAGED;
+            }
+
+            return "Y".equalsIgnoreCase(acceptEula())
+                ? SqlDataPlaneProvider.MANAGED
+                : SqlDataPlaneProvider.NONE;
         }
 
         /**

--- a/src/main/java/io/floci/az/config/EmulatorConfig.java
+++ b/src/main/java/io/floci/az/config/EmulatorConfig.java
@@ -532,12 +532,24 @@ public interface EmulatorConfig {
         boolean enabled();
 
         /**
-         * When {@code true}, no SQL Server container is started; servers are created in state and
-         * transition immediately to {@code state=Ready} (no EULA required). The data plane is
-         * unavailable (no live JDBC endpoint). Useful for tests without Docker.
+         * Legacy data-plane switch. Prefer {@code data-plane.provider}. When the provider is not
+         * explicitly configured, {@code true} maps to {@link SqlDataPlaneProvider#NONE} and
+         * {@code false} maps to {@link SqlDataPlaneProvider#MANAGED}.
          */
-        @WithDefault("false")
-        boolean mocked();
+        @Deprecated
+        Optional<Boolean> mocked();
+
+        SqlDataPlaneConfig dataPlane();
+
+        /**
+         * Resolves the explicit provider, then the legacy {@code mocked} alias, then the
+         * control-plane-only default.
+         */
+        default SqlDataPlaneProvider dataPlaneProvider() {
+            return dataPlane().provider().orElseGet(() -> mocked()
+                .map(value -> value ? SqlDataPlaneProvider.NONE : SqlDataPlaneProvider.MANAGED)
+                .orElse(SqlDataPlaneProvider.NONE));
+        }
 
         /**
          * Must be set to "Y" to accept the Microsoft SQL Server EULA.
@@ -568,6 +580,17 @@ public interface EmulatorConfig {
         /** Default host port. 0 lets the OS pick a free port (recommended when running multiple servers). */
         @WithDefault("0")
         int defaultPort();
+    }
+
+    interface SqlDataPlaneConfig {
+        /** Azure SQL data-plane provider: none, managed, or external. */
+        Optional<SqlDataPlaneProvider> provider();
+    }
+
+    enum SqlDataPlaneProvider {
+        NONE,
+        MANAGED,
+        EXTERNAL
     }
 
     /**

--- a/src/main/java/io/floci/az/core/BannerLogger.java
+++ b/src/main/java/io/floci/az/core/BannerLogger.java
@@ -9,16 +9,21 @@ import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
+import java.util.Locale;
+
 @ApplicationScoped
 public class BannerLogger {
 
     private static final Logger LOGGER = Logger.getLogger(BannerLogger.class);
 
-    @Inject
-    EmulatorConfig config;
+    private final EmulatorConfig config;
+    private final CosmosEngineRegistry cosmosEngineRegistry;
 
     @Inject
-    CosmosEngineRegistry cosmosEngineRegistry;
+    public BannerLogger(EmulatorConfig config, CosmosEngineRegistry cosmosEngineRegistry) {
+        this.config = config;
+        this.cosmosEngineRegistry = cosmosEngineRegistry;
+    }
 
     void onStart(@Observes StartupEvent ev) {
         LOGGER.info("=== FLOCI - AZ Starting ===");
@@ -72,6 +77,12 @@ public class BannerLogger {
         }
         if (config.services().keyVault().enabled()) {
             sb.append(serviceStatus("keyvault", true, getStorageMode("keyvault")));
+        }
+        if (config.services().sql().enabled()) {
+            String provider = config.services().sql().dataPlaneProvider().name()
+                .toLowerCase(Locale.ROOT);
+            sb.append(String.format("   %-9s [%s]  data-plane: %-8s storage: %s\n",
+                "sql", "enabled ", provider, getStorageMode("sql")));
         }
         if (config.services().eventHub().enabled()) {
             String amqpInfo = "amqp:" + config.services().eventHub().amqpPort()
@@ -156,6 +167,7 @@ public class BannerLogger {
             case "cosmos"    -> config.storage().services().cosmos().mode().orElse(config.storage().mode());
             case "keyvault"  -> config.storage().services().keyVault().mode().orElse(config.storage().mode());
             case "servicebus" -> config.storage().services().serviceBus().mode().orElse(config.storage().mode());
+            case "sql"       -> config.storage().services().sql().mode().orElse(config.storage().mode());
             default          -> config.storage().mode();
         };
     }

--- a/src/main/java/io/floci/az/services/sql/SqlConnectionInfo.java
+++ b/src/main/java/io/floci/az/services/sql/SqlConnectionInfo.java
@@ -22,8 +22,8 @@ public record SqlConnectionInfo(
     /**
      * Builds connection strings for the given host/port and credentials.
      *
-     * @param host      hostname — always {@code localhost} in single-node dev mode
-     * @param port      the host port that the SQL Server container is bound to
+     * @param host      reachable data-plane hostname
+     * @param port      reachable SQL Server port
      * @param login     SQL Server login (typically {@code sa})
      * @param password  SQL Server password
      * @param database  database name, or {@code null} / empty for server-level strings

--- a/src/main/java/io/floci/az/services/sql/SqlHandler.java
+++ b/src/main/java/io/floci/az/services/sql/SqlHandler.java
@@ -2,7 +2,6 @@ package io.floci.az.services.sql;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.AzureRequest;
 import io.floci.az.core.AzureServiceHandler;
@@ -21,8 +20,10 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+
+import static io.floci.az.config.EmulatorConfig.SqlDataPlaneProvider.EXTERNAL;
+import static io.floci.az.config.EmulatorConfig.SqlDataPlaneProvider.NONE;
 
 /**
  * HTTP handler for Azure SQL Database management-plane requests.
@@ -50,14 +51,21 @@ public class SqlHandler implements AzureServiceHandler, Resettable {
 
     private static final Logger LOG = Logger.getLogger(SqlHandler.class);
 
-    @Inject EmulatorConfig config;
-    @Inject SqlState       state;
-    @Inject SqlServerManager serverManager;
-
-    private final ObjectMapper mapper = new ObjectMapper();
+    private final EmulatorConfig config;
+    private final SqlState state;
+    private final SqlServerManager serverManager;
+    private final ObjectMapper mapper;
 
     /** Guards concurrent server-start operations (per server name). */
     private final ConcurrentHashMap<String, Object> startLocks = new ConcurrentHashMap<>();
+
+    @Inject
+    public SqlHandler(EmulatorConfig config, SqlState state, SqlServerManager serverManager) {
+        this.config = config;
+        this.state = state;
+        this.serverManager = serverManager;
+        this.mapper = new ObjectMapper();
+    }
 
     @Override public String getServiceType()           { return "sql"; }
 
@@ -176,7 +184,12 @@ public class SqlHandler implements AzureServiceHandler, Resettable {
     }
 
     private Response createOrUpdateServer(AzureRequest request, String serverName) {
-        if (!config.services().sql().enabled()) return serviceDisabled();
+        if (!config.services().sql().enabled()) {
+            return serviceDisabled();
+        }
+        if (config.services().sql().dataPlaneProvider() == EXTERNAL) {
+            return dataPlaneProviderUnavailable();
+        }
 
         try {
             JsonNode body = readBody(request.bodyStream());
@@ -203,9 +216,8 @@ public class SqlHandler implements AzureServiceHandler, Resettable {
                     null, 0, "localhost", tags, databases, firewallRules, Instant.now());
                 state.putServer(entry);
 
-                if (config.services().sql().mocked()) {
-                    // Mocked mode: no SQL Server container (no Docker, no EULA). The server is
-                    // pure ARM state and reports state=Ready; the data plane is unavailable.
+                if (config.services().sql().dataPlaneProvider() == NONE) {
+                    // Control-plane-only mode: no Docker access or EULA requirement.
                     state.putDatabase(serverName, SqlState.SqlDatabaseEntry.master(serverName));
                     return Response.status(201).entity(serverResponse(entry)).build();
                 }
@@ -227,15 +239,11 @@ public class SqlHandler implements AzureServiceHandler, Resettable {
                     }
                 } catch (SqlServerManager.EulaNotAcceptedException e) {
                     state.removeServer(serverName);
-                    return Response.status(503)
-                        .entity(Map.of("error", "EulaNotAccepted", "message", e.getMessage()))
-                        .build();
+                    return ArmErrors.error(503, "EulaNotAccepted", e.getMessage());
                 } catch (Exception e) {
                     state.removeServer(serverName);
                     LOG.errorf(e, "Failed to start SQL Server container for server=%s", serverName);
-                    return Response.status(500)
-                        .entity(Map.of("error", "ContainerStartFailed", "message", e.getMessage()))
-                        .build();
+                    return ArmErrors.error(500, "ContainerStartFailed", e.getMessage());
                 }
             } else {
                 entry = state.getServer(serverName).get();
@@ -422,27 +430,24 @@ public class SqlHandler implements AzureServiceHandler, Resettable {
     // ── Convenience /connect ──────────────────────────────────────────────────
 
     private Response handleServerConnect(String serverName) {
-        return state.getServer(serverName)
-            .map(s -> {
-                SqlConnectionInfo info = SqlConnectionInfo.of(
-                    s.fullyQualifiedDomainName(), s.hostPort(),
-                    s.administratorLogin(), "***", null);
-                return Response.ok(connectResponse(s, info, null)).build();
-            })
-            .orElse(notFound("Server '" + serverName + "' not found"));
+        Optional<SqlState.SqlServerEntry> server = state.getServer(serverName);
+        if (server.isEmpty()) {
+            return notFound("Server '" + serverName + "' not found");
+        }
+        return connectResponse(server.get(), null);
     }
 
     private Response handleDatabaseConnect(String serverName, String dbName) {
         Optional<SqlState.SqlServerEntry> serverOpt = state.getServer(serverName);
-        if (serverOpt.isEmpty()) return notFound("Server '" + serverName + "' not found");
+        if (serverOpt.isEmpty()) {
+            return notFound("Server '" + serverName + "' not found");
+        }
         Optional<SqlState.SqlDatabaseEntry> dbOpt = state.getDatabase(serverName, dbName);
-        if (dbOpt.isEmpty()) return notFound("Database '" + dbName + "' not found");
+        if (dbOpt.isEmpty()) {
+            return notFound("Database '" + dbName + "' not found");
+        }
 
-        SqlState.SqlServerEntry server = serverOpt.get();
-        SqlConnectionInfo info = SqlConnectionInfo.of(
-            server.fullyQualifiedDomainName(), server.hostPort(),
-            server.administratorLogin(), "***", dbName);
-        return Response.ok(connectResponse(server, info, dbName)).build();
+        return connectResponse(serverOpt.get(), dbName);
     }
 
     // ── Response builders ─────────────────────────────────────────────────────
@@ -451,14 +456,11 @@ public class SqlHandler implements AzureServiceHandler, Resettable {
         Map<String, Object> props = new LinkedHashMap<>();
         props.put("administratorLogin", s.administratorLogin());
         props.put("version", "12.0");
-        props.put("state", (config.services().sql().mocked() || s.containerId() != null) ? "Ready" : "Creating");
+        props.put("state", (config.services().sql().dataPlaneProvider() == NONE
+            || s.containerId() != null) ? "Ready" : "Creating");
         props.put("fullyQualifiedDomainName", s.fullyQualifiedDomainName());
         props.put("minimalTlsVersion", "None");
         props.put("publicNetworkAccess", "Enabled");
-        // floci-az convenience — not in the real spec. This is the reachable port (the published
-        // host port for host networking, or the in-network container port when floci-az runs in a
-        // container). Prefer the /connect endpoint, which returns the matching reachable host.
-        if (s.hostPort() > 0) props.put("localPort", s.hostPort());
 
         Map<String, Object> resp = new LinkedHashMap<>();
         resp.put("id", s.armId());
@@ -510,10 +512,16 @@ public class SqlHandler implements AzureServiceHandler, Resettable {
         return resp;
     }
 
-    private Map<String, Object> connectResponse(SqlState.SqlServerEntry server,
-                                                 SqlConnectionInfo info, String database) {
+    private Response connectResponse(SqlState.SqlServerEntry server, String database) {
+        if (config.services().sql().dataPlaneProvider() == NONE) {
+            return dataPlaneNotEnabled();
+        }
+        if (server.hostPort() <= 0) {
+            return ArmErrors.error(409, "DataPlaneNotReady",
+                "SQL data plane for server '" + server.serverName() + "' is not ready.");
+        }
         SqlConnectionInfo real = SqlConnectionInfo.of(
-            server.fullyQualifiedDomainName(), server.hostPort(),
+            server.dataPlaneHost(), server.hostPort(),
             server.administratorLogin(), server.administratorLoginPassword(),
             database);
         Map<String, Object> resp = new LinkedHashMap<>();
@@ -525,7 +533,7 @@ public class SqlHandler implements AzureServiceHandler, Resettable {
         resp.put("connectionString", real.adoNet());
         resp.put("pyodbc",        real.pyodbc());
         resp.put("entityFramework", real.efCore());
-        return resp;
+        return Response.ok(resp).build();
     }
 
     // ── Parsing helpers ───────────────────────────────────────────────────────
@@ -600,6 +608,17 @@ public class SqlHandler implements AzureServiceHandler, Resettable {
         return Response.status(503).entity(Map.of(
             "error", Map.of("code", "ServiceDisabled",
                 "message", "Azure SQL Database service is disabled on this emulator."))).build();
+    }
+
+    private static Response dataPlaneNotEnabled() {
+        return ArmErrors.error(409, "DataPlaneNotEnabled",
+            "Azure SQL data plane is disabled. Set floci-az.services.sql.data-plane.provider "
+                + "to managed to enable connection discovery.");
+    }
+
+    private static Response dataPlaneProviderUnavailable() {
+        return ArmErrors.error(503, "DataPlaneProviderUnavailable",
+            "Azure SQL external data-plane provider is not configured in this version.");
     }
 
     /**

--- a/src/main/java/io/floci/az/services/sql/SqlHandler.java
+++ b/src/main/java/io/floci/az/services/sql/SqlHandler.java
@@ -516,6 +516,9 @@ public class SqlHandler implements AzureServiceHandler, Resettable {
         if (config.services().sql().dataPlaneProvider() == NONE) {
             return dataPlaneNotEnabled();
         }
+        if (config.services().sql().dataPlaneProvider() == EXTERNAL) {
+            return dataPlaneProviderUnavailable();
+        }
         if (server.hostPort() <= 0) {
             return ArmErrors.error(409, "DataPlaneNotReady",
                 "SQL data plane for server '" + server.serverName() + "' is not ready.");

--- a/src/main/java/io/floci/az/services/sql/SqlState.java
+++ b/src/main/java/io/floci/az/services/sql/SqlState.java
@@ -267,13 +267,13 @@ public class SqlState {
                 id, port, reachableHost, tags, databases, firewallRules, createdAt);
         }
 
-        /**
-         * The host an application uses to reach the data plane. Azure would expose
-         * {@code {name}.database.windows.net}; floci-az returns the actually-reachable host —
-         * {@code localhost} for host networking, or the container name when floci-az runs
-         * inside Docker on a shared network.
-         */
+        /** Azure-shaped public hostname returned by ARM resource responses. */
         public String fullyQualifiedDomainName() {
+            return serverName + ".database.windows.net";
+        }
+
+        /** Reachable host returned by the emulator-specific connection discovery endpoint. */
+        public String dataPlaneHost() {
             return host != null && !host.isBlank() ? host : "localhost";
         }
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -156,7 +156,10 @@ floci-az:
       consumer-groups: "$Default,my-consumer-group"
     sql:
       enabled: true
-      mocked: false         # false = back servers with a real SQL Server container (needs accept-eula=Y). true = no Docker; servers are pure ARM state (no EULA)
+      # data-plane.provider defaults to none. Set to managed for a real SQL Server container.
+      # data-plane:
+      #   provider: managed
+      # mocked: false       # Deprecated alias: true = none, false = managed
       # accept-eula: "Y"     # Must be set to "Y" to accept the Microsoft SQL Server EULA
       image: "mcr.microsoft.com/mssql/server:2025-latest"
       sa-password: "FlociAz_Strong123!"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -156,7 +156,7 @@ floci-az:
       consumer-groups: "$Default,my-consumer-group"
     sql:
       enabled: true
-      # data-plane.provider defaults to none. Set to managed for a real SQL Server container.
+      # data-plane.provider defaults to none, unless accept-eula=Y preserves legacy managed mode.
       # data-plane:
       #   provider: managed
       # mocked: false       # Deprecated alias: true = none, false = managed

--- a/src/test/java/io/floci/az/config/EmulatorConfigSqlTest.java
+++ b/src/test/java/io/floci/az/config/EmulatorConfigSqlTest.java
@@ -1,0 +1,27 @@
+package io.floci.az.config;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static io.floci.az.config.EmulatorConfig.SqlDataPlaneProvider.MANAGED;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Answers.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class EmulatorConfigSqlTest {
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void acceptedEulaPreservesLegacyManagedProvider() {
+        EmulatorConfig.SqlServiceConfig sql = mock(EmulatorConfig.SqlServiceConfig.class, CALLS_REAL_METHODS);
+        EmulatorConfig.SqlDataPlaneConfig dataPlane = mock(EmulatorConfig.SqlDataPlaneConfig.class);
+        when(sql.dataPlane()).thenReturn(dataPlane);
+        when(dataPlane.provider()).thenReturn(Optional.empty());
+        when(sql.mocked()).thenReturn(Optional.empty());
+        when(sql.acceptEula()).thenReturn("Y");
+
+        assertEquals(MANAGED, sql.dataPlaneProvider());
+    }
+}

--- a/src/test/java/io/floci/az/services/sql/SqlHandlerExternalTest.java
+++ b/src/test/java/io/floci/az/services/sql/SqlHandlerExternalTest.java
@@ -1,0 +1,48 @@
+package io.floci.az.services.sql;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+@QuarkusTest
+@TestProfile(SqlHandlerExternalTest.ExternalProfile.class)
+class SqlHandlerExternalTest {
+
+    @Inject
+    SqlState state;
+
+    @BeforeEach
+    void resetState() {
+        given().post("/_admin/reset").then().statusCode(204);
+    }
+
+    @Test
+    void externalProviderRejectsConnectionDiscoveryForPersistedManagedServer() {
+        state.putServer(new SqlState.SqlServerEntry(
+            "externalserver", "test-sub", "test-rg", "eastus", "sa", "StrongPass1!",
+            null, 14330, "localhost", Map.of(), new ConcurrentHashMap<>(),
+            new ConcurrentHashMap<>(), Instant.now()));
+
+        given()
+            .when().get("/devstoreaccount1-sql/servers/externalserver/connect")
+            .then().statusCode(503)
+            .body("error.code", equalTo("DataPlaneProviderUnavailable"));
+    }
+
+    public static class ExternalProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("floci-az.services.sql.data-plane.provider", "external");
+        }
+    }
+}

--- a/src/test/java/io/floci/az/services/sql/SqlHandlerManagedTest.java
+++ b/src/test/java/io/floci/az/services/sql/SqlHandlerManagedTest.java
@@ -1,0 +1,42 @@
+package io.floci.az.services.sql;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+/** Tests managed-provider validation without requiring Docker. */
+@QuarkusTest
+@TestProfile(SqlHandlerManagedTest.ManagedProfile.class)
+@DisplayName("SqlHandler — managed provider validation")
+class SqlHandlerManagedTest {
+
+    public static class ManagedProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                "floci-az.services.sql.data-plane.provider", "managed",
+                "floci-az.services.sql.mocked", "true");
+        }
+    }
+
+    @Test
+    @DisplayName("explicit managed provider overrides legacy mocked alias and requires EULA")
+    void managedProviderRequiresEula() {
+        given()
+            .contentType("application/json")
+            .body("{\"location\":\"eastus\",\"properties\":{"
+                + "\"administratorLogin\":\"sa\","
+                + "\"administratorLoginPassword\":\"FlociAz_Strong123!\"}}")
+            .when().put("/subscriptions/test-sub/resourceGroups/test-rg/providers/Microsoft.Sql"
+                + "/servers/managedserver?api-version=2021-11-01")
+            .then().statusCode(503)
+            .body("error.code", equalTo("EulaNotAccepted"));
+    }
+}

--- a/src/test/java/io/floci/az/services/sql/SqlHandlerMockedTest.java
+++ b/src/test/java/io/floci/az/services/sql/SqlHandlerMockedTest.java
@@ -13,12 +13,11 @@ import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.*;
 
 /**
- * Tests for {@link SqlHandler} in {@code mocked=true} mode: servers are created in state with no
- * SQL Server container and no EULA requirement, transitioning immediately to {@code state=Ready}.
+ * Verifies the deprecated {@code mocked=true} alias still selects the control-plane-only provider.
  */
 @QuarkusTest
 @TestProfile(SqlHandlerMockedTest.MockedProfile.class)
-@DisplayName("SqlHandler — mocked mode (no Docker, no EULA)")
+@DisplayName("SqlHandler — legacy mocked mode compatibility")
 @SuppressWarnings("unused")
 class SqlHandlerMockedTest {
 
@@ -51,6 +50,8 @@ class SqlHandlerMockedTest {
             .then().statusCode(201)
             .body("name", equalTo("mockedserver"))
             .body("properties.state", equalTo("Ready"))
+            .body("properties.fullyQualifiedDomainName",
+                equalTo("mockedserver.database.windows.net"))
             .body("properties", not(hasKey("localPort")));
     }
 

--- a/src/test/java/io/floci/az/services/sql/SqlHandlerTest.java
+++ b/src/test/java/io/floci/az/services/sql/SqlHandlerTest.java
@@ -21,7 +21,7 @@ import static org.hamcrest.Matchers.*;
  *   <li>checkNameAvailability</li>
  *   <li>Firewall rule CRUD (metadata, no Docker)</li>
  *   <li>Connection policy default</li>
- *   <li>EULA guard — 503 when ACCEPT_EULA is not set</li>
+ *   <li>Default control-plane-only provisioning without Docker or EULA</li>
  * </ul>
  *
  * <p>Tests that require an actual SQL Server container (CREATE DATABASE, JDBC
@@ -122,20 +122,27 @@ class SqlHandlerTest {
             .body("error.message", containsString("administratorLoginPassword"));
     }
 
-    // ── EULA guard ────────────────────────────────────────────────────────────
+    // ── Default data-plane provider ──────────────────────────────────────────
 
     @Test
-    @DisplayName("PUT server returns 503 when EULA not accepted")
-    void putServerEulaNotAccepted() {
-        // Default config has acceptEula="" — should get 503
+    @DisplayName("default provider creates Azure-shaped control-plane state without EULA")
+    void putServerDefaultsToControlPlaneOnly() {
         given()
             .contentType("application/json")
             .body("{\"location\":\"eastus\",\"properties\":{"
                 + "\"administratorLogin\":\"sa\","
                 + "\"administratorLoginPassword\":\"FlociAz_Strong123!\"}}")
-            .when().put(BASE + "/servers/eulatest?api-version=2021-11-01")
-            .then().statusCode(503)
-            .body("error", equalTo("EulaNotAccepted"));
+            .when().put(BASE + "/servers/controlplane?api-version=2021-11-01")
+            .then().statusCode(201)
+            .body("properties.state", equalTo("Ready"))
+            .body("properties.fullyQualifiedDomainName",
+                equalTo("controlplane.database.windows.net"))
+            .body("properties", not(hasKey("localPort")));
+
+        given()
+            .when().get("/" + ACCOUNT + "-sql/servers/controlplane/connect")
+            .then().statusCode(409)
+            .body("error.code", equalTo("DataPlaneNotEnabled"));
     }
 
     // ── Firewall rules (no container needed) ─────────────────────────────────

--- a/src/test/java/io/floci/az/services/sql/SqlStateTest.java
+++ b/src/test/java/io/floci/az/services/sql/SqlStateTest.java
@@ -47,6 +47,8 @@ class SqlStateTest {
         Optional<SqlState.SqlServerEntry> found = state.getServer("myserver");
         assertTrue(found.isPresent());
         assertEquals("myserver", found.get().serverName());
+        assertEquals("myserver.database.windows.net", found.get().fullyQualifiedDomainName());
+        assertEquals("localhost", found.get().dataPlaneHost());
     }
 
     @Test
@@ -217,7 +219,8 @@ class SqlStateTest {
         assertEquals("new-container", updated.containerId());
         assertEquals(14444, updated.hostPort());
         assertEquals("floci-az-sql-srv", updated.host());
-        assertEquals("floci-az-sql-srv", updated.fullyQualifiedDomainName());
+        assertEquals("floci-az-sql-srv", updated.dataPlaneHost());
+        assertEquals("srv.database.windows.net", updated.fullyQualifiedDomainName());
         // original is immutable
         assertEquals("container-abc", original.containerId());
     }


### PR DESCRIPTION
## Summary

- add explicit SQL data-plane providers: `none`, `managed`, and reserved `external`
- default SQL to fast control-plane-only provisioning with no Docker or EULA requirement
- retain the deprecated `mocked` setting as a compatibility alias
- return Azure-shaped FQDNs and remove `localPort` from ARM resources
- return `DataPlaneNotEnabled` from connection discovery when no data plane is configured
- update configuration, compatibility tests, banner output, and documentation

## Tests

- focused SQL suite: 40 tests passed
- full repository suite: 749 tests passed

First of two dependent fork PRs. The follow-up adds asynchronous managed provisioning.

Refs #138