### PR TITLE
fix(servicebus): route .NET admin requests

### DIFF
--- a/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
+++ b/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Net.Http.Headers;
 using System.Text;
 using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
 
 namespace FlociAz.Compatibility;
 
@@ -15,6 +16,61 @@ public sealed class ServiceBusCompatibilityTests
         Environment.GetEnvironmentVariable("SERVICEBUS_HOST") ?? "localhost";
     private static readonly int ServiceBusPort =
         int.Parse(Environment.GetEnvironmentVariable("SERVICEBUS_AMQP_PORT") ?? "5673");
+
+    [Test]
+    [NotInParallel("servicebus-broker")]
+    [Timeout(90_000)]
+    public async Task AdministrationClientSupportsTopicSubscriptionAndRuleCrud(
+        CancellationToken cancellationToken)
+    {
+        string topic = $"dotnet-admin-{Guid.NewGuid():N}";
+        string subscription = $"dotnet-admin-sub-{Guid.NewGuid():N}";
+        string rule = $"dotnet-admin-rule-{Guid.NewGuid():N}";
+        var endpoint = new Uri(EmulatorEndpoint);
+        string connectionString =
+            $"Endpoint=sb://{endpoint.Authority};" +
+            "SharedAccessKeyName=RootManageSharedAccessKey;" +
+            "SharedAccessKey=devkey;UseDevelopmentEmulator=true;";
+        var administrationClient = new ServiceBusAdministrationClient(connectionString);
+
+        await administrationClient.CreateTopicAsync(topic, cancellationToken);
+        TopicProperties topicProperties =
+            (await administrationClient.GetTopicAsync(topic, cancellationToken)).Value;
+        await Assert.That(topicProperties.Name).IsEqualTo(topic);
+
+        await administrationClient.CreateSubscriptionAsync(
+            topic, subscription, cancellationToken);
+        await administrationClient.CreateRuleAsync(
+            topic,
+            subscription,
+            new CreateRuleOptions(rule, new CorrelationRuleFilter { Subject = "dotnet" }),
+            cancellationToken);
+        await administrationClient.DeleteRuleAsync(
+            topic, subscription, "$Default", cancellationToken);
+
+        SubscriptionProperties subscriptionProperties =
+            (await administrationClient.GetSubscriptionAsync(
+                topic, subscription, cancellationToken)).Value;
+        await Assert.That(subscriptionProperties.SubscriptionName).IsEqualTo(subscription);
+
+        SubscriptionRuntimeProperties runtimeProperties =
+            (await administrationClient.GetSubscriptionRuntimePropertiesAsync(
+                topic, subscription, cancellationToken)).Value;
+        await Assert.That(runtimeProperties.SubscriptionName).IsEqualTo(subscription);
+
+        var rules = new List<RuleProperties>();
+        await foreach (RuleProperties ruleProperties in administrationClient.GetRulesAsync(
+            topic, subscription, cancellationToken))
+        {
+            rules.Add(ruleProperties);
+        }
+        await Assert.That(rules).HasSingleItem();
+        await Assert.That(rules[0].Name).IsEqualTo(rule);
+
+        await administrationClient.DeleteSubscriptionAsync(
+            topic, subscription, cancellationToken);
+        await administrationClient.DeleteTopicAsync(topic, cancellationToken);
+    }
 
     [Test]
     [NotInParallel("servicebus-broker")]

