### PR TITLE
fix(servicebus): support session DLQ access

### DIFF
--- a/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
+++ b/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
@@ -178,6 +178,59 @@ public sealed class ServiceBusCompatibilityTests
     }
 
     [Test]
+    [Timeout(90_000)]
+    public async Task SessionSubscriptionDeadLetterQueueSupportsPeekAndNonSessionReceive(
+        CancellationToken cancellationToken)
+    {
+        const string serviceBusNamespace = "default";
+        string topic = $"session-dlq-topic-{Guid.NewGuid():N}";
+        string subscription = $"session-dlq-sub-{Guid.NewGuid():N}";
+        string sessionId = $"session-{Guid.NewGuid():N}";
+        await EnsureNamespace(serviceBusNamespace, cancellationToken);
+        await EnsureTopic(serviceBusNamespace, topic, cancellationToken);
+        await EnsureSessionSubscription(
+            serviceBusNamespace, topic, subscription, cancellationToken);
+
+        string connectionString =
+            $"Endpoint=sb://{ServiceBusHost}:{ServiceBusPort};" +
+            "SharedAccessKeyName=RootManageSharedAccessKey;" +
+            "SharedAccessKey=devkey;UseDevelopmentEmulator=true;";
+
+        await using var client = new ServiceBusClient(connectionString, new ServiceBusClientOptions
+        {
+            RetryOptions = { TryTimeout = TimeSpan.FromSeconds(10) }
+        });
+        await using ServiceBusSender sender = client.CreateSender(topic);
+        var outgoing = new ServiceBusMessage("session dead letter")
+        {
+            MessageId = Guid.NewGuid().ToString("N"),
+            SessionId = sessionId,
+            Subject = "important"
+        };
+        outgoing.ApplicationProperties["tenant"] = "contoso";
+        await sender.SendMessageAsync(outgoing, cancellationToken);
+
+        await using (ServiceBusSessionReceiver sessionReceiver = await client.AcceptSessionAsync(
+            topic, subscription, sessionId, new ServiceBusSessionReceiverOptions(), cancellationToken))
+        {
+            ServiceBusReceivedMessage message = await Receive(sessionReceiver, cancellationToken);
+            await sessionReceiver.DeadLetterMessageAsync(
+                message, "validation-failed", "invalid payload", cancellationToken);
+        }
+
+        await using ServiceBusReceiver deadLetterReceiver = client.CreateReceiver(
+            topic, subscription, new ServiceBusReceiverOptions { SubQueue = SubQueue.DeadLetter });
+        ServiceBusReceivedMessage? peeked = await deadLetterReceiver.PeekMessageAsync(
+            cancellationToken: cancellationToken);
+        await Assert.That(peeked).IsNotNull();
+        await AssertDeadLetterProperties(peeked!, outgoing.MessageId, sessionId);
+
+        ServiceBusReceivedMessage received = await Receive(deadLetterReceiver, cancellationToken);
+        await AssertDeadLetterProperties(received, outgoing.MessageId, sessionId);
+        await deadLetterReceiver.CompleteMessageAsync(received, cancellationToken);
+    }
+
+    [Test]
     [Timeout(120_000)]
     public async Task DotnetSdkSuppressesDuplicateMessageIdsForQueuesAndTopics(
         CancellationToken cancellationToken)
@@ -474,6 +527,41 @@ public sealed class ServiceBusCompatibilityTests
             "",
             "Subscription",
             cancellationToken);
