### PR TITLE
docs(sponsors): list current sponsors and describe tiers by recognition

### DIFF
--- a/README.md
+++ b/README.md
@@ -884,6 +884,37 @@ To prevent configuration errors, note what Floci AZ **does not** do:
 
 Join the Floci community on [Slack](https://join.slack.com/t/floci/shared_invite/zt-3tjn02s3q-A00kEjJ1cZxsg_imTfy6Cw) or [GitHub Discussions](https://github.com/orgs/floci-io/discussions). Feature ideas, compatibility questions, design tradeoffs, and rough proposals are welcome.
 
+## Sponsors
+
+Floci is independent open source, funded by the people and companies who use it.
+Sponsorship buys gratitude and nothing else: every emulated service is free for
+everyone, forever, and no sponsor gets features, priority, or roadmap influence
+that the rest of the Flock does not.
+
+### 🥇 Gold
+
+Large logo with top placement in the emulator READMEs and on floci.io, plus a
+mention in release notes.
+
+[IceGuard](https://github.com/iceguard) · [Softmax](https://softmax.com/)
+
+### 🥈 Silver
+
+Logo in the emulator READMEs and on floci.io, plus a mention in release notes.
+
+*Your logo here. [Become a sponsor](https://github.com/sponsors/floci-io).*
+
+### 🥉 Community
+
+Name in the emulator READMEs, a sponsor badge on GitHub, and our sincere thanks.
+
+[AutoScout24](https://www.autoscout24.com) · [Nexxion AI](https://nexxion.ai/)
+
+Every sponsor, including the Friends of the Flock who support Floci outside these
+tiers, is listed in [THANKS.md](https://github.com/floci-io/.github/blob/main/THANKS.md).
+
+**[Sponsor Floci](https://github.com/sponsors/floci-io)**
+
 ## Star History
 
 <p align="center">


### PR DESCRIPTION
## Summary

Tiers now describe placement and visibility only, and both rosters come from the shared sponsor roster.

Two problems this fixes. The tier text promised roadmap input, a dedicated support channel, custom integration help and priority issue support, while State of the Flock #001 says the opposite in public: sponsorship "buys gratitude and nothing else, and no sponsor gets features, priority, or roadmap influence that the rest of the Flock does not." And the roster was stale: the Gold slot advertised "your logo here" while IceGuard and Softmax were already sponsoring, and Community listed one name out of two.

The long tail of sponsors now links to `THANKS.md` in floci-io/.github. Implements decision 0014.

**Depends on [floci-io/.github#2](https://github.com/floci-io/.github/pull/2)** — the THANKS.md link 404s until that merges, so this should merge after it.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## Azure Compatibility

n/a — README only.

## Checklist

- [ ] `./mvnw test` passes locally — not run; README-only change. Gate instead: zero em-dashes, no dollar amounts, no influence/priority/support promise, nav anchors still resolve, and the rendered block is byte-identical across all four emulator READMEs.
- [ ] New or updated integration test added — n/a (docs)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)