### PR TITLE
fix(cosmos): enable .NET SDK queries

### DIFF
--- a/compatibility-tests/sdk-test-dotnet/CosmosCompatibilityTests.cs
+++ b/compatibility-tests/sdk-test-dotnet/CosmosCompatibilityTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.ObjectModel;
 using Microsoft.Azure.Cosmos;
 using Newtonsoft.Json;
 
@@ -29,9 +30,15 @@ public sealed class CosmosCompatibilityTests
 
         try
         {
+            var properties = new ContainerProperties("items", "/pk");
+            properties.IndexingPolicy.CompositeIndexes.Add(
+                new Collection<CompositePath>
+                {
+                    new() { Path = "/rank", Order = CompositePathSortOrder.Ascending },
+                    new() { Path = "/id", Order = CompositePathSortOrder.Ascending }
+                });
             Container container = await database.CreateContainerAsync(
-                new ContainerProperties("items", "/pk"),
-                cancellationToken: cancellationToken);
+                properties, cancellationToken: cancellationToken);
             await container.CreateItemAsync(
                 new QueryItem("one", "a", 3),
                 new PartitionKey("a"),
@@ -57,6 +64,15 @@ public sealed class CosmosCompatibilityTests
             await Assert.That(ordered[0].Rank).IsEqualTo(1);
             await Assert.That(ordered[1].Rank).IsEqualTo(2);
             await Assert.That(ordered[2].Rank).IsEqualTo(3);
+
+            List<QueryItem> multiOrdered = await ReadAll(
+                container.GetItemQueryIterator<QueryItem>(
+                    "SELECT * FROM c ORDER BY c.rank, c.id"),
+                cancellationToken);
+            await Assert.That(multiOrdered.Count).IsEqualTo(3);
+            await Assert.That(multiOrdered[0].Id).IsEqualTo("two");
+            await Assert.That(multiOrdered[1].Id).IsEqualTo("three");
+            await Assert.That(multiOrdered[2].Id).IsEqualTo("one");
 
             List<int> counts = await ReadAll(
                 container.GetItemQueryIterator<int>("SELECT VALUE COUNT(1) FROM c"),

--- a/compatibility-tests/sdk-test-dotnet/CosmosCompatibilityTests.cs
+++ b/compatibility-tests/sdk-test-dotnet/CosmosCompatibilityTests.cs
@@ -1,0 +1,97 @@
+using Microsoft.Azure.Cosmos;
+using Newtonsoft.Json;
+
+namespace FlociAz.Compatibility;
+
+[NotInParallel]
+public sealed class CosmosCompatibilityTests
+{
+    private const string CosmosKey =
+        "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
+    private static readonly string EmulatorEndpoint =
+        Environment.GetEnvironmentVariable("FLOCI_AZ_ENDPOINT") ?? "http://localhost:4577";
+
+    [Test]
+    [Timeout(60_000)]
+    public async Task DotnetSdkExecutesQueries(CancellationToken cancellationToken)
+    {
+        using var client = new CosmosClient(
+            $"{EmulatorEndpoint}/devstoreaccount1-cosmos/",
+            CosmosKey,
+            new CosmosClientOptions
+            {
+                ConnectionMode = ConnectionMode.Gateway,
+                LimitToEndpoint = true
+            });
+
+        string databaseId = $"dotnet-query-{Guid.NewGuid():N}";
+        Database database = await client.CreateDatabaseAsync(databaseId, cancellationToken: cancellationToken);
+
+        try
+        {
+            Container container = await database.CreateContainerAsync(
+                new ContainerProperties("items", "/pk"),
+                cancellationToken: cancellationToken);
+            await container.CreateItemAsync(
+                new QueryItem("one", "a", 3),
+                new PartitionKey("a"),
+                cancellationToken: cancellationToken);
+            await container.CreateItemAsync(
+                new QueryItem("two", "b", 1),
+                new PartitionKey("b"),
+                cancellationToken: cancellationToken);
+            await container.CreateItemAsync(
+                new QueryItem("three", "a", 2),
+                new PartitionKey("a"),
+                cancellationToken: cancellationToken);
+
+            List<QueryItem> selected = await ReadAll(
+                container.GetItemQueryIterator<QueryItem>("SELECT * FROM c"), cancellationToken);
+            await Assert.That(selected.Select(item => item.Id))
+                .IsEquivalentTo(["one", "two", "three"]);
+
+            List<QueryItem> ordered = await ReadAll(
+                container.GetItemQueryIterator<QueryItem>("SELECT * FROM c ORDER BY c.rank"),
+                cancellationToken);
+            await Assert.That(ordered.Count).IsEqualTo(3);
+            await Assert.That(ordered[0].Rank).IsEqualTo(1);
+            await Assert.That(ordered[1].Rank).IsEqualTo(2);
+            await Assert.That(ordered[2].Rank).IsEqualTo(3);
+
+            List<int> counts = await ReadAll(
+                container.GetItemQueryIterator<int>("SELECT VALUE COUNT(1) FROM c"),
+                cancellationToken);
+            await Assert.That(counts).IsEquivalentTo([3]);
+
+            List<QueryItem> crossPartition = await ReadAll(
+                container.GetItemQueryIterator<QueryItem>(
+                    new QueryDefinition("SELECT * FROM c WHERE c.pk = @pk")
+                        .WithParameter("@pk", "b")),
+                cancellationToken);
+            await Assert.That(crossPartition.Select(item => item.Id)).IsEquivalentTo(["two"]);
+        }
+        finally
+        {
+            await database.DeleteAsync(cancellationToken: cancellationToken);
+        }
+    }
+
+    private static async Task<List<T>> ReadAll<T>(
+        FeedIterator<T> iterator,
+        CancellationToken cancellationToken)
+    {
+        var results = new List<T>();
+        while (iterator.HasMoreResults)
+        {
+            FeedResponse<T> page = await iterator.ReadNextAsync(cancellationToken);
+            results.AddRange(page);
+        }
+
+        return results;
+    }
+
+    private sealed record QueryItem(
+        [property: JsonProperty("id")] string Id,
+        [property: JsonProperty("pk")] string PartitionKey,
+        [property: JsonProperty("rank")] int Rank);
+}

--- a/compatibility-tests/sdk-test-dotnet/Dockerfile
+++ b/compatibility-tests/sdk-test-dotnet/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY SdkTestDotnet.csproj .
 RUN dotnet restore
 
-COPY ServiceBusCompatibilityTests.cs .
+COPY *.cs .
 RUN dotnet build --no-restore
 
 RUN mkdir -p /results

--- a/compatibility-tests/sdk-test-dotnet/SdkTestDotnet.csproj
+++ b/compatibility-tests/sdk-test-dotnet/SdkTestDotnet.csproj
@@ -9,6 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="TUnit" Version="1.63.0" />
   </ItemGroup>
 </Project>

--- a/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
@@ -45,6 +45,32 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
     private static final String K_COLL = "|coll|";
     private static final String K_DOC  = "|doc|";
 
+    /**
+     * Configuration advertised by the Cosmos DB gateway for the SDK's client-side query planner.
+     * The .NET SDK rejects an empty object before sending any query request.
+     */
+    private static final Map<String, Object> QUERY_ENGINE_CONFIGURATION = Map.ofEntries(
+            Map.entry("maxSqlQueryInputLength", 262144),
+            Map.entry("maxJoinsPerSqlQuery", 5),
+            Map.entry("maxLogicalAndPerSqlQuery", 500),
+            Map.entry("maxLogicalOrPerSqlQuery", 500),
+            Map.entry("maxUdfRefPerSqlQuery", 10),
+            Map.entry("maxInExpressionItemsCount", 16000),
+            Map.entry("queryMaxInMemorySortDocumentCount", 500),
+            Map.entry("maxQueryRequestTimeoutFraction", 0.9),
+            Map.entry("sqlAllowNonFiniteNumbers", false),
+            Map.entry("sqlAllowAggregateFunctions", true),
+            Map.entry("sqlAllowSubQuery", true),
+            Map.entry("sqlAllowScalarSubQuery", true),
+            Map.entry("allowNewKeywords", true),
+            Map.entry("sqlAllowLike", true),
+            Map.entry("sqlAllowGroupByClause", true),
+            Map.entry("maxSpatialQueryCells", 12),
+            Map.entry("spatialMaxGeometryPointCount", 256),
+            Map.entry("sqlDisableOptimizationFlags", 0),
+            Map.entry("sqlAllowTop", true),
+            Map.entry("enableSpatialIndexing", true));
+
     private final StorageBackend<String, StoredObject> store;
     private final CosmosQueryEngine queryEngine = new CosmosQueryEngine();
 
@@ -211,9 +237,9 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         body.put("userReplicationPolicy",        Map.of("asyncReplication", false, "minReplicaSetSize", 1, "maxReplicasetSize", 4));
         body.put("systemReplicationPolicy",      Map.of("minReplicaSetSize", 1, "maxReplicasetSize", 4));
         body.put("readPolicy",                   Map.of("primaryReadCoefficient", 1, "secondaryReadCoefficient", 1));
-        body.put("queryEngineConfiguration",     "{}");
 
         try {
+            body.put("queryEngineConfiguration", MAPPER.writeValueAsString(QUERY_ENGINE_CONFIGURATION));
             return Response.ok(MAPPER.writeValueAsString(body))
                     .type("application/json")
                     .header("x-ms-request-charge", "1")
@@ -310,7 +336,7 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         }
 
         Instant now  = Instant.now();
-        String  rid  = newRid(8);
+        String  rid  = newRid(8, dbRid(req.accountName(), dbId));
         String  etag = newEtag();
 
         @SuppressWarnings("unchecked")
@@ -404,18 +430,27 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
      * return one range covering the full hash space ("" … "FF").</p>
      */
     private Response listPartitionKeyRanges(AzureRequest req, String dbId, String collId) {
-        Optional<StoredObject> coll = store.get(collKey(req.accountName(), dbId, collId));
+        Optional<StoredObject> coll = findContainer(req.accountName(), dbId, collId);
         if (coll.isEmpty()) return notFound(collId);
 
         String collRid = (String) parseData(coll.get()).getOrDefault("_rid", newRid(8));
         String etag    = coll.get().etag();
         long   ts      = coll.get().lastModified().getEpochSecond();
+        String quotedEtag = quoted(etag);
+
+        if (quotedEtag.equals(req.headers().getHeaderString("If-None-Match"))) {
+            return Response.notModified()
+                    .header("etag", quotedEtag)
+                    .header("x-ms-activity-id", UUID.randomUUID().toString())
+                    .header("x-ms-version", "2018-12-31")
+                    .build();
+        }
 
         Map<String, Object> range = new LinkedHashMap<>();
         range.put("id",           "0");
         range.put("_rid",         newRid(12));
         range.put("_self",        "dbs/" + dbId + "/colls/" + collId + "/pkranges/0");
-        range.put("_etag",        quoted(etag));
+        range.put("_etag",        quotedEtag);
         range.put("_ts",          ts);
         range.put("minInclusive", "");
         range.put("maxExclusive", "FF");
@@ -430,6 +465,7 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
 
         try {
             return Response.ok(MAPPER.writeValueAsString(body), "application/json")
+                    .header("etag",                quotedEtag)
                     .header("x-ms-request-charge", "1")
                     .header("x-ms-item-count",     "1")
                     .header("x-ms-activity-id",    UUID.randomUUID().toString())
@@ -438,6 +474,38 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         } catch (JsonProcessingException e) {
             return Response.serverError().build();
         }
+    }
+
+    private Optional<StoredObject> findContainer(String account, String dbId, String collId) {
+        Optional<StoredObject> byName = store.get(collKey(account, dbId, collId));
+        if (byName.isPresent()) {
+            return byName;
+        }
+
+        // The .NET SDK reads partition ranges through the resource-ID link returned by the gateway.
+        Optional<String> databaseName = findDatabaseName(account, dbId);
+        if (databaseName.isEmpty()) {
+            return Optional.empty();
+        }
+
+        String collectionPrefix = account + K_COLL + databaseName.get() + "|";
+        return store.scan(key -> key.startsWith(collectionPrefix))
+                .stream()
+                .filter(stored -> collId.equals(parseData(stored).get("_rid")))
+                .findFirst();
+    }
+
+    private Optional<String> findDatabaseName(String account, String dbId) {
+        if (store.get(dbKey(account, dbId)).isPresent()) {
+            return Optional.of(dbId);
+        }
+
+        return store.scan(key -> key.startsWith(account + K_DB))
+                .stream()
+                .map(this::parseData)
+                .filter(database -> dbId.equals(database.get("_rid")))
+                .map(database -> String.valueOf(database.get("id")))
+                .findFirst();
     }
 
     /**
@@ -1409,8 +1477,17 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
      * @param byteLen 4 (database), 8 (collection), or 16 (document)
      */
     private String newRid(int byteLen) {
+        return newRid(byteLen, null);
+    }
+
+    private String newRid(int byteLen, String parentRid) {
         byte[] b = new byte[byteLen];
         new Random().nextBytes(b);
+
+        if (parentRid != null && !parentRid.isBlank()) {
+            byte[] parentBytes = Base64.getDecoder().decode(parentRid.replace('-', '/'));
+            System.arraycopy(parentBytes, 0, b, 0, Math.min(parentBytes.length, b.length));
+        }
 
         if (byteLen == 8) {
             // bit 7 of byte[4] must be 1 for the SDK to recognise this as a collection RID

--- a/src/main/java/io/floci/az/services/cosmos/CosmosQueryEngine.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosQueryEngine.java
@@ -57,7 +57,9 @@ public class CosmosQueryEngine {
             String aggregateType,        // "SUM","AVG","MIN","MAX" — scalar aggregate without GROUP BY
             String aggregateField,       // field path for the aggregate (already alias-stripped)
             boolean distinct,            // SELECT DISTINCT
-            List<String> groupBy         // GROUP BY field expressions (empty = no GROUP BY)
+            List<String> groupBy,        // GROUP BY field expressions (empty = no GROUP BY)
+            boolean wrappedCountProjection,
+            String rootAlias
     ) {}
 
     public record QueryResult(List<Object> items, int count) {}
@@ -86,7 +88,11 @@ public class CosmosQueryEngine {
 
         // COUNT(1) / COUNT(*) — scalar
         if (q.countQuery()) {
-            return new QueryResult(List.of((long) filtered.size()), 1);
+            Object count = (long) filtered.size();
+            if (q.wrappedCountProjection()) {
+                count = List.of(Map.of("item", count));
+            }
+            return new QueryResult(List.of(count), 1);
         }
 
         // SUM / AVG / MIN / MAX without GROUP BY — scalar aggregate
@@ -118,12 +124,14 @@ public class CosmosQueryEngine {
         List<Object> results;
         if (q.selectValue() && q.selectFields() != null && q.selectFields().size() == 1) {
             String path = q.selectFields().get(0);
-            results = filtered.stream().map(doc -> resolve(doc, path)).collect(Collectors.toCollection(ArrayList::new));
+            results = filtered.stream()
+                    .map(doc -> path.equals(q.rootAlias()) ? doc : resolve(doc, path))
+                    .collect(Collectors.toCollection(ArrayList::new));
         } else if (q.selectFields() == null) {
             results = new ArrayList<>(filtered);
         } else {
             results = filtered.stream()
-                    .map(doc -> (Object) projectDoc(doc, q.selectFields()))
+                    .map(doc -> (Object) projectDoc(doc, q.selectFields(), q.rootAlias()))
                     .collect(Collectors.toCollection(ArrayList::new));
         }
 
@@ -147,6 +155,10 @@ public class CosmosQueryEngine {
             "(?is)EXISTS\\s*\\(\\s*SELECT\\s+VALUE\\s+(\\w+)\\s+"
                     + "FROM\\s+\\1\\s+IN\\s+([\\w.]+)"
                     + "(?:\\s+WHERE\\s+(.+))?\\s*\\)");
+    private static final Pattern DOTNET_WRAPPED_COUNT_PATTERN = Pattern.compile(
+            "(?i)^SELECT\\s+VALUE\\s+\\[\\{\\s*\"item\"\\s*:\\s*COUNT\\s*\\((?:1|\\*)\\)\\s*}]\\s+FROM\\b");
+    private static final Pattern DOTNET_ORDER_BY_ITEM_PATTERN = Pattern.compile(
+            "\\[\\{\\s*\"item\"\\s*:\\s*(.+)\\s*}]", Pattern.CASE_INSENSITIVE);
 
     ParsedQuery parse(String sql) {
         String upper = sql.toUpperCase();
@@ -170,6 +182,19 @@ public class CosmosQueryEngine {
         int groupByIdx = fromIdx >= 0 ? indexOfKeyword(upper, "GROUP BY", fromIdx) : -1;
         int orderIdx   = indexOfKeyword(upper, "ORDER BY", Math.max(fromIdx, 0));
         int offsetIdx  = indexOfKeyword(upper, "OFFSET",   Math.max(Math.max(orderIdx, groupByIdx), 0));
+        String rootAlias = "c";
+        if (fromIdx >= 0) {
+            int fromEnd = minPositive(whereIdx, groupByIdx, orderIdx, offsetIdx, sql.length());
+            String[] fromTokens = sql.substring(fromIdx + 4, fromEnd).trim().split("\\s+");
+            if (fromTokens.length > 0 && !fromTokens[0].isBlank()) {
+                rootAlias = fromTokens[0];
+                if (fromTokens.length > 2 && "AS".equalsIgnoreCase(fromTokens[1])) {
+                    rootAlias = fromTokens[2];
+                } else if (fromTokens.length == 2) {
+                    rootAlias = fromTokens[1];
+                }
+            }
+        }
 
         // WHERE clause text — ends at the first of: GROUP BY, ORDER BY, OFFSET, or end
         String where = null;
@@ -206,6 +231,7 @@ public class CosmosQueryEngine {
         // COUNT query: only true when there is no GROUP BY
         boolean countQuery = groupBy.isEmpty()
                 && (upper.contains("COUNT(1)") || upper.contains("COUNT(*)"));
+        boolean wrappedCountProjection = countQuery && DOTNET_WRAPPED_COUNT_PATTERN.matcher(sql).find();
 
         // SELECT clause
         boolean selectValue   = false;
@@ -250,7 +276,7 @@ public class CosmosQueryEngine {
         }
 
         return new ParsedQuery(countQuery, selectValue, selectFields, where, orderBy, top, offset, limit,
-                aggregateType, aggregateField, distinct, groupBy);
+                aggregateType, aggregateField, distinct, groupBy, wrappedCountProjection, rootAlias);
     }
 
     // -----------------------------------------------------------------------
@@ -260,6 +286,8 @@ public class CosmosQueryEngine {
     boolean evalExpr(Map<String, Object> doc, String expr) {
         expr = expr.trim();
         if (expr.isEmpty()) return true;
+        if ("true".equalsIgnoreCase(expr)) return true;
+        if ("false".equalsIgnoreCase(expr)) return false;
 
         // Strip balanced outer parens
         if (expr.startsWith("(") && matchingCloseParen(expr, 0) == expr.length() - 1) {
@@ -530,7 +558,7 @@ public class CosmosQueryEngine {
     // Projection
     // -----------------------------------------------------------------------
 
-    private Map<String, Object> projectDoc(Map<String, Object> doc, List<String> fields) {
+    private Map<String, Object> projectDoc(Map<String, Object> doc, List<String> fields, String rootAlias) {
         Map<String, Object> result = new LinkedHashMap<>();
         for (String field : fields) {
             int asIdx = findTopLevelKeyword(field, "AS");
@@ -547,7 +575,7 @@ public class CosmosQueryEngine {
                     alias = expr.contains(".") ? expr.substring(expr.indexOf('.') + 1) : expr;
                 }
             }
-            Object val = resolveExpr(doc, expr);
+            Object val = expr.equals(rootAlias) ? doc : resolveExpr(doc, expr);
             setNested(result, alias, val);
         }
         return result;
@@ -795,6 +823,13 @@ public class CosmosQueryEngine {
         if ("null".equalsIgnoreCase(expr))  return null;
         if ("true".equalsIgnoreCase(expr))  return Boolean.TRUE;
         if ("false".equalsIgnoreCase(expr)) return Boolean.FALSE;
+
+        Matcher orderByItem = DOTNET_ORDER_BY_ITEM_PATTERN.matcher(expr);
+        if (orderByItem.matches()) {
+            Map<String, Object> item = new LinkedHashMap<>();
+            item.put("item", resolveExpr(doc, orderByItem.group(1).trim()));
+            return List.of(item);
+        }
 
         // Numeric literal
         if (expr.matches("-?\\d+(\\.\\d+)?([eE][+-]?\\d+)?")) {

--- a/src/main/java/io/floci/az/services/cosmos/CosmosQueryEngine.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosQueryEngine.java
@@ -158,7 +158,7 @@ public class CosmosQueryEngine {
     private static final Pattern DOTNET_WRAPPED_COUNT_PATTERN = Pattern.compile(
             "(?i)^SELECT\\s+VALUE\\s+\\[\\{\\s*\"item\"\\s*:\\s*COUNT\\s*\\((?:1|\\*)\\)\\s*}]\\s+FROM\\b");
     private static final Pattern DOTNET_ORDER_BY_ITEM_PATTERN = Pattern.compile(
-            "\\[\\{\\s*\"item\"\\s*:\\s*(.+)\\s*}]", Pattern.CASE_INSENSITIVE);
+            "\\{\\s*\"item\"\\s*:\\s*(.+)\\s*}", Pattern.CASE_INSENSITIVE);
 
     ParsedQuery parse(String sql) {
         String upper = sql.toUpperCase();
@@ -779,7 +779,9 @@ public class CosmosQueryEngine {
 
     List<String> splitTopLevel(String s, char delim) {
         List<String> result = new ArrayList<>();
-        int depth = 0;
+        int parenthesisDepth = 0;
+        int bracketDepth = 0;
+        int braceDepth = 0;
         boolean inStr = false;
         char strCh = 0;
         int start = 0;
@@ -790,9 +792,13 @@ public class CosmosQueryEngine {
                 if (c == strCh) inStr = false;
             } else if (c == '\'' || c == '"') {
                 inStr = true; strCh = c;
-            } else if (c == '(') { depth++;
-            } else if (c == ')') { depth--;
-            } else if (c == delim && depth == 0) {
+            } else if (c == '(') { parenthesisDepth++;
+            } else if (c == ')') { parenthesisDepth--;
+            } else if (c == '[') { bracketDepth++;
+            } else if (c == ']') { bracketDepth--;
+            } else if (c == '{') { braceDepth++;
+            } else if (c == '}') { braceDepth--;
+            } else if (c == delim && parenthesisDepth == 0 && bracketDepth == 0 && braceDepth == 0) {
                 result.add(s.substring(start, i));
                 start = i + 1;
             }
@@ -824,11 +830,21 @@ public class CosmosQueryEngine {
         if ("true".equalsIgnoreCase(expr))  return Boolean.TRUE;
         if ("false".equalsIgnoreCase(expr)) return Boolean.FALSE;
 
-        Matcher orderByItem = DOTNET_ORDER_BY_ITEM_PATTERN.matcher(expr);
-        if (orderByItem.matches()) {
-            Map<String, Object> item = new LinkedHashMap<>();
-            item.put("item", resolveExpr(doc, orderByItem.group(1).trim()));
-            return List.of(item);
+        if (expr.startsWith("[") && expr.endsWith("]")) {
+            List<Map<String, Object>> items = new ArrayList<>();
+            for (String rawItem : splitTopLevel(expr.substring(1, expr.length() - 1), ',')) {
+                Matcher orderByItem = DOTNET_ORDER_BY_ITEM_PATTERN.matcher(rawItem.trim());
+                if (!orderByItem.matches()) {
+                    items.clear();
+                    break;
+                }
+                Map<String, Object> item = new LinkedHashMap<>();
+                item.put("item", resolveExpr(doc, orderByItem.group(1).trim()));
+                items.add(item);
+            }
+            if (!items.isEmpty()) {
+                return items;
+            }
         }
 
         // Numeric literal

--- a/src/test/java/io/floci/az/services/cosmos/CosmosAccountInfoTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosAccountInfoTest.java
@@ -1,0 +1,79 @@
+package io.floci.az.services.cosmos;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@QuarkusTest
+class CosmosAccountInfoTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    @Test
+    void accountAdvertisesDotnetQueryEngineConfiguration() throws Exception {
+        String serializedConfiguration = given()
+                .get("/queryconfig-cosmos/")
+                .then()
+                .statusCode(200)
+                .extract()
+                .path("queryEngineConfiguration");
+
+        Map<String, Object> configuration = MAPPER.readValue(
+                serializedConfiguration, new TypeReference<>() {});
+
+        assertFalse(configuration.isEmpty());
+        assertEquals(262144, configuration.get("maxSqlQueryInputLength"));
+        assertEquals(16000, configuration.get("maxInExpressionItemsCount"));
+        assertTrue((Boolean) configuration.get("sqlAllowAggregateFunctions"));
+        assertTrue((Boolean) configuration.get("sqlAllowGroupByClause"));
+        assertTrue((Boolean) configuration.get("sqlAllowTop"));
+    }
+
+    @Test
+    void partitionKeyRangesCanBeReadThroughRidLink() {
+        String base = "/queryconfig-cosmos";
+        String databaseRid = given().contentType("application/json").body("{\"id\":\"db\"}")
+                .post(base + "/dbs").then().statusCode(201)
+                .extract().path("_rid");
+        String containerRid = given().contentType("application/json")
+                .body("{\"id\":\"items\",\"partitionKey\":{\"paths\":[\"/pk\"],\"kind\":\"Hash\"}}")
+                .post(base + "/dbs/db/colls")
+                .then().statusCode(201)
+                .extract().path("_rid");
+        byte[] databaseRidBytes = Base64.getDecoder().decode(databaseRid.replace('-', '/'));
+        byte[] containerRidBytes = Base64.getDecoder().decode(containerRid.replace('-', '/'));
+        assertArrayEquals(databaseRidBytes, Arrays.copyOf(containerRidBytes, databaseRidBytes.length));
+
+        Response response = given().pathParam("databaseRid", databaseRid).pathParam("containerRid", containerRid)
+                .get(base + "/dbs/{databaseRid}/colls/{containerRid}/pkranges");
+        response.then().statusCode(200)
+                .body("_count", is(1))
+                .body("PartitionKeyRanges[0].minInclusive", is(""))
+                .body("PartitionKeyRanges[0].maxExclusive", is("FF"));
+
+        given().pathParam("databaseRid", databaseRid).pathParam("containerRid", containerRid)
+                .header("If-None-Match", response.header("etag"))
+                .get(base + "/dbs/{databaseRid}/colls/{containerRid}/pkranges")
+                .then().statusCode(304);
+
+        String otherDatabaseRid = given().contentType("application/json").body("{\"id\":\"other\"}")
+                .post(base + "/dbs").then().statusCode(201)
+                .extract().path("_rid");
+        given().pathParam("databaseRid", otherDatabaseRid).pathParam("containerRid", containerRid)
+                .get(base + "/dbs/{databaseRid}/colls/{containerRid}/pkranges")
+                .then().statusCode(404);
+    }
+}

--- a/src/test/java/io/floci/az/services/cosmos/CosmosQueryEngineOrderByTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosQueryEngineOrderByTest.java
@@ -134,6 +134,25 @@ class CosmosQueryEngineOrderByTest {
     }
 
     @Test
+    void dotnetRewrittenMultiOrderByQueryReturnsEveryPlannerItem() {
+        List<Map<String, Object>> docs = List.of(
+                Map.of("id", "z", "rank", 1),
+                Map.of("id", "a", "rank", 1));
+
+        CosmosQueryEngine.QueryResult result = engine.execute("""
+                SELECT items._rid,
+                       [{"item": items.rank}, {"item": items.id}] AS orderByItems,
+                       items AS payload
+                FROM items
+                ORDER BY items.rank, items.id
+                """, List.of(), docs);
+
+        Map<?, ?> first = (Map<?, ?>) result.items().getFirst();
+        assertEquals(List.of(Map.of("item", 1), Map.of("item", "a")), first.get("orderByItems"));
+        assertEquals("a", ((Map<?, ?>) first.get("payload")).get("id"));
+    }
+
+    @Test
     void dotnetRewrittenCountQueryReturnsAggregateProjection() {
         CosmosQueryEngine.QueryResult result = engine.execute("""
                 SELECT VALUE [{"item": COUNT(1)}]

--- a/src/test/java/io/floci/az/services/cosmos/CosmosQueryEngineOrderByTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosQueryEngineOrderByTest.java
@@ -113,4 +113,33 @@ class CosmosQueryEngineOrderByTest {
         assertEquals(List.of("b", "a"),
                 r.items().stream().map(d -> ((Map<?, ?>) d).get("id")).toList());
     }
+
+    @Test
+    void dotnetRewrittenOrderByQueryReturnsPlannerEnvelope() {
+        List<Map<String, Object>> docs = List.of(
+                Map.of("id", "high", "rank", 2),
+                Map.of("id", "low", "rank", 1));
+
+        CosmosQueryEngine.QueryResult result = engine.execute("""
+                SELECT items._rid, [{"item": items.rank}] AS orderByItems, items AS payload
+                FROM items
+                WHERE (true)
+                ORDER BY items.rank
+                """, List.of(), docs);
+
+        assertEquals(2, result.count());
+        Map<?, ?> first = (Map<?, ?>) result.items().get(0);
+        assertEquals(List.of(Map.of("item", 1)), first.get("orderByItems"));
+        assertEquals("low", ((Map<?, ?>) first.get("payload")).get("id"));
+    }
+
+    @Test
+    void dotnetRewrittenCountQueryReturnsAggregateProjection() {
+        CosmosQueryEngine.QueryResult result = engine.execute("""
+                SELECT VALUE [{"item": COUNT(1)}]
+                FROM c
+                """, List.of(), List.of(Map.of("id", "one"), Map.of("id", "two")));
+
+        assertEquals(List.of(List.of(Map.of("item", 2L))), result.items());
+    }
 }


### PR DESCRIPTION
## Summary

- return an Azure-compatible queryEngineConfiguration for Cosmos account discovery
- support RID-based partition-key-range refreshes and ETag responses used by .NET
- handle .NET client query-planner envelopes, including multiple ORDER BY items
- add Microsoft.Azure.Cosmos compatibility and focused protocol coverage

Follow-up: #235 documents deliberate query-planner configuration differences.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature
- [ ] Breaking change
- [ ] Docs / chore

## Azure Compatibility

Supports the official .NET SDK query planning and gateway request shapes. Floci-AZ deliberately advertises sqlAllowLike=true and sqlDisableOptimizationFlags=0; #235 documents why.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Conventional Commits

Tests: focused 14 passed; Cosmos suite 116 passed; .NET build clean; live .NET query test passed.

Closes #216