### PR TITLE
fix(blob): default unusable blob content types to application/octet-stream

### DIFF
--- a/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
+++ b/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
@@ -429,7 +429,7 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
                 .header("Last-Modified", RFC1123_DATE_TIME.format(so.lastModified()))
                 .header("ETag", so.etag())
                 .header("x-ms-blob-type", so.metadata().getOrDefault("BlobType", "BlockBlob"))
-                .header(HttpHeaders.CONTENT_TYPE, so.metadata().getOrDefault("Content-Type", "application/octet-stream"))
+                .header(HttpHeaders.CONTENT_TYPE, usableContentType(so.metadata().get("Content-Type")))
                 .header(HttpHeaders.CONTENT_LENGTH, contentLength)
                 .header("x-ms-blob-content-length", totalSize)
                 .header("Accept-Ranges", "bytes")
@@ -571,7 +571,7 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
                     RFC1123_DATE_TIME.format(so.lastModified()),
                     so.etag(),
                     (long) so.data().length,
-                    so.metadata().getOrDefault("Content-Type", "application/octet-stream"),
+                    usableContentType(so.metadata().get("Content-Type")),
                     so.metadata().getOrDefault("BlobType", "BlockBlob")
             ), includes(request.queryParams().get("include"), "metadata") ? userMetadata(so.metadata()) : null));
         });
@@ -787,13 +787,30 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
         if (contentType == null) {
             contentType = request.headers().getHeaderString(HttpHeaders.CONTENT_TYPE);
         }
-        metadata.put("Content-Type", contentType != null ? contentType : "application/octet-stream");
+        metadata.put("Content-Type", usableContentType(contentType));
         BLOB_HTTP_PROPERTY_HEADERS.forEach((requestHeader, responseHeader) -> {
             String value = request.headers().getHeaderString(requestHeader);
             if (value != null) {
                 metadata.put(responseHeader, value);
             }
         });
