### PR TITLE
fix(servicebus): report runtime counts

### DIFF
--- a/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
+++ b/compatibility-tests/sdk-test-dotnet/ServiceBusCompatibilityTests.cs
@@ -23,7 +23,7 @@ public sealed class ServiceBusCompatibilityTests
     public async Task AdministrationClientSupportsTopicSubscriptionAndRuleCrud(
         CancellationToken cancellationToken)
     {
-        string topic = $"dotnet-admin-{Guid.NewGuid():N}";
+        string topic = $"dotnet-admin-{Guid.NewGuid():N}-queue";
         string subscription = $"dotnet-admin-sub-{Guid.NewGuid():N}";
         string rule = $"dotnet-admin-rule-{Guid.NewGuid():N}";
         var endpoint = new Uri(EmulatorEndpoint);
@@ -70,6 +70,117 @@ public sealed class ServiceBusCompatibilityTests
         await administrationClient.DeleteSubscriptionAsync(
             topic, subscription, cancellationToken);
         await administrationClient.DeleteTopicAsync(topic, cancellationToken);
+    }
+
+    [Test]
+    [NotInParallel("servicebus-broker")]
+    [Timeout(90_000)]
+    public async Task AdministrationClientReportsQueueRuntimeMessageCounts(
+        CancellationToken cancellationToken)
+    {
+        const string serviceBusNamespace = "default";
+        string queue = $"dotnet-counts-{Guid.NewGuid():N}";
+        string secondQueue = $"dotnet-counts-secondary-{Guid.NewGuid():N}";
+        await EnsureNamespace(serviceBusNamespace, cancellationToken);
+        await EnsureQueue(serviceBusNamespace, queue, cancellationToken);
+        await EnsureQueue(serviceBusNamespace, secondQueue, cancellationToken);
+
+        await using var client = new ServiceBusClient(DataPlaneConnectionString());
+        await using ServiceBusSender sender = client.CreateSender(queue);
+        await sender.SendMessageAsync(new ServiceBusMessage("one"), cancellationToken);
+        await sender.SendMessageAsync(new ServiceBusMessage("two"), cancellationToken);
+        await sender.SendMessageAsync(new ServiceBusMessage("three"), cancellationToken);
+        await using ServiceBusSender secondSender = client.CreateSender(secondQueue);
+        await secondSender.SendMessageAsync(new ServiceBusMessage("secondary"), cancellationToken);
+
+        var administrationClient = new ServiceBusAdministrationClient(
+            AdministrationConnectionString());
+        QueueRuntimeProperties enqueued = await WaitForQueueRuntimeProperties(
+            administrationClient,
+            queue,
+            properties => properties.ActiveMessageCount == 3,
+            cancellationToken);
+        await Assert.That(enqueued.ActiveMessageCount).IsEqualTo(3);
+        await Assert.That(enqueued.DeadLetterMessageCount).IsEqualTo(0);
+        await Assert.That(enqueued.TotalMessageCount).IsEqualTo(3);
+
+        await using ServiceBusReceiver receiver = client.CreateReceiver(queue);
+        ServiceBusReceivedMessage deadLettered = await Receive(receiver, cancellationToken);
+        await receiver.DeadLetterMessageAsync(deadLettered, cancellationToken: cancellationToken);
+
+        QueueRuntimeProperties afterDeadLetter = await WaitForQueueRuntimeProperties(
+            administrationClient,
+            queue,
+            properties => properties.ActiveMessageCount == 2 &&
+                properties.DeadLetterMessageCount == 1,
+            cancellationToken);
+        await Assert.That(afterDeadLetter.ActiveMessageCount).IsEqualTo(2);
+        await Assert.That(afterDeadLetter.DeadLetterMessageCount).IsEqualTo(1);
+        await Assert.That(afterDeadLetter.TotalMessageCount).IsEqualTo(3);
+
+        var listed = new Dictionary<string, QueueRuntimeProperties>();
+        await foreach (QueueRuntimeProperties properties in
+            administrationClient.GetQueuesRuntimePropertiesAsync(cancellationToken))
+        {
+            if (properties.Name == queue || properties.Name == secondQueue)
+            {
+                listed[properties.Name] = properties;
+            }
+        }
+        await Assert.That(listed).Count().IsEqualTo(2);
+        await Assert.That(listed[queue].ActiveMessageCount).IsEqualTo(2);
+        await Assert.That(listed[queue].DeadLetterMessageCount).IsEqualTo(1);
+        await Assert.That(listed[secondQueue].ActiveMessageCount).IsEqualTo(1);
+        await Assert.That(listed[secondQueue].DeadLetterMessageCount).IsEqualTo(0);
+    }
+
+    [Test]
+    [NotInParallel("servicebus-broker")]
+    [Timeout(90_000)]
+    public async Task ManagementPlaneReportsSubscriptionRuntimeMessageCounts(
+        CancellationToken cancellationToken)
+    {
+        const string serviceBusNamespace = "default";
+        string topic = $"dotnet-count-topic-{Guid.NewGuid():N}";
+        string subscription = $"dotnet-count-sub-{Guid.NewGuid():N}";
+        await EnsureNamespace(serviceBusNamespace, cancellationToken);
+        await EnsureTopic(serviceBusNamespace, topic, cancellationToken);
+        await EnsureSubscription(
+            serviceBusNamespace, topic, subscription, cancellationToken);
+
+        await using var client = new ServiceBusClient(DataPlaneConnectionString());
+        await using ServiceBusSender sender = client.CreateSender(topic);
+        await sender.SendMessageAsync(new ServiceBusMessage("one"), cancellationToken);
+        await sender.SendMessageAsync(new ServiceBusMessage("two"), cancellationToken);
+
+        var administrationClient = new ServiceBusAdministrationClient(
+            AdministrationConnectionString());
+        SubscriptionRuntimeProperties enqueued =
+            await WaitForSubscriptionRuntimeProperties(
+            administrationClient,
+            topic,
+            subscription,
+            properties => properties.ActiveMessageCount == 2,
+            cancellationToken);
+        await Assert.That(enqueued.ActiveMessageCount).IsEqualTo(2);
+        await Assert.That(enqueued.DeadLetterMessageCount).IsEqualTo(0);
+        await Assert.That(enqueued.TotalMessageCount).IsEqualTo(2);
+
+        await using ServiceBusReceiver receiver = client.CreateReceiver(topic, subscription);
+        ServiceBusReceivedMessage deadLettered = await Receive(receiver, cancellationToken);
+        await receiver.DeadLetterMessageAsync(deadLettered, cancellationToken: cancellationToken);
+
+        SubscriptionRuntimeProperties afterDeadLetter =
+            await WaitForSubscriptionRuntimeProperties(
+            administrationClient,
+            topic,
+            subscription,
+            properties => properties.ActiveMessageCount == 1 &&
+                properties.DeadLetterMessageCount == 1,
+            cancellationToken);
+        await Assert.That(afterDeadLetter.ActiveMessageCount).IsEqualTo(1);
+        await Assert.That(afterDeadLetter.DeadLetterMessageCount).IsEqualTo(1);
+        await Assert.That(afterDeadLetter.TotalMessageCount).IsEqualTo(2);
     }
 
     [Test]