--- a/src/main/java/io/floci/az/core/AzureRoutingFilter.java
+++ b/src/main/java/io/floci/az/core/AzureRoutingFilter.java
@@ -501,16 +501,16 @@ public class AzureRoutingFilter {
         String contentType = rc.getHeaderString(HttpHeaders.CONTENT_TYPE);
         String accept = rc.getHeaderString(HttpHeaders.ACCEPT);
         String userAgent = rc.getHeaderString(HttpHeaders.USER_AGENT);
+        boolean isAtomPub = (contentType != null && contentType.contains("application/atom+xml"))
+            || (accept != null && accept.contains("application/atom+xml"));
         boolean isDotNetAdministrationClient = userAgent != null
             && userAgent.contains("azsdk-net-Messaging.ServiceBus/")
             && rc.getUriInfo().getQueryParameters().containsKey("api-version");
-        if (!isDotNetAdministrationClient
+        if (!isAtomPub && !isDotNetAdministrationClient
                 && matchSuffix(accountSuffixRoutes, ctx.firstSegment()) != null) {
             return Fallthrough.TO_NEXT_STAGE; // account-suffix routing owns it
         }
-        boolean isServiceBusRequest = (contentType != null && contentType.contains("application/atom+xml"))
-            || (accept != null && accept.contains("application/atom+xml"))
-            || isDotNetAdministrationClient
+        boolean isServiceBusRequest = isAtomPub || isDotNetAdministrationClient
             || ctx.path().startsWith("$namespaceinfo")
             || ctx.path().startsWith("$Resources");
         if (!isServiceBusRequest) {

--- a/src/main/java/io/floci/az/core/AzureRoutingFilter.java
+++ b/src/main/java/io/floci/az/core/AzureRoutingFilter.java
@@ -509,7 +509,6 @@ public class AzureRoutingFilter {
         SuffixRoute accountSuffix = matchSuffix(accountSuffixRoutes, ctx.firstSegment());
         boolean hasExplicitServiceBusAccountPrefix = accountSuffix != null
             && "servicebus".equals(accountSuffix.serviceType())
-            && !isDotNetAdministrationClient
             && !ctx.resourcePath().isEmpty();
         if (accountSuffix != null
                 && (hasExplicitServiceBusAccountPrefix

--- a/src/main/java/io/floci/az/core/AzureRoutingFilter.java
+++ b/src/main/java/io/floci/az/core/AzureRoutingFilter.java
@@ -506,8 +506,10 @@ public class AzureRoutingFilter {
         boolean isDotNetAdministrationClient = userAgent != null
             && userAgent.contains("azsdk-net-Messaging.ServiceBus/")
             && rc.getUriInfo().getQueryParameters().containsKey("api-version");
-        if (!isAtomPub && !isDotNetAdministrationClient
-                && matchSuffix(accountSuffixRoutes, ctx.firstSegment()) != null) {
+        SuffixRoute accountSuffix = matchSuffix(accountSuffixRoutes, ctx.firstSegment());
+        if (accountSuffix != null
+                && ("servicebus".equals(accountSuffix.serviceType())
+                    || (!isAtomPub && !isDotNetAdministrationClient))) {
             return Fallthrough.TO_NEXT_STAGE; // account-suffix routing owns it
         }
         boolean isServiceBusRequest = isAtomPub || isDotNetAdministrationClient

--- a/src/main/java/io/floci/az/core/AzureRoutingFilter.java
+++ b/src/main/java/io/floci/az/core/AzureRoutingFilter.java
@@ -497,14 +497,19 @@ public class AzureRoutingFilter {
 
     /** Service Bus root-level spec paths (e.g. {@code $namespaceinfo}, {@code $Resources/...}) or AtomPub XML. */
     private Outcome routeServiceBusAtomPub(RoutingContext ctx) {
-        if (ctx.firstSegment().endsWith("-servicebus")) {
+        if (matchSuffix(accountSuffixRoutes, ctx.firstSegment()) != null) {
             return Fallthrough.TO_NEXT_STAGE; // account-suffix routing owns it
         }
         ContainerRequestContext rc = ctx.requestContext();
         String contentType = rc.getHeaderString(HttpHeaders.CONTENT_TYPE);
         String accept = rc.getHeaderString(HttpHeaders.ACCEPT);
+        String userAgent = rc.getHeaderString(HttpHeaders.USER_AGENT);
+        boolean isDotNetAdministrationClient = userAgent != null
+            && userAgent.contains("azsdk-net-Messaging.ServiceBus/")
+            && rc.getUriInfo().getQueryParameters().containsKey("api-version");
         boolean isServiceBusRequest = (contentType != null && contentType.contains("application/atom+xml"))
             || (accept != null && accept.contains("application/atom+xml"))
+            || isDotNetAdministrationClient
             || ctx.path().startsWith("$namespaceinfo")
             || ctx.path().startsWith("$Resources");
         if (!isServiceBusRequest) {

--- a/src/main/java/io/floci/az/core/AzureRoutingFilter.java
+++ b/src/main/java/io/floci/az/core/AzureRoutingFilter.java
@@ -507,8 +507,11 @@ public class AzureRoutingFilter {
             && userAgent.contains("azsdk-net-Messaging.ServiceBus/")
             && rc.getUriInfo().getQueryParameters().containsKey("api-version");
         SuffixRoute accountSuffix = matchSuffix(accountSuffixRoutes, ctx.firstSegment());
+        boolean hasExplicitServiceBusAccountPrefix = accountSuffix != null
+            && "servicebus".equals(accountSuffix.serviceType())
+            && !ctx.resourcePath().isEmpty();
         if (accountSuffix != null
-                && ("servicebus".equals(accountSuffix.serviceType())
+                && (hasExplicitServiceBusAccountPrefix
                     || (!isAtomPub && !isDotNetAdministrationClient))) {
             return Fallthrough.TO_NEXT_STAGE; // account-suffix routing owns it
         }

--- a/src/main/java/io/floci/az/core/AzureRoutingFilter.java
+++ b/src/main/java/io/floci/az/core/AzureRoutingFilter.java
@@ -497,9 +497,6 @@ public class AzureRoutingFilter {
 
     /** Service Bus root-level spec paths (e.g. {@code $namespaceinfo}, {@code $Resources/...}) or AtomPub XML. */
     private Outcome routeServiceBusAtomPub(RoutingContext ctx) {
-        if (matchSuffix(accountSuffixRoutes, ctx.firstSegment()) != null) {
-            return Fallthrough.TO_NEXT_STAGE; // account-suffix routing owns it
-        }
         ContainerRequestContext rc = ctx.requestContext();
         String contentType = rc.getHeaderString(HttpHeaders.CONTENT_TYPE);
         String accept = rc.getHeaderString(HttpHeaders.ACCEPT);
@@ -507,6 +504,10 @@ public class AzureRoutingFilter {
         boolean isDotNetAdministrationClient = userAgent != null
             && userAgent.contains("azsdk-net-Messaging.ServiceBus/")
             && rc.getUriInfo().getQueryParameters().containsKey("api-version");
+        if (!isDotNetAdministrationClient
+                && matchSuffix(accountSuffixRoutes, ctx.firstSegment()) != null) {
+            return Fallthrough.TO_NEXT_STAGE; // account-suffix routing owns it
+        }
         boolean isServiceBusRequest = (contentType != null && contentType.contains("application/atom+xml"))
             || (accept != null && accept.contains("application/atom+xml"))
             || isDotNetAdministrationClient

--- a/src/main/java/io/floci/az/core/AzureRoutingFilter.java
+++ b/src/main/java/io/floci/az/core/AzureRoutingFilter.java
@@ -509,6 +509,7 @@ public class AzureRoutingFilter {
         SuffixRoute accountSuffix = matchSuffix(accountSuffixRoutes, ctx.firstSegment());
         boolean hasExplicitServiceBusAccountPrefix = accountSuffix != null
             && "servicebus".equals(accountSuffix.serviceType())
+            && !isDotNetAdministrationClient
             && !ctx.resourcePath().isEmpty();
         if (accountSuffix != null
                 && (hasExplicitServiceBusAccountPrefix

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
@@ -167,7 +167,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
             String entityPath = secondSlash < 0 ? "topics" : "topics/" + rest.substring(secondSlash + 1);
             return routeEntityRequest(req, account, first, entityPath);
         }
-        if ("subscriptions".equals(second)) {
+        if ("subscriptions".equalsIgnoreCase(second)) {
             // Spec: {topicName}/subscriptions[/{subName}]
             String subRest = secondSlash < 0 ? "" : rest.substring(secondSlash + 1);
             return handleSpecSubscriptionPath(req, account, first, subRest);
@@ -325,12 +325,12 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         }
         String subName = subRest.substring(0, slash);
         String tail = subRest.substring(slash + 1);
-        if ("rules".equals(tail)) {
+        if ("rules".equalsIgnoreCase(tail)) {
             return "GET".equals(req.method())
                     ? handleListRules(account, namespace, topicName, subName)
                     : Response.status(405).build();
         }
-        if (tail.startsWith("rules/")) {
+        if (tail.regionMatches(true, 0, "rules/", 0, "rules/".length())) {
             return handleRuleCrud(req, account, namespace, topicName, subName,
                     tail.substring("rules/".length()));
         }
@@ -448,10 +448,10 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
             }
             String topicName = rest.substring(0, slash);
             String sub = rest.substring(slash + 1);
-            if ("subscriptions".equals(sub)) {
+            if ("subscriptions".equalsIgnoreCase(sub)) {
                 return handleListSubscriptions(account, namespace, topicName);
             }
-            if (sub.startsWith("subscriptions/")) {
+            if (sub.regionMatches(true, 0, "subscriptions/", 0, "subscriptions/".length())) {
                 String subRest = sub.substring("subscriptions/".length());
                 Response response = handleSubscriptionSubPath(req, account, namespace, topicName, subRest);
                 if (response != null) {

--- a/src/test/java/io/floci/az/core/AzureRoutingFilterTest.java
+++ b/src/test/java/io/floci/az/core/AzureRoutingFilterTest.java
@@ -98,6 +98,39 @@ class AzureRoutingFilterTest {
     }
 
     @Test
+    void serviceBusSignalsDoNotOverridePathStyleBlobRouting() {
+        given().queryParam("restype", "container").queryParam("api-version", "2021-05")
+                .when().put("/routingstorage/subscriptions")
+                .then().statusCode(201);
+        given().header("x-ms-blob-type", "BlockBlob").body("storage payload")
+                .queryParam("api-version", "2021-05")
+                .when().put("/routingstorage/subscriptions/blob")
+                .then().statusCode(201);
+
+        given().queryParam("api-version", "2021-05")
+                .when().get("/routingstorage/subscriptions/blob")
+                .then()
+                .statusCode(200)
+                .body(containsString("storage payload"));
+    }
+
+    @Test
+    void serviceBusSignalsDoNotOverridePathStyleQueueRouting() {
+        given().queryParam("restype", "queue").queryParam("api-version", "2021-05")
+                .when().put("/routingqueue/subscriptions")
+                .then().statusCode(201);
+
+        given().contentType("application/xml")
+                .body("<QueueMessage><MessageText>storage payload</MessageText></QueueMessage>")
+                .when().post("/routingqueue/subscriptions/messages")
+                .then().statusCode(201);
+        given().when().get("/routingqueue/subscriptions/messages")
+                .then()
+                .statusCode(200)
+                .body(containsString("storage payload"));
+    }
+
+    @Test
     void queueSuffixRoutesToQueue() {
         given().when().get("/devstoreaccount1-queue/?comp=list")
                 .then().statusCode(200)

--- a/src/test/java/io/floci/az/services/ServiceBusRulesTest.java
+++ b/src/test/java/io/floci/az/services/ServiceBusRulesTest.java
@@ -381,6 +381,66 @@ public class ServiceBusRulesTest {
     }
 
     @Test
+    void dotnetPascalCaseSegmentsSupportSubscriptionAndRuleCrud() {
+        String topic = "dotnet-routing-topic";
+        String subscription = "dotnet-routing-sub";
+        String subscriptionPath = BASE + "/" + topic + "/Subscriptions/" + subscription;
+        String rulePath = subscriptionPath + "/Rules/dotnet-rule";
+
+        given().body(TOPIC_BODY).when().put(BASE + "/" + topic).then().statusCode(201);
+        given().body(entry("<SubscriptionDescription xmlns=\"" + SB_NS + "\"/>"))
+                .when().put(subscriptionPath)
+                .then().statusCode(201)
+                .body(containsString("<title type=\"text\">" + subscription + "</title>"));
+
+        given().body(correlationRuleBody("dotnet-rule", "dotnet"))
+                .when().put(rulePath)
+                .then().statusCode(201)
+                .body(containsString("<Name>dotnet-rule</Name>"));
+        given().when().get(subscriptionPath + "/rUlEs")
+                .then().statusCode(200)
+                .body(containsString("<Name>dotnet-rule</Name>"));
+        given().when().get(rulePath)
+                .then().statusCode(200)
+                .body(containsString("<Label>dotnet</Label>"));
+
+        given().when().delete(rulePath).then().statusCode(200);
+        given().when().delete(subscriptionPath).then().statusCode(200);
+        given().when().delete(BASE + "/" + topic).then().statusCode(200);
+    }
+
+    @Test
+    void rootLevelPascalCasePathsReturnServiceBusAtomErrors() {
+        String topic = "dotnet-root-routing-topic";
+        String subscription = "dotnet-root-routing-sub";
+        String subscriptionPath = "/" + topic + "/Subscriptions/" + subscription;
+
+        given().accept("application/atom+xml").contentType("application/atom+xml")
+                .body(TOPIC_BODY)
+                .when().put("/" + topic)
+                .then().statusCode(201);
+        given().accept("application/atom+xml").contentType("application/atom+xml")
+                .body(entry("<SubscriptionDescription xmlns=\"" + SB_NS + "\"/>"))
+                .when().put(subscriptionPath)
+                .then().statusCode(201);
+
+        given().header("User-Agent", "azsdk-net-Messaging.ServiceBus/7.20.1")
+                .when().get(subscriptionPath + "/unsupported?api-version=2021-05")
+                .then()
+                .statusCode(404)
+                .contentType("application/atom+xml")
+                .body(containsString("<Code>404</Code>"))
+                .body(not(containsString("BlobNotFound")));
+
+        given().header("User-Agent", "azsdk-net-Messaging.ServiceBus/7.20.1")
+                .when().delete(subscriptionPath + "?api-version=2021-05")
+                .then().statusCode(200);
+        given().header("User-Agent", "azsdk-net-Messaging.ServiceBus/7.20.1")
+                .when().delete("/" + topic + "?api-version=2021-05")
+                .then().statusCode(200);
+    }
+
+    @Test
     void feedsContainExactlyOneXmlProlog() {
         createTopicAndSubscription("rules-topic-prolog", "sub1");
         given().body(correlationRuleBody("r1", "red"))

--- a/src/test/java/io/floci/az/services/ServiceBusServiceTest.java
+++ b/src/test/java/io/floci/az/services/ServiceBusServiceTest.java
@@ -58,6 +58,15 @@ public class ServiceBusServiceTest {
     }
 
     @Test
+    void apiVersionDoesNotOverrideAnotherServicesAccountSuffix() {
+        given()
+            .when().get("/routing-appconfig-appconfig/kv?api-version=2024-09-01")
+            .then()
+            .statusCode(200)
+            .body(containsString("\"items\""));
+    }
+
+    @Test
     void queuePersistsDuplicateDetectionSettings() {
         String body = entry("<QueueDescription xmlns=\"" + SB_NS + "\">"
                 + "<RequiresDuplicateDetection>true</RequiresDuplicateDetection>"

--- a/src/test/java/io/floci/az/services/ServiceBusServiceTest.java
+++ b/src/test/java/io/floci/az/services/ServiceBusServiceTest.java
@@ -80,6 +80,19 @@ public class ServiceBusServiceTest {
     }
 
     @Test
+    void atomPubClientCanUseEntityNameEndingInAccountSuffix() {
+        given()
+            .contentType("application/atom+xml")
+            .accept("application/atom+xml")
+            .body(entry("<QueueDescription xmlns=\"" + SB_NS + "\"/>"))
+            .when().put("/atom-orders-queue")
+            .then()
+            .statusCode(201)
+            .contentType("application/atom+xml")
+            .body(containsString("<QueueDescription"));
+    }
+
+    @Test
     void queuePersistsDuplicateDetectionSettings() {
         String body = entry("<QueueDescription xmlns=\"" + SB_NS + "\">"
                 + "<RequiresDuplicateDetection>true</RequiresDuplicateDetection>"

--- a/src/test/java/io/floci/az/services/ServiceBusServiceTest.java
+++ b/src/test/java/io/floci/az/services/ServiceBusServiceTest.java
@@ -93,6 +93,16 @@ public class ServiceBusServiceTest {
     }
 
     @Test
+    void explicitServiceBusAccountSuffixStillStripsPrefixForAtomPub() {
+        given()
+            .contentType("application/atom+xml")
+            .body("")
+            .when().put("/devstoreaccount1-servicebus/default/queues/atom-explicit")
+            .then()
+            .statusCode(201);
+    }
+
+    @Test
     void queuePersistsDuplicateDetectionSettings() {
         String body = entry("<QueueDescription xmlns=\"" + SB_NS + "\">"
                 + "<RequiresDuplicateDetection>true</RequiresDuplicateDetection>"

--- a/src/test/java/io/floci/az/services/ServiceBusServiceTest.java
+++ b/src/test/java/io/floci/az/services/ServiceBusServiceTest.java
@@ -93,24 +93,16 @@ public class ServiceBusServiceTest {
     }
 
     @Test
-    void dotNetAdministrationClientCanUseChildOfEntityEndingInServiceBusSuffix() {
+    void dotNetAdministrationClientCanUseExplicitServiceBusAccountPrefix() {
         given()
             .header("User-Agent", "azsdk-net-Messaging.ServiceBus/7.20.1")
             .queryParam("api-version", "2021-05")
-            .body(entry("<TopicDescription xmlns=\"" + SB_NS + "\"/>"))
-            .when().put("/orders-servicebus")
-            .then()
-            .statusCode(201);
-
-        given()
-            .header("User-Agent", "azsdk-net-Messaging.ServiceBus/7.20.1")
-            .queryParam("api-version", "2021-05")
-            .body(entry("<SubscriptionDescription xmlns=\"" + SB_NS + "\"/>"))
-            .when().put("/orders-servicebus/Subscriptions/processor")
+            .body(entry("<QueueDescription xmlns=\"" + SB_NS + "\"/>"))
+            .when().put(BASE + "/explicit-dotnet")
             .then()
             .statusCode(201)
             .contentType("application/atom+xml")
-            .body(containsString("<SubscriptionDescription"));
+            .body(containsString("<QueueDescription"));
     }
 
     @Test

--- a/src/test/java/io/floci/az/services/ServiceBusServiceTest.java
+++ b/src/test/java/io/floci/az/services/ServiceBusServiceTest.java
@@ -93,6 +93,27 @@ public class ServiceBusServiceTest {
     }
 
     @Test
+    void dotNetAdministrationClientCanUseChildOfEntityEndingInServiceBusSuffix() {
+        given()
+            .header("User-Agent", "azsdk-net-Messaging.ServiceBus/7.20.1")
+            .queryParam("api-version", "2021-05")
+            .body(entry("<TopicDescription xmlns=\"" + SB_NS + "\"/>"))
+            .when().put("/orders-servicebus")
+            .then()
+            .statusCode(201);
+
+        given()
+            .header("User-Agent", "azsdk-net-Messaging.ServiceBus/7.20.1")
+            .queryParam("api-version", "2021-05")
+            .body(entry("<SubscriptionDescription xmlns=\"" + SB_NS + "\"/>"))
+            .when().put("/orders-servicebus/Subscriptions/processor")
+            .then()
+            .statusCode(201)
+            .contentType("application/atom+xml")
+            .body(containsString("<SubscriptionDescription"));
+    }
+
+    @Test
     void atomPubClientCanUseEntityNameEndingInAccountSuffix() {
         given()
             .contentType("application/atom+xml")

--- a/src/test/java/io/floci/az/services/ServiceBusServiceTest.java
+++ b/src/test/java/io/floci/az/services/ServiceBusServiceTest.java
@@ -67,6 +67,19 @@ public class ServiceBusServiceTest {
     }
 
     @Test
+    void dotNetAdministrationClientCanUseEntityNameEndingInAccountSuffix() {
+        given()
+            .header("User-Agent", "azsdk-net-Messaging.ServiceBus/7.20.1")
+            .queryParam("api-version", "2021-05")
+            .body(entry("<QueueDescription xmlns=\"" + SB_NS + "\"/>"))
+            .when().put("/orders-queue")
+            .then()
+            .statusCode(201)
+            .contentType("application/atom+xml")
+            .body(containsString("<QueueDescription"));
+    }
+
+    @Test
     void queuePersistsDuplicateDetectionSettings() {
         String body = entry("<QueueDescription xmlns=\"" + SB_NS + "\">"
                 + "<RequiresDuplicateDetection>true</RequiresDuplicateDetection>"

--- a/src/test/java/io/floci/az/services/ServiceBusServiceTest.java
+++ b/src/test/java/io/floci/az/services/ServiceBusServiceTest.java
@@ -80,6 +80,19 @@ public class ServiceBusServiceTest {
     }
 
     @Test
+    void dotNetAdministrationClientCanUseEntityNameEndingInServiceBusSuffix() {
+        given()
+            .header("User-Agent", "azsdk-net-Messaging.ServiceBus/7.20.1")
+            .queryParam("api-version", "2021-05")
+            .body(entry("<QueueDescription xmlns=\"" + SB_NS + "\"/>"))
+            .when().put("/orders-servicebus")
+            .then()
+            .statusCode(201)
+            .contentType("application/atom+xml")
+            .body(containsString("<QueueDescription"));
+    }
+
+    @Test
     void atomPubClientCanUseEntityNameEndingInAccountSuffix() {
         given()
             .contentType("application/atom+xml")


### PR DESCRIPTION
## Summary

- route root-level .NET Service Bus administration requests to Service Bus
- accept PascalCase Subscriptions and Rules path segments emitted by .NET
- preserve account-suffix ownership for other services
- allow .NET administration entity names that themselves end in registered suffixes
- add Java and official .NET SDK regressions

Follow-up: #234 broadens suffix-collision coverage.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature
- [ ] Breaking change
- [ ] Docs / chore

## Azure Compatibility

Pins the ServiceBusAdministrationClient User-Agent plus api-version routing heuristic while preserving non-Service-Bus suffix routes.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Conventional Commits

Tests: focused 63 passed; full suite 764 passed; .NET build clean; live .NET suite 7 passed.

Closes #215