### PR TITLE
fix(eventhub): route sends addressed the way the Azure SDKs address them

### DIFF
--- a/src/main/java/io/floci/az/services/eventhub/ArtemisConfigGenerator.java
+++ b/src/main/java/io/floci/az/services/eventhub/ArtemisConfigGenerator.java
@@ -182,8 +182,7 @@ public class ArtemisConfigGenerator {
 
         for (String cg : consumerGroups) {
             String cgAddr = entityAddr + "/" + cg;
-            String divertName = (hostname + "-" + entity + "-to-" + cg)
-                    .replaceAll("[^A-Za-z0-9_-]", "-");
+            String divertName = divertName(hostname, entity, "to", cg);
 
             addresses.startAttr("address", "name", cgAddr)
                        .start("anycast")
@@ -232,8 +231,7 @@ public class ArtemisConfigGenerator {
 
             for (String cg : consumerGroups) {
                 String targetCgAddr = "amqp://" + host + "/" + namespace + "/" + entity + "/" + cg;
-                String divertName = (scheme + "-" + host + "-" + entity + "-to-" + cg)
-                        .replaceAll("[^A-Za-z0-9_-]", "-");
+                String divertName = divertName(scheme, host, entity, "to", cg);
 
                 diverts.startAttr("divert", "name", divertName)
                          .elem("address", entityAddr)
@@ -242,6 +240,26 @@ public class ArtemisConfigGenerator {
                        .end("divert");
             }
         }
+    }
+
+    /**
+     * A divert name that is readable and cannot collide with another one.
+     *
+     * Artemis skips a duplicate binding without saying so, which would leave one consumer group's
+     * queue receiving nothing while every send still succeeded. Two diverts reducing to the same
+     * name is easy to arrange: Azure allows dots in a hub or consumer-group name and Artemis names
+     * should not carry them, so {@code eh.1} and {@code eh-1} sanitize alike; and the separator
+     * between the parts is legal inside a part, so entity {@code a-to-b} with group {@code c}
+     * joins to the same string as entity {@code a} with group {@code b-to-c}.
+     *
+     * The suffix is what makes the name unique — a hash over the exact parts, built from
+     * {@link String#hashCode()}, whose value the language specification pins so the generated
+     * broker.xml is the same on every run and every JVM. The readable part is kept in front of it
+     * so the file can still be read.
+     */
+    private static String divertName(String... parts) {
+        String readable = String.join("-", parts).replaceAll("[^A-Za-z0-9_-]", "-");
+        return readable + "-" + Integer.toHexString(List.of(parts).hashCode());
     }
 
     private static List<String> parseConsumerGroups(String raw) {

--- a/src/main/java/io/floci/az/services/eventhub/ArtemisConfigGenerator.java
+++ b/src/main/java/io/floci/az/services/eventhub/ArtemisConfigGenerator.java
@@ -8,6 +8,7 @@ import jakarta.inject.Inject;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -166,8 +167,7 @@ public class ArtemisConfigGenerator {
     private void appendAnycastTopology(XmlBuilder addresses, XmlBuilder diverts,
                                         String hostname, String namespace, String entity,
                                         List<String> consumerGroups) {
-        // uamqp lowercases the hostname portion of AMQP URIs, so we must match that
-        String entityAddr = "amqp://" + hostname.toLowerCase(java.util.Locale.US) + "/" + namespace + "/" + entity;
+        String entityAddr = anycastEntityAddress(hostname, namespace, entity);
 
         // An explicit (non-durable) queue at the entity address lets the sender link attach.
         // The exclusive diverts below intercept all messages before they reach this queue,
@@ -182,7 +182,7 @@ public class ArtemisConfigGenerator {
 
         for (String cg : consumerGroups) {
             String cgAddr = entityAddr + "/" + cg;
-            String divertName = divertName(hostname, entity, "to", cg);
+            String divertName = anycastDivertName(hostname, entity, cg);
 
             addresses.startAttr("address", "name", cgAddr)
                        .start("anycast")
@@ -240,6 +240,24 @@ public class ArtemisConfigGenerator {
                        .end("divert");
             }
         }
+    }
+
+    /**
+     * The entity address the uamqp topology hangs off, and the name of the divert from it to one
+     * consumer group's queue.
+     *
+     * {@code EventHubNamespaceManager} rebuilds this same topology over Jolokia when it starts a
+     * namespace, so it calls these rather than spelling the strings a second time. Two spellings
+     * that drift apart do not fail — the diverts are exclusive, so the broker ends up holding two
+     * of them over one route and delivers every message twice. The host is lowercased because
+     * uamqp lowercases the host portion of the URIs it sends.
+     */
+    static String anycastEntityAddress(String hostname, String namespace, String entity) {
+        return "amqp://" + hostname.toLowerCase(Locale.US) + "/" + namespace + "/" + entity;
+    }
+
+    static String anycastDivertName(String hostname, String entity, String consumerGroup) {
+        return divertName(hostname, entity, "to", consumerGroup);
     }
 
     /**

--- a/src/main/java/io/floci/az/services/eventhub/ArtemisConfigGenerator.java
+++ b/src/main/java/io/floci/az/services/eventhub/ArtemisConfigGenerator.java
@@ -51,6 +51,7 @@ public class ArtemisConfigGenerator {
 
             for (String hostname : hostnames) {
                 appendAnycastTopology(addresses, diverts, hostname, namespace, entityName, cgs);
+                appendAzureAddressing(addresses, diverts, hostname, namespace, entityName, cgs);
             }
         }
         return buildBrokerXml(addresses, diverts);
@@ -197,6 +198,49 @@ public class ArtemisConfigGenerator {
                      .elem("forwarding-address", cgAddr)
                      .elem("exclusive", true)
                    .end("divert");
+        }
+    }
+
+    /**
+     * Appends the address form the Azure SDKs actually send to: {@code {scheme}://{host}/{entity}},
+     * where the namespace is the HOST and the path is only the hub — no namespace path segment.
+     *
+     * Without this a send matches no configured address, {@code auto-create-addresses} creates one
+     * with no queues bound, and the message is discarded with no error anywhere. Both schemes are
+     * generated because SDKs put {@code amqps} in the address whatever the transport turns out to
+     * be, while some send {@code amqp}.
+     *
+     * The diverts feed the same per-consumer-group queues the uamqp topology uses, so a consumer on
+     * either address form reads the same messages.
+     */
+    private void appendAzureAddressing(XmlBuilder addresses, XmlBuilder diverts,
+                                       String hostname, String namespace, String entity,
+                                       List<String> consumerGroups) {
+        String host = hostname.toLowerCase(java.util.Locale.US);
+        for (String scheme : List.of("amqp", "amqps")) {
+            String entityAddr = scheme + "://" + host + "/" + entity;
+
+            // Non-durable queue so the sender link can attach; the exclusive diverts below take
+            // every message before it reaches this queue.
+            addresses.startAttr("address", "name", entityAddr)
+                       .start("anycast")
+                         .startAttr("queue", "name", entityAddr)
+                           .elem("durable", false)
+                         .end("queue")
+                       .end("anycast")
+                     .end("address");
+
+            for (String cg : consumerGroups) {
+                String targetCgAddr = "amqp://" + host + "/" + namespace + "/" + entity + "/" + cg;
+                String divertName = (scheme + "-" + host + "-" + entity + "-to-" + cg)
+                        .replaceAll("[^A-Za-z0-9_-]", "-");
+
+                diverts.startAttr("divert", "name", divertName)
+                         .elem("address", entityAddr)
+                         .elem("forwarding-address", targetCgAddr)
+                         .elem("exclusive", true)
+                       .end("divert");
+            }
         }
     }
 

--- a/src/main/java/io/floci/az/services/eventhub/EventHubNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/eventhub/EventHubNamespaceManager.java
@@ -275,7 +275,11 @@ public class EventHubNamespaceManager {
         for (String hostname : hostnames) {
             for (Map.Entry<String, List<String>> entry : entities.entrySet()) {
                 String entityName = entry.getKey();
-                String entityAddr = "amqp://" + hostname.toLowerCase(java.util.Locale.US) + "/" + namespace + "/" + entityName;
+                // Address and divert name both have to match what ArtemisConfigGenerator wrote
+                // into broker.xml. The diverts are exclusive, so where the two disagree the broker
+                // holds two of them over one route and delivers every message twice.
+                String entityAddr =
+                        ArtemisConfigGenerator.anycastEntityAddress(hostname, namespace, entityName);
 
                 jolokiaExec(http, baseUrl, auth, mbean,
                         "createAddress(java.lang.String,java.lang.String)",
@@ -283,8 +287,8 @@ public class EventHubNamespaceManager {
 
                 for (String cg : entry.getValue()) {
                     String cgAddr = entityAddr + "/" + cg;
-                    String divertName = (hostname + "-" + entityName + "-to-" + cg)
-                            .replaceAll("[^A-Za-z0-9_-]", "-");
+                    String divertName =
+                            ArtemisConfigGenerator.anycastDivertName(hostname, entityName, cg);
 
                     jolokiaExec(http, baseUrl, auth, mbean,
                             "createAddress(java.lang.String,java.lang.String)",

--- a/src/test/java/io/floci/az/services/eventhub/ArtemisConfigGeneratorTest.java
+++ b/src/test/java/io/floci/az/services/eventhub/ArtemisConfigGeneratorTest.java
@@ -1,0 +1,63 @@
+package io.floci.az.services.eventhub;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ArtemisConfigGeneratorTest {
+
+    private static final Pattern DIVERT_NAME = Pattern.compile("<divert name=\"([^\"]+)\"");
+
+    private static List<String> divertNames(String namespace, Map<String, List<String>> entities) {
+        String brokerXml = new ArtemisConfigGenerator(null).generate(namespace, entities);
+        List<String> names = new ArrayList<>();
+        Matcher matcher = DIVERT_NAME.matcher(brokerXml);
+        while (matcher.find()) {
+            names.add(matcher.group(1));
+        }
+        return names;
+    }
+
+    private static void assertAllDistinct(List<String> names) {
+        Set<String> distinct = new HashSet<>(names);
+        assertEquals(names.size(), distinct.size(),
+                "divert names collide, so Artemis would skip a binding: " + names);
+    }
+
+    /**
+     * Azure allows a dot in a hub name and Artemis names should not carry one, so two hubs that
+     * differ only there would reduce to the same divert name.
+     */
+    @Test
+    void hubNamesThatSanitizeAlikeKeepDistinctDivertNames() {
+        assertAllDistinct(divertNames("ns", Map.of(
+                "eh.1", List.of("$Default"),
+                "eh-1", List.of("$Default"))));
+    }
+
+    /**
+     * The separator joining the parts of a divert name is itself legal inside a hub or consumer
+     * group name, so the parts have to stay distinguishable after they are joined.
+     */
+    @Test
+    void namesThatJoinToTheSameStringKeepDistinctDivertNames() {
+        assertAllDistinct(divertNames("ns", Map.of(
+                "a-to-b", List.of("c"),
+                "a", List.of("b-to-c"))));
+    }
+
+    /** The generated file must not change between runs, or every namespace restart rewrites it. */
+    @Test
+    void generatingTwiceProducesTheSameNames() {
+        Map<String, List<String>> entities = Map.of("eh1", List.of("$Default", "my-consumer-group"));
+        assertEquals(divertNames("ns", entities), divertNames("ns", entities));
+    }
+}

--- a/src/test/java/io/floci/az/services/eventhub/ArtemisConfigGeneratorTest.java
+++ b/src/test/java/io/floci/az/services/eventhub/ArtemisConfigGeneratorTest.java
@@ -11,6 +11,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ArtemisConfigGeneratorTest {
 
@@ -52,6 +53,27 @@ class ArtemisConfigGeneratorTest {
         assertAllDistinct(divertNames("ns", Map.of(
                 "a-to-b", List.of("c"),
                 "a", List.of("b-to-c"))));
+    }
+
+    /**
+     * EventHubNamespaceManager rebuilds this same topology over Jolokia, naming it through
+     * {@code anycastEntityAddress} and {@code anycastDivertName}. If the generator ever spells
+     * either one itself again the two drift apart, and because the diverts are exclusive the
+     * broker holds two of them over one route — which does not fail, it just delivers every
+     * message twice.
+     */
+    @Test
+    void anycastDivertsAreNamedThroughTheSharedHelpers() {
+        String brokerXml = new ArtemisConfigGenerator(null)
+                .generate("ns", Map.of("eh1", List.of("$Default")));
+
+        String expected = "<divert name=\""
+                + ArtemisConfigGenerator.anycastDivertName("localhost", "eh1", "$Default")
+                + "\"><address>"
+                + ArtemisConfigGenerator.anycastEntityAddress("localhost", "ns", "eh1")
+                + "</address>";
+        assertTrue(brokerXml.contains(expected),
+                "the generator no longer names its diverts the way the namespace manager does");
     }
 
     /** The generated file must not change between runs, or every namespace restart rewrites it. */


### PR DESCRIPTION
Fixes #240.

> Rebased onto `main` now that #237 has merged, so this is standalone: three commits, `ArtemisConfigGenerator` + `EventHubNamespaceManager` + a test.

## The bug

Some SDKs put the namespace in the **host** and only the hub in the path: `amqps://{namespace}/{hub}`. The generated topology has `amqp://{host}/{namespace}/{entity}` and the path-only multicast form — the uamqp and rhea-promise conventions, but not that.

*(Corrected from an earlier version of this description, which claimed this was how the Azure SDKs address a hub generally. It is not: Java, .NET and JS send a path-only address — thank you for the pointer to `EventHubProducerAsyncClient`. Verified here that the Rust SDK does send the full form, so it is Python and Rust rather than Python alone.)*

So the send matches no configured address, `auto-create-addresses=true` creates one with **no queues bound**, and Artemis discards the message. Nothing reports a problem: the broker acknowledges it, the SDK returns success, and `TotalMessageCount` stays at 0.

That silence is the reason this survived — it is indistinguishable from a working publish unless you go and look at the broker.

## The change

`appendAzureAddressing` generates, per hostname and for both schemes:

- address `{scheme}://{host}/{entity}` with a non-durable queue, so the sender link can attach;
- exclusive diverts into the same per-consumer-group queues the existing anycast topology feeds.

Purely additive — the Node and Python address forms are untouched, and a consumer on either form reads the same messages.

**Why both schemes:** SDKs put `amqps` in the address string whatever the transport turns out to be. Our client connects over plain AMQP via a custom endpoint and still targets `amqps://localhost/eh1`. Generating one scheme would leave a silent hole for whichever SDK does the opposite.

## Verification

`./mvnw package` — **877 tests, 0 failures**.

Checked at the queue level rather than by trusting a successful send, since that is exactly what hid the bug. Publishing one event, before and after:

| Queue | Before | After |
|---|---|---|
| broker `TotalMessageCount` | 0 | 2 |
| `amqp://localhost/emulatorns1/eh1/$Default` | 0 | 1 |
| `amqp://localhost/emulatorns1/eh1/my-consumer-group` | 0 | 1 |
| `amqps://localhost/eh1` (sender attach) | — | 0 |

One copy per consumer group, none stranded in the attach queues, and nothing duplicated across the two scheme variants.

## Since your review

**The divert-name collisions** Greptile found are fixed with a hash of the exact parts, and the two cases it named are pinned by tests that fail without it.

**The double delivery you spotted** is fixed here rather than on #242, so this PR is correct on its own. `EventHubNamespaceManager` rebuilt the same anycast topology over Jolokia and had its own copy of the entity address and the divert name; both call sites now go through `anycastEntityAddress` / `anycastDivertName`, and a test asserts the generator names its diverts the way the manager does. Verified on a running broker: 13 diverts installed, exactly what broker.xml declares, and the JMS compat suite green.

## Two things I deliberately did not change

**The per-hostname duplication.** The topology is generated separately for `localhost` and the container name, so publishing on one and consuming on the other still would not cross over. That asymmetry predates this change and I did not want to redesign it inside a bug fix — #242 removes it for the entity family by normalising the address in the AMQP layer.

**`auto-create-addresses`.** Leaving it on means any future addressing mismatch is silent in the same way. Turning it off for these hubs would convert that into an attach failure, which seems worth having — but it could break setups relying on ad-hoc addresses, so it felt like your call rather than mine.

The consumer-side address form (`.../ConsumerGroups/{group}/Partitions/{id}`) is not here — it needs the partition design being discussed in #239.
