### PR TITLE
docs: clarify Service Bus session DLQ access

### DIFF
--- a/docs/services/service-bus.md
+++ b/docs/services/service-bus.md
@@ -78,6 +78,10 @@ within that session. Attach responses include Azure's `com.microsoft:locked-unti
 Session ownership lasts for the receiver link. Session state and explicit session-lock renewal are
 not currently emulated.
 
+Read a session-enabled entity's dead-letter subqueue with an ordinary receiver. Azure SDKs do not
+expose session receivers for dead-letter subqueues, and receiving from that subqueue does not
+require a session lock.
+
 ## Message peeking
 
 Queue and subscription receivers support Azure SDK `peekMessages()` calls through each entity's


### PR DESCRIPTION
## Summary

Document that dead-letter subqueues for session-enabled Service Bus entities are read with ordinary receivers.

The previous implementation attempted to support session-filtered dead-letter receivers, but official SDKs do not expose that operation and available evidence indicates Azure does not support it. #223 already fixes dead-letter access through the supported ordinary-receiver path.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## Azure Compatibility

Python rejects the session-plus-subqueue combination, while .NET and Go document ordinary receivers for dead-letter subqueues. This PR records that supported SDK behavior without adding an unverified wire-protocol deviation.

## Checklist

- [ ] `./mvnw test` passes locally (docs-only change)
- [ ] New or updated integration test added (not applicable)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)