### PR TITLE
fix: honor Cosmos patch filter predicates

### DIFF
--- a/compatibility-tests/sdk-test-dotnet/CosmosTransactionalBatchCompatibilityTests.cs
+++ b/compatibility-tests/sdk-test-dotnet/CosmosTransactionalBatchCompatibilityTests.cs
@@ -1,0 +1,107 @@
+using System.Net;
+using Microsoft.Azure.Cosmos;
+using Newtonsoft.Json.Linq;
+
+namespace FlociAz.Compatibility;
+
+[NotInParallel]
+public sealed class CosmosTransactionalBatchCompatibilityTests
+{
+    private static readonly string EmulatorEndpoint =
+        Environment.GetEnvironmentVariable("FLOCI_AZ_ENDPOINT") ?? "http://localhost:4577";
+
+    [Test]
+    [Timeout(60_000)]
+    public async Task DotnetSdkExecutesTransactionalBatches(CancellationToken cancellationToken)
+    {
+        string account = $"dotnetbatch{Guid.NewGuid():N}";
+        string databaseName = $"db-{Guid.NewGuid():N}";
+        string containerName = $"items-{Guid.NewGuid():N}";
+        using CosmosClient client = CreateClient(account);
+        Database database = await client.CreateDatabaseAsync(databaseName, cancellationToken: cancellationToken);
+        Container container = await database.CreateContainerAsync(
+            new ContainerProperties(containerName, "/tenant"),
+            cancellationToken: cancellationToken);
+
+        try
+        {
+            await container.CreateItemAsync(
+                new { id = "one", tenant = "u1", kind = "a", count = 1 },
+                new PartitionKey("u1"),
+                cancellationToken: cancellationToken);
+
+            using TransactionalBatchResponse patch = await container
+                .CreateTransactionalBatch(new PartitionKey("u1"))
+                .PatchItem("one",
+                [
+                    PatchOperation.Set("/kind", "z"),
+                    PatchOperation.Increment("/count", 10)
+                ])
+                .ExecuteAsync(cancellationToken);
+
+            await Assert.That(patch.StatusCode).IsEqualTo(HttpStatusCode.OK);
+            await Assert.That(patch.Count).IsEqualTo(1);
+            await Assert.That(patch[0].StatusCode).IsEqualTo(HttpStatusCode.OK);
+
+            ItemResponse<JObject> patched = await container.ReadItemAsync<JObject>(
+                "one", new PartitionKey("u1"), cancellationToken: cancellationToken);
+            await Assert.That(patched.Resource.Value<string>("kind")).IsEqualTo("z");
+            await Assert.That(patched.Resource.Value<int>("count")).IsEqualTo(11);
+
+            using TransactionalBatchResponse filteredPatch = await container
+                .CreateTransactionalBatch(new PartitionKey("u1"))
+                .PatchItem("one", [PatchOperation.Set("/kind", "ignored")],
+                    new TransactionalBatchPatchItemRequestOptions
+                    {
+                        FilterPredicate = "FROM c WHERE c.kind = 'no-match'"
+                    })
+                .ExecuteAsync(cancellationToken);
+
+            await Assert.That(filteredPatch.StatusCode).IsEqualTo(HttpStatusCode.PreconditionFailed);
+            await Assert.That(filteredPatch[0].StatusCode).IsEqualTo(HttpStatusCode.PreconditionFailed);
+
+            using TransactionalBatchResponse rolledBack = await container
+                .CreateTransactionalBatch(new PartitionKey("u1"))
+                .ReplaceItem("one", new { id = "one", tenant = "u1", kind = "replacement", count = 99 })
+                .DeleteItem("missing")
+                .ExecuteAsync(cancellationToken);
+
+            await Assert.That(rolledBack.StatusCode).IsEqualTo(HttpStatusCode.NotFound);
+            await Assert.That(rolledBack[0].StatusCode).IsEqualTo(HttpStatusCode.FailedDependency);
+            await Assert.That(rolledBack[1].StatusCode).IsEqualTo(HttpStatusCode.NotFound);
+
+            ItemResponse<JObject> afterRollback = await container.ReadItemAsync<JObject>(
+                "one", new PartitionKey("u1"), cancellationToken: cancellationToken);
+            await Assert.That(afterRollback.Resource.Value<string>("kind")).IsEqualTo("z");
+            await Assert.That(afterRollback.Resource.Value<int>("count")).IsEqualTo(11);
+
+            using TransactionalBatchResponse staleEtag = await container
+                .CreateTransactionalBatch(new PartitionKey("u1"))
+                .DeleteItem("one", new TransactionalBatchItemRequestOptions { IfMatchEtag = "stale" })
+                .ExecuteAsync(cancellationToken);
+
+            await Assert.That(staleEtag.StatusCode).IsEqualTo(HttpStatusCode.PreconditionFailed);
+            await Assert.That(staleEtag[0].StatusCode).IsEqualTo(HttpStatusCode.PreconditionFailed);
+
+            ItemResponse<JObject> afterStaleEtag = await container.ReadItemAsync<JObject>(
+                "one", new PartitionKey("u1"), cancellationToken: cancellationToken);
+            await Assert.That(afterStaleEtag.Resource.Value<string>("kind")).IsEqualTo("z");
+            await Assert.That(afterStaleEtag.Resource.Value<int>("count")).IsEqualTo(11);
+        }
+        finally
+        {
+            await database.DeleteAsync(cancellationToken: cancellationToken);
+        }
+    }
+
+    private static CosmosClient CreateClient(string account)
+    {
+        string endpoint = $"{EmulatorEndpoint.TrimEnd('/')}/{account}-cosmos/";
+        return new CosmosClient(endpoint, Convert.ToBase64String(new byte[64]), new CosmosClientOptions
+        {
+            ConnectionMode = ConnectionMode.Gateway,
+            LimitToEndpoint = true,
+            RequestTimeout = TimeSpan.FromSeconds(10)
+        });
+    }
+}

