### PR TITLE
fix: expose Service Bus runtime metadata

### DIFF
--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
@@ -1042,7 +1042,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                 + "<Status>Active</Status>"
                 + "<EntityAvailabilityStatus>Available</EntityAvailabilityStatus>"
                 + "<MessageCount>" + counts.total() + "</MessageCount>"
-                + runtimeMetadataXml(s.createdAt(), s.updatedAt())
+                + runtimeTimestampsXml(s.createdAt(), s.updatedAt())
                 + countDetailsXml(counts)
                 + "</SubscriptionDescription>";
     }
@@ -1116,8 +1116,11 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
     }
 
     private String runtimeMetadataXml(Instant createdAt, Instant updatedAt) {
-        return "<SizeInBytes>0</SizeInBytes>"
-                + "<CreatedAt>" + ISO8601.format(createdAt) + "</CreatedAt>"
+        return "<SizeInBytes>0</SizeInBytes>" + runtimeTimestampsXml(createdAt, updatedAt);
+    }
+
+    private String runtimeTimestampsXml(Instant createdAt, Instant updatedAt) {
+        return "<CreatedAt>" + ISO8601.format(createdAt) + "</CreatedAt>"
                 + "<UpdatedAt>" + ISO8601.format(updatedAt) + "</UpdatedAt>";
     }
 

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
@@ -926,6 +926,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                 + "<Status>Active</Status>"
                 + "<EntityAvailabilityStatus>Available</EntityAvailabilityStatus>"
                 + "<MessageCount>" + counts.total() + "</MessageCount>"
+                + runtimeMetadataXml(q.createdAt(), q.updatedAt())
                 + countDetailsXml(counts)
                 + "</QueueDescription>";
     }
@@ -977,6 +978,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                 + "<AutoDeleteOnIdle>P10675199DT2H48M5.4775807S</AutoDeleteOnIdle>"
                 + "<Status>Active</Status>"
                 + "<EntityAvailabilityStatus>Available</EntityAvailabilityStatus>"
+                + runtimeMetadataXml(t.createdAt(), t.updatedAt())
                 + countDetailsXml(ServiceBusNamespaceManager.MessageCounts.ZERO)
                 + "</TopicDescription>";
     }
@@ -1040,6 +1042,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                 + "<Status>Active</Status>"
                 + "<EntityAvailabilityStatus>Available</EntityAvailabilityStatus>"
                 + "<MessageCount>" + counts.total() + "</MessageCount>"
+                + runtimeMetadataXml(s.createdAt(), s.updatedAt())
                 + countDetailsXml(counts)
                 + "</SubscriptionDescription>";
     }
@@ -1110,6 +1113,12 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                 + "<sb:TransferDeadLetterMessageCount>0</sb:TransferDeadLetterMessageCount>"
                 + "<sb:TransferMessageCount>0</sb:TransferMessageCount>"
                 + "</CountDetails>";
+    }
+
+    private String runtimeMetadataXml(Instant createdAt, Instant updatedAt) {
+        return "<SizeInBytes>0</SizeInBytes>"
+                + "<CreatedAt>" + ISO8601.format(createdAt) + "</CreatedAt>"
+                + "<UpdatedAt>" + ISO8601.format(updatedAt) + "</UpdatedAt>";
     }
 
     // ── Storage key helpers ───────────────────────────────────────────────────

--- a/src/test/java/io/floci/az/services/ServiceBusServiceTest.java
+++ b/src/test/java/io/floci/az/services/ServiceBusServiceTest.java
@@ -309,7 +309,10 @@ public class ServiceBusServiceTest {
                 .body(containsString("<MessageCount>0</MessageCount>"))
                 .body(containsString("<CountDetails xmlns:sb=\"" + SB_COUNT_NS + "\">"))
                 .body(containsString("<sb:ActiveMessageCount>0</sb:ActiveMessageCount>"))
-                .body(containsString("<sb:DeadLetterMessageCount>0</sb:DeadLetterMessageCount>"));
+                .body(containsString("<sb:DeadLetterMessageCount>0</sb:DeadLetterMessageCount>"))
+                .body(containsString("<SizeInBytes>0</SizeInBytes>"))
+                .body(containsString("<CreatedAt>"))
+                .body(containsString("<UpdatedAt>"));
 
         given().body(entry("<TopicDescription xmlns=\"" + SB_NS + "\"/>"))
                 .when().put(BASE + "/runtime-count-topic")
@@ -321,7 +324,10 @@ public class ServiceBusServiceTest {
                 .body(containsString("<MessageCount>0</MessageCount>"))
                 .body(containsString("<CountDetails xmlns:sb=\"" + SB_COUNT_NS + "\">"))
                 .body(containsString("<sb:ActiveMessageCount>0</sb:ActiveMessageCount>"))
-                .body(containsString("<sb:DeadLetterMessageCount>0</sb:DeadLetterMessageCount>"));
+                .body(containsString("<sb:DeadLetterMessageCount>0</sb:DeadLetterMessageCount>"))
+                .body(containsString("<SizeInBytes>0</SizeInBytes>"))
+                .body(containsString("<CreatedAt>"))
+                .body(containsString("<UpdatedAt>"));
     }
 
     @Test

--- a/src/test/java/io/floci/az/services/ServiceBusServiceTest.java
+++ b/src/test/java/io/floci/az/services/ServiceBusServiceTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 
 @QuarkusTest
 public class ServiceBusServiceTest {
@@ -325,7 +326,7 @@ public class ServiceBusServiceTest {
                 .body(containsString("<CountDetails xmlns:sb=\"" + SB_COUNT_NS + "\">"))
                 .body(containsString("<sb:ActiveMessageCount>0</sb:ActiveMessageCount>"))
                 .body(containsString("<sb:DeadLetterMessageCount>0</sb:DeadLetterMessageCount>"))
-                .body(containsString("<SizeInBytes>0</SizeInBytes>"))
+                .body(not(containsString("<SizeInBytes>")))
                 .body(containsString("<CreatedAt>"))
                 .body(containsString("<UpdatedAt>"));
     }


### PR DESCRIPTION
## Summary

Expose persisted `CreatedAt` and `UpdatedAt` timestamps in Service Bus queue, topic, and subscription descriptions. Include `SizeInBytes` on queue and topic descriptions only; subscription responses omit it.

The branch has been rebased after #225 was squash-merged. Its diff contains only the runtime metadata change and regression assertions in `ServiceBusHandler.java` and `ServiceBusServiceTest.java` (21 additions, 2 deletions).

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

An absent queue `SizeInBytes` causes the Java administration SDK to throw when unboxing its nullable parsed value into a primitive `long`. Queue and topic descriptions now supply zero-byte size metadata. Subscriptions omit the element because Azure and the SDK models do not define it there. All three entity descriptions expose their persisted creation and update timestamps.

## Validation

- Regression assertions cover timestamp presence, queue size, and the absence of subscription size.
- All current CI and native compatibility checks pass on `a80d776`.
- Timestamp-value assertions and `AccessedAt` remain separate follow-up work, as requested in review.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
