### PR TITLE
feat(blob): support append blobs with add SAS permission

### DIFF
--- a/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
+++ b/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
@@ -267,6 +267,8 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
                     response = putBlock(request, containerName, blobName);
                 } else if ("PUT".equalsIgnoreCase(method) && "blocklist".equals(comp)) {
                     response = putBlockList(request, containerName, blobName);
+                } else if ("PUT".equalsIgnoreCase(method) && "appendblock".equals(comp)) {
+                    response = appendBlock(request, containerName, blobName);
                 } else if (("GET".equalsIgnoreCase(method) || "HEAD".equalsIgnoreCase(method))
                         && "blocklist".equals(comp)) {
                     response = getBlockList(request, containerName, blobName);
@@ -354,8 +356,8 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
      * True only for a genuine PutBlob.
      *
      * <p>Azure multiplexes many operations onto {@code PUT /{container}/{blob}}: the {@code comp}
-     * values this handler does not implement (lease, snapshot, properties, tier, tags, page,
-     * appendblock, ...), plus CopyBlob and the Data Lake rename, which carry no {@code comp} at all
+     * values this handler does not implement (lease, snapshot, properties, tier, tags, page, ...),
+     * plus CopyBlob and the Data Lake rename, which carry no {@code comp} at all
      * and are discriminated by a header. Routing any of those to {@code putBlob} replaces the blob
      * with the request body — usually empty — and answers 201, so the caller sees success while the
      * content is destroyed. Only an unqualified PUT is a PutBlob.
@@ -1996,6 +1998,52 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
 
             return Response.status(Response.Status.ACCEPTED).build();
         });