+
+    private static Task EnsureSessionSubscription(
+        string serviceBusNamespace,
+        string topic,
+        string subscription,
+        CancellationToken cancellationToken)
+    {
+        const string description = """
+            <entry xmlns="http://www.w3.org/2005/Atom">
+              <content type="application/xml">
+                <SubscriptionDescription xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect">
+                  <RequiresSession>true</RequiresSession>
+                </SubscriptionDescription>
+              </content>
+            </entry>
+            """;
+        return PutEntity(
+            $"{EmulatorEndpoint}/devstoreaccount1-servicebus/{serviceBusNamespace}/topics/{topic}" +
+            $"/subscriptions/{subscription}",
+            description,
+            "Subscription",
+            cancellationToken);
+    }
+
+    private static async Task AssertDeadLetterProperties(
+        ServiceBusReceivedMessage message, string expectedMessageId, string expectedSessionId)
+    {
+        await Assert.That(message.Body.ToString()).IsEqualTo("session dead letter");
+        await Assert.That(message.MessageId).IsEqualTo(expectedMessageId);
+        await Assert.That(message.SessionId).IsEqualTo(expectedSessionId);
+        await Assert.That(message.Subject).IsEqualTo("important");
+        await Assert.That(message.ApplicationProperties["tenant"]).IsEqualTo("contoso");
+        await Assert.That(message.DeadLetterReason).IsEqualTo("validation-failed");
+        await Assert.That(message.DeadLetterErrorDescription).IsEqualTo("invalid payload");
+    }
 
     private static async Task EnsureQueue(
         string serviceBusNamespace,

--- a/pom.xml
+++ b/pom.xml
@@ -306,13 +306,23 @@
                                     failOnNoReplacements="true" />
                                 <replace
                                     file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java"
+                                    token="import org.apache.qpid.proton.amqp.messaging.Modified;"
+                                    value="import org.apache.qpid.proton.amqp.messaging.Modified;&#10;import org.apache.qpid.proton.amqp.messaging.Rejected;"
+                                    failOnNoReplacements="true" />
+                                <replace
+                                    file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java"
                                     token="if (settleImmediate) {"
-                                    value="if (settleImmediate) { delivery.disposition(remoteState);"
+                                    value="if (settleImmediate) { delivery.disposition(remoteState instanceof Rejected ? new Rejected() : remoteState);"
                                     failOnNoReplacements="true" />
                                 <replace
                                     file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java"
                                     token="if (Boolean.TRUE.equals(modification.getDeliveryFailed())) {"
                                     value="if (!Boolean.TRUE.equals(modification.getUndeliverableHere())) {"
+                                    failOnNoReplacements="true" />
+                                <replace
+                                    file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java"
+                                    token="sessionSPI.reject(brokerConsumer, message);"
+                                    value="ServiceBusDeadLetterSupport.apply(message, (Rejected) remoteState); sessionSPI.reject(brokerConsumer, message);"
                                     failOnNoReplacements="true" />
                             </target>
                         </configuration>

--- a/src/artemis-amqp-patch/java/org/apache/activemq/artemis/protocol/amqp/proton/ServiceBusDeadLetterSupport.java
+++ b/src/artemis-amqp-patch/java/org/apache/activemq/artemis/protocol/amqp/proton/ServiceBusDeadLetterSupport.java
@@ -1,0 +1,29 @@
+package org.apache.activemq.artemis.protocol.amqp.proton;
+
+import java.util.Map;
+
+import org.apache.activemq.artemis.api.core.ActiveMQPropertyConversionException;
+import org.apache.activemq.artemis.api.core.Message;
+import org.apache.qpid.proton.amqp.messaging.Rejected;
+import org.apache.qpid.proton.amqp.transport.ErrorCondition;
+
+/** Applies Azure dead-letter outcome metadata to the message before Artemis reroutes it. */
+public final class ServiceBusDeadLetterSupport {
+
+   private ServiceBusDeadLetterSupport() {
+   }
+
+   public static void apply(Message message, Rejected rejected)
+      throws ActiveMQPropertyConversionException {
+      ErrorCondition error = rejected.getError();
+      if (error == null || error.getInfo() == null) {
+         return;
+      }
+
+      for (Object rawEntry : error.getInfo().entrySet()) {
+         Map.Entry<?, ?> entry = (Map.Entry<?, ?>) rawEntry;
+         message.putObjectProperty(entry.getKey().toString(), entry.getValue());
+      }
+      message.reencode();
+   }
+}

--- a/src/artemis-amqp-patch/java/org/apache/activemq/artemis/protocol/amqp/proton/ServiceBusDeadLetterSupport.java
+++ b/src/artemis-amqp-patch/java/org/apache/activemq/artemis/protocol/amqp/proton/ServiceBusDeadLetterSupport.java
@@ -1,9 +1,11 @@
 package org.apache.activemq.artemis.protocol.amqp.proton;
 
+import java.util.Date;
 import java.util.Map;
 
 import org.apache.activemq.artemis.api.core.ActiveMQPropertyConversionException;
 import org.apache.activemq.artemis.api.core.Message;
+import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.qpid.proton.amqp.messaging.Rejected;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 
@@ -22,8 +24,21 @@ public final class ServiceBusDeadLetterSupport {
 
       for (Object rawEntry : error.getInfo().entrySet()) {
          Map.Entry<?, ?> entry = (Map.Entry<?, ?>) rawEntry;
-         message.putObjectProperty(entry.getKey().toString(), entry.getValue());
+         message.putObjectProperty(entry.getKey().toString(), compatiblePropertyValue(entry.getValue()));
       }
       message.reencode();
+   }
+
+   private static Object compatiblePropertyValue(Object value) {
+      if (value == null || value instanceof Boolean || value instanceof Byte
+         || value instanceof Short || value instanceof Integer || value instanceof Long
+         || value instanceof Float || value instanceof Double || value instanceof String
+         || value instanceof SimpleString || value instanceof byte[]) {
+         return value;
+      }
+      if (value instanceof Date date) {
+         return date.toInstant().toString();
+      }
+      return value.toString();
    }
 }

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -271,8 +271,6 @@ public class ServiceBusNamespaceManager {
             createManagementAddress(http, baseUrl, auth, mbean, deadLetterQueue);
             applySessionMetadata(http, baseUrl, auth, mbean, queueName,
                     requiresSession, lockDurationSeconds);
-            applySessionMetadata(http, baseUrl, auth, mbean, deadLetterQueue,
-                    requiresSession, lockDurationSeconds);
             jolokiaExec(http, baseUrl, auth, mbean,
                     "addAddressSettings(java.lang.String,java.lang.String)",
                     jsonArr(queueName, addressSettings));
@@ -420,8 +418,6 @@ public class ServiceBusNamespaceManager {
             createManagementAddress(http, baseUrl, auth, mbean, queueName);
             createManagementAddress(http, baseUrl, auth, mbean, deadLetterQueue);
             applySessionMetadata(http, baseUrl, auth, mbean, queueName,
-                    requiresSession, lockDurationSeconds);
-            applySessionMetadata(http, baseUrl, auth, mbean, deadLetterQueue,
                     requiresSession, lockDurationSeconds);
             jolokiaExec(http, baseUrl, auth, mbean,
                     "addAddressSettings(java.lang.String,java.lang.String)",

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusConfigGeneratorTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusConfigGeneratorTest.java
@@ -137,6 +137,7 @@ class ServiceBusConfigGeneratorTest {
                 "org/apache/activemq/artemis/protocol/amqp/proton/AmqpTransferTagGenerator.class",
                 "org/apache/activemq/artemis/protocol/amqp/proton/DefaultSenderController.class",
                 "org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerReceiverContext.class",
+                "org/apache/activemq/artemis/protocol/amqp/proton/ServiceBusDeadLetterSupport.class",
                 "org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.class");
         try (InputStream stream = getClass().getResourceAsStream(
                 ServiceBusNamespaceManager.ARTEMIS_AMQP_PATCH_RESOURCE)) {

--- a/src/test/java/org/apache/activemq/artemis/protocol/amqp/proton/ServiceBusDeadLetterSupportTest.java
+++ b/src/test/java/org/apache/activemq/artemis/protocol/amqp/proton/ServiceBusDeadLetterSupportTest.java
@@ -1,0 +1,48 @@
+package org.apache.activemq.artemis.protocol.amqp.proton;
+
+import org.apache.activemq.artemis.api.core.Message;
+import org.apache.qpid.proton.amqp.Symbol;
+import org.apache.qpid.proton.amqp.messaging.Rejected;
+import org.apache.qpid.proton.amqp.transport.ErrorCondition;
+import org.junit.jupiter.api.Test;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class ServiceBusDeadLetterSupportTest {
+
+    @Test
+    void convertsUnsupportedDeadLetterProperties() throws Exception {
+        Message message = mock(Message.class);
+        Rejected rejected = new Rejected();
+        ErrorCondition error = new ErrorCondition();
+        Instant modifiedAt = Instant.parse("2026-08-28T00:00:00Z");
+        error.setInfo(Map.of(
+                Symbol.valueOf("modified-at"), Date.from(modifiedAt),
+                Symbol.valueOf("attempt"), 3));
+        rejected.setError(error);
+
+        Path patchJar = Path.of("target", "classes", "artemis",
+                "artemis-amqp-protocol-2.44.0-floci-az-artemis-amqp-patch.jar");
+        try (URLClassLoader loader = new URLClassLoader(
+                new URL[]{patchJar.toUri().toURL()}, getClass().getClassLoader())) {
+            Class<?> support = Class.forName(
+                    "org.apache.activemq.artemis.protocol.amqp.proton.ServiceBusDeadLetterSupport",
+                    true,
+                    loader);
+            support.getMethod("apply", Message.class, Rejected.class)
+                    .invoke(null, message, rejected);
+        }
+
+        verify(message).putObjectProperty("modified-at", modifiedAt.toString());
+        verify(message).putObjectProperty("attempt", 3);
+        verify(message).reencode();
+    }
+}


### PR DESCRIPTION
## Summary

- preserve session metadata while dead-lettering session messages
- acknowledge processed AMQP dead-letter commands with the SDK-compatible outcome
- persist dead-letter reason, description, and supported modified properties
- normalize unsupported AMQP Info values before writing Artemis properties
- add Java/.NET SDK and focused patch-JAR coverage

Follow-up: #231 enables session receivers directly on dead-letter queues.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature
- [ ] Breaking change
- [ ] Docs / chore

## Azure Compatibility

Matches Java and .NET SDK dead-letter command behavior and prevents unsupported AMQP types from aborting dead-letter processing.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Conventional Commits

Tests: focused Service Bus 62 passed; Java live suite 17 passed; .NET live suite 7 passed; property-conversion unit test passed.

Fixes #213