--- a/compatibility-tests/sdk-test-dotnet/Dockerfile
+++ b/compatibility-tests/sdk-test-dotnet/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY SdkTestDotnet.csproj .
 RUN dotnet restore
 
-COPY ServiceBusCompatibilityTests.cs .
+COPY *.cs .
 RUN dotnet build --no-restore
 
 RUN mkdir -p /results

--- a/compatibility-tests/sdk-test-dotnet/SdkTestDotnet.csproj
+++ b/compatibility-tests/sdk-test-dotnet/SdkTestDotnet.csproj
@@ -9,6 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="TUnit" Version="1.63.0" />
   </ItemGroup>
 </Project>

--- a/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
@@ -762,7 +762,8 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
     /**
      * Execute a transactional batch request.
      *
-     * <p>The request body is a JSON array of operation objects, each with at minimum
+     * <p>The request body is a JSON array or the RecordIO/HybridRow payload used by the
+     * .NET SDK. Each operation has at minimum
      * {@code "operationType"} and, depending on the type, {@code "id"} and/or
      * {@code "resourceBody"}.</p>
      *
@@ -782,9 +783,13 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         Object defaultTtl = containerDefaultTtl(collFound);
 
         List<Map<String, Object>> operations;
+        boolean hybridRow;
         try {
             byte[] raw = req.bodyStream().readAllBytes();
-            operations = MAPPER.readValue(raw, new TypeReference<>() {});
+            hybridRow = CosmosHybridRowBatchCodec.isHybridRow(raw);
+            operations = hybridRow
+                    ? CosmosHybridRowBatchCodec.decodeOperations(raw)
+                    : MAPPER.readValue(raw, new TypeReference<>() {});
         } catch (IOException e) {
             return errorResponse(400, "BadRequest", "Invalid batch request body.");
         }
@@ -845,13 +850,18 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         }
 
         try {
-            return Response.ok(MAPPER.writeValueAsString(results), "application/json")
+            Object responseBody = hybridRow
+                    ? CosmosHybridRowBatchCodec.encodeResults(results)
+                    : MAPPER.writeValueAsString(results);
+            String contentType = hybridRow ? "application/octet-stream" : "application/json";
+            int status = hybridRow && failed ? 207 : 200;
+            return Response.status(status).entity(responseBody).type(contentType)
                     .header("x-ms-request-charge",  String.valueOf(results.size()))
                     .header("x-ms-session-token",   "0:0#1")
                     .header("x-ms-activity-id",     UUID.randomUUID().toString())
                     .header("x-ms-version",         "2018-12-31")
                     .build();
-        } catch (JsonProcessingException e) {
+        } catch (IOException e) {
             return Response.serverError().build();
         }
     }
@@ -951,6 +961,11 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
             operations.add((Map<String, Object>) operation);
         }
         Map<String, Object> document = parseData(found.get());
+        String filterPredicate = body.get("condition") instanceof String value ? value : null;
+        if (filterPredicate != null && !filterPredicate.isBlank()
+                && queryEngine.execute("SELECT * " + filterPredicate, List.of(), List.of(document)).count() == 0) {
+            return batchResultError(412);
+        }
         applyPatchOperations(document, operations);
 
         Instant now = Instant.now();

--- a/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
@@ -629,8 +629,12 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         // The Cosmos DB PATCH body can arrive in two forms:
         //   1. {"operations": [...]}  — Java / Python SDKs
         //   2. [{op, path, value}, …] — Node SDK (sends the array directly)
-        List<Map<String, Object>> operations = parsePatchBody(req);
-        applyPatchOperations(doc, operations);
+        PatchRequest patch = parsePatchBody(req);
+        if (patch.condition() != null && !patch.condition().isBlank()
+                && queryEngine.execute("SELECT * " + patch.condition(), List.of(), List.of(doc)).count() == 0) {
+            return errorResponse(412, "PreconditionFailed", "The patch filter predicate was not satisfied.");
+        }
+        applyPatchOperations(doc, patch.operations());
 
         Instant now  = Instant.now();
         String  etag = newEtag();
@@ -1383,23 +1387,28 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
      * </ul>
      */
     @SuppressWarnings("unchecked")