+    }
+
+    private Response appendBlock(AzureRequest request, String containerName, String blobName) {
+        Response authFailure = authorizeAppend(request, containerName, blobName);
+        if (authFailure != null) {
+            return authFailure;
+        }
+        try {
+            byte[] appended = request.bodyStream().readAllBytes();
+            return leaseService.exclusively(() -> {
+                String key = objKey(request.accountName(), containerName, blobName);
+                Optional<StoredObject> existing = store.get(key);
+                if (existing.isEmpty()) {
+                    return new AzureErrorResponse("BlobNotFound", "The specified blob does not exist.")
+                            .toXmlResponse(Response.Status.NOT_FOUND.getStatusCode());
+                }
+                StoredObject blob = existing.get();
+                if (!"AppendBlob".equals(blob.metadata().get("BlobType"))) {
+                    return new AzureErrorResponse("InvalidBlobType", "The blob type is invalid for this operation.")
+                            .toXmlResponse(Response.Status.CONFLICT.getStatusCode());
+                }
+                Response conditionFailure = validateBlobConditions(request, existing);
+                if (conditionFailure != null) {
+                    return conditionFailure;
+                }
+                Response leaseFailure = leaseService.validateWrite(request, key);
+                if (leaseFailure != null) {
+                    return leaseFailure;
+                }
+
+                byte[] data = Arrays.copyOf(blob.data(), blob.data().length + appended.length);
+                System.arraycopy(appended, 0, data, blob.data().length, appended.length);
+                Map<String, String> metadata = new HashMap<>(blob.metadata());
+                int blockCount = Integer.parseInt(metadata.getOrDefault("AppendBlockCount", "0")) + 1;
+                metadata.put("AppendBlockCount", Integer.toString(blockCount));
+                String etag = UUID.randomUUID().toString();
+                store.put(key, new StoredObject(blobName, data, metadata, Instant.now(), etag));
+                return Response.status(Response.Status.CREATED)
+                        .header("ETag", etag)
+                        .header("x-ms-blob-append-offset", blob.data().length)
+                        .header("x-ms-blob-committed-block-count", blockCount)
+                        .build();
+            });
+        } catch (IOException e) {
+            return Response.serverError().build();
+        }
     }
 
     private Response deleteBlob(AzureRequest request, String containerName, String blobName) {

--- a/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
+++ b/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
@@ -2023,6 +2023,10 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
                 if (conditionFailure != null) {
                     return conditionFailure;
                 }
+                Response appendConditionFailure = validateAppendConditions(request, blob, appended.length);
+                if (appendConditionFailure != null) {
+                    return appendConditionFailure;
+                }
                 Response leaseFailure = leaseService.validateWrite(request, key);
                 if (leaseFailure != null) {
                     return leaseFailure;
@@ -2044,6 +2048,50 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
         } catch (IOException e) {
             return Response.serverError().build();
         }
+    }
+
+    private static Response validateAppendConditions(AzureRequest request, StoredObject blob, int appendedLength) {
+        String appendPosition = request.headers().getHeaderString("x-ms-blob-condition-appendpos");
+        if (appendPosition != null) {
+            Long expectedOffset = parseAppendCondition(appendPosition);
+            if (expectedOffset == null) {
+                return invalidAppendConditionHeader();
+            }
+            if (expectedOffset != blob.data().length) {
+                return new AzureErrorResponse("AppendPositionConditionNotMet",
+                        "The append position condition specified was not met.")
+                        .toXmlResponse(Response.Status.PRECONDITION_FAILED.getStatusCode());
+            }
+        }
+
+        String maxSize = request.headers().getHeaderString("x-ms-blob-condition-maxsize");
+        if (maxSize != null) {
+            Long maximumSize = parseAppendCondition(maxSize);
+            if (maximumSize == null) {
+                return invalidAppendConditionHeader();
+            }
+            if ((long) blob.data().length + appendedLength > maximumSize) {
+                return new AzureErrorResponse("MaxBlobSizeConditionNotMet",
+                        "The max blob size condition specified was not met.")
+                        .toXmlResponse(Response.Status.PRECONDITION_FAILED.getStatusCode());
+            }
+        }
+        return null;
+    }
+
+    private static Long parseAppendCondition(String value) {
+        try {
+            long parsed = Long.parseLong(value);
+            return parsed >= 0 ? parsed : null;
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private static Response invalidAppendConditionHeader() {
+        return new AzureErrorResponse("InvalidHeaderValue",
+                "The value for one of the HTTP headers is not in the correct format.")
+                .toXmlResponse(Response.Status.BAD_REQUEST.getStatusCode());
     }
 
     private Response deleteBlob(AzureRequest request, String containerName, String blobName) {

--- a/src/test/java/io/floci/az/services/BlobCompDispatchTest.java
+++ b/src/test/java/io/floci/az/services/BlobCompDispatchTest.java
@@ -14,7 +14,7 @@ import static org.hamcrest.Matchers.equalTo;
  * {@code putBlob} for every unrecognised {@code comp} value.
  *
  * <p>Azure's blob endpoint multiplexes many operations onto {@code PUT /{container}/{blob}},
- * discriminated by {@code comp} (lease, snapshot, properties, tier, tags, page, appendblock) or by
+ * discriminated by {@code comp} (lease, snapshot, properties, tier, tags, page) or by
  * a header ({@code x-ms-copy-source}). None of those are implemented here. Before this guard they
  * were all routed to {@code putBlob}, which <em>replaced the blob with the request body</em> —
  * usually empty — and answered {@code 201 Created}. The SDK saw success while the data was gone.
@@ -57,7 +57,7 @@ public class BlobCompDispatchTest {
     @ParameterizedTest
     @ValueSource(strings = {
             "snapshot", "properties", "tier", "tags",
-            "page", "appendblock", "undelete", "expiry", "seal"
+            "page", "undelete", "expiry", "seal"
     })
     void unimplementedBlobCompIsNotMistakenForPutBlob(String comp) {
         given()

--- a/src/test/java/io/floci/az/services/BlobCompDispatchTest.java
+++ b/src/test/java/io/floci/az/services/BlobCompDispatchTest.java
@@ -68,6 +68,18 @@ public class BlobCompDispatchTest {
     }
 
     @Test
+    void appendBlockOnBlockBlobIsNotMistakenForPutBlob() {
+        given()
+                .body("appended content")
+                .when().put("/{account}/{container}/{blob}?comp=appendblock", ACCOUNT, CONTAINER, BLOB)
+                .then()
+                .statusCode(409)
+                .header("x-ms-error-code", equalTo("InvalidBlobType"));
+
+        assertBlobIntact();
+    }
+
+    @Test
     void copyBlobIsNotMistakenForPutBlob() {
         given()
                 .header("x-ms-copy-source",

--- a/src/test/java/io/floci/az/services/BlobServiceTest.java
+++ b/src/test/java/io/floci/az/services/BlobServiceTest.java
@@ -492,6 +492,76 @@ public class BlobServiceTest {
     }
 
     @Test
+    void appendOnlySasCanAppendToAppendBlob() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        given()
+            .header("x-ms-blob-type", "AppendBlob")
+            .body("")
+            .put("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB);
+
+        given()
+            .body("first")
+            .when().put("/{account}/{container}/{blob}?comp=appendblock&{sas}",
+                    ACCOUNT, CONTAINER, BLOB, sas("a", "b", CONTAINER, BLOB))
+            .then()
+            .statusCode(201)
+            .header("x-ms-blob-append-offset", "0")
+            .header("x-ms-blob-committed-block-count", "1");
+
+        given()
+            .when().get("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(200)
+            .body(equalTo("first"));
+    }
+
+    @Test
+    void appendBlockHonorsConditionsAndLeaseGuards() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        given()
+            .header("x-ms-blob-type", "AppendBlob")
+            .body("")
+            .put("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB)
+            .then().statusCode(201);
+
+        given()
+            .header("If-Match", "wrong-etag")
+            .body("blocked")
+            .put("/{account}/{container}/{blob}?comp=appendblock", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(412)
+            .header("x-ms-error-code", "ConditionNotMet");
+
+        String leaseId = given()
+            .header("x-ms-lease-action", "acquire")
+            .header("x-ms-lease-duration", "-1")
+            .put("/{account}/{container}/{blob}?comp=lease", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(201)
+            .extract().header("x-ms-lease-id");
+
+        given()
+            .body("blocked")
+            .put("/{account}/{container}/{blob}?comp=appendblock", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(412)
+            .header("x-ms-error-code", "LeaseIdMissing");
+
+        given()
+            .header("x-ms-lease-id", leaseId)
+            .body("appended")
+            .put("/{account}/{container}/{blob}?comp=appendblock", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(201);
+
+        given()
+            .when().get("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(200)
+            .body(equalTo("appended"));
+    }
+
+    @Test
     void createOnlySasCanCreateButCannotOverwriteBlob() {
         given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
         String createOnlySas = sas("c", "b", CONTAINER, BLOB);

--- a/src/test/java/io/floci/az/services/BlobServiceTest.java
+++ b/src/test/java/io/floci/az/services/BlobServiceTest.java
@@ -532,6 +532,22 @@ public class BlobServiceTest {
             .statusCode(412)
             .header("x-ms-error-code", "ConditionNotMet");
 
+        given()
+            .header("x-ms-blob-condition-appendpos", "1")
+            .body("blocked")
+            .put("/{account}/{container}/{blob}?comp=appendblock", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(412)
+            .header("x-ms-error-code", "AppendPositionConditionNotMet");
+
+        given()
+            .header("x-ms-blob-condition-maxsize", "0")
+            .body("blocked")
+            .put("/{account}/{container}/{blob}?comp=appendblock", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(412)
+            .header("x-ms-error-code", "MaxBlobSizeConditionNotMet");
+
         String leaseId = given()
             .header("x-ms-lease-action", "acquire")
             .header("x-ms-lease-duration", "-1")


### PR DESCRIPTION
## Summary
- Implement Append Block for existing Append Blobs and preserve append offsets and committed block counts.
- Map append-only user-delegation SAS permission a exclusively to Append Block.

## Type of change
- [x] New feature (feat:)

## Azure Compatibility
- Matches Blob user-delegation SAS Add permission semantics for Append Block.

## Checklist
- [ ] ./mvnw test passes locally (blocked: available JDK is 21; project requires Java 25)
- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits
