### PR TITLE
feat(servicebus): honor per-entity MaxDeliveryCount and LockDuration

### DIFF
--- a/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
+++ b/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
@@ -307,6 +307,70 @@ public sealed class ServiceBusCompatibilityTests
         await deadLetterReceiver.CompleteMessageAsync(expired, cancellationToken);
     }
 
+    [Test]
+    [NotInParallel("servicebus-broker")]
+    [Timeout(90_000)]
+    public async Task MaxDeliveryCountDeadLettersWhenExceeded(CancellationToken cancellationToken)
+    {
+        const string serviceBusNamespace = "default";
+        string queue = $"dotnet-mdc-{Guid.NewGuid():N}";
+        await EnsureNamespace(serviceBusNamespace, cancellationToken);
+        await EnsureQueue(serviceBusNamespace, queue, maxDeliveryCount: 2, cancellationToken);
+
+        string connectionString =
+            $"Endpoint=sb://{ServiceBusHost}:{ServiceBusPort};" +
+            "SharedAccessKeyName=RootManageSharedAccessKey;" +
+            "SharedAccessKey=devkey;UseDevelopmentEmulator=true;";
+        await using var client = new ServiceBusClient(connectionString, new ServiceBusClientOptions
+        {
+            RetryOptions = { TryTimeout = TimeSpan.FromSeconds(30) }
+        });
+
+        await using ServiceBusSender sender = client.CreateSender(queue);
+        await sender.SendMessageAsync(new ServiceBusMessage("poison"), cancellationToken);
+
+        // Exhaust the entity's two delivery attempts by abandoning both. Only the relative
+        // delivery count is asserted: the emulator's AMQP delivery-count header is 1-based
+        // where Azure's is 0-based, and this SDK adds one on receive.
+        await using ServiceBusReceiver receiver = client.CreateReceiver(queue);
+        ServiceBusReceivedMessage first = await Receive(receiver, cancellationToken);
+        await receiver.AbandonMessageAsync(first, cancellationToken: cancellationToken);
+        ServiceBusReceivedMessage second = await Receive(receiver, cancellationToken);
+        await Assert.That(second.DeliveryCount).IsEqualTo(first.DeliveryCount + 1);
+        await receiver.AbandonMessageAsync(second, cancellationToken: cancellationToken);
+
+        await Assert.That(await receiver.ReceiveMessageAsync(
+            TimeSpan.FromSeconds(1), cancellationToken)).IsNull();
+
+        await using ServiceBusReceiver deadLetterReceiver = client.CreateReceiver(
+            queue, new ServiceBusReceiverOptions { SubQueue = SubQueue.DeadLetter });
+        ServiceBusReceivedMessage deadLettered = await Receive(deadLetterReceiver, cancellationToken);
+        await Assert.That(deadLettered.Body.ToString()).IsEqualTo("poison");
+        await deadLetterReceiver.CompleteMessageAsync(deadLettered, cancellationToken);
+    }
+
+    private static async Task EnsureQueue(
+        string serviceBusNamespace,
+        string queue,
+        int maxDeliveryCount,
+        CancellationToken cancellationToken)
+    {
+        string body = $"""
+            <entry xmlns="http://www.w3.org/2005/Atom">
+              <content type="application/xml">
+                <QueueDescription xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect">
+                  <MaxDeliveryCount>{maxDeliveryCount}</MaxDeliveryCount>
+                </QueueDescription>
+              </content>
+            </entry>
+            """;
+        await PutEntity(
+            $"{EmulatorEndpoint}/devstoreaccount1-servicebus/{serviceBusNamespace}/queues/{queue}",
+            body,
+            "Queue",
+            cancellationToken);
+    }
+
     private static async Task AssertExpiresIntoDeadLetterQueue(
         ServiceBusClient client,
         string queue,

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/EmulatorConfig.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/EmulatorConfig.java
@@ -438,12 +438,22 @@ public final class EmulatorConfig {
 
     /** Creates a queue via the floci-az management API (ATOM XML). */
     static void ensureServiceBusQueue(String queueName, boolean requiresSession) throws Exception {
+        ensureServiceBusQueue(queueName,
+                requiresSession ? "<RequiresSession>true</RequiresSession>" : null);
+    }
+
+    /**
+     * Creates a queue via the floci-az management API with the given inner
+     * {@code QueueDescription} elements (e.g. {@code <MaxDeliveryCount>2</MaxDeliveryCount>}),
+     * or an empty body when {@code descriptionElements} is null.
+     */
+    static void ensureServiceBusQueue(String queueName, String descriptionElements) throws Exception {
         String url = BASE + "/" + ACCOUNT + "-servicebus/" + SERVICEBUS_NAMESPACE
                 + "/queues/" + queueName;
-        String body = requiresSession
+        String body = descriptionElements != null
                 ? "<entry xmlns=\"http://www.w3.org/2005/Atom\"><content type=\"application/xml\">"
                   + "<QueueDescription xmlns=\"http://schemas.microsoft.com/netservices/2010/10/servicebus/connect\">"
-                  + "<RequiresSession>true</RequiresSession></QueueDescription></content></entry>"
+                  + descriptionElements + "</QueueDescription></content></entry>"
                 : "";
         byte[] bodyBytes = body.getBytes(StandardCharsets.UTF_8);
         HttpURLConnection conn = (HttpURLConnection) URI.create(url).toURL().openConnection();

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/ServiceBusCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/ServiceBusCompatibilityTest.java
@@ -127,6 +127,51 @@ class ServiceBusCompatibilityTest {
     }
 
     @Test
+    @DisplayName("entity MaxDeliveryCount dead-letters after the configured attempts")
+    void maxDeliveryCountDeadLettersAfterEntityLimit() throws Exception {
+        String queue = uniqueName("mdc");
+        EmulatorConfig.ensureServiceBusQueue(queue, "<MaxDeliveryCount>2</MaxDeliveryCount>");
+        String payload = "mdc-" + UUID.randomUUID();
+
+        send(queue, payload);
+
+        // Exhaust the entity's two delivery attempts by abandoning both. Only the relative
+        // delivery count is asserted: the emulator's AMQP delivery-count header is 1-based
+        // where Azure's is 0-based, and this SDK reads the header verbatim.
+        long previousCount = -1;
+        for (int attempt = 1; attempt <= 2; attempt++) {
+            try (ServiceBusReceiverClient receiver = peekLockReceiver(queue)) {
+                ServiceBusReceivedMessage msg = receiver.receiveMessages(1, RECV_TIMEOUT)
+                        .stream().findFirst().orElse(null);
+                assertNotNull(msg, "Expected delivery attempt " + attempt);
+                assertTrue(msg.getDeliveryCount() > previousCount,
+                        "Delivery count should increase on each attempt");
+                previousCount = msg.getDeliveryCount();
+                receiver.abandon(msg);
+            }
+        }
+
+        // The third attempt must yield nothing: the broker dead-lettered the message.
+        try (ServiceBusReceiverClient receiver = peekLockReceiver(queue)) {
+            long count = receiver.receiveMessages(1, Duration.ofSeconds(2)).stream().count();
+            assertEquals(0, count, "Message should be gone after MaxDeliveryCount attempts");
+        }
+
+        try (ServiceBusReceiverClient dlqReceiver = EmulatorConfig.serviceBusClientBuilder()
+                .receiver()
+                .queueName(queue)
+                .subQueue(com.azure.messaging.servicebus.models.SubQueue.DEAD_LETTER_QUEUE)
+                .receiveMode(ServiceBusReceiveMode.PEEK_LOCK)
+                .buildClient()) {
+            ServiceBusReceivedMessage dlqMsg = dlqReceiver.receiveMessages(1, RECV_TIMEOUT)
+                    .stream().findFirst().orElse(null);
+            assertNotNull(dlqMsg, "Message should be dead-lettered after exceeding MaxDeliveryCount");
+            assertEquals(payload, dlqMsg.getBody().toString());
+            dlqReceiver.complete(dlqMsg);
+        }
+    }
+
+    @Test
     @DisplayName("message properties round-trip correctly")
     void messageProperties() throws Exception {
         String queue = uniqueQueue();

--- a/docs/services/service-bus.md
+++ b/docs/services/service-bus.md
@@ -150,8 +150,8 @@ services:
 | `FLOCI_AZ_SERVICES_SERVICE_BUS_AMQP_PORT` | `5673` | Host port for AMQP (Artemis) |
 | `FLOCI_AZ_SERVICES_SERVICE_BUS_AMQP_TLS_PORT` | `5674` | Host port for AMQPS |
 | `FLOCI_AZ_SERVICES_SERVICE_BUS_ARTEMIS_IMAGE` | `apache/activemq-artemis:2.44.0` | Artemis image; must match bundled protocol patches |
-| `FLOCI_AZ_SERVICES_SERVICE_BUS_MAX_DELIVERY_COUNT` | `10` | Max delivery attempts before dead-lettering |
-| `FLOCI_AZ_SERVICES_SERVICE_BUS_LOCK_DURATION_SECONDS` | `60` | Peek-lock duration |
+| `FLOCI_AZ_SERVICES_SERVICE_BUS_MAX_DELIVERY_COUNT` | `10` | Default max delivery attempts before dead-lettering, for entities that do not set `MaxDeliveryCount` |
+| `FLOCI_AZ_SERVICES_SERVICE_BUS_LOCK_DURATION_SECONDS` | `60` | Default peek-lock duration, for entities that do not set `LockDuration` |
 
 ### application.yml
 
@@ -164,13 +164,24 @@ floci-az:
       amqp-port: 5673
       amqp-tls-port: 5674
       artemis-image: "apache/activemq-artemis:2.44.0"
-      max-delivery-count: 10
-      lock-duration-seconds: 60
+      max-delivery-count: 10      # default when the entity omits MaxDeliveryCount
+      lock-duration-seconds: 60   # default when the entity omits LockDuration
 ```
+
+### Per-entity delivery settings
+
+Queues and subscriptions honor `MaxDeliveryCount` (1–2000) and `LockDuration`
+(up to `PT5M`) from the entity-create payload, matching Azure. A message is
+dead-lettered once its delivery count exceeds the entity's `MaxDeliveryCount`.
+`LockDuration` is enforced for session-enabled entities (session locks expire
+and can be reacquired after the configured duration); non-session peek-lock
+expiry is not enforced by the broker. Entities that omit either property fall
+back to the configured defaults above.
 
 ## Out of scope (future work)
 
 - Session state and explicit session-lock renewal
+- Non-session peek-lock expiry enforcement
 - Deferred messages and auto-forwarding
-- Duplicate detection and message transactions
+- Message transactions
 - Geo-disaster recovery and partitioned entities

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusEntityXml.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusEntityXml.java
@@ -14,6 +14,8 @@ final class ServiceBusEntityXml {
             Duration.ofSeconds(DEFAULT_DUPLICATE_DETECTION_HISTORY_SECONDS);
     private static final long MIN_DUPLICATE_DETECTION_HISTORY_SECONDS = Duration.ofSeconds(20).toSeconds();
     private static final long MAX_DUPLICATE_DETECTION_HISTORY_SECONDS = Duration.ofDays(7).toSeconds();
+    private static final int MAX_DELIVERY_COUNT_LIMIT = 2000;
+    private static final long MAX_LOCK_DURATION_SECONDS = Duration.ofMinutes(5).toSeconds();
 
     private ServiceBusEntityXml() {}
 
@@ -63,4 +65,43 @@ final class ServiceBusEntityXml {
     }
 
     record MessageLifetimeSettings(long ttlMillis, boolean deadLetterOnExpiration) {}
+
+    /**
+     * Parses the per-entity delivery settings from a queue or subscription description.
+     * Null components mean the element was absent from the payload; the handler falls
+     * back to the configured emulator-wide defaults in that case.
+     */
+    static DeliverySettings parseDelivery(String xml) {
+        Integer maxDeliveryCount = null;
+        String rawCount = XmlParser.extractFirst(xml, "MaxDeliveryCount", null);
+        if (rawCount != null) {
+            try {
+                maxDeliveryCount = Integer.valueOf(rawCount.trim());
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("MaxDeliveryCount must be an integer", e);
+            }
+            if (maxDeliveryCount < 1 || maxDeliveryCount > MAX_DELIVERY_COUNT_LIMIT) {
+                throw new IllegalArgumentException(
+                        "MaxDeliveryCount must be between 1 and " + MAX_DELIVERY_COUNT_LIMIT);
+            }
+        }
+        Long lockDurationSeconds = null;
+        String rawLock = XmlParser.extractFirst(xml, "LockDuration", null);
+        if (rawLock != null) {
+            final Duration lock;
+            try {
+                lock = Duration.parse(rawLock.trim());
+            } catch (DateTimeParseException e) {
+                throw new IllegalArgumentException("LockDuration must be an ISO-8601 duration", e);
+            }
+            if (lock.isNegative() || lock.isZero() || lock.getNano() != 0
+                    || lock.getSeconds() > MAX_LOCK_DURATION_SECONDS) {
+                throw new IllegalArgumentException("LockDuration must be between PT1S and PT5M");
+            }
+            lockDurationSeconds = lock.getSeconds();
+        }
+        return new DeliverySettings(maxDeliveryCount, lockDurationSeconds);
+    }
+
+    record DeliverySettings(Integer maxDeliveryCount, Long lockDurationSeconds) {}
 }

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
@@ -267,9 +267,11 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         boolean requiresSession = body.contains("<RequiresSession>true</RequiresSession>");
         ServiceBusEntityXml.DuplicateDetectionSettings duplicateDetection;
         ServiceBusEntityXml.MessageLifetimeSettings lifetime;
+        ServiceBusEntityXml.DeliverySettings delivery;
         try {
             duplicateDetection = ServiceBusEntityXml.duplicateDetection(body);
             lifetime = ServiceBusEntityXml.parseMessageLifetime(body);
+            delivery = ServiceBusEntityXml.parseDelivery(body);
         } catch (IllegalArgumentException e) {
             return badRequestAtom(e.getMessage());
         }
@@ -279,7 +281,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         }
         // Default to queue (empty body, QueueDescription, or ambiguous)
         return handleCreateQueue(
-                account, ns, entityName, requiresSession, duplicateDetection, lifetime);
+                account, ns, entityName, requiresSession, duplicateDetection, lifetime, delivery);
     }
 
     private Response handleSpecEntityDelete(String account, String ns, String entityName) {
@@ -481,7 +483,8 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                 try {
                     yield handleCreateQueue(account, namespace, queueName, requiresSession,
                             ServiceBusEntityXml.duplicateDetection(body),
-                            ServiceBusEntityXml.parseMessageLifetime(body));
+                            ServiceBusEntityXml.parseMessageLifetime(body),
+                            ServiceBusEntityXml.parseDelivery(body));
                 } catch (IllegalArgumentException e) {
                     yield badRequestAtom(e.getMessage());
                 }
@@ -504,7 +507,8 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
     private Response handleCreateQueue(String account, String namespace, String queueName,
                                         boolean requiresSession,
                                         ServiceBusEntityXml.DuplicateDetectionSettings duplicateDetection,
-                                        ServiceBusEntityXml.MessageLifetimeSettings lifetime) {
+                                        ServiceBusEntityXml.MessageLifetimeSettings lifetime,
+                                        ServiceBusEntityXml.DeliverySettings delivery) {
         String key = queueKey(account, namespace, queueName);
         if (store.get(key).isPresent()) {
             ServiceBusModels.QueueEntity existing =
@@ -517,13 +521,16 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         }
         EmulatorConfig.ServiceBusConfig sb = config.services().serviceBus();
         ServiceBusModels.QueueEntity queue = ServiceBusModels.QueueEntity.defaults(
-                queueName, sb.maxDeliveryCount(), sb.lockDurationSeconds(), requiresSession,
-                duplicateDetection, lifetime);
+                queueName,
+                delivery.maxDeliveryCount() != null ? delivery.maxDeliveryCount() : sb.maxDeliveryCount(),
+                delivery.lockDurationSeconds() != null ? delivery.lockDurationSeconds() : sb.lockDurationSeconds(),
+                requiresSession, duplicateDetection, lifetime);
         store.put(key, toStoredObject(key, queue));
 
         try {
             namespaceManager.jolokiaCreateQueue(namespace, queueName,
-                    queue.requiresSession(), queue.lockDurationSeconds(), duplicateDetection, lifetime);
+                    queue.requiresSession(), queue.lockDurationSeconds(),
+                    queue.maxDeliveryCount(), duplicateDetection, lifetime);
         } catch (Exception e) {
             LOG.warnf(e, "Failed to provision queue '%s' in Artemis for namespace '%s'", queueName, namespace);
         }
@@ -662,7 +669,8 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                 try {
                     yield handleCreateSubscription(account, namespace, topicName, subName,
                             requiresSession, body,
-                            ServiceBusEntityXml.parseMessageLifetime(body));
+                            ServiceBusEntityXml.parseMessageLifetime(body),
+                            ServiceBusEntityXml.parseDelivery(body));
                 } catch (IllegalArgumentException e) {
                     yield badRequestAtom(e.getMessage());
                 }
@@ -687,7 +695,8 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
     private Response handleCreateSubscription(String account, String namespace,
                                                 String topicName, String subName,
                                                 boolean requiresSession, String body,
-                                                ServiceBusEntityXml.MessageLifetimeSettings lifetime) {
+                                                ServiceBusEntityXml.MessageLifetimeSettings lifetime,
+                                                ServiceBusEntityXml.DeliverySettings delivery) {
         Optional<StoredObject> storedTopic = store.get(topicKey(account, namespace, topicName));
         if (storedTopic.isEmpty()) {
             return notFoundAtom("Topic not found: " + topicName);
@@ -716,7 +725,9 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
 
         EmulatorConfig.ServiceBusConfig sb = config.services().serviceBus();
         ServiceBusModels.SubscriptionEntity sub = ServiceBusModels.SubscriptionEntity.defaults(
-                topicName, subName, sb.maxDeliveryCount(), sb.lockDurationSeconds(),
+                topicName, subName,
+                delivery.maxDeliveryCount() != null ? delivery.maxDeliveryCount() : sb.maxDeliveryCount(),
+                delivery.lockDurationSeconds() != null ? delivery.lockDurationSeconds() : sb.lockDurationSeconds(),
                 requiresSession, lifetime);
         store.put(key, toStoredObject(key, sub));
         String ruleStoreKey = ruleKey(account, namespace, topicName, subName, initialRule.name());
@@ -731,6 +742,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
             namespaceManager.jolokiaCreateSubscription(
                     namespace, topicName, subName, selector,
                     sub.requiresSession(), sub.lockDurationSeconds(),
+                    sub.maxDeliveryCount(),
                     new ServiceBusEntityXml.DuplicateDetectionSettings(
                             topic.requiresDuplicateDetection(),
                             topic.duplicateDetectionHistorySeconds()),

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -246,10 +246,10 @@ public class ServiceBusNamespaceManager {
             String queueName,
             boolean requiresSession,
             long lockDurationSeconds,
+            int maxDeliveryAttempts,
             ServiceBusEntityXml.DuplicateDetectionSettings duplicateDetection,
             ServiceBusEntityXml.MessageLifetimeSettings lifetime) {
         String deadLetterQueue = queueName + DEAD_LETTER_QUEUE_SUFFIX;
-        int maxDeliveryAttempts = config.services().serviceBus().maxDeliveryCount();
         String addressSettings = "{\"deadLetterAddress\":" + jsonString(deadLetterQueue)
                 + ",\"maxDeliveryAttempts\":" + maxDeliveryAttempts
                 + ",\"autoCreateQueues\":false,\"autoCreateAddresses\":false}";
@@ -390,12 +390,12 @@ public class ServiceBusNamespaceManager {
             String filter,
             boolean requiresSession,
             long lockDurationSeconds,
+            int maxDeliveryAttempts,
             ServiceBusEntityXml.DuplicateDetectionSettings duplicateDetection,
             ServiceBusEntityXml.MessageLifetimeSettings lifetime) {
         String queueName = topicName + "/Subscriptions/" + subName;
         String deadLetterQueue = queueName + DEAD_LETTER_QUEUE_SUFFIX;
         String divertName = queueName + SUBSCRIPTION_DIVERT_SUFFIX;
-        int maxDeliveryAttempts = config.services().serviceBus().maxDeliveryCount();
         String addressSettings = "{\"deadLetterAddress\":" + jsonString(deadLetterQueue)
                 + ",\"maxDeliveryAttempts\":" + maxDeliveryAttempts
                 + ",\"autoCreateQueues\":false,\"autoCreateAddresses\":false}";

--- a/src/test/java/io/floci/az/services/ServiceBusServiceTest.java
+++ b/src/test/java/io/floci/az/services/ServiceBusServiceTest.java
@@ -167,6 +167,72 @@ public class ServiceBusServiceTest {
                 .body(containsString("DefaultMessageTimeToLive must be positive"));
     }
 
+    @Test
+    void queuePersistsMaxDeliveryCountAndLockDuration() {
+        String body = entry("<QueueDescription xmlns=\"" + SB_NS + "\">"
+                + "<LockDuration>PT30S</LockDuration>"
+                + "<MaxDeliveryCount>5</MaxDeliveryCount>"
+                + "</QueueDescription>");
+
+        given().body(body).when().put(BASE + "/delivery-queue")
+                .then().statusCode(201)
+                .body(containsString("<LockDuration>PT30S</LockDuration>"))
+                .body(containsString("<MaxDeliveryCount>5</MaxDeliveryCount>"));
+
+        given().when().get(BASE + "/delivery-queue")
+                .then().statusCode(200)
+                .body(containsString("<LockDuration>PT30S</LockDuration>"))
+                .body(containsString("<MaxDeliveryCount>5</MaxDeliveryCount>"));
+    }
+
+    @Test
+    void subscriptionPersistsMaxDeliveryCountAndLockDuration() {
+        given().body(entry("<TopicDescription xmlns=\"" + SB_NS + "\"/>"))
+                .when().put(BASE + "/delivery-topic")
+                .then().statusCode(201);
+
+        String subscriptionBody = entry("<SubscriptionDescription xmlns=\"" + SB_NS + "\">"
+                + "<LockDuration>PT45S</LockDuration>"
+                + "<MaxDeliveryCount>3</MaxDeliveryCount>"
+                + "</SubscriptionDescription>");
+        given().body(subscriptionBody)
+                .when().put(BASE + "/delivery-topic/subscriptions/delivery-subscription")
+                .then().statusCode(201)
+                .body(containsString("<LockDuration>PT45S</LockDuration>"))
+                .body(containsString("<MaxDeliveryCount>3</MaxDeliveryCount>"));
+    }
+
+    @Test
+    void deliverySettingsDefaultToConfiguredValues() {
+        given().body(entry("<QueueDescription xmlns=\"" + SB_NS + "\"/>"))
+                .when().put(BASE + "/delivery-default-queue")
+                .then().statusCode(201)
+                .body(containsString("<LockDuration>PT1M</LockDuration>"))
+                .body(containsString("<MaxDeliveryCount>10</MaxDeliveryCount>"));
+    }
+
+    @Test
+    void rejectsMaxDeliveryCountOutsideAzureLimits() {
+        String body = entry("<QueueDescription xmlns=\"" + SB_NS + "\">"
+                + "<MaxDeliveryCount>0</MaxDeliveryCount>"
+                + "</QueueDescription>");
+
+        given().body(body).when().put(BASE + "/delivery-invalid-count")
+                .then().statusCode(400)
+                .body(containsString("MaxDeliveryCount must be between 1 and 2000"));
+    }
+
+    @Test
+    void rejectsLockDurationAboveFiveMinutes() {
+        String body = entry("<QueueDescription xmlns=\"" + SB_NS + "\">"
+                + "<LockDuration>PT6M</LockDuration>"
+                + "</QueueDescription>");
+
+        given().body(body).when().put(BASE + "/delivery-invalid-lock")
+                .then().statusCode(400)
+                .body(containsString("LockDuration must be between PT1S and PT5M"));
+    }
+
     private static String entry(String description) {
         return "<entry xmlns=\"http://www.w3.org/2005/Atom\"><content type=\"application/xml\">"
                 + description + "</content></entry>";

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusEntityXmlTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusEntityXmlTest.java
@@ -6,6 +6,7 @@ import java.time.Duration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -42,5 +43,52 @@ class ServiceBusEntityXmlTest {
         assertThrows(IllegalArgumentException.class,
                 () -> ServiceBusEntityXml.parseMessageLifetime(
                         "<DefaultMessageTimeToLive>-PT1S</DefaultMessageTimeToLive>"));
+    }
+
+    @Test
+    void deliverySettingsAbsentElementsAreNull() {
+        ServiceBusEntityXml.DeliverySettings settings = ServiceBusEntityXml.parseDelivery("");
+
+        assertNull(settings.maxDeliveryCount());
+        assertNull(settings.lockDurationSeconds());
+    }
+
+    @Test
+    void parsesMaxDeliveryCountAndLockDuration() {
+        ServiceBusEntityXml.DeliverySettings settings = ServiceBusEntityXml.parseDelivery("""
+                <QueueDescription>
+                  <LockDuration>PT30S</LockDuration>
+                  <MaxDeliveryCount>5</MaxDeliveryCount>
+                </QueueDescription>
+                """);
+
+        assertEquals(5, settings.maxDeliveryCount());
+        assertEquals(30L, settings.lockDurationSeconds());
+    }
+
+    @Test
+    void rejectsMaxDeliveryCountOutsideAzureLimits() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ServiceBusEntityXml.parseDelivery(
+                        "<MaxDeliveryCount>0</MaxDeliveryCount>"));
+        assertThrows(IllegalArgumentException.class,
+                () -> ServiceBusEntityXml.parseDelivery(
+                        "<MaxDeliveryCount>2001</MaxDeliveryCount>"));
+        assertThrows(IllegalArgumentException.class,
+                () -> ServiceBusEntityXml.parseDelivery(
+                        "<MaxDeliveryCount>many</MaxDeliveryCount>"));
+    }
+
+    @Test
+    void rejectsLockDurationOutsideAzureLimits() {
+        assertThrows(IllegalArgumentException.class,
+                () -> ServiceBusEntityXml.parseDelivery(
+                        "<LockDuration>PT6M</LockDuration>"));
+        assertThrows(IllegalArgumentException.class,
+                () -> ServiceBusEntityXml.parseDelivery(
+                        "<LockDuration>PT0S</LockDuration>"));
+        assertThrows(IllegalArgumentException.class,
+                () -> ServiceBusEntityXml.parseDelivery(
+                        "<LockDuration>soon</LockDuration>"));
     }
 }


### PR DESCRIPTION
## Summary

Queues and subscriptions now honor `MaxDeliveryCount` (1–2000) and `LockDuration` (PT1S–PT5M) from the entity-create payload instead of always using the namespace-wide `FLOCI_AZ_SERVICES_SERVICE_BUS_*` defaults. The resolved values are passed into the Artemis address settings so dead-lettering and session-lock expiry follow the entity's own configuration. Out-of-range values return a 400 ATOM error.

Closes #125

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

Limits match the Service Bus management API (`MaxDeliveryCount` 1–2000, `LockDuration` max PT5M). Verified with the Java SDK (`ServiceBusCompatibilityTest`) and the .NET SDK (`ServiceBusCompatibilityTests.cs`): a queue created with `MaxDeliveryCount=2` dead-letters after the 2nd abandon. Non-session peek-lock expiry is still not enforced by the broker (documented).

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

https://claude.ai/code/session_012mQkJ7Daai9eaJzL2Z6XVs
