### PR TITLE
fix(servicebus): reap orphaned sidecars

### DIFF
--- a/src/main/java/io/floci/az/core/docker/ContainerLifecycleManager.java
+++ b/src/main/java/io/floci/az/core/docker/ContainerLifecycleManager.java
@@ -416,12 +416,81 @@ public class ContainerLifecycleManager {
      * @param name the container name to remove
      */
     public void removeIfExists(String name) {
+        tryRemoveIfExists(name);
+    }
+
+    private boolean tryRemoveIfExists(String name) {
         try {
             dockerClient.removeContainerCmd(name).withForce(true).exec();
             LOG.infov("Removed stale container {0}", name);
+            return true;
         } catch (NotFoundException ignored) {
+            return false;
         } catch (Exception e) {
             LOG.debugv("Could not remove container {0}: {1}", name, e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * Removes containers whose owning emulator container no longer exists or is stopped. Name and
+     * emulator-label checks constrain the candidates; an explicit owner label proves whether each
+     * matching sidecar is orphaned. Ownerless legacy containers and containers whose owner cannot
+     * be inspected are left untouched because they cannot be removed safely.
+     *
+     * @return the number of orphaned containers successfully removed
+     */
+    public int removeOrphanedContainers(
+            String namePrefix, Map<String, String> requiredLabels, String ownerLabel) {
+        List<Container> containers = dockerClient.listContainersCmd().withShowAll(true).exec();
+        int removed = 0;
+        for (Container container : containers) {
+            if (hasNamePrefix(container, namePrefix)
+                    && hasRequiredLabels(container, requiredLabels)
+                    && ownerIsStoppedOrMissing(container, ownerLabel)
+                    && tryRemoveIfExists(container.getId())) {
+                removed++;
+            }
+        }
+        return removed;
+    }
+
+    private static boolean hasNamePrefix(Container container, String namePrefix) {
+        String[] names = container.getNames();
+        if (names == null) {
+            return false;
+        }
+        for (String name : names) {
+            String normalized = name.startsWith("/") ? name.substring(1) : name;
+            if (normalized.startsWith(namePrefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean hasRequiredLabels(
+            Container container, Map<String, String> requiredLabels) {
+        Map<String, String> labels = container.getLabels();
+        return labels != null && requiredLabels.entrySet().stream()
+                .allMatch(entry -> entry.getValue().equals(labels.get(entry.getKey())));
+    }
+
+    private boolean ownerIsStoppedOrMissing(Container container, String ownerLabel) {
+        Map<String, String> labels = container.getLabels();
+        String ownerId = labels == null ? null : labels.get(ownerLabel);
+        if (ownerId == null || ownerId.isBlank()) {
+            return false;
+        }
+        try {
+            InspectContainerResponse owner = dockerClient.inspectContainerCmd(ownerId).exec();
+            return owner.getState() != null && !Boolean.TRUE.equals(owner.getState().getRunning());
+        } catch (NotFoundException e) {
+            return true;
+        } catch (Exception e) {
+            LOG.warnv("Could not inspect owner container {0}; skipping orphan cleanup: {1}",
+                    ownerId, e.getMessage());
+            return false;
         }
     }
 

--- a/src/main/java/io/floci/az/core/docker/CurrentContainerNetworkResolver.java
+++ b/src/main/java/io/floci/az/core/docker/CurrentContainerNetworkResolver.java
@@ -45,6 +45,27 @@ public class CurrentContainerNetworkResolver {
         return resolve().map(CurrentContainerNetwork::ipAddress);
     }
 
+    /** Returns the current emulator's Docker container id when running in Docker. */
+    public Optional<String> resolveContainerId() {
+        if (!containerDetector.isRunningInContainer()) {
+            return Optional.empty();
+        }
+        String candidate = currentContainerId();
+        if (candidate.isBlank()) {
+            return Optional.empty();
+        }
+        try {
+            InspectContainerResponse inspect = dockerClient.inspectContainerCmd(candidate).exec();
+            String containerId = inspect.getId();
+            return Optional.of(
+                    containerId == null || containerId.isBlank() ? candidate : containerId);
+        } catch (Exception e) {
+            LOG.debugv("Could not resolve current Docker container {0}: {1}",
+                    candidate, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
     Optional<CurrentContainerNetwork> resolve() {
         Optional<CurrentContainerNetwork> cached = cachedNetwork;
         if (cached != null) {

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusContainerManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusContainerManager.java
@@ -41,6 +41,14 @@ public class ServiceBusContainerManager {
         if (sb.mocked()) {
             LOG.info("Service Bus service mocked — skipping container startup");
         } else {
+            try {
+                int reaped = namespaceManager.reapOrphanedContainers();
+                if (reaped > 0) {
+                    LOG.infov("Removed {0} orphaned Service Bus container(s)", reaped);
+                }
+            } catch (Exception e) {
+                LOG.errorf(e, "Could not reap orphaned Service Bus containers");
+            }
             LOG.info("Service Bus service enabled — namespace starts on first entity management call");
         }
     }

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -6,6 +6,7 @@ import io.floci.az.core.docker.ContainerBuilder;
 import io.floci.az.core.docker.ContainerLifecycleManager;
 import io.floci.az.core.docker.ContainerLifecycleManager.EndpointInfo;
 import io.floci.az.core.docker.ContainerSpec;
+import io.floci.az.core.docker.CurrentContainerNetworkResolver;
 import io.floci.az.services.eventhub.ArtemisTlsGenerator;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -21,6 +22,7 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Base64;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -78,6 +80,8 @@ public class ServiceBusNamespaceManager {
     private static final String TOPIC_ADDRESS_SUFFIX = "/$Topic";
     private static final String TOPIC_DIVERT_SUFFIX = "/$TopicDivert";
     private static final String SESSION_METADATA_PREFIX = "floci-az:servicebus-session:";
+    private static final String SERVICE_LABEL = "servicebus";
+    private static final String OWNER_CONTAINER_LABEL = "floci_owner_container";
     private static final String DUPLICATE_DETECTION_MBEAN =
             "io.floci.az.artemis:type=ServiceBusDuplicateDetection";
     private static final String EXPIRY_MBEAN = "io.floci.az.artemis:type=ServiceBusExpiry";
@@ -104,6 +108,7 @@ public class ServiceBusNamespaceManager {
     private final EmulatorConfig config;
     private final ContainerBuilder containerBuilder;
     private final ContainerLifecycleManager lifecycleManager;
+    private final CurrentContainerNetworkResolver currentContainerResolver;
     private final ServiceBusConfigGenerator configGenerator;
     private final ArtemisTlsGenerator tlsGenerator;
 
@@ -111,11 +116,13 @@ public class ServiceBusNamespaceManager {
     public ServiceBusNamespaceManager(EmulatorConfig config,
                                        ContainerBuilder containerBuilder,
                                        ContainerLifecycleManager lifecycleManager,
+                                       CurrentContainerNetworkResolver currentContainerResolver,
                                        ServiceBusConfigGenerator configGenerator,
                                        ArtemisTlsGenerator tlsGenerator) {
         this.config = config;
         this.containerBuilder = containerBuilder;
         this.lifecycleManager = lifecycleManager;
+        this.currentContainerResolver = currentContainerResolver;
         this.configGenerator = configGenerator;
         this.tlsGenerator = tlsGenerator;
     }
@@ -148,6 +155,7 @@ public class ServiceBusNamespaceManager {
         ContainerSpec spec = containerBuilder.newContainer(config.services().serviceBus().artemisImage())
                 .withName(containerName)
                 .withEnv("ANONYMOUS_LOGIN", "true")
+                .withLabels(serviceContainerLabels())
                 .withPortBinding(AMQP_PORT, amqpHostPort)
                 .withPortBinding(AMQPS_PORT, amqpsHostPort)
                 .withDynamicPort(JOLOKIA_PORT)
@@ -195,6 +203,20 @@ public class ServiceBusNamespaceManager {
         LOG.infov("Service Bus namespace ''{0}'' ready: amqp:{1}, amqps:{2}",
                 namespaceName, amqpEndpoint, amqpsEndpoint);
         return state;
+    }
+
+    int reapOrphanedContainers() {
+        return lifecycleManager.removeOrphanedContainers(
+                containerName(""), ContainerStorageHelper.defaultLabels(config),
+                OWNER_CONTAINER_LABEL);
+    }
+
+    Map<String, String> serviceContainerLabels() {
+        Map<String, String> labels = new LinkedHashMap<>();
+        labels.put("floci_service", SERVICE_LABEL);
+        currentContainerResolver.resolveContainerId()
+                .ifPresent(ownerId -> labels.put(OWNER_CONTAINER_LABEL, ownerId));
+        return labels;
     }
 
     /** Registers a mocked namespace with no backing broker — management API only. */

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -127,6 +127,14 @@ public class ServiceBusNamespaceManager {
         this.tlsGenerator = tlsGenerator;
     }
 
+    ServiceBusNamespaceManager(EmulatorConfig config,
+                               ContainerBuilder containerBuilder,
+                               ContainerLifecycleManager lifecycleManager,
+                               ServiceBusConfigGenerator configGenerator,
+                               ArtemisTlsGenerator tlsGenerator) {
+        this(config, containerBuilder, lifecycleManager, null, configGenerator, tlsGenerator);
+    }
+
     public synchronized NamespaceState startNamespace(
             String namespaceName, int amqpHostPort, int amqpsHostPort) {
         NamespaceState existing = namespaces.get(namespaceName);
@@ -214,8 +222,10 @@ public class ServiceBusNamespaceManager {
     Map<String, String> serviceContainerLabels() {
         Map<String, String> labels = new LinkedHashMap<>();
         labels.put("floci_service", SERVICE_LABEL);
-        currentContainerResolver.resolveContainerId()
-                .ifPresent(ownerId -> labels.put(OWNER_CONTAINER_LABEL, ownerId));
+        if (currentContainerResolver != null) {
+            currentContainerResolver.resolveContainerId()
+                    .ifPresent(ownerId -> labels.put(OWNER_CONTAINER_LABEL, ownerId));
+        }
         return labels;
     }
 

--- a/src/test/java/io/floci/az/core/docker/ContainerLifecycleManagerCleanupTest.java
+++ b/src/test/java/io/floci/az/core/docker/ContainerLifecycleManagerCleanupTest.java
@@ -1,0 +1,130 @@
+package io.floci.az.core.docker;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.InspectContainerCmd;
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.command.ListContainersCmd;
+import com.github.dockerjava.api.command.RemoveContainerCmd;
+import com.github.dockerjava.api.exception.NotFoundException;
+import com.github.dockerjava.api.model.Container;
+import io.floci.az.config.EmulatorConfig;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.RETURNS_SELF;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ContainerLifecycleManagerCleanupTest {
+
+    @Test
+    void removesOnlyMatchingContainersWhoseOwnerIsGone() {
+        DockerClient dockerClient = mock(DockerClient.class);
+        ListContainersCmd listCmd = mock(ListContainersCmd.class, RETURNS_SELF);
+        when(dockerClient.listContainersCmd()).thenReturn(listCmd);
+
+        Container orphan = container(
+                "orphan", new String[]{"/floci-az-run-one-servicebus-default"},
+                ownedLabels("run-one", "gone-owner"));
+        Container live = container(
+                "live", new String[]{"/floci-az-run-one-servicebus-live"},
+                ownedLabels("run-one", "live-owner"));
+        Container ownerless = container(
+                "ownerless", new String[]{"/floci-az-run-one-servicebus-legacy"},
+                emulatorLabels("run-one"));
+        Container foreignNamespace = container(
+                "foreign-namespace", new String[]{"/floci-az-run-one-servicebus-other"},
+                ownedLabels("run-two", "gone-owner"));
+        Container unrelatedService = container(
+                "unrelated-service", new String[]{"/floci-az-run-one-postgres-default"},
+                ownedLabels("run-one", "gone-owner"));
+        when(listCmd.exec()).thenReturn(
+                List.of(orphan, live, ownerless, foreignNamespace, unrelatedService));
+
+        InspectContainerCmd goneOwnerCmd = mock(InspectContainerCmd.class);
+        when(dockerClient.inspectContainerCmd("gone-owner")).thenReturn(goneOwnerCmd);
+        when(goneOwnerCmd.exec()).thenThrow(new NotFoundException("gone"));
+        InspectContainerCmd liveOwnerCmd = mock(InspectContainerCmd.class);
+        InspectContainerResponse liveOwner = mock(InspectContainerResponse.class, RETURNS_SELF);
+        when(dockerClient.inspectContainerCmd("live-owner")).thenReturn(liveOwnerCmd);
+        when(liveOwnerCmd.exec()).thenReturn(liveOwner);
+        when(liveOwner.getState()).thenReturn(mock(InspectContainerResponse.ContainerState.class));
+        when(liveOwner.getState().getRunning()).thenReturn(true);
+
+        RemoveContainerCmd removeCmd = mock(RemoveContainerCmd.class, RETURNS_SELF);
+        when(dockerClient.removeContainerCmd("orphan")).thenReturn(removeCmd);
+
+        int removed = manager(dockerClient).removeOrphanedContainers(
+                "floci-az-run-one-servicebus-",
+                emulatorLabels("run-one"), "floci_owner_container");
+
+        assertEquals(1, removed);
+        verify(removeCmd).withForce(true);
+        verify(removeCmd).exec();
+        verify(dockerClient, never()).removeContainerCmd("live");
+        verify(dockerClient, never()).removeContainerCmd("ownerless");
+        verify(dockerClient, never()).removeContainerCmd("foreign-namespace");
+        verify(dockerClient, never()).removeContainerCmd("unrelated-service");
+    }
+
+    @Test
+    void doesNotCountFailedRemovalAsReaped() {
+        DockerClient dockerClient = mock(DockerClient.class);
+        ListContainersCmd listCmd = mock(ListContainersCmd.class, RETURNS_SELF);
+        when(dockerClient.listContainersCmd()).thenReturn(listCmd);
+        Container orphan = container(
+                "orphan", new String[]{"/floci-az-servicebus-default"},
+                ownedLabels(null, "gone-owner"));
+        when(listCmd.exec()).thenReturn(List.of(orphan));
+        InspectContainerCmd ownerCmd = mock(InspectContainerCmd.class);
+        when(dockerClient.inspectContainerCmd("gone-owner")).thenReturn(ownerCmd);
+        when(ownerCmd.exec()).thenThrow(new NotFoundException("gone"));
+        RemoveContainerCmd removeCmd = mock(RemoveContainerCmd.class, RETURNS_SELF);
+        when(dockerClient.removeContainerCmd("orphan")).thenReturn(removeCmd);
+        when(removeCmd.exec()).thenThrow(new IllegalStateException("remove failed"));
+
+        int removed = manager(dockerClient).removeOrphanedContainers(
+                "floci-az-servicebus-", emulatorLabels(null), "floci_owner_container");
+
+        assertEquals(0, removed);
+    }
+
+    private static Container container(String id, String[] names, Map<String, String> labels) {
+        Container container = mock(Container.class);
+        when(container.getId()).thenReturn(id);
+        when(container.getNames()).thenReturn(names);
+        when(container.getLabels()).thenReturn(labels);
+        return container;
+    }
+
+    private static Map<String, String> ownedLabels(String namespace, String owner) {
+        Map<String, String> labels = new LinkedHashMap<>(emulatorLabels(namespace));
+        labels.put("floci_owner_container", owner);
+        return labels;
+    }
+
+    private static Map<String, String> emulatorLabels(String namespace) {
+        Map<String, String> labels = new LinkedHashMap<>();
+        labels.put("floci", "true");
+        labels.put("floci_emulator", "floci-az");
+        if (namespace != null) {
+            labels.put("floci_namespace", namespace);
+        }
+        return labels;
+    }
+
+    private static ContainerLifecycleManager manager(DockerClient dockerClient) {
+        return new ContainerLifecycleManager(
+                dockerClient,
+                mock(ImageCacheService.class),
+                mock(ContainerDetector.class),
+                mock(PortAllocator.class),
+                mock(EmulatorConfig.class));
+    }
+}

--- a/src/test/java/io/floci/az/core/docker/CurrentContainerNetworkResolverOwnerTest.java
+++ b/src/test/java/io/floci/az/core/docker/CurrentContainerNetworkResolverOwnerTest.java
@@ -1,0 +1,64 @@
+package io.floci.az.core.docker;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.InspectContainerCmd;
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CurrentContainerNetworkResolverOwnerTest {
+
+    @Test
+    void resolvesVerifiedDockerContainerId() {
+        DockerClient dockerClient = mock(DockerClient.class);
+        ContainerDetector detector = mock(ContainerDetector.class);
+        when(detector.isRunningInContainer()).thenReturn(true);
+        InspectContainerCmd inspectCmd = mock(InspectContainerCmd.class);
+        InspectContainerResponse inspect = mock(InspectContainerResponse.class);
+        when(dockerClient.inspectContainerCmd("hostname-id")).thenReturn(inspectCmd);
+        when(inspectCmd.exec()).thenReturn(inspect);
+        when(inspect.getId()).thenReturn("full-container-id");
+
+        assertEquals(Optional.of("full-container-id"),
+                resolver(dockerClient, detector).resolveContainerId());
+    }
+
+    @Test
+    void returnsEmptyWhenCurrentContainerCannotBeVerified() {
+        DockerClient dockerClient = mock(DockerClient.class);
+        ContainerDetector detector = mock(ContainerDetector.class);
+        when(detector.isRunningInContainer()).thenReturn(true);
+        InspectContainerCmd inspectCmd = mock(InspectContainerCmd.class);
+        when(dockerClient.inspectContainerCmd("hostname-id")).thenReturn(inspectCmd);
+        when(inspectCmd.exec()).thenThrow(new IllegalStateException("inspect failed"));
+
+        assertEquals(Optional.empty(), resolver(dockerClient, detector).resolveContainerId());
+    }
+
+    @Test
+    void skipsDockerLookupOutsideAContainer() {
+        DockerClient dockerClient = mock(DockerClient.class);
+        ContainerDetector detector = mock(ContainerDetector.class);
+        when(detector.isRunningInContainer()).thenReturn(false);
+
+        assertEquals(Optional.empty(), resolver(dockerClient, detector).resolveContainerId());
+        verify(dockerClient, never()).inspectContainerCmd("hostname-id");
+    }
+
+    private static CurrentContainerNetworkResolver resolver(
+            DockerClient dockerClient, ContainerDetector detector) {
+        return new CurrentContainerNetworkResolver(dockerClient, detector) {
+            @Override
+            String currentContainerId() {
+                return "hostname-id";
+            }
+        };
+    }
+}

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusContainerManagerTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusContainerManagerTest.java
@@ -1,0 +1,54 @@
+package io.floci.az.services.servicebus;
+
+import io.floci.az.config.EmulatorConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ServiceBusContainerManagerTest {
+
+    private final EmulatorConfig config = mock(EmulatorConfig.class);
+    private final EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
+    private final EmulatorConfig.ServiceBusConfig serviceBus = mock(EmulatorConfig.ServiceBusConfig.class);
+    private final ServiceBusNamespaceManager namespaceManager = mock(ServiceBusNamespaceManager.class);
+
+    @BeforeEach
+    void setUp() {
+        when(config.services()).thenReturn(services);
+        when(services.serviceBus()).thenReturn(serviceBus);
+        when(serviceBus.enabled()).thenReturn(true);
+    }
+
+    @Test
+    void reapsOrphanedContainersWhenBrokerModeStarts() {
+        when(serviceBus.mocked()).thenReturn(false);
+
+        new ServiceBusContainerManager(config, namespaceManager).onStart(null);
+
+        verify(namespaceManager).reapOrphanedContainers();
+    }
+
+    @Test
+    void skipsCleanupInMockedMode() {
+        when(serviceBus.mocked()).thenReturn(true);
+
+        new ServiceBusContainerManager(config, namespaceManager).onStart(null);
+
+        verify(namespaceManager, never()).reapOrphanedContainers();
+    }
+
+    @Test
+    void cleanupFailureDoesNotFailApplicationStartup() {
+        when(serviceBus.mocked()).thenReturn(false);
+        when(namespaceManager.reapOrphanedContainers())
+                .thenThrow(new IllegalStateException("Docker unavailable"));
+
+        assertDoesNotThrow(
+                () -> new ServiceBusContainerManager(config, namespaceManager).onStart(null));
+    }
+}

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusOrphanCleanupTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusOrphanCleanupTest.java
@@ -1,0 +1,72 @@
+package io.floci.az.services.servicebus;
+
+import io.floci.az.config.EmulatorConfig;
+import io.floci.az.core.docker.ContainerBuilder;
+import io.floci.az.core.docker.ContainerLifecycleManager;
+import io.floci.az.core.docker.CurrentContainerNetworkResolver;
+import io.floci.az.services.eventhub.ArtemisTlsGenerator;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ServiceBusOrphanCleanupTest {
+
+    @Test
+    void scopesCleanupToConfiguredResourceNamespaceAndServicePrefix() {
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        EmulatorConfig.DockerConfig docker = mock(EmulatorConfig.DockerConfig.class);
+        when(config.docker()).thenReturn(docker);
+        when(docker.resourceNamespace()).thenReturn(Optional.of("run-one"));
+        ContainerLifecycleManager lifecycleManager = mock(ContainerLifecycleManager.class);
+        when(lifecycleManager.removeOrphanedContainers(
+                "floci-az-run-one-servicebus-",
+                Map.of(
+                        "floci", "true",
+                        "floci_emulator", "floci-az",
+                        "floci_namespace", "run-one"),
+                "floci_owner_container"))
+                .thenReturn(2);
+
+        ServiceBusNamespaceManager manager = new ServiceBusNamespaceManager(
+                config,
+                mock(ContainerBuilder.class),
+                lifecycleManager,
+                mock(CurrentContainerNetworkResolver.class),
+                mock(ServiceBusConfigGenerator.class),
+                mock(ArtemisTlsGenerator.class));
+
+        assertEquals(2, manager.reapOrphanedContainers());
+        verify(lifecycleManager).removeOrphanedContainers(
+                "floci-az-run-one-servicebus-",
+                Map.of(
+                        "floci", "true",
+                        "floci_emulator", "floci-az",
+                        "floci_namespace", "run-one"),
+                "floci_owner_container");
+    }
+
+    @Test
+    void labelsSidecarWithVerifiedOwnerContainer() {
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        CurrentContainerNetworkResolver currentContainer =
+                mock(CurrentContainerNetworkResolver.class);
+        when(currentContainer.resolveContainerId()).thenReturn(Optional.of("owner-id"));
+        ServiceBusNamespaceManager manager = new ServiceBusNamespaceManager(
+                config,
+                mock(ContainerBuilder.class),
+                mock(ContainerLifecycleManager.class),
+                currentContainer,
+                mock(ServiceBusConfigGenerator.class),
+                mock(ArtemisTlsGenerator.class));
+
+        assertEquals(Map.of(
+                "floci_service", "servicebus",
+                "floci_owner_container", "owner-id"), manager.serviceContainerLabels());
+    }
+}

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusOrphanCleanupTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusOrphanCleanupTest.java
@@ -69,4 +69,16 @@ class ServiceBusOrphanCleanupTest {
                 "floci_service", "servicebus",
                 "floci_owner_container", "owner-id"), manager.serviceContainerLabels());
     }
+
+    @Test
+    void existingFiveArgumentConstructionRemainsSupported() {
+        ServiceBusNamespaceManager manager = new ServiceBusNamespaceManager(
+                mock(EmulatorConfig.class),
+                mock(ContainerBuilder.class),
+                mock(ContainerLifecycleManager.class),
+                mock(ServiceBusConfigGenerator.class),
+                mock(ArtemisTlsGenerator.class));
+
+        assertEquals(Map.of("floci_service", "servicebus"), manager.serviceContainerLabels());
+    }
 }


### PR DESCRIPTION
## Summary

- label Service Bus sidecars with their verified owning emulator container ID
- reap only sidecars whose owner container is stopped or gone
- scope cleanup by canonical name prefix and emulator/resource-namespace labels
- preserve live, ownerless, and unverifiable containers; keep failures non-fatal

This cleanup only applies when Floci-AZ itself runs in Docker and can attach its container ID as the owner label. Host-run emulators leave sidecars ownerless, so this PR deliberately preserves them.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature
- [ ] Breaking change
- [ ] Docs / chore

## Azure Compatibility

No wire-protocol change; this narrows Docker sidecar lifecycle cleanup.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Conventional Commits

Tests: focused cleanup/startup 10 passed; full repository 769 passed.

Refs #218