### PR TITLE
fix(eventhub): make the AMQP data plane usable from the Azure SDKs (CBS + library patches)

### DIFF
--- a/src/main/java/io/floci/az/services/eventhub/ArtemisConfigGenerator.java
+++ b/src/main/java/io/floci/az/services/eventhub/ArtemisConfigGenerator.java
@@ -25,6 +25,8 @@ import java.util.Map;
 public class ArtemisConfigGenerator {
 
     private static final String DEFAULT_CONSUMER_GROUP = "$Default";
+    private static final String CBS_ADDRESS = "$cbs";
+    private static final String CBS_INTERCEPT_ADDRESS = "$cbs-intercept";
 
     private final EmulatorConfig config;
 
@@ -89,7 +91,8 @@ public class ArtemisConfigGenerator {
                 .elem("name", "floci-az-eventhubs")
                 .start("acceptors")
                   .startAttr("acceptor", "name", "amqp")
-                    .raw("tcp://0.0.0.0:5672?protocols=AMQP")
+                    .raw("tcp://0.0.0.0:5672?protocols=AMQP"
+                        + ";saslMechanisms=MSSBCBS,ANONYMOUS,PLAIN;maxMessageSize=1048576")
                   .end("acceptor")
                   .startAttr("acceptor", "name", "amqps")
                     .raw("tcp://0.0.0.0:5671?protocols=AMQP"
@@ -97,7 +100,9 @@ public class ArtemisConfigGenerator {
                         + ";keyStorePath=/var/lib/artemis-instance/etc-override/artemis.p12"
                         + ";keyStorePassword=" + ArtemisTlsGenerator.KEYSTORE_PASSWORD
                         + ";keyStoreType=PKCS12"
-                        + ";needClientAuth=false")
+                        + ";needClientAuth=false"
+                        + ";saslMechanisms=MSSBCBS,ANONYMOUS,PLAIN"
+                        + ";maxMessageSize=1048576")
                   .end("acceptor")
                 .end("acceptors")
                 .elem("security-enabled", false)
@@ -111,12 +116,29 @@ public class ArtemisConfigGenerator {
                 .end("address-settings")
                 .start("addresses")
                   .raw(addresses.build())
+                  .startAttr("address", "name", CBS_ADDRESS)
+                    .selfClose("multicast")
+                  .end("address")
+                  .startAttr("address", "name", CBS_INTERCEPT_ADDRESS)
+                    .start("anycast")
+                      .selfClose("queue", "name", CBS_INTERCEPT_ADDRESS)
+                    .end("anycast")
+                  .end("address")
                 .end("addresses");
 
-        String divertsXml = diverts.build();
-        if (!divertsXml.isEmpty()) {
-            xml.start("diverts").raw(divertsXml).end("diverts");
-        }
+        // The CBS divert is unconditional: every Azure SDK puts a token on $cbs before
+        // opening entity links, and it is the CbsResponder — attached to the intercept
+        // queue — that answers. Without it the put-token reply carries no status-code
+        // and the SDK cannot authorize.
+        xml.start("diverts")
+             .raw(diverts.build())
+             .startAttr("divert", "name", "cbs-request-intercept")
+               .elem("address", CBS_ADDRESS)
+               .elem("forwarding-address", CBS_INTERCEPT_ADDRESS)
+               .selfClose("filter", "string", "operation = 'put-token'")
+               .elem("exclusive", true)
+             .end("divert")
+           .end("diverts");
 
         xml.end("core").end("configuration");
         return "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n" + xml.build();

--- a/src/main/java/io/floci/az/services/eventhub/EventHubNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/eventhub/EventHubNamespaceManager.java
@@ -77,9 +77,18 @@ public class EventHubNamespaceManager {
      * Starts an Artemis container for the given namespace and registers it.
      * Host ports of {@code 0} mean "allocate dynamically".
      */
-    public NamespaceState startNamespace(String namespaceName,
+    public synchronized NamespaceState startNamespace(String namespaceName,
                                           Map<String, List<String>> entities,
                                           int amqpHostPort, int amqpsHostPort) {
+        // Synchronized, and re-checking inside the lock, as the Service Bus manager does:
+        // the handler's own existence check is not atomic with this call, so two
+        // overlapping creates would otherwise each start a broker and a responder, and
+        // the second registration would orphan the first — leaking a daemon thread and
+        // its Proton reactor's file descriptors.
+        NamespaceState existing = namespaces.get(namespaceName);
+        if (existing != null) {
+            return existing;
+        }
         String containerName = containerName(namespaceName);
         List<String> amqpHostnames = List.of("localhost", containerName);
 

--- a/src/main/java/io/floci/az/services/eventhub/EventHubNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/eventhub/EventHubNamespaceManager.java
@@ -51,6 +51,15 @@ public class EventHubNamespaceManager {
      */
     public record NamespaceState(String containerId, int amqpHostPort, int amqpsHostPort, String tlsCertPem, boolean mocked) {}
 
+    // Artemis library patches, shared with the Service Bus broker — see where they are
+    // copied in below for why each is needed.
+    static final String PROTON_PATCH_RESOURCE = "/artemis/proton-j-0.34.1-floci-az-proton-patch.jar";
+    static final String ARTEMIS_AMQP_PATCH_RESOURCE =
+            "/artemis/artemis-amqp-protocol-2.44.0-floci-az-artemis-amqp-patch.jar";
+    private static final String PROTON_J_PATH = "/opt/activemq-artemis/lib/proton-j-0.34.1.jar";
+    private static final String ARTEMIS_AMQP_PATH =
+            "/opt/activemq-artemis/lib/artemis-amqp-protocol-2.44.0.jar";
+
     private final ConcurrentHashMap<String, NamespaceState> namespaces = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, ServiceBusCbsResponder> cbsResponders = new ConcurrentHashMap<>();
 
@@ -123,6 +132,15 @@ public class EventHubNamespaceManager {
                 "/var/lib/artemis-instance/etc-override/broker.xml");
         lifecycleManager.copyBytesToContainer(containerId, tls.pkcs12Bytes(),
                 "/var/lib/artemis-instance/etc-override/artemis.p12");
+        // The same two library patches the Service Bus broker gets. Artemis never
+        // advertises max-message-size on ATTACH (spec-legal: unset means "no limit"),
+        // but the Azure SDKs read the absent field as a zero-byte limit and reject
+        // every send — so the patched proton-j sets it. The patched amqp-protocol
+        // carries the MSSBCBS SASL mechanism the acceptors offer.
+        lifecycleManager.copyBytesToContainer(containerId, loadResource(PROTON_PATCH_RESOURCE),
+                PROTON_J_PATH);
+        lifecycleManager.copyBytesToContainer(containerId, loadResource(ARTEMIS_AMQP_PATCH_RESOURCE),
+                ARTEMIS_AMQP_PATH);
 
         ContainerLifecycleManager.ContainerInfo info = lifecycleManager.startCreated(containerId, spec);
 
@@ -339,5 +357,17 @@ public class EventHubNamespaceManager {
         }
         throw new RuntimeException(
                 "Artemis did not open " + label + " port " + endpoint + " within 60s");
+    }
+
+    private static byte[] loadResource(String resource) {
+        try (java.io.InputStream stream =
+                EventHubNamespaceManager.class.getResourceAsStream(resource)) {
+            if (stream == null) {
+                throw new IllegalStateException("Embedded Artemis resource not found: " + resource);
+            }
+            return stream.readAllBytes();
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to read embedded Artemis resource: " + resource, e);
+        }
     }
 }

--- a/src/main/java/io/floci/az/services/eventhub/EventHubNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/eventhub/EventHubNamespaceManager.java
@@ -186,7 +186,10 @@ public class EventHubNamespaceManager {
      *
      * @return {@code true} if the namespace existed and was stopped; {@code false} if unknown
      */
-    public boolean stopNamespace(String namespaceName) {
+    public synchronized boolean stopNamespace(String namespaceName) {
+        // Shares startNamespace's lock: a delete arriving mid-start would otherwise see
+        // no namespace, clean nothing up, and let the start it raced publish a namespace
+        // the caller had already deleted — leaving its container and responder running.
         NamespaceState state = namespaces.remove(namespaceName);
         if (state == null) {
             return false;

--- a/src/main/java/io/floci/az/services/eventhub/EventHubNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/eventhub/EventHubNamespaceManager.java
@@ -6,6 +6,7 @@ import io.floci.az.core.docker.ContainerBuilder;
 import io.floci.az.core.docker.ContainerLifecycleManager;
 import io.floci.az.core.docker.ContainerLifecycleManager.EndpointInfo;
 import io.floci.az.core.docker.ContainerSpec;
+import io.floci.az.services.servicebus.ServiceBusCbsResponder;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import org.jboss.logging.Logger;
@@ -51,6 +52,7 @@ public class EventHubNamespaceManager {
     public record NamespaceState(String containerId, int amqpHostPort, int amqpsHostPort, String tlsCertPem, boolean mocked) {}
 
     private final ConcurrentHashMap<String, NamespaceState> namespaces = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, ServiceBusCbsResponder> cbsResponders = new ConcurrentHashMap<>();
 
     private final EmulatorConfig config;
     private final ContainerBuilder containerBuilder;
@@ -120,6 +122,13 @@ public class EventHubNamespaceManager {
         EndpointInfo amqpsEndpoint = info.getEndpoint(AMQPS_PORT);
         waitForPort(amqpsEndpoint, "AMQPS");
 
+        // Answers the CBS put-token every Azure SDK sends before opening entity links;
+        // the broker.xml divert routes those requests to the intercept queue this
+        // attaches to. Same responder the Service Bus namespaces use.
+        ServiceBusCbsResponder cbs = new ServiceBusCbsResponder(amqpEndpoint.host(), amqpEndpoint.port());
+        cbs.start();
+        cbsResponders.put(namespaceName, cbs);
+
         // Topology is pre-configured in broker.xml; Jolokia setup runs in background
         // to handle any dynamic additions (e.g. consumer groups created after startup).
         EndpointInfo jolokiaEndpoint = info.getEndpoint(JOLOKIA_PORT);
@@ -154,6 +163,10 @@ public class EventHubNamespaceManager {
         NamespaceState state = namespaces.remove(namespaceName);
         if (state == null) {
             return false;
+        }
+        ServiceBusCbsResponder cbs = cbsResponders.remove(namespaceName);
+        if (cbs != null) {
+            cbs.stop();
         }
         if (!state.mocked() && state.containerId() != null) {
             lifecycleManager.stopAndRemove(state.containerId(), null);

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusCbsResponder.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusCbsResponder.java
@@ -21,11 +21,17 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Daemon thread that handles AMQP CBS (Claims Based Security) for a Service Bus namespace.
+ * Daemon thread that handles AMQP CBS (Claims Based Security) for a namespace.
  *
- * The Azure Service Bus SDK always sends a PUT TOKEN request to the {@code $cbs} address
- * before opening any entity links. This responder receives those requests and replies with
- * status-code 200 on the {@code $cbs} response link, unblocking the SDK.
+ * The Azure SDKs always send a PUT TOKEN request to the {@code $cbs} address before opening
+ * any entity links. This responder receives those requests — routed to the intercept queue by
+ * the broker.xml divert — and replies on the {@code $cbs} response link, unblocking the SDK.
+ *
+ * Used by both Service Bus and Event Hubs namespaces.
+ *
+ * The reply carries status-code 202 (Accepted), as the AMQP CBS specification requires for
+ * put-token. Some SDK stacks accept 200; others reject anything but 202 (the Rust
+ * {@code fe2o3-amqp-cbs} hard-codes it), so the specified code is the interoperable one.
  *
  * Uses proton-j directly since it is the same low-level AMQP library the SDK uses internally.
  */
@@ -164,8 +170,8 @@ public class ServiceBusCbsResponder {
             Message response = Message.Factory.create();
             response.setCorrelationId(correlationId);
             Map<String, Object> props = new HashMap<>();
-            props.put("status-code", 200);
-            props.put("status-description", "OK");
+            props.put("status-code", 202);
+            props.put("status-description", "Accepted");
             response.setApplicationProperties(new ApplicationProperties(props));
 
             byte[] encoded = new byte[512];


### PR DESCRIPTION
Addresses #227. **Two defects that stop any Azure SDK getting off the ground against an Event Hubs namespace.** Delivery is not complete after this — see "What is still missing".

Both defects are the same shape: Service Bus already has the fix, Event Hubs was never given it.

## 1. Nothing answers `$cbs`, so no SDK can authorize

The `put-token` every Azure SDK sends before its first link got a reply with no `status-code`. `ServiceBusCbsResponder` exists and `ServiceBusNamespaceManager` starts it; `EventHubNamespaceManager` did not. Two brokers start, one responder:

```
INFO [EventHubNamespaceManager]  Starting Artemis broker for Event Hubs namespace 'emulatorns1' (plain:5,672, TLS:5,671)
INFO [ServiceBusNamespaceManager] Starting Artemis broker for Service Bus namespace 'default' (plain:5,673, TLS:5,674)
INFO [ServiceBusCbsResponder]     CBS responder started for 172.17.0.13:5,672
```

`broker.xml` gains the `$cbs` / `$cbs-intercept` addresses and the `cbs-request-intercept` divert; the manager starts and stops the responder alongside the broker.

## 2. Sends fail with a zero-byte size limit

The `max-message-size` problem from #128, which was fixed for Service Bus by shipping a patched proton-j whose `ReceiverImpl` sets the field — the Event Hubs container never received it. Both library patches are now copied in, exactly as `ServiceBusNamespaceManager` does:

- **proton-j** — server receiver links advertise `max-message-size`, so SDKs stop reading the absent field as a 0 KB cap;
- **artemis-amqp-protocol** — carries the MSSBCBS SASL mechanism. The acceptors advertise it, so without this jar they were offering a mechanism the broker could not serve.

## Also: the put-token status code

The reply changes from `200 OK` to `202 Accepted`. The AMQP CBS specification requires 202 for put-token; some stacks tolerate 200, others reject anything else (the Rust `fe2o3-amqp-cbs` hard-codes it). Flagging explicitly since it touches Service Bus — the full suite is green, Service Bus tests included.

## Also: a concurrency guard (from review)

`startNamespace` is now `synchronized` with the existence check inside the lock, mirroring `ServiceBusNamespaceManager`. The handler's own check is not atomic with the call, so overlapping creates could each start a responder and orphan the previous one — the leak behind #154. It also closes a pre-existing window where two creates could start two containers.

## Verification

`./mvnw package` — **827 tests, 0 failures**.

> Reproducing locally: the Quarkus test port is 8081. If something else holds it the whole suite fails to bind — `-Dquarkus.http.test-port=<free port>` works around it.

With the Azure Rust SDK (`azure_messaging_eventhubs` 0.15) against a local build, publishing to an Event Hubs namespace. Each row is a stage that previously failed and now passes:

| Stage | Before | After |
|---|---|---|
| authorize (CBS) | `StatusCode is nor found` | ✅ |
| `create_batch` | `No message size available` | ✅ |
| send accepted by broker | — | ✅ |

## What is still missing

**Messages are not yet delivered.** The send is accepted, but the topology does not define the address the SDK targets (`amqps://{fqns}/{hub}`), so with `auto-create-addresses=true` it is created with no queues bound and the message is discarded — broker `TotalMessageCount` stays 0. The generated addresses are `amqp://{host}/{namespace}/{entity}`: different scheme, plus a namespace segment the SDK does not send. That predates this PR and is bound up with the consumer-side addressing, so I have kept it with the partition work in #239 rather than splitting it across two changes.

Consuming fails at:

```
get_eventhub_properties failed: Transport Implementation Error: StatusCode is nor found
```

That is the Event Hubs `$management` READ used to enumerate partitions before receiving — Artemis has no notion of it, so nothing replies with a `status-code`. It is the same shape as the CBS gap and might suit the same divert-plus-responder pattern, but it needs real Event Hubs management semantics rather than a fixed reply, so I have left it out of this change. Happy to take it on if you would like it done the same way.
