### PR TITLE
fix(servicebus): unpack AMQP batches

### DIFF
--- a/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
+++ b/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
@@ -86,6 +86,54 @@ public sealed class ServiceBusCompatibilityTests
     }
 
     [Test]
+    [Timeout(90_000)]
+    public async Task DotnetSdkUnpacksBatchedMessagesBeforeSubscriptionRouting(
+        CancellationToken cancellationToken)
+    {
+        const string serviceBusNamespace = "default";
+        string topic = $"batch-topic-{Guid.NewGuid():N}";
+        string subscription = $"batch-sub-{Guid.NewGuid():N}";
+        await EnsureNamespace(serviceBusNamespace, cancellationToken);
+        await EnsureTopic(serviceBusNamespace, topic, cancellationToken);
+        await EnsureFilteredSubscription(
+            serviceBusNamespace, topic, subscription, "accepted", cancellationToken);
+
+        string connectionString =
+            $"Endpoint=sb://{ServiceBusHost}:{ServiceBusPort};" +
+            "SharedAccessKeyName=RootManageSharedAccessKey;" +
+            "SharedAccessKey=devkey;UseDevelopmentEmulator=true;";
+        await using var client = new ServiceBusClient(connectionString, new ServiceBusClientOptions
+        {
+            RetryOptions = { TryTimeout = TimeSpan.FromSeconds(10) }
+        });
+        await using ServiceBusSender sender = client.CreateSender(topic);
+        using ServiceBusMessageBatch batch = await sender.CreateMessageBatchAsync(cancellationToken);
+        for (var index = 0; index < 3; index++)
+        {
+            var message = new ServiceBusMessage($"message-{index}")
+            {
+                MessageId = Guid.NewGuid().ToString("N"),
+                Subject = "accepted"
+            };
+            message.ApplicationProperties["index"] = index;
+            await Assert.That(batch.TryAddMessage(message)).IsTrue();
+        }
+        await sender.SendMessagesAsync(batch, cancellationToken);
+
+        await using ServiceBusReceiver receiver = client.CreateReceiver(topic, subscription);
+        IReadOnlyList<ServiceBusReceivedMessage> received = await receiver.ReceiveMessagesAsync(
+            3, ReceiveTimeout, cancellationToken);
+        await Assert.That(received.Count).IsEqualTo(3);
+        for (var index = 0; index < received.Count; index++)
+        {
+            await Assert.That(received[index].Body.ToString()).IsEqualTo($"message-{index}");
+            await Assert.That(received[index].Subject).IsEqualTo("accepted");
+            await Assert.That(received[index].ApplicationProperties["index"]).IsEqualTo(index);
+            await receiver.CompleteMessageAsync(received[index], cancellationToken);
+        }
+    }
+
+    [Test]
     [Timeout(60_000)]
     public async Task DotnetSdkSupportsSessionReceivers(CancellationToken cancellationToken)
     {
@@ -474,6 +522,33 @@ public sealed class ServiceBusCompatibilityTests
             "",
             "Subscription",
             cancellationToken);
