### PR TITLE
test: cover Cosmos HybridRow batch opcodes

### DIFF
--- a/compatibility-tests/sdk-test-dotnet/CosmosTransactionalBatchCompatibilityTests.cs
+++ b/compatibility-tests/sdk-test-dotnet/CosmosTransactionalBatchCompatibilityTests.cs
@@ -48,6 +48,26 @@ public sealed class CosmosTransactionalBatchCompatibilityTests
             await Assert.That(patched.Resource.Value<string>("kind")).IsEqualTo("z");
             await Assert.That(patched.Resource.Value<int>("count")).IsEqualTo(11);
 
+            using TransactionalBatchResponse opcodeBatch = await container
+                .CreateTransactionalBatch(new PartitionKey("u1"))
+                .CreateItem(new { id = "created", tenant = "u1", kind = "create" })
+                .ReadItem("one")
+                .UpsertItem(new { id = "upserted", tenant = "u1", kind = "upsert" })
+                .ExecuteAsync(cancellationToken);
+
+            await Assert.That(opcodeBatch.StatusCode).IsEqualTo(HttpStatusCode.OK);
+            await Assert.That(opcodeBatch.Count).IsEqualTo(3);
+            await Assert.That(opcodeBatch[0].StatusCode).IsEqualTo(HttpStatusCode.Created);
+            await Assert.That(opcodeBatch[1].StatusCode).IsEqualTo(HttpStatusCode.OK);
+            await Assert.That(opcodeBatch[2].StatusCode).IsEqualTo(HttpStatusCode.Created);
+
+            ItemResponse<JObject> created = await container.ReadItemAsync<JObject>(
+                "created", new PartitionKey("u1"), cancellationToken: cancellationToken);
+            ItemResponse<JObject> upserted = await container.ReadItemAsync<JObject>(
+                "upserted", new PartitionKey("u1"), cancellationToken: cancellationToken);
+            await Assert.That(created.Resource.Value<string>("kind")).IsEqualTo("create");
+            await Assert.That(upserted.Resource.Value<string>("kind")).IsEqualTo("upsert");
+
             using TransactionalBatchResponse filteredPatch = await container
                 .CreateTransactionalBatch(new PartitionKey("u1"))
                 .PatchItem("one", [PatchOperation.Set("/kind", "ignored")],

--- a/src/test/java/io/floci/az/services/cosmos/CosmosHybridRowBatchCodecTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosHybridRowBatchCodecTest.java
@@ -28,6 +28,11 @@ class CosmosHybridRowBatchCodecTest {
                     + "fxMEAAAAAgAAAAdtaXNzaW5n";
     private static final String IF_MATCH_DELETE_CAPTURE =
             "gfDY/38BCgAAAIHx2P9/GgAAADpfNJeBcFThfxMEAAAAAgAAAANvbmUUCQVzdGFsZQ==";
+    private static final String CREATE_READ_UPSERT_CAPTURE =
+            "gfDY/38BCgAAAIHx2P9/MgAAAIy0GfCBcFThf0MAAAAAAgAAACN7ImlkIjoiY3JlYXRlZCIs"
+                    + "InBrIjoicCIsInZhbHVlIjoxfYHx2P9/FgAAAI7kXlCBcFThfxMCAAAAAgAAAAdjcmVhdGVk"
+                    + "gfHY/38yAAAAJIqEvIFwVOF/QxQAAAACAAAAI3siaWQiOiJjcmVhdGVkIiwicGsiOiJwIiwidm"
+                    + "FsdWUiOjJ9";
 
     @Test
     void decodesPatchBodyCapturedFromDotnetSdk() throws IOException {
@@ -60,6 +65,18 @@ class CosmosHybridRowBatchCodecTest {
         Map<String, Object> conditionalDelete =
                 CosmosHybridRowBatchCodec.decodeOperations(decode(IF_MATCH_DELETE_CAPTURE)).getFirst();
         assertEquals("stale", conditionalDelete.get("ifMatch"));
+    }
+
+    @Test
+    void decodesCreateReadAndUpsertOpcodes() throws IOException {
+        List<Map<String, Object>> operations =
+                CosmosHybridRowBatchCodec.decodeOperations(decode(CREATE_READ_UPSERT_CAPTURE));
+
+        assertEquals(List.of("Create", "Read", "Upsert"),
+                operations.stream().map(operation -> operation.get("operationType")).toList());
+        assertEquals(1, ((Map<?, ?>) operations.get(0).get("resourceBody")).get("value"));
+        assertEquals("created", operations.get(1).get("id"));
+        assertEquals(2, ((Map<?, ?>) operations.get(2).get("resourceBody")).get("value"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Add RecordIO/HybridRow fixtures that pin Create, Read, and Upsert transactional-batch opcode decoding.

Depends on #222. This PR temporarily includes its parent commits; the diff narrows after #222 merges.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## Azure Compatibility

The .NET SDK uses opcodes 0, 2, and 20 for Create, Read, and Upsert. The decoder already maps them; this adds wire-format regression coverage.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Focused test: `./mvnw test -Dtest=CosmosHybridRowBatchCodecTest`