@@ -556,6 +667,68 @@ public sealed class ServiceBusCompatibilityTests
             await receiver.ReceiveMessageAsync(ReceiveTimeout, cancellationToken);
         await Assert.That(message).IsNotNull();
         return message!;
+    }
+
+    private static string DataPlaneConnectionString() =>
+        $"Endpoint=sb://{ServiceBusHost}:{ServiceBusPort};" +
+        "SharedAccessKeyName=RootManageSharedAccessKey;" +
+        "SharedAccessKey=devkey;UseDevelopmentEmulator=true;";
+
+    private static string AdministrationConnectionString()
+    {
+        var endpoint = new Uri(EmulatorEndpoint);
+        return $"Endpoint=sb://{endpoint.Authority};" +
+            "SharedAccessKeyName=RootManageSharedAccessKey;" +
+            "SharedAccessKey=devkey;UseDevelopmentEmulator=true;";
+    }
+
+    private static async Task<QueueRuntimeProperties> WaitForQueueRuntimeProperties(
+        ServiceBusAdministrationClient administrationClient,
+        string queue,
+        Func<QueueRuntimeProperties, bool> condition,
+        CancellationToken cancellationToken)
+    {
+        DateTimeOffset deadline = DateTimeOffset.UtcNow.AddSeconds(15);
+        QueueRuntimeProperties? properties = null;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            properties = (await administrationClient.GetQueueRuntimePropertiesAsync(
+                queue, cancellationToken)).Value;
+            if (condition(properties))
+            {
+                return properties;
+            }
+            await Task.Delay(250, cancellationToken);
+        }
+        throw new TimeoutException(
+            $"Queue runtime counts did not converge: active={properties?.ActiveMessageCount}, " +
+            $"deadLetter={properties?.DeadLetterMessageCount}, total={properties?.TotalMessageCount}");
+    }
+
+    private static async Task<SubscriptionRuntimeProperties> WaitForSubscriptionRuntimeProperties(
+        ServiceBusAdministrationClient administrationClient,
+        string topic,
+        string subscription,
+        Func<SubscriptionRuntimeProperties, bool> condition,
+        CancellationToken cancellationToken)
+    {
+        DateTimeOffset deadline = DateTimeOffset.UtcNow.AddSeconds(15);
+        SubscriptionRuntimeProperties? properties = null;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            properties = (await administrationClient.GetSubscriptionRuntimePropertiesAsync(
+                topic, subscription, cancellationToken)).Value;
+            if (condition(properties))
+            {
+                return properties;
+            }
+            await Task.Delay(250, cancellationToken);
+        }
+        throw new TimeoutException(
+            $"Subscription runtime counts did not converge: " +
+            $"active={properties?.ActiveMessageCount}, " +
+            $"deadLetter={properties?.DeadLetterMessageCount}, " +
+            $"total={properties?.TotalMessageCount}");
     }
 
     private static async Task EnsureNamespace(

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
@@ -70,7 +70,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
     private static final String DEFAULT_NAMESPACE = "default";
     /** Main Service Bus namespace for entity descriptions. */
     private static final String SB_NS = "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect";
-    /** Separate namespace used by MessageCountDetails child elements (per spec). */
+    /** Separate namespace used by CountDetails child elements (per spec). */
     private static final String SB_COUNT_NS = "http://schemas.microsoft.com/netservices/2011/06/servicebus";
     private static final DateTimeFormatter ISO8601 = ServiceBusModels.ISO8601;
 
@@ -882,6 +882,15 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
 
     /** Entry XML carries no {@code <?xml?>} prolog so it can be embedded in feeds; responses prepend it. */
     private String queueEntryXml(String namespace, ServiceBusModels.QueueEntity q) {
+        ServiceBusNamespaceManager.MessageCounts counts =
+                namespaceManager.getMessageCounts(namespace, q.name());
+        return queueEntryXml(namespace, q, counts);
+    }
+
+    private String queueEntryXml(
+            String namespace,
+            ServiceBusModels.QueueEntity q,
+            ServiceBusNamespaceManager.MessageCounts counts) {
         String created = ISO8601.format(q.createdAt());
         String updated = ISO8601.format(q.updatedAt());
         return "<entry xmlns=\"http://www.w3.org/2005/Atom\">"
@@ -890,12 +899,13 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                 + "<published>" + created + "</published>"
                 + "<updated>" + updated + "</updated>"
                 + "<content type=\"application/xml\">"
-                + queueDescriptionXml(q)
+                + queueDescriptionXml(q, counts)
                 + "</content>"
                 + "</entry>";
     }
 
-    private String queueDescriptionXml(ServiceBusModels.QueueEntity q) {
+    private String queueDescriptionXml(ServiceBusModels.QueueEntity q,
+                                       ServiceBusNamespaceManager.MessageCounts counts) {
         String lockDuration = isoDuration(q.lockDurationSeconds());
         return "<QueueDescription xmlns=\"" + SB_NS + "\">"
                 + "<MaxSizeInMegabytes>" + q.maxSizeInMegabytes() + "</MaxSizeInMegabytes>"
@@ -915,12 +925,16 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                 + "<AutoDeleteOnIdle>P10675199DT2H48M5.4775807S</AutoDeleteOnIdle>"
                 + "<Status>Active</Status>"
                 + "<EntityAvailabilityStatus>Available</EntityAvailabilityStatus>"
-                + messageCountDetailsXml()
+                + "<MessageCount>" + counts.total() + "</MessageCount>"
+                + countDetailsXml(counts)
                 + "</QueueDescription>";
     }
 
     private String queueFeedXml(String namespace, List<ServiceBusModels.QueueEntity> queues) {
         String now = ISO8601.format(Instant.now());
+        Map<String, ServiceBusNamespaceManager.MessageCounts> counts =
+                namespaceManager.getMessageCounts(
+                        namespace, queues.stream().map(ServiceBusModels.QueueEntity::name).toList());
         StringBuilder sb = new StringBuilder();
         sb.append(XML_PROLOG)
           .append("<feed xmlns=\"http://www.w3.org/2005/Atom\">")
@@ -928,7 +942,8 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
           .append("<id>https://localhost/").append(xmlEsc(namespace)).append("/$Resources/queues</id>")
           .append("<updated>").append(now).append("</updated>");
         for (ServiceBusModels.QueueEntity q : queues) {
-            sb.append(queueEntryXml(namespace, q));
+            sb.append(queueEntryXml(
+                    namespace, q, counts.getOrDefault(q.name(), ServiceBusNamespaceManager.MessageCounts.ZERO)));
         }
         sb.append("</feed>");
         return sb.toString();
@@ -962,7 +977,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                 + "<AutoDeleteOnIdle>P10675199DT2H48M5.4775807S</AutoDeleteOnIdle>"
                 + "<Status>Active</Status>"
                 + "<EntityAvailabilityStatus>Available</EntityAvailabilityStatus>"
-                + messageCountDetailsXml()
+                + countDetailsXml(ServiceBusNamespaceManager.MessageCounts.ZERO)
                 + "</TopicDescription>";
     }
 
@@ -982,6 +997,16 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
     }
 
     private String subscriptionEntryXml(String namespace, ServiceBusModels.SubscriptionEntity s) {
+        String queueName = s.topicName() + "/Subscriptions/" + s.name();
+        ServiceBusNamespaceManager.MessageCounts counts =
+                namespaceManager.getMessageCounts(namespace, queueName);
+        return subscriptionEntryXml(namespace, s, counts);
+    }
+
+    private String subscriptionEntryXml(
+            String namespace,
+            ServiceBusModels.SubscriptionEntity s,
+            ServiceBusNamespaceManager.MessageCounts counts) {
         String created = ISO8601.format(s.createdAt());
         String updated = ISO8601.format(s.updatedAt());
         String lockDuration = isoDuration(s.lockDurationSeconds());
@@ -992,12 +1017,15 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                 + "<published>" + created + "</published>"
                 + "<updated>" + updated + "</updated>"
                 + "<content type=\"application/xml\">"
-                + subscriptionDescriptionXml(s, lockDuration)
+                + subscriptionDescriptionXml(s, lockDuration, counts)
                 + "</content>"
                 + "</entry>";
     }
 
-    private String subscriptionDescriptionXml(ServiceBusModels.SubscriptionEntity s, String lockDuration) {
+    private String subscriptionDescriptionXml(
+            ServiceBusModels.SubscriptionEntity s,
+            String lockDuration,
+            ServiceBusNamespaceManager.MessageCounts counts) {
         return "<SubscriptionDescription xmlns=\"" + SB_NS + "\">"
                 + "<LockDuration>" + lockDuration + "</LockDuration>"
                 + "<MaxDeliveryCount>" + s.maxDeliveryCount() + "</MaxDeliveryCount>"
@@ -1011,13 +1039,18 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                 + "<AutoDeleteOnIdle>P10675199DT2H48M5.4775807S</AutoDeleteOnIdle>"
                 + "<Status>Active</Status>"
                 + "<EntityAvailabilityStatus>Available</EntityAvailabilityStatus>"
-                + messageCountDetailsXml()
+                + "<MessageCount>" + counts.total() + "</MessageCount>"
+                + countDetailsXml(counts)
                 + "</SubscriptionDescription>";
     }
 
     private String subscriptionFeedXml(String namespace, String topicName,
                                         List<ServiceBusModels.SubscriptionEntity> subs) {
         String now = ISO8601.format(Instant.now());
+        Map<String, ServiceBusNamespaceManager.MessageCounts> counts =
+                namespaceManager.getMessageCounts(namespace, subs.stream()
+                        .map(sub -> sub.topicName() + "/Subscriptions/" + sub.name())
+                        .toList());
         StringBuilder sb = new StringBuilder();
         sb.append(XML_PROLOG)
           .append("<feed xmlns=\"http://www.w3.org/2005/Atom\">")
@@ -1026,7 +1059,10 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
           .append(xmlEsc(topicName)).append("/subscriptions</id>")
           .append("<updated>").append(now).append("</updated>");
         for (ServiceBusModels.SubscriptionEntity s : subs) {
-            sb.append(subscriptionEntryXml(namespace, s));
+            String queueName = s.topicName() + "/Subscriptions/" + s.name();
+            sb.append(subscriptionEntryXml(
+                    namespace, s,
+                    counts.getOrDefault(queueName, ServiceBusNamespaceManager.MessageCounts.ZERO)));
         }
         sb.append("</feed>");
         return sb.toString();
@@ -1066,17 +1102,16 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
     }
 
     /**
-     * Returns a {@code <MessageCountDetails>} element using the spec-mandated 2011/06 namespace.
-     * All counts are zero because message state lives entirely in Artemis.
+     * Returns a {@code <CountDetails>} element using the spec-mandated 2011/06 namespace.
      */
-    private String messageCountDetailsXml() {
-        return "<MessageCountDetails xmlns=\"" + SB_COUNT_NS + "\">"
-                + "<ActiveMessageCount>0</ActiveMessageCount>"
-                + "<DeadLetterMessageCount>0</DeadLetterMessageCount>"
+    private String countDetailsXml(ServiceBusNamespaceManager.MessageCounts counts) {
+        return "<CountDetails xmlns=\"" + SB_COUNT_NS + "\">"
+                + "<ActiveMessageCount>" + counts.active() + "</ActiveMessageCount>"
+                + "<DeadLetterMessageCount>" + counts.deadLetter() + "</DeadLetterMessageCount>"
                 + "<ScheduledMessageCount>0</ScheduledMessageCount>"
                 + "<TransferDeadLetterMessageCount>0</TransferDeadLetterMessageCount>"
                 + "<TransferMessageCount>0</TransferMessageCount>"
-                + "</MessageCountDetails>";
+                + "</CountDetails>";
     }
 
     // ── Storage key helpers ───────────────────────────────────────────────────

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
@@ -1101,16 +1101,14 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         return sb.toString();
     }
 
-    /**
-     * Returns a {@code <CountDetails>} element using the spec-mandated 2011/06 namespace.
-     */
+    /** Returns CountDetails in the entity namespace with count children in the 2011/06 namespace. */
     private String countDetailsXml(ServiceBusNamespaceManager.MessageCounts counts) {
-        return "<CountDetails xmlns=\"" + SB_COUNT_NS + "\">"
-                + "<ActiveMessageCount>" + counts.active() + "</ActiveMessageCount>"
-                + "<DeadLetterMessageCount>" + counts.deadLetter() + "</DeadLetterMessageCount>"
-                + "<ScheduledMessageCount>0</ScheduledMessageCount>"
-                + "<TransferDeadLetterMessageCount>0</TransferDeadLetterMessageCount>"
-                + "<TransferMessageCount>0</TransferMessageCount>"
+        return "<CountDetails xmlns:sb=\"" + SB_COUNT_NS + "\">"
+                + "<sb:ActiveMessageCount>" + counts.active() + "</sb:ActiveMessageCount>"
+                + "<sb:DeadLetterMessageCount>" + counts.deadLetter() + "</sb:DeadLetterMessageCount>"
+                + "<sb:ScheduledMessageCount>0</sb:ScheduledMessageCount>"
+                + "<sb:TransferDeadLetterMessageCount>0</sb:TransferDeadLetterMessageCount>"
+                + "<sb:TransferMessageCount>0</sb:TransferMessageCount>"
                 + "</CountDetails>";
     }
 

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -1,5 +1,7 @@
 package io.floci.az.services.servicebus;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.docker.ContainerStorageHelper;
 import io.floci.az.core.docker.ContainerBuilder;
@@ -12,6 +14,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
 
+import javax.management.ObjectName;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.Socket;
@@ -38,6 +41,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class ServiceBusNamespaceManager {
 
     private static final Logger LOG = Logger.getLogger(ServiceBusNamespaceManager.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
 
     static final String ARTEMIS_EXTENSION_RESOURCE = "/artemis/servicebus-artemis-extension.jar";
     static final String PROTON_PATCH_RESOURCE = "/artemis/proton-j-0.34.1-floci-az-proton-patch.jar";
@@ -74,6 +78,7 @@ public class ServiceBusNamespaceManager {
     private static final int AMQP_PORT = 5672;
     private static final int AMQPS_PORT = 5671;
     private static final int JOLOKIA_PORT = 8161;
+    private static final Duration MESSAGE_COUNT_TIMEOUT = Duration.ofSeconds(3);
     private static final String MANAGEMENT_SUFFIX = "/$management";
     private static final String DEAD_LETTER_QUEUE_SUFFIX = "/$DeadLetterQueue";
     private static final String SUBSCRIPTION_DIVERT_SUFFIX = "/$Divert";
@@ -101,6 +106,14 @@ public class ServiceBusNamespaceManager {
             String jolokiaHost,
             int jolokiaPort,
             boolean mocked) {}
+
+    public record MessageCounts(long active, long deadLetter) {
+        static final MessageCounts ZERO = new MessageCounts(0, 0);
+
+        long total() {
+            return Math.addExact(active, deadLetter);
+        }
+    }
 
     private final ConcurrentHashMap<String, NamespaceState> namespaces = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, ServiceBusCbsResponder> cbsResponders = new ConcurrentHashMap<>();
@@ -259,6 +272,41 @@ public class ServiceBusNamespaceManager {
 
     public Map<String, NamespaceState> listNamespaces() {
         return Map.copyOf(namespaces);
+    }
+
+    /** Reads live queue and dead-letter queue depths from Artemis. */
+    public MessageCounts getMessageCounts(String namespaceName, String queueName) {
+        return getMessageCounts(namespaceName, List.of(queueName))
+                .getOrDefault(queueName, MessageCounts.ZERO);
+    }
+
+    /** Reads live queue and dead-letter queue depths from Artemis in one bounded Jolokia request. */
+    public Map<String, MessageCounts> getMessageCounts(
+            String namespaceName, List<String> queueNames) {
+        if (queueNames.isEmpty()) {
+            return Map.of();
+        }
+        NamespaceState state = namespaces.get(namespaceName);
+        if (state == null || state.mocked()) {
+            return zeroMessageCounts(queueNames);
+        }
+
+        String baseUrl = "http://" + state.jolokiaHost() + ":" + state.jolokiaPort()
+                + "/console/jolokia";
+        String auth = Base64.getEncoder().encodeToString(
+                "artemis:artemis".getBytes(StandardCharsets.UTF_8));
+        HttpClient http = HttpClient.newHttpClient();
+        try {
+            return jolokiaReadMessageCounts(
+                    http, baseUrl, auth, namespaceName, queueNames);
+        } catch (Exception e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            LOG.warnf(e, "Failed to read message counts for %d queues in namespace '%s'",
+                    queueNames.size(), namespaceName);
+            return zeroMessageCounts(queueNames);
+        }
     }
 
     public void shutdownAll() {
@@ -672,6 +720,96 @@ public class ServiceBusNamespaceManager {
         } catch (Exception e) {
             LOG.debugv("Jolokia call failed ({0}): {1}", operation.split("\\(")[0], e.getMessage());
         }
+    }
+
+    private static Map<String, MessageCounts> jolokiaReadMessageCounts(
+            HttpClient http, String baseUrl, String auth, String namespaceName,
+            List<String> queueNames) throws IOException, InterruptedException {
+        String body = jolokiaMessageCountRequest(namespaceName, queueNames);
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(baseUrl))
+                .timeout(MESSAGE_COUNT_TIMEOUT)
+                .header("Content-Type", "application/json")
+                .header("Authorization", "Basic " + auth)
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build();
+        HttpResponse<String> response = http.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() != 200) {
+            throw new IOException("Jolokia HTTP status " + response.statusCode());
+        }
+        return parseJolokiaMessageCounts(queueNames, response.body());
+    }
+
+    static String jolokiaMessageCountRequest(
+            String namespaceName, List<String> queueNames) throws IOException {
+        var requests = MAPPER.createArrayNode();
+        for (String queueName : queueNames) {
+            for (String suffix : List.of("", DEAD_LETTER_QUEUE_SUFFIX)) {
+                var request = requests.addObject();
+                request.put("type", "read");
+                request.put("mbean", queueMBean(namespaceName, queueName + suffix));
+                request.put("attribute", "MessageCount");
+            }
+        }
+        return MAPPER.writeValueAsString(requests);
+    }
+
+    static Map<String, MessageCounts> parseJolokiaMessageCounts(
+            List<String> queueNames, String responseBody) throws IOException {
+        JsonNode responses = MAPPER.readTree(responseBody);
+        int expectedResponses = queueNames.size() * 2;
+        if (!responses.isArray() || responses.size() != expectedResponses) {
+            throw new IOException("Expected " + expectedResponses
+                    + " Jolokia responses, received " + responses.size());
+        }
+        Map<String, MessageCounts> counts = new LinkedHashMap<>();
+        for (int i = 0; i < queueNames.size(); i++) {
+            long active = parseJolokiaMessageCount(responses.get(i * 2));
+            long deadLetter = parseJolokiaMessageCount(responses.get(i * 2 + 1));
+            counts.put(queueNames.get(i), new MessageCounts(active, deadLetter));
+        }
+        return Map.copyOf(counts);
+    }
+
+    static long parseJolokiaMessageCount(String responseBody) throws IOException {
+        return parseJolokiaMessageCount(MAPPER.readTree(responseBody));
+    }
+
+    private static long parseJolokiaMessageCount(JsonNode response) throws IOException {
+        if (response.path("status").asInt() != 200) {
+            throw new IOException("Jolokia response status " + response.path("status").asInt());
+        }
+        JsonNode value = response.path("value");
+        long count;
+        if (value.isIntegralNumber()) {
+            count = value.longValue();
+        } else if (value.isTextual()) {
+            try {
+                count = Long.parseLong(value.textValue());
+            } catch (NumberFormatException e) {
+                throw new IOException("Invalid Jolokia MessageCount value: " + value, e);
+            }
+        } else {
+            throw new IOException("Missing Jolokia MessageCount value");
+        }
+        if (count < 0) {
+            throw new IOException("Negative Jolokia MessageCount value: " + count);
+        }
+        return count;
+    }
+
+    private static Map<String, MessageCounts> zeroMessageCounts(List<String> queueNames) {
+        Map<String, MessageCounts> counts = new LinkedHashMap<>();
+        queueNames.forEach(queueName -> counts.put(queueName, MessageCounts.ZERO));
+        return Map.copyOf(counts);
+    }
+
+    static String queueMBean(String namespaceName, String queueName) {
+        return "org.apache.activemq.artemis:broker="
+                + ObjectName.quote("floci-az-servicebus-" + namespaceName)
+                + ",component=addresses,address=" + ObjectName.quote(queueName)
+                + ",subcomponent=queues,routing-type=" + ObjectName.quote("anycast")
+                + ",queue=" + ObjectName.quote(queueName);
     }
 
     private static String jsonString(String value) {

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -757,15 +757,13 @@ public class ServiceBusNamespaceManager {
     static Map<String, MessageCounts> parseJolokiaMessageCounts(
             List<String> queueNames, String responseBody) throws IOException {
         JsonNode responses = MAPPER.readTree(responseBody);
-        int expectedResponses = queueNames.size() * 2;
-        if (!responses.isArray() || responses.size() != expectedResponses) {
-            throw new IOException("Expected " + expectedResponses
-                    + " Jolokia responses, received " + responses.size());
+        if (!responses.isArray()) {
+            throw new IOException("Expected a Jolokia response array");
         }
         Map<String, MessageCounts> counts = new LinkedHashMap<>();
         for (int i = 0; i < queueNames.size(); i++) {
-            long active = parseJolokiaMessageCountOrZero(responses.get(i * 2));
-            long deadLetter = parseJolokiaMessageCountOrZero(responses.get(i * 2 + 1));
+            long active = parseJolokiaMessageCountOrZero(responses.path(i * 2));
+            long deadLetter = parseJolokiaMessageCountOrZero(responses.path(i * 2 + 1));
             counts.put(queueNames.get(i), new MessageCounts(active, deadLetter));
         }
         return Map.copyOf(counts);

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -764,11 +764,19 @@ public class ServiceBusNamespaceManager {
         }
         Map<String, MessageCounts> counts = new LinkedHashMap<>();
         for (int i = 0; i < queueNames.size(); i++) {
-            long active = parseJolokiaMessageCount(responses.get(i * 2));
-            long deadLetter = parseJolokiaMessageCount(responses.get(i * 2 + 1));
+            long active = parseJolokiaMessageCountOrZero(responses.get(i * 2));
+            long deadLetter = parseJolokiaMessageCountOrZero(responses.get(i * 2 + 1));
             counts.put(queueNames.get(i), new MessageCounts(active, deadLetter));
         }
         return Map.copyOf(counts);
+    }
+
+    private static long parseJolokiaMessageCountOrZero(JsonNode response) {
+        try {
+            return parseJolokiaMessageCount(response);
+        } catch (IOException e) {
+            return 0;
+        }
     }
 
     static long parseJolokiaMessageCount(String responseBody) throws IOException {

--- a/src/test/java/io/floci/az/core/AzureRoutingFilterTest.java
+++ b/src/test/java/io/floci/az/core/AzureRoutingFilterTest.java
@@ -137,6 +137,17 @@ class AzureRoutingFilterTest {
                 .body(containsString("EnumerationResults"));
     }
 
+    @Test
+    void serviceBusSdkSignalOverridesEntityNameAccountSuffix() {
+        given().header("User-Agent", "azsdk-net-Messaging.ServiceBus/7.20.1")
+                .queryParam("api-version", "2021-05")
+                .when().get("/orders-queue")
+                .then()
+                .statusCode(404)
+                .contentType("application/atom+xml")
+                .body(containsString("<Code>404</Code>"));
+    }
+
     /**
      * The six {@code -cosmos-*} engine suffixes (disabled by default) each echo their exact
      * serviceType in the terminal 503 — pinning the suffix map and the mandatory longest-first

--- a/src/test/java/io/floci/az/services/ServiceBusServiceTest.java
+++ b/src/test/java/io/floci/az/services/ServiceBusServiceTest.java
@@ -291,9 +291,9 @@ public class ServiceBusServiceTest {
                 .then()
                 .statusCode(201)
                 .body(containsString("<MessageCount>0</MessageCount>"))
-                .body(containsString("<CountDetails xmlns=\"" + SB_COUNT_NS + "\">"))
-                .body(containsString("<ActiveMessageCount>0</ActiveMessageCount>"))
-                .body(containsString("<DeadLetterMessageCount>0</DeadLetterMessageCount>"));
+                .body(containsString("<CountDetails xmlns:sb=\"" + SB_COUNT_NS + "\">"))
+                .body(containsString("<sb:ActiveMessageCount>0</sb:ActiveMessageCount>"))
+                .body(containsString("<sb:DeadLetterMessageCount>0</sb:DeadLetterMessageCount>"));
 
         given().body(entry("<TopicDescription xmlns=\"" + SB_NS + "\"/>"))
                 .when().put(BASE + "/runtime-count-topic")
@@ -303,9 +303,9 @@ public class ServiceBusServiceTest {
                 .then()
                 .statusCode(201)
                 .body(containsString("<MessageCount>0</MessageCount>"))
-                .body(containsString("<CountDetails xmlns=\"" + SB_COUNT_NS + "\">"))
-                .body(containsString("<ActiveMessageCount>0</ActiveMessageCount>"))
-                .body(containsString("<DeadLetterMessageCount>0</DeadLetterMessageCount>"));
+                .body(containsString("<CountDetails xmlns:sb=\"" + SB_COUNT_NS + "\">"))
+                .body(containsString("<sb:ActiveMessageCount>0</sb:ActiveMessageCount>"))
+                .body(containsString("<sb:DeadLetterMessageCount>0</sb:DeadLetterMessageCount>"));
     }
 
     @Test

--- a/src/test/java/io/floci/az/services/ServiceBusServiceTest.java
+++ b/src/test/java/io/floci/az/services/ServiceBusServiceTest.java
@@ -12,6 +12,8 @@ public class ServiceBusServiceTest {
     private static final String BASE = "/devstoreaccount1-servicebus";
     private static final String SB_NS =
             "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect";
+    private static final String SB_COUNT_NS =
+            "http://schemas.microsoft.com/netservices/2011/06/servicebus";
 
     @Test
     void testExistingPathRouting() {
@@ -280,6 +282,30 @@ public class ServiceBusServiceTest {
                 .then().statusCode(201)
                 .body(containsString("<LockDuration>PT1M</LockDuration>"))
                 .body(containsString("<MaxDeliveryCount>10</MaxDeliveryCount>"));
+    }
+
+    @Test
+    void queueAndSubscriptionDescriptionsExposeRuntimeCountShape() {
+        given().body(entry("<QueueDescription xmlns=\"" + SB_NS + "\"/>"))
+                .when().put(BASE + "/runtime-count-queue")
+                .then()
+                .statusCode(201)
+                .body(containsString("<MessageCount>0</MessageCount>"))
+                .body(containsString("<CountDetails xmlns=\"" + SB_COUNT_NS + "\">"))
+                .body(containsString("<ActiveMessageCount>0</ActiveMessageCount>"))
+                .body(containsString("<DeadLetterMessageCount>0</DeadLetterMessageCount>"));
+
+        given().body(entry("<TopicDescription xmlns=\"" + SB_NS + "\"/>"))
+                .when().put(BASE + "/runtime-count-topic")
+                .then().statusCode(201);
+        given().body(entry("<SubscriptionDescription xmlns=\"" + SB_NS + "\"/>"))
+                .when().put(BASE + "/runtime-count-topic/subscriptions/runtime-count-sub")
+                .then()
+                .statusCode(201)
+                .body(containsString("<MessageCount>0</MessageCount>"))
+                .body(containsString("<CountDetails xmlns=\"" + SB_COUNT_NS + "\">"))
+                .body(containsString("<ActiveMessageCount>0</ActiveMessageCount>"))
+                .body(containsString("<DeadLetterMessageCount>0</DeadLetterMessageCount>"));
     }
 
     @Test

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusNamespaceManagerTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusNamespaceManagerTest.java
@@ -1,0 +1,93 @@
+package io.floci.az.services.servicebus;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ServiceBusNamespaceManagerTest {
+
+    @Test
+    void parsesNumericAndTextJolokiaMessageCounts() throws IOException {
+        assertEquals(7, ServiceBusNamespaceManager.parseJolokiaMessageCount(
+                "{\"status\":200,\"value\":7}"));
+        assertEquals(11, ServiceBusNamespaceManager.parseJolokiaMessageCount(
+                "{\"status\":200,\"value\":\"11\"}"));
+    }
+
+    @Test
+    void rejectsFailedOrMalformedJolokiaMessageCounts() {
+        assertThrows(IOException.class, () ->
+                ServiceBusNamespaceManager.parseJolokiaMessageCount(
+                        "{\"status\":404,\"error\":\"not found\"}"));
+        assertThrows(IOException.class, () ->
+                ServiceBusNamespaceManager.parseJolokiaMessageCount(
+                        "{\"status\":200,\"value\":\"unknown\"}"));
+        assertThrows(IOException.class, () ->
+                ServiceBusNamespaceManager.parseJolokiaMessageCount(
+                        "{\"status\":200,\"value\":-1}"));
+    }
+
+    @Test
+    void batchesAllQueueAndDeadLetterCountsIntoOneJolokiaRequest() throws IOException {
+        String body = ServiceBusNamespaceManager.jolokiaMessageCountRequest(
+                "default", List.of("orders", "topic/Subscriptions/processor"));
+
+        var requests = new ObjectMapper().readTree(body);
+        assertEquals(4, requests.size());
+        assertTrue(requests.get(0).path("mbean").asText().contains("queue=\"orders\""));
+        assertTrue(requests.get(1).path("mbean").asText()
+                .contains("queue=\"orders/$DeadLetterQueue\""));
+        assertTrue(requests.get(2).path("mbean").asText()
+                .contains("queue=\"topic/Subscriptions/processor\""));
+        assertTrue(requests.get(3).path("mbean").asText()
+                .contains("queue=\"topic/Subscriptions/processor/$DeadLetterQueue\""));
+    }
+
+    @Test
+    void parsesBatchedQueueAndDeadLetterCounts() throws IOException {
+        var counts = ServiceBusNamespaceManager.parseJolokiaMessageCounts(
+                List.of("orders", "processor"),
+                "[{\"status\":200,\"value\":3},{\"status\":200,\"value\":1},"
+                        + "{\"status\":200,\"value\":5},{\"status\":200,\"value\":2}]");
+
+        assertEquals(new ServiceBusNamespaceManager.MessageCounts(3, 1), counts.get("orders"));
+        assertEquals(new ServiceBusNamespaceManager.MessageCounts(5, 2), counts.get("processor"));
+    }
+
+    @Test
+    void rejectsIncompleteBatchedCountResponses() {
+        assertThrows(IOException.class, () ->
+                ServiceBusNamespaceManager.parseJolokiaMessageCounts(
+                        List.of("orders"), "[{\"status\":200,\"value\":3}]"));
+    }
+
+    @Test
+    void queueMBeanTargetsAnycastAddressAndQueue() {
+        String mbean = ServiceBusNamespaceManager.queueMBean(
+                "default", "orders/Subscriptions/processor");
+
+        assertTrue(mbean.contains("broker=\"floci-az-servicebus-default\""));
+        assertTrue(mbean.contains("address=\"orders/Subscriptions/processor\""));
+        assertTrue(mbean.contains("routing-type=\"anycast\""));
+        assertTrue(mbean.endsWith("queue=\"orders/Subscriptions/processor\""));
+    }
+
+    @Test
+    void mockedNamespaceReturnsZeroCountsWithoutJolokia() {
+        var manager = new ServiceBusNamespaceManager(null, null, null, null, null);
+        manager.startMockedNamespace("default");
+
+        ServiceBusNamespaceManager.MessageCounts counts =
+                manager.getMessageCounts("default", "queue");
+
+        assertEquals(0, counts.active());
+        assertEquals(0, counts.deadLetter());
+        assertEquals(0, counts.total());
+    }
+}

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusNamespaceManagerTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusNamespaceManagerTest.java
@@ -61,6 +61,17 @@ class ServiceBusNamespaceManagerTest {
     }
 
     @Test
+    void preservesHealthyCountsWhenOneBatchedReadFails() throws IOException {
+        var counts = ServiceBusNamespaceManager.parseJolokiaMessageCounts(
+                List.of("orders", "processor"),
+                "[{\"status\":500,\"error\":\"unavailable\"},{\"status\":200,\"value\":1},"
+                        + "{\"status\":200,\"value\":5},{\"status\":200,\"value\":2}]");
+
+        assertEquals(new ServiceBusNamespaceManager.MessageCounts(0, 1), counts.get("orders"));
+        assertEquals(new ServiceBusNamespaceManager.MessageCounts(5, 2), counts.get("processor"));
+    }
+
+    @Test
     void rejectsIncompleteBatchedCountResponses() {
         assertThrows(IOException.class, () ->
                 ServiceBusNamespaceManager.parseJolokiaMessageCounts(

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusNamespaceManagerTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusNamespaceManagerTest.java
@@ -72,10 +72,14 @@ class ServiceBusNamespaceManagerTest {
     }
 
     @Test
-    void rejectsIncompleteBatchedCountResponses() {
-        assertThrows(IOException.class, () ->
-                ServiceBusNamespaceManager.parseJolokiaMessageCounts(
-                        List.of("orders"), "[{\"status\":200,\"value\":3}]"));
+    void preservesAvailableCountsWhenBatchedResponsesAreIncomplete() throws IOException {
+        var counts = ServiceBusNamespaceManager.parseJolokiaMessageCounts(
+                List.of("orders", "processor"),
+                "[{\"status\":200,\"value\":3},{\"status\":200,\"value\":1},"
+                        + "{\"status\":200,\"value\":5}]");
+
+        assertEquals(new ServiceBusNamespaceManager.MessageCounts(3, 1), counts.get("orders"));
+        assertEquals(new ServiceBusNamespaceManager.MessageCounts(5, 0), counts.get("processor"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- read live active/dead-letter depths from Artemis through one bounded Jolokia bulk request
- expose Azure-compatible MessageCount and CountDetails for queues and subscriptions
- keep CountDetails in the 2010 entity namespace while using 2011-prefixed child counters
- preserve zero-count mocked behavior and degrade gracefully on Jolokia failures
- add parser, response-shape, routing, and official .NET SDK runtime-count tests

## Dependency

Depends on #221. Cross-fork stacking temporarily includes its commits; this diff narrows after #221 merges.

Follow-up: #232 adds SizeInBytes, CreatedAt, and UpdatedAt runtime metadata.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature
- [ ] Breaking change
- [ ] Docs / chore

## Azure Compatibility

Matches Service Bus Atom namespace requirements so Java and .NET administration SDK runtime properties deserialize correctly.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Conventional Commits

Tests: focused 66 passed; full Maven 773 passed; .NET build clean; live .NET suite 9 passed.

Closes #214