+
+    private static Task EnsureFilteredSubscription(
+        string serviceBusNamespace,
+        string topic,
+        string subscription,
+        string subject,
+        CancellationToken cancellationToken)
+    {
+        string description = $"""
+            <entry xmlns="http://www.w3.org/2005/Atom">
+              <content type="application/xml">
+                <SubscriptionDescription xmlns:i="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://schemas.microsoft.com/netservices/2010/10/servicebus/connect">
+                  <DefaultRuleDescription>
+                    <Filter i:type="CorrelationFilter"><Label>{subject}</Label></Filter>
+                    <Name>subject-filter</Name>
+                  </DefaultRuleDescription>
+                </SubscriptionDescription>
+              </content>
+            </entry>
+            """;
+        return PutEntity(
+            $"{EmulatorEndpoint}/devstoreaccount1-servicebus/{serviceBusNamespace}/topics/{topic}" +
+            $"/subscriptions/{subscription}",
+            description,
+            "Subscription",
+            cancellationToken);
+    }
 
     private static async Task EnsureQueue(
         string serviceBusNamespace,

--- a/pom.xml
+++ b/pom.xml
@@ -300,6 +300,16 @@
                                     value="address = SimpleString.of(targetAddress.startsWith(&quot;/&quot;) ? targetAddress.substring(1) : targetAddress);"
                                     failOnNoReplacements="true" />
                                 <replace
+                                    file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerReceiverContext.java"
+                                    token="import org.apache.activemq.artemis.protocol.amqp.broker.AMQPSessionCallback;"
+                                    value="import org.apache.activemq.artemis.protocol.amqp.broker.AMQPMessage;&#10;import org.apache.activemq.artemis.protocol.amqp.broker.AMQPSessionCallback;&#10;import org.apache.activemq.artemis.protocol.amqp.broker.ServiceBusBatchSupport;"
+                                    failOnNoReplacements="true" />
+                                <replace
+                                    file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerReceiverContext.java"
+                                    token="sessionSPI.serverSend(this, tx, receiver, delivery, address, deduceRoutingType(message), routingContext, message);"
+                                    value="if (message instanceof AMQPMessage amqpMessage &amp;&amp; ServiceBusBatchSupport.isBatch(amqpMessage)) {&#10;            for (Message batchMessage : ServiceBusBatchSupport.decode(amqpMessage, sessionSPI.getCoreMessageObjectPools())) {&#10;               sessionSPI.serverSend(this, tx, receiver, delivery, address, deduceRoutingType(batchMessage), routingContext, batchMessage);&#10;            }&#10;         } else {&#10;            sessionSPI.serverSend(this, tx, receiver, delivery, address, deduceRoutingType(message), routingContext, message);&#10;         }"
+                                    failOnNoReplacements="true" />
+                                <replace
                                     file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java"
                                     token="doAck(message);"
                                     value="doAck(message); delivery.disposition(Accepted.getInstance());"

--- a/src/artemis-amqp-patch/java/org/apache/activemq/artemis/protocol/amqp/broker/ServiceBusBatchSupport.java
+++ b/src/artemis-amqp-patch/java/org/apache/activemq/artemis/protocol/amqp/broker/ServiceBusBatchSupport.java
@@ -1,0 +1,78 @@
+package org.apache.activemq.artemis.protocol.amqp.broker;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.activemq.artemis.core.persistence.CoreMessageObjectPools;
+import org.apache.activemq.artemis.protocol.amqp.util.TLSEncode;
+import org.apache.qpid.proton.amqp.Binary;
+import org.apache.qpid.proton.amqp.messaging.AmqpSequence;
+import org.apache.qpid.proton.amqp.messaging.AmqpValue;
+import org.apache.qpid.proton.amqp.messaging.Data;
+import org.apache.qpid.proton.amqp.messaging.Footer;
+import org.apache.qpid.proton.amqp.messaging.Section;
+import org.apache.qpid.proton.codec.DecoderImpl;
+import org.apache.qpid.proton.codec.ReadableBuffer;
+
+/** Decodes Azure Service Bus batched-message-format transfers into individual AMQP messages. */
+public final class ServiceBusBatchSupport {
+
+   private static final long BATCHED_MESSAGE_FORMAT = 0x80013700L;
+
+   private ServiceBusBatchSupport() {
+   }
+
+   public static boolean isBatch(AMQPMessage message) {
+      return (message.getMessageFormat() & 0xFFFFFFFFL) == BATCHED_MESSAGE_FORMAT;
+   }
+
+   public static List<AMQPStandardMessage> decode(
+      AMQPMessage envelope, CoreMessageObjectPools objectPools) {
+      if (!isBatch(envelope)) {
+         throw new IllegalArgumentException("Message does not use Azure batched-message-format");
+      }
+
+      ReadableBuffer buffer = envelope.getData().duplicate().rewind();
+      DecoderImpl decoder = TLSEncode.getDecoder();
+      List<byte[]> encodedMessages = new ArrayList<>();
+
+      decoder.setBuffer(buffer);
+      try {
+         while (buffer.hasRemaining()) {
+            Section section = (Section) decoder.readObject();
+            if (section instanceof Data data) {
+               encodedMessages.add(copyPayload(data));
+            } else if (section instanceof AmqpValue || section instanceof AmqpSequence) {
+               throw new IllegalArgumentException(
+                  "Azure batched-message-format body must contain only AMQP Data sections");
+            } else if (section instanceof Footer) {
+               break;
+            }
+         }
+      } finally {
+         decoder.setBuffer(null);
+      }
+
+      if (encodedMessages.isEmpty()) {
+         throw new IllegalArgumentException(
+            "Azure batched-message-format transfer contains no messages");
+      }
+      return encodedMessages.stream()
+         .map(payload -> new AMQPStandardMessage(
+            AMQPMessage.DEFAULT_MESSAGE_FORMAT, payload, null, objectPools))
+         .toList();
+   }
+
+   private static byte[] copyPayload(Data section) {
+      Binary encodedMessage = section.getValue();
+      if (encodedMessage == null || encodedMessage.getLength() == 0) {
+         throw new IllegalArgumentException(
+            "Azure batched-message-format contains an empty message");
+      }
+
+      int start = encodedMessage.getArrayOffset();
+      return Arrays.copyOfRange(
+         encodedMessage.getArray(), start, start + encodedMessage.getLength());
+   }
+}

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusConfigGeneratorTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusConfigGeneratorTest.java
@@ -134,6 +134,7 @@ class ServiceBusConfigGeneratorTest {
     void packagesArtemisPatchesForAzureSdkSemantics() throws Exception {
         Set<String> expectedClasses = Set.of(
                 "org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.class",
+                "org/apache/activemq/artemis/protocol/amqp/broker/ServiceBusBatchSupport.class",
                 "org/apache/activemq/artemis/protocol/amqp/proton/AmqpTransferTagGenerator.class",
                 "org/apache/activemq/artemis/protocol/amqp/proton/DefaultSenderController.class",
                 "org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerReceiverContext.class",


### PR DESCRIPTION
## Summary

- recognize Azure Service Bus batched-message-format transfers (0x80013700)
- decode each AMQP Data section into an independent broker message before routing
- preserve per-message bodies, subjects, application properties, and subscription filtering
- add a .NET SDK regression test that sends a three-message ServiceBusMessageBatch

Fixes #212

## Testing

- Maven focused Service Bus tests — 62 passed
- dotnet build in compatibility-tests/sdk-test-dotnet — 0 warnings, 0 errors
- live Docker + Artemis targeted .NET SDK regression — 1 passed
- live Docker + Artemis full .NET Service Bus compatibility suite — 7 passed