### PR TITLE
chore: remove FUNDING.yml so the sponsor button inherits the org default

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-# These are supported funding model platforms
-
-github: [hectorvent]


### PR DESCRIPTION
## Summary

floci-az was the only emulator carrying its own `.github/FUNDING.yml`, and it pointed at a personal account (`github: [hectorvent]`). That overrode the org-wide default in [floci-io/.github](https://github.com/floci-io/.github/blob/main/.github/FUNDING.yml), so GitHub's Sponsor button on this repo targeted a different account from every sponsor link in the README and on floci.io.

Removing the file makes floci-az inherit `github: floci-io`, matching floci, floci-gcp and floci-oci, none of which carry a local copy.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

Typed `chore` rather than `fix` deliberately: this repo cuts releases with semantic-release, and removing a metadata file is not a user-facing change that should trigger a patch version.

## Azure Compatibility

n/a — repository configuration only.

## Checklist

- [ ] `./mvnw test` passes locally — not run; this deletes one metadata file and touches no code or build input. Gate instead: exactly one file changed (3 deletions), no other GitHub funding config remains in the repo, and the README sponsor links still point at the org.
- [ ] New or updated integration test added — n/a
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)