-    private List<Map<String, Object>> parsePatchBody(AzureRequest req) {
+    private PatchRequest parsePatchBody(AzureRequest req) {
         try {
             byte[] raw = req.bodyStream().readAllBytes();
             String trimmed = new String(raw, StandardCharsets.UTF_8).trim();
             if (trimmed.startsWith("[")) {
                 // Node SDK: raw operations array
-                return MAPPER.readValue(trimmed, new TypeReference<>() {});
+                return new PatchRequest(MAPPER.readValue(trimmed, new TypeReference<>() {}), null);
             } else {
                 // Java/Python SDK: {"operations": [...]}
                 Map<String, Object> body = MAPPER.readValue(trimmed, new TypeReference<>() {});
-                return body.get("operations") instanceof List<?> l
+                List<Map<String, Object>> operations = body.get("operations") instanceof List<?> l
                         ? (List<Map<String, Object>>) l : List.of();
+                String condition = body.get("condition") instanceof String value ? value : null;
+                return new PatchRequest(operations, condition);
             }
         } catch (IOException e) {
             LOG.warnf("Failed to parse PATCH body: %s", e.getMessage());
-            return List.of();
+            return new PatchRequest(List.of(), null);
         }
+    }
+
+    private record PatchRequest(List<Map<String, Object>> operations, String condition) {
     }
 
     private byte[] toBytes(Object obj) {

--- a/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
@@ -854,7 +854,7 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
                     ? CosmosHybridRowBatchCodec.encodeResults(results)
                     : MAPPER.writeValueAsString(results);
             String contentType = hybridRow ? "application/octet-stream" : "application/json";
-            int status = hybridRow && failed ? 207 : 200;
+            int status = failed ? 207 : 200;
             return Response.status(status).entity(responseBody).type(contentType)
                     .header("x-ms-request-charge",  String.valueOf(results.size()))
                     .header("x-ms-session-token",   "0:0#1")

--- a/src/main/java/io/floci/az/services/cosmos/CosmosHybridRowBatchCodec.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosHybridRowBatchCodec.java
@@ -1,0 +1,317 @@
+package io.floci.az.services.cosmos;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.CRC32;
+
+/** Codec for the RecordIO/HybridRow transactional-batch format used by Microsoft.Azure.Cosmos. */
+final class CosmosHybridRowBatchCodec {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static final byte[] SEGMENT_HEADER = {
+        (byte) 0x81, (byte) 0xf0, (byte) 0xd8, (byte) 0xff, 0x7f, 0x01, 0x0a, 0x00, 0x00, 0x00
+    };
+    private static final byte[] RECORD_HEADER_PREFIX = {
+        (byte) 0x81, (byte) 0xf1, (byte) 0xd8, (byte) 0xff, 0x7f
+    };
+    private static final byte[] OPERATION_ROW_HEADER = {
+        (byte) 0x81, 0x70, 0x54, (byte) 0xe1, 0x7f
+    };
+    private static final byte[] RESULT_ROW_HEADER = {
+        (byte) 0x81, 0x71, 0x54, (byte) 0xe1, 0x7f
+    };
+
+    private static final int RECORD_HEADER_LENGTH = 13;
+    private static final int RECORD_LENGTH_OFFSET = 5;
+    private static final int RECORD_CRC_OFFSET = 9;
+    private static final int ID_VARIABLE_INDEX = 2;
+    private static final int RESOURCE_BODY_VARIABLE_INDEX = 4;
+    private static final int TYPE_INT32 = 7;
+    private static final int TYPE_UINT32 = 11;
+    private static final int TYPE_FLOAT64 = 16;
+    private static final int TYPE_UTF8 = 20;
+    private static final int TYPE_BOOLEAN_FALSE = 2;
+    private static final int TYPE_BOOLEAN_TRUE = 3;
+
+    private static final int TOKEN_IF_MATCH = 9;
+    private static final int TOKEN_IF_NONE_MATCH = 10;
+    private static final int TOKEN_RETRY_AFTER_MILLISECONDS = 5;
+    private static final int TOKEN_REQUEST_CHARGE = 6;
+
+    private static final Map<Integer, String> OPERATION_TYPES = Map.of(
+            0, "Create",
+            1, "Patch",
+            2, "Read",
+            4, "Delete",
+            5, "Replace",
+            20, "Upsert");
+
+    private CosmosHybridRowBatchCodec() {
+    }
+
+    static boolean isHybridRow(byte[] payload) {
+        return startsWith(payload, 0, SEGMENT_HEADER);
+    }
+
+    static List<Map<String, Object>> decodeOperations(byte[] payload) throws IOException {
+        if (!isHybridRow(payload)) {
+            throw new IOException("Missing HybridRow RecordIO segment header");
+        }
+
+        List<Map<String, Object>> operations = new ArrayList<>();
+        int offset = SEGMENT_HEADER.length;
+        while (offset < payload.length) {
+            if (!startsWith(payload, offset, RECORD_HEADER_PREFIX)
+                    || payload.length - offset < RECORD_HEADER_LENGTH) {
+                throw new IOException("Invalid HybridRow RecordIO record header");
+            }
+
+            int bodyLength = readInt32(payload, offset + RECORD_LENGTH_OFFSET);
+            int bodyOffset = offset + RECORD_HEADER_LENGTH;
+            if (bodyLength <= 0 || bodyLength > payload.length - bodyOffset) {
+                throw new IOException("Invalid HybridRow RecordIO record length");
+            }
+
+            long expectedCrc = Integer.toUnsignedLong(readInt32(payload, offset + RECORD_CRC_OFFSET));
+            CRC32 crc = new CRC32();
+            crc.update(payload, bodyOffset, bodyLength);
+            if (crc.getValue() != expectedCrc) {
+                throw new IOException("HybridRow RecordIO CRC mismatch");
+            }
+
+            operations.add(decodeOperation(payload, bodyOffset, bodyLength));
+            offset = bodyOffset + bodyLength;
+        }
+
+        if (operations.isEmpty()) {
+            throw new IOException("HybridRow batch contains no operations");
+        }
+        return operations;
+    }
+
+    static byte[] encodeResults(List<Map<String, Object>> results) throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        output.write(SEGMENT_HEADER);
+        for (Map<String, Object> result : results) {
+            byte[] body = encodeResult(result);
+            output.write(RECORD_HEADER_PREFIX);
+            writeInt32(output, body.length);
+
+            CRC32 crc = new CRC32();
+            crc.update(body);
+            writeInt32(output, (int) crc.getValue());
+            output.write(body);
+        }
+        return output.toByteArray();
+    }
+
+    private static Map<String, Object> decodeOperation(byte[] payload, int bodyOffset, int bodyLength)
+            throws IOException {
+        int end = bodyOffset + bodyLength;
+        Cursor cursor = new Cursor(payload, bodyOffset, end);
+        cursor.expect(OPERATION_ROW_HEADER);
+
+        int presence = cursor.readUnsignedByte();
+        if ((presence & 0x03) != 0x03) {
+            throw new IOException("HybridRow operation is missing mandatory fields");
+        }
+
+        String operationType = OPERATION_TYPES.get(cursor.readInt32());
+        int resourceType = cursor.readInt32();
+        if (operationType == null || resourceType != 2) {
+            throw new IOException("Unsupported HybridRow batch operation");
+        }
+
+        byte[][] variableColumns = new byte[5][];
+        for (int index = 0; index < variableColumns.length; index++) {
+            if ((presence & (1 << (index + 2))) != 0) {
+                variableColumns[index] = cursor.readVariable();
+            }
+        }
+
+        Map<String, Object> operation = new LinkedHashMap<>();
+        operation.put("operationType", operationType);
+        if (variableColumns[ID_VARIABLE_INDEX] != null) {
+            operation.put("id", new String(variableColumns[ID_VARIABLE_INDEX], StandardCharsets.UTF_8));
+        }
+        if (variableColumns[RESOURCE_BODY_VARIABLE_INDEX] != null) {
+            operation.put("resourceBody", MAPPER.readValue(variableColumns[RESOURCE_BODY_VARIABLE_INDEX],
+                    new TypeReference<Map<String, Object>>() {}));
+        }
+
+        while (cursor.hasRemaining()) {
+            int type = cursor.readUnsignedByte();
+            int token = cursor.readVarUInt();
+            switch (type) {
+                case TYPE_UTF8 -> {
+                    String value = new String(cursor.readVariable(), StandardCharsets.UTF_8);
+                    if (token == TOKEN_IF_MATCH) {
+                        operation.put("ifMatch", value);
+                    } else if (token == TOKEN_IF_NONE_MATCH) {
+                        operation.put("ifNoneMatch", value);
+                    }
+                }
+                case TYPE_INT32, TYPE_UINT32 -> cursor.skip(4);
+                case TYPE_FLOAT64 -> cursor.skip(8);
+                case TYPE_BOOLEAN_FALSE, TYPE_BOOLEAN_TRUE -> {
+                    // The value is carried by the type code.
+                }
+                default -> throw new IOException("Unsupported HybridRow sparse field type");
+            }
+        }
+        return operation;
+    }
+
+    private static byte[] encodeResult(Map<String, Object> result) throws IOException {
+        ByteArrayOutputStream body = new ByteArrayOutputStream();
+        body.write(RESULT_ROW_HEADER);
+
+        String etag = result.get("eTag") instanceof String value ? value : null;
+        byte[] resourceBody = result.get("resourceBody") instanceof Map<?, ?> value
+                ? MAPPER.writeValueAsBytes(value) : null;
+        int presence = 0x03;
+        if (etag != null) {
+            presence |= 0x04;
+        }
+        if (resourceBody != null) {
+            presence |= 0x08;
+        }
+        body.write(presence);
+
+        writeInt32(body, ((Number) result.get("statusCode")).intValue());
+        writeInt32(body, ((Number) result.getOrDefault("subStatusCode", 0)).intValue());
+        if (etag != null) {
+            writeVariable(body, etag.getBytes(StandardCharsets.UTF_8));
+        }
+        if (resourceBody != null) {
+            writeVariable(body, resourceBody);
+        }
+
+        body.write(TYPE_UINT32);
+        writeVarUInt(body, TOKEN_RETRY_AFTER_MILLISECONDS);
+        writeInt32(body, 0);
+
+        body.write(TYPE_FLOAT64);
+        writeVarUInt(body, TOKEN_REQUEST_CHARGE);
+        writeFloat64(body, ((Number) result.getOrDefault("requestCharge", 1.0)).doubleValue());
+        return body.toByteArray();
+    }
+
+    private static boolean startsWith(byte[] value, int offset, byte[] prefix) {
+        if (offset < 0 || value.length - offset < prefix.length) {
+            return false;
+        }
+        for (int index = 0; index < prefix.length; index++) {
+            if (value[offset + index] != prefix[index]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static int readInt32(byte[] value, int offset) {
+        return ByteBuffer.wrap(value, offset, Integer.BYTES).order(ByteOrder.LITTLE_ENDIAN).getInt();
+    }
+
+    private static void writeInt32(ByteArrayOutputStream output, int value) {
+        output.writeBytes(ByteBuffer.allocate(Integer.BYTES)
+                .order(ByteOrder.LITTLE_ENDIAN).putInt(value).array());
+    }
+
+    private static void writeFloat64(ByteArrayOutputStream output, double value) {
+        output.writeBytes(ByteBuffer.allocate(Double.BYTES)
+                .order(ByteOrder.LITTLE_ENDIAN).putDouble(value).array());
+    }
+
+    private static void writeVariable(ByteArrayOutputStream output, byte[] value) {
+        writeVarUInt(output, value.length);
+        output.writeBytes(value);
+    }
+
+    private static void writeVarUInt(ByteArrayOutputStream output, int value) {
+        int remaining = value;
+        do {
+            int next = remaining & 0x7f;
+            remaining >>>= 7;
+            output.write(remaining == 0 ? next : next | 0x80);
+        } while (remaining != 0);
+    }
+
+    private static final class Cursor {
+        private final byte[] payload;
+        private final int end;
+        private int offset;
+
+        private Cursor(byte[] payload, int offset, int end) {
+            this.payload = payload;
+            this.offset = offset;
+            this.end = end;
+        }
+
+        private boolean hasRemaining() {
+            return offset < end;
+        }
+
+        private void expect(byte[] expected) throws IOException {
+            if (!startsWith(payload, offset, expected) || expected.length > end - offset) {
+                throw new IOException("Unexpected HybridRow schema");
+            }
+            offset += expected.length;
+        }
+
+        private int readUnsignedByte() throws IOException {
+            require(1);
+            return Byte.toUnsignedInt(payload[offset++]);
+        }
+
+        private int readInt32() throws IOException {
+            require(Integer.BYTES);
+            int value = CosmosHybridRowBatchCodec.readInt32(payload, offset);
+            offset += Integer.BYTES;
+            return value;
+        }
+
+        private int readVarUInt() throws IOException {
+            int value = 0;
+            for (int shift = 0; shift < Integer.SIZE; shift += 7) {
+                int next = readUnsignedByte();
+                value |= (next & 0x7f) << shift;
+                if ((next & 0x80) == 0) {
+                    return value;
+                }
+            }
+            throw new IOException("Invalid HybridRow variable-length integer");
+        }
+
+        private byte[] readVariable() throws IOException {
+            int length = readVarUInt();
+            require(length);
+            byte[] value = new byte[length];
+            System.arraycopy(payload, offset, value, 0, length);
+            offset += length;
+            return value;
+        }
+
+        private void skip(int length) throws IOException {
+            require(length);
+            offset += length;
+        }
+
+        private void require(int length) throws IOException {
+            if (length < 0 || length > end - offset) {
+                throw new IOException("Truncated HybridRow value");
+            }
+        }
+    }
+}

--- a/src/test/java/io/floci/az/services/cosmos/CosmosContainerTtlTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosContainerTtlTest.java
@@ -205,7 +205,7 @@ public class CosmosContainerTtlTest {
                 .header("x-ms-documentdb-partitionkey", "[\"x\"]")
                 .body("[{\"operationType\":\"Read\",\"id\":\"a\"},{\"operationType\":\"Read\",\"id\":\"b\"}]")
                 .when().post(BASE + "/dbs/" + DB + "/colls/events/docs")
-                .then().statusCode(200)
+                .then().statusCode(207)
                 .body("statusCode", contains(404, 424));
 
         // conditional point and batch mutations also treat the expired doc as absent
@@ -227,7 +227,7 @@ public class CosmosContainerTtlTest {
                           "resourceBody": {"id":"a","category":"x"}
                         }]""".formatted(expiredEtag.replace("\"", "\\\"")))
                 .when().post(BASE + "/dbs/" + DB + "/colls/events/docs")
-                .then().statusCode(200).body("[0].statusCode", is(404));
+                .then().statusCode(207).body("[0].statusCode", is(404));
 
         // an expired doc no longer blocks re-creating the same id
         insertDoc("events", "{\"id\":\"a\",\"category\":\"x\"}");

--- a/src/test/java/io/floci/az/services/cosmos/CosmosHybridRowBatchCodecTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosHybridRowBatchCodecTest.java
@@ -1,0 +1,108 @@
+package io.floci.az.services.cosmos;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.CRC32;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CosmosHybridRowBatchCodecTest {
+
+    private static final String PATCH_CAPTURE =
+            "gfDY/38BCgAAAIHx2P9/dAAAAM44guiBcFThf1MBAAAAAgAAAANvbmVheyJvcGVyYXRpb25zIjpb"
+                    + "eyJvcCI6InNldCIsInBhdGgiOiIva2luZCIsInZhbHVlIjoieiJ9LHsib3AiOiJpbmNyIiwicGF0aCI6"
+                    + "Ii9jb3VudCIsInZhbHVlIjoxMH1dfQ==";
+    private static final String REPLACE_DELETE_CAPTURE =
+            "gfDY/38BCgAAAIHx2P9/TQAAAJKKVRCBcFThf1MFAAAAAgAAAANvbmU6eyJpZCI6Im9uZSIsInRl"
+                    + "bmFudCI6InUxIiwia2luZCI6InJlcGxhY2VtZW50IiwiY291bnQiOjk5fYHx2P9/FgAAAAtBUkGBcFTh"
+                    + "fxMEAAAAAgAAAAdtaXNzaW5n";
+    private static final String IF_MATCH_DELETE_CAPTURE =
+            "gfDY/38BCgAAAIHx2P9/GgAAADpfNJeBcFThfxMEAAAAAgAAAANvbmUUCQVzdGFsZQ==";
+
+    @Test
+    void decodesPatchBodyCapturedFromDotnetSdk() throws IOException {
+        List<Map<String, Object>> operations = CosmosHybridRowBatchCodec.decodeOperations(decode(PATCH_CAPTURE));
+
+        assertEquals(1, operations.size());
+        Map<String, Object> patch = operations.getFirst();
+        assertEquals("Patch", patch.get("operationType"));
+        assertEquals("one", patch.get("id"));
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> patchOperations =
+                (List<Map<String, Object>>) ((Map<String, Object>) patch.get("resourceBody")).get("operations");
+        assertEquals(List.of("set", "incr"), patchOperations.stream().map(value -> value.get("op")).toList());
+        assertEquals(10, patchOperations.get(1).get("value"));
+    }
+
+    @Test
+    void decodesMultipleRecordsAndSparseEtag() throws IOException {
+        List<Map<String, Object>> operations =
+                CosmosHybridRowBatchCodec.decodeOperations(decode(REPLACE_DELETE_CAPTURE));
+
+        assertEquals(2, operations.size());
+        assertEquals("Replace", operations.get(0).get("operationType"));
+        assertEquals("replacement",
+                ((Map<?, ?>) operations.get(0).get("resourceBody")).get("kind"));
+        assertEquals("Delete", operations.get(1).get("operationType"));
+        assertEquals("missing", operations.get(1).get("id"));
+
+        Map<String, Object> conditionalDelete =
+                CosmosHybridRowBatchCodec.decodeOperations(decode(IF_MATCH_DELETE_CAPTURE)).getFirst();
+        assertEquals("stale", conditionalDelete.get("ifMatch"));
+    }
+
+    @Test
+    void rejectsCorruptRecordCrc() {
+        byte[] payload = decode(PATCH_CAPTURE);
+        payload[payload.length - 1] ^= 1;
+
+        IOException exception = assertThrows(IOException.class,
+                () -> CosmosHybridRowBatchCodec.decodeOperations(payload));
+        assertEquals("HybridRow RecordIO CRC mismatch", exception.getMessage());
+    }
+
+    @Test
+    void encodesRecordIoResultsWithValidLengthsAndCrcs() throws IOException {
+        List<Map<String, Object>> results = List.of(
+                Map.of("statusCode", 200, "subStatusCode", 0, "requestCharge", 1.0,
+                        "eTag", "\"etag\"", "resourceBody", Map.of("id", "one")),
+                Map.of("statusCode", 404, "subStatusCode", 0, "requestCharge", 1.0));
+
+        byte[] encoded = CosmosHybridRowBatchCodec.encodeResults(results);
+        assertTrue(CosmosHybridRowBatchCodec.isHybridRow(encoded));
+
+        int offset = 10;
+        for (int record = 0; record < results.size(); record++) {
+            assertArrayEquals(new byte[] {(byte) 0x81, (byte) 0xf1, (byte) 0xd8, (byte) 0xff, 0x7f},
+                    Arrays.copyOfRange(encoded, offset, offset + 5));
+            int length = readInt32(encoded, offset + 5);
+            long expectedCrc = Integer.toUnsignedLong(readInt32(encoded, offset + 9));
+            CRC32 crc = new CRC32();
+            crc.update(encoded, offset + 13, length);
+            assertEquals(expectedCrc, crc.getValue());
+            assertArrayEquals(new byte[] {(byte) 0x81, 0x71, 0x54, (byte) 0xe1, 0x7f},
+                    Arrays.copyOfRange(encoded, offset + 13, offset + 18));
+            offset += 13 + length;
+        }
+        assertEquals(encoded.length, offset);
+    }
+
+    private static byte[] decode(String value) {
+        return Base64.getDecoder().decode(value);
+    }
+
+    private static int readInt32(byte[] value, int offset) {
+        return ByteBuffer.wrap(value, offset, Integer.BYTES).order(ByteOrder.LITTLE_ENDIAN).getInt();
+    }
+}

--- a/src/test/java/io/floci/az/services/cosmos/CosmosItemConditionTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosItemConditionTest.java
@@ -100,7 +100,7 @@ class CosmosItemConditionTest {
                           "resourceBody": {"id":"one","pk":"p","value":2}
                         }]""")
                 .post(DOCS)
-                .then().statusCode(200).body("[0].statusCode", is(412));
+                .then().statusCode(207).body("[0].statusCode", is(412));
 
         readDocument().then().statusCode(200).body("value", is(1));
     }
@@ -128,7 +128,7 @@ class CosmosItemConditionTest {
                           }
                         ]""".formatted(etag.replace("\"", "\\\"")))
                 .post(DOCS)
-                .then().statusCode(200)
+                .then().statusCode(207)
                 .body("statusCode", contains(424, 412));
 
         readDocument().then().statusCode(200).body("value", is(1));

--- a/src/test/java/io/floci/az/services/cosmos/CosmosItemConditionTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosItemConditionTest.java
@@ -58,6 +58,24 @@ class CosmosItemConditionTest {
     }
 
     @Test
+    void patchFilterPredicateRejectsWithoutChangingDocument() {
+        createDocument(1);
+
+        given().contentType("application/json")
+                .header("x-ms-documentdb-partitionkey", PARTITION_KEY)
+                .body("""
+                        {
+                          "condition": "FROM c WHERE c.value = 2",
+                          "operations": [{"op":"set","path":"/value","value":3}]
+                        }""")
+                .patch(DOCS + "/one")
+                .then().statusCode(412)
+                .body("code", is("PreconditionFailed"));
+
+        readDocument().then().statusCode(200).body("value", is(1));
+    }
+
+    @Test
     void upsertHonorsIfMatchAndIfNoneMatch() {
         String etag = createDocument(1);
 

--- a/src/test/java/io/floci/az/services/cosmos/CosmosTransactionalBatchTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosTransactionalBatchTest.java
@@ -44,7 +44,7 @@ class CosmosTransactionalBatchTest {
                           {"operationType":"Delete","id":"missing"}
                         ]""")
                 .post(DOCS)
-                .then().statusCode(200)
+                .then().statusCode(207)
                 .body("statusCode", contains(424, 404));
 
         read("one").then().statusCode(200).body("value", is(1));
@@ -93,7 +93,7 @@ class CosmosTransactionalBatchTest {
                           {"operationType":"Read","id":"one"}
                         ]""")
                 .post(DOCS)
-                .then().statusCode(200)
+                .then().statusCode(207)
                 .body("statusCode", contains(400, 424));
 
         read("one").then().statusCode(200)


### PR DESCRIPTION
## Summary

Evaluate standalone Cosmos PATCH filter predicates before applying mutations and return 412 when the predicate is false.

Depends on #222. This PR temporarily includes its parent commits; the diff narrows after #222 merges.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

CosmosItemRequestOptions.FilterPredicate was previously ignored for standalone patch requests. A false predicate now returns PreconditionFailed without mutating the document.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Focused test: `./mvnw test -Dtest=CosmosItemConditionTest`