+    }
+
+    /**
+     * Returns a content type safe to send back, substituting {@code application/octet-stream} - the
+     * default {@code Get Blob Properties} documents for a blob with no content type specified - for one
+     * that is missing, empty, or not a valid media type.
+     */
+    private static String usableContentType(String contentType) {
+        if (contentType == null || contentType.isBlank()) {
+            return MediaType.APPLICATION_OCTET_STREAM;
+        }
+        try {
+            MediaType.valueOf(contentType);
+        } catch (IllegalArgumentException e) {
+            return MediaType.APPLICATION_OCTET_STREAM;
+        }
+        return contentType;
     }
 
     /**

--- a/src/test/java/io/floci/az/services/BlobServiceTest.java
+++ b/src/test/java/io/floci/az/services/BlobServiceTest.java
@@ -1289,6 +1289,104 @@ public class BlobServiceTest {
             .header("Content-Type", not(emptyOrNullString()));
     }
 
+    @Test
+    void putBlobWithEmptyContentTypeServesOctetStream() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+
+        given()
+            .header("x-ms-blob-type", "BlockBlob")
+            .header("x-ms-blob-content-type", "")
+            .body(BLOB_CONTENT)
+            .when().put("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB)
+            .then().statusCode(201);
+
+        given()
+            .when().head("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(200)
+            .header("Content-Type", startsWith("application/octet-stream"));
+    }
+
+    @Test
+    void putBlobWithUnparseableContentTypeServesOctetStream() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+
+        given()
+            .header("x-ms-blob-type", "BlockBlob")
+            .header("x-ms-blob-content-type", "not-a-media-type")
+            .body(BLOB_CONTENT)
+            .when().put("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB)
+            .then().statusCode(201);
+
+        given()
+            .when().head("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(200)
+            .header("Content-Type", startsWith("application/octet-stream"));
+    }
+
+    @Test
+    void getBlobWithEmptyContentTypeStillReturnsContent() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+
+        given()
+            .header("x-ms-blob-type", "BlockBlob")
+            .header("x-ms-blob-content-type", "")
+            .body(BLOB_CONTENT)
+            .when().put("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB)
+            .then().statusCode(201);
+
+        given()
+            .when().get("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(200)
+            .header("Content-Type", startsWith("application/octet-stream"))
+            .body(equalTo(BLOB_CONTENT));
+    }
+
+    @Test
+    void listBlobsWithEmptyContentTypeReportsOctetStream() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+
+        given()
+            .header("x-ms-blob-type", "BlockBlob")
+            .header("x-ms-blob-content-type", "")
+            .body(BLOB_CONTENT)
+            .when().put("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB)
+            .then().statusCode(201);
+
+        given()
+            .when().get("/{account}/{container}?restype=container&comp=list", ACCOUNT, CONTAINER)
+            .then()
+            .statusCode(200)
+            .body(containsString("<Content-Type>application/octet-stream</Content-Type>"));
+    }
+
+    @Test
+    void committedBlockBlobWithEmptyContentTypeServesOctetStream() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        String blockId = Base64.getEncoder().encodeToString("block-1".getBytes(StandardCharsets.UTF_8));
+
+        given()
+            .body("chunk")
+            .when().put("/{account}/{container}/{blob}?comp=block&blockid={id}",
+                    ACCOUNT, CONTAINER, BLOB, blockId)
+            .then().statusCode(201);
+
+        given()
+            .header("x-ms-blob-content-type", "")
+            .contentType("application/xml")
+            .body("<BlockList><Latest>" + blockId + "</Latest></BlockList>")
+            .when().put("/{account}/{container}/{blob}?comp=blocklist", ACCOUNT, CONTAINER, BLOB)
+            .then().statusCode(201);
+
+        given()
+            .when().head("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(200)
+            .header("Content-Type", startsWith("application/octet-stream"));
+    }
+
     private static void putTestBlob(String content) {
         given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
         given()


### PR DESCRIPTION
## Summary

`Get Blob Properties` (HEAD), `Get Blob` and `List Blobs` answer `HTTP 500` for any blob whose stored `Content-Type` is empty or not a valid media type. The blob becomes permanently unreadable, so every later request for it fails, including the metadata-only HEAD.

Currently, the content type is client-supplied and stored as is, but JAX-RS parses it again while rendering the response, so an unusable value throws after the handler has already returned:

```
java.lang.IllegalArgumentException: Failed to parse media type
  at org.jboss.resteasy.reactive.common.headers.MediaTypeHeaderDelegate.internalParse
  at org.jboss.resteasy.reactive.common.jaxrs.ResponseImpl.getMediaType(ResponseImpl.java:209)
  at org.jboss.resteasy.reactive.server.handlers.ResponseHandler.handle(ResponseHandler.java:78)
```

Because the throw happens in the response-rendering path, Quarkus emits a bare 500 with no Azure `<Error>` body and no `x-ms-error-code`.

This PR substitutes `application/octet-stream` (what Azure reports for a blob whose content type was never set) when the stored value is missing, empty, or unparseable.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

Behavior on `PUT Blob` with `x-ms-blob-content-type`, then `HEAD` (Get Blob Properties):

| `x-ms-blob-content-type` sent | Azure | floci-az before | floci-az after |
| --- | --- | --- | --- |
| header absent | `200` `application/octet-stream` | `200` `application/octet-stream` | `200` `application/octet-stream` |
| present, empty | `200` `application/octet-stream` | **`500`** | `200` `application/octet-stream` |

- [Get Blob Properties](https://learn.microsoft.com/en-us/rest/api/storageservices/get-blob-properties) documents the `Content-Type` response header as "The content type that's specified for the blob. If no content type is specified, the default content type is `application/octet-stream`." That default is what this fix falls back to.
- [Put Blob](https://learn.microsoft.com/en-us/rest/api/storageservices/put-blob) documents `Content-Type` as "Optional. The MIME content type of the blob. The default type is `application/octet-stream`", and specifies no validation of the value. An empty `x-ms-blob-content-type` therefore means "none specified" rather than "the empty media type", which is what makes `application/octet-stream` the correct answer for the empty case.

## Scope

Applied at the write boundary (`addBlobHttpProperties`, used by `Put Blob` and `Put Block List`) and again
where the stored value is emitted (`Get Blob`/`Get Blob Properties` header, and the `List Blobs`
`<Content-Type>` element).

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Tests

Five tests in `BlobServiceTest`, one per affected path; all five reproduce the 500 before the
fix:

| Test | Guards |
| --- | --- |
| `putBlobWithEmptyContentTypeServesOctetStream` | Get Blob Properties after `Put Blob` |
| `putBlobWithUnparseableContentTypeServesOctetStream` | the malformed, non-empty case |
| `getBlobWithEmptyContentTypeStillReturnsContent` | Get Blob still returns the payload |
| `listBlobsWithEmptyContentTypeReportsOctetStream` | the `<Content-Type>` element in List Blobs |
| `committedBlockBlobWithEmptyContentTypeServesOctetStream` | the Put Block List write path |

---

Resolves https://github.com/floci-io/floci-az/issues/211