### PR TITLE
test: cover Service Bus administration suffix routing

### DIFF
--- a/src/test/java/io/floci/az/services/ServiceBusServiceTest.java
+++ b/src/test/java/io/floci/az/services/ServiceBusServiceTest.java
@@ -2,6 +2,8 @@ package io.floci.az.services;
 
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.containsString;
@@ -73,6 +75,20 @@ public class ServiceBusServiceTest {
             .queryParam("api-version", "2021-05")
             .body(entry("<QueueDescription xmlns=\"" + SB_NS + "\"/>"))
             .when().put("/orders-queue")
+            .then()
+            .statusCode(201)
+            .contentType("application/atom+xml")
+            .body(containsString("<QueueDescription"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"orders-table", "orders-appconfig", "orders-keyvault", "orders-functions"})
+    void dotNetAdministrationClientOverridesEveryConflictingAccountSuffix(String entityName) {
+        given()
+            .header("User-Agent", "azsdk-net-Messaging.ServiceBus/7.20.1")
+            .queryParam("api-version", "2021-05")
+            .body(entry("<QueueDescription xmlns=\"" + SB_NS + "\"/>"))
+            .when().put("/" + entityName)
             .then()
             .statusCode(201)
             .contentType("application/atom+xml")


### PR DESCRIPTION
## Summary

Cover .NET Service Bus administration entities whose names collide with registered account suffix routes.

Depends on #221. This PR temporarily includes its parent commits; the diff narrows after #221 merges.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## Azure Compatibility

The parameterized regression test covers entity names ending in -table, -appconfig, -keyvault, and -functions when the .NET administration User-Agent and api-version marker are present.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Focused test: `./mvnw test -Dtest=ServiceBusServiceTest`