### PR TITLE
chore(eventhub): start a real broker by default

### DIFF
--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -71,6 +71,10 @@
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>
+            <artifactId>azure-messaging-eventhubs</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.azure</groupId>
             <artifactId>azure-messaging-eventgrid</artifactId>
         </dependency>
         <dependency>

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/EmulatorConfig.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/EmulatorConfig.java
@@ -10,6 +10,7 @@ import com.azure.cosmos.CosmosClient;
 import com.azure.cosmos.CosmosClientBuilder;
 import com.azure.data.appconfiguration.ConfigurationClient;
 import com.azure.data.appconfiguration.ConfigurationClientBuilder;
+import com.azure.messaging.eventhubs.EventHubClientBuilder;
 import com.azure.messaging.servicebus.ServiceBusClientBuilder;
 import com.azure.security.keyvault.secrets.SecretClient;
 import com.azure.security.keyvault.secrets.SecretClientBuilder;
@@ -204,6 +205,12 @@ public final class EmulatorConfig {
     static boolean eventHubMocked = false;
 
     /**
+     * AMQPS port of the Event Hubs Artemis broker, as the emulator reported it.
+     * Set by {@link #ensureEventHubNamespace()}.
+     */
+    static int eventHubAmqpsPort = EVENTHUB_AMQPS_PORT;
+
+    /**
      * Starts the default Event Hubs namespace on-demand via the floci-az management API.
      * Idempotent: returns 200 if the namespace is already running.
      *
@@ -237,15 +244,55 @@ public final class EmulatorConfig {
             Map<String, Object> json = mapper.readValue(responseBody, Map.class);
             Object mockedValue = json.get("mocked");
             eventHubMocked = Boolean.TRUE.equals(mockedValue);
+
+            // Prefer the env var (Docker: EVENTHUB_AMQPS_PORT is the internal port).
+            String envPort = System.getenv("EVENTHUB_AMQPS_PORT");
+            if (envPort != null && !envPort.isEmpty()) {
+                eventHubAmqpsPort = Integer.parseInt(envPort);
+            } else if (json.get("amqpsPort") instanceof Number port) {
+                eventHubAmqpsPort = port.intValue();
+            }
+
+            if (!eventHubMocked) {
+                installTrustAll();
+            }
         } catch (Exception e) {
             // If we can't parse the response, leave eventHubMocked as false
         }
     }
 
     /**
+     * Returns an EventHubClientBuilder connected to the emulator's AMQPS port.
+     *
+     * The namespace is named by its Azure fully-qualified form, which is what a client
+     * configured for a real namespace and redirected by a custom endpoint sends — the address
+     * the broker is asked for carries that host, so this is the case worth covering.
+     *
+     * Like the Service Bus builder, this goes over TLS: the SDK hardcodes {@code enableSsl=true}
+     * once {@code customEndpointAddress} is set, so ANONYMOUS_PEER disables chain and hostname
+     * verification for the Artemis self-signed cert.
+     */
+    static EventHubClientBuilder eventHubClientBuilder() {
+        String connStr = String.format(
+                "Endpoint=sb://%s;SharedAccessKeyName=RootManageSharedAccessKey;"
+                + "SharedAccessKey=devkey;",
+                eventHubFullyQualifiedNamespace());
+        EventHubClientBuilder builder = new EventHubClientBuilder()
+                .connectionString(connStr, EVENTHUB_NAME)
+                .customEndpointAddress("https://" + EVENTHUB_HOST + ":" + eventHubAmqpsPort)
+                .transportType(AmqpTransportType.AMQP);
+        setAnonymousPeer(builder);
+        return builder;
+    }
+
+    /** The namespace as Azure names it, capitals and all. */
+    static String eventHubFullyQualifiedNamespace() {
+        return EVENTHUB_NAMESPACE + ".servicebus.windows.net";
+    }
+
+/**
      * Returns the AMQP entity address that Artemis has pre-configured as an ANYCAST address.
-     * The hostname portion must be lowercase because ArtemisConfigGenerator lowercases it
-     * when building the broker.xml addresses.
+     * The hostname is lowercased to match what uamqp sends; the broker configures both spellings.
      */
     static String amqpEntityAddress() {
         return "amqp://" + EVENTHUB_HOST.toLowerCase() + "/" + EVENTHUB_NAMESPACE + "/" + EVENTHUB_NAME;
@@ -385,12 +432,22 @@ public final class EmulatorConfig {
      * uses a self-signed cert that doesn't match the Docker service hostname.
      */
     private static void setAnonymousPeer(ServiceBusClientBuilder builder) {
+        setAnonymousPeer(ServiceBusClientBuilder.class, builder);
+    }
+
+    /** The Event Hubs builder hides {@code verifyMode} the same way; see above. */
+    private static void setAnonymousPeer(EventHubClientBuilder builder) {
+        setAnonymousPeer(EventHubClientBuilder.class, builder);
+    }
+
+    private static void setAnonymousPeer(Class<?> builderType, Object builder) {
         try {
-            Method m = ServiceBusClientBuilder.class.getDeclaredMethod("verifyMode", SslDomain.VerifyMode.class);
+            Method m = builderType.getDeclaredMethod("verifyMode", SslDomain.VerifyMode.class);
             m.setAccessible(true);
             m.invoke(builder, SslDomain.VerifyMode.ANONYMOUS_PEER);
         } catch (Exception e) {
-            throw new RuntimeException("Failed to set ANONYMOUS_PEER on ServiceBusClientBuilder", e);
+            throw new RuntimeException(
+                    "Failed to set ANONYMOUS_PEER on " + builderType.getSimpleName(), e);
         }
     }
 

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/EventHubSdkCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/EventHubSdkCompatibilityTest.java
@@ -1,0 +1,261 @@
+package io.floci.az.compat;
+
+import com.azure.messaging.eventhubs.EventData;
+import com.azure.messaging.eventhubs.EventHubConsumerClient;
+import com.azure.messaging.eventhubs.EventHubProducerClient;
+import com.azure.messaging.eventhubs.EventHubProperties;
+import com.azure.messaging.eventhubs.models.CreateBatchOptions;
+import com.azure.messaging.eventhubs.models.EventPosition;
+import com.azure.messaging.eventhubs.models.PartitionEvent;
+import jakarta.jms.Connection;
+import jakarta.jms.JMSException;
+import jakarta.jms.MessageProducer;
+import jakarta.jms.Session;
+import jakarta.jms.TextMessage;
+import org.junit.jupiter.api.*;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Event Hubs compatibility tests driven by the Azure Event Hubs SDK.
+ *
+ * The sibling {@link EventHubCompatibilityTest} speaks raw AMQP through JMS, which reaches the
+ * broker without ever asking it for anything Event Hubs specific. This one goes through the SDK a
+ * real application uses, so it covers what only the SDK asks for: the hub's partition list over
+ * {@code $management}, a send fanned out across those partitions, and a receiver that names where
+ * in the stream to start.
+ *
+ * The start position is the part worth stating plainly: the SDK expresses every one of them —
+ * "earliest" included — as an AMQP selector over a message annotation, so a receiver that cannot
+ * have its start position honoured cannot attach at all.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.DisplayName.class)
+@DisplayName("Event Hubs SDK Compatibility")
+class EventHubSdkCompatibilityTest {
+
+    private static final String CONSUMER_GROUP = "$Default";
+    private static final Duration RECEIVE_TIMEOUT = Duration.ofSeconds(3);
+    private static final int EVENT_COUNT = 8;
+    /**
+     * How many events one read takes off a partition. Comfortably more than this test sends, so an
+     * earlier test's leftovers cannot fill the read and starve out this test's own events.
+     */
+    private static final int RECEIVE_LIMIT = EVENT_COUNT * 4;
+
+    private EventHubProducerClient producer;
+    private String testId;
+
+    @BeforeAll
+    void setup() throws Exception {
+        EmulatorConfig.assumeEmulatorRunning();
+        EmulatorConfig.ensureEventHubNamespace();
+        Assumptions.assumeTrue(!EmulatorConfig.eventHubMocked,
+                "Event Hubs is in mocked mode (no Artemis broker) — SDK tests skipped");
+        producer = EmulatorConfig.eventHubClientBuilder().buildProducerClient();
+    }
+
+    @AfterAll
+    void teardown() {
+        if (producer != null) {
+            producer.close();
+        }
+    }
+
+    @BeforeEach
+    void newTestId() {
+        testId = UUID.randomUUID().toString().replace("-", "");
+    }
+
+    @Test
+    @DisplayName("01. Hub properties list the configured partitions")
+    void hubPropertiesListPartitions() {
+        EventHubProperties properties = producer.getEventHubProperties();
+
+        assertEquals(EmulatorConfig.EVENTHUB_NAME, properties.getName());
+        List<String> partitionIds = new ArrayList<>();
+        properties.getPartitionIds().forEach(partitionIds::add);
+        assertFalse(partitionIds.isEmpty(), "the hub reported no partitions");
+        assertEquals(partitionIds.size(), new HashSet<>(partitionIds).size(),
+                "partition ids are not distinct: " + partitionIds);
+    }
+
+    @Test
+    @DisplayName("02. Events sent without a key spread over the partitions")
+    void eventsSpreadOverPartitions() {
+        List<String> partitionIds = partitionIds();
+        Assumptions.assumeTrue(partitionIds.size() > 1,
+                "the hub has one partition — nothing to spread over");
+
+        send(EVENT_COUNT);
+
+        Set<String> partitionsUsed = new HashSet<>();
+        int received = 0;
+        for (String partitionId : partitionIds) {
+            List<String> bodies = receiveFrom(partitionId, EventPosition.earliest());
+            received += bodies.size();
+            if (!bodies.isEmpty()) {
+                partitionsUsed.add(partitionId);
+            }
+        }
+
+        assertEquals(EVENT_COUNT, received, "not every event was received back");
+        assertTrue(partitionsUsed.size() > 1,
+                "every event landed in one partition: " + partitionsUsed);
+    }
+
+    @Test
+    @DisplayName("03. A partition key keeps its events together")
+    void partitionKeyKeepsEventsTogether() {
+        String key = "key-" + testId;
+        try (EventHubProducerClient keyed = EmulatorConfig.eventHubClientBuilder().buildProducerClient()) {
+            var batch = keyed.createBatch(new CreateBatchOptions().setPartitionKey(key));
+            for (int i = 0; i < EVENT_COUNT; i++) {
+                assertTrue(batch.tryAdd(event(i)), "the batch would not take event " + i);
+            }
+            keyed.send(batch);
+        }
+
+        Set<String> partitionsUsed = new HashSet<>();
+        int received = 0;
+        for (String partitionId : partitionIds()) {
+            List<String> bodies = receiveFrom(partitionId, EventPosition.earliest());
+            received += bodies.size();
+            if (!bodies.isEmpty()) {
+                partitionsUsed.add(partitionId);
+            }
+        }
+
+        assertEquals(EVENT_COUNT, received, "not every event was received back");
+        assertEquals(1, partitionsUsed.size(),
+                "one partition key was spread over several partitions: " + partitionsUsed);
+    }
+
+    /**
+     * The SDK addresses a pinned partition as {@code {hub}/Partitions/{id}} rather than annotating
+     * the message, so this covers a send that never reaches the partition-choosing code at all.
+     * Without a sender address at that path the send is acked against an auto-created address and
+     * the events are gone.
+     */
+    @Test
+    @DisplayName("04. Events sent to a named partition arrive on that partition")
+    void explicitPartitionSendsArriveOnThatPartition() {
+        List<String> partitionIds = partitionIds();
+        String target = partitionIds.get(partitionIds.size() - 1);
+
+        try (EventHubProducerClient pinned = EmulatorConfig.eventHubClientBuilder().buildProducerClient()) {
+            var batch = pinned.createBatch(new CreateBatchOptions().setPartitionId(target));
+            for (int i = 0; i < EVENT_COUNT; i++) {
+                assertTrue(batch.tryAdd(event(i)), "the batch would not take event " + i);
+            }
+            pinned.send(batch);
+        }
+
+        for (String partitionId : partitionIds) {
+            List<String> bodies = receiveFrom(partitionId, EventPosition.earliest());
+            if (partitionId.equals(target)) {
+                assertEquals(EVENT_COUNT, bodies.size(),
+                        "partition " + target + " did not receive the events addressed to it");
+            } else {
+                assertEquals(List.of(), bodies,
+                        "partition " + partitionId + " received events addressed to " + target);
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("05. A receiver started at the latest position skips what came before")
+    void latestPositionSkipsEarlierEvents() {
+        List<String> partitionIds = partitionIds();
+        send(EVENT_COUNT);
+
+        int received = 0;
+        for (String partitionId : partitionIds) {
+            received += receiveFrom(partitionId, EventPosition.latest()).size();
+        }
+
+        assertEquals(0, received, "a receiver at the latest position replayed earlier events");
+    }
+
+    /**
+     * A producer and a consumer that spell the hub's address differently still meet.
+     *
+     * The SDK names the entity alone; the Python and Rust SDKs name it under
+     * {@code {scheme}://{host}/}. Both are the same hub, so both have to reach the same partition
+     * queues. They did not while the topology was generated once per spelling: each spelling had
+     * its own private set of queues, and every one-SDK test passed because it used the same
+     * spelling at both ends. Qpid JMS stands in for the other SDKs here — what matters is the
+     * address on the wire, not which client library wrote it.
+     */
+    @Test
+    @DisplayName("06. A producer addressing the hub by URI reaches the same partitions")
+    void uriAddressedSendsReachTheSamePartitions() throws JMSException {
+        String uriForm = "amqps://" + EmulatorConfig.eventHubFullyQualifiedNamespace()
+                + "/" + EmulatorConfig.EVENTHUB_NAME;
+
+        try (Connection conn = EmulatorConfig.buildAmqpConnectionFactory().createConnection();
+             Session session = conn.createSession(false, Session.AUTO_ACKNOWLEDGE)) {
+            conn.start();
+            MessageProducer producer = session.createProducer(session.createQueue(uriForm));
+            for (int i = 0; i < EVENT_COUNT; i++) {
+                TextMessage msg = session.createTextMessage("event-" + i);
+                msg.setStringProperty("testId", testId);
+                producer.send(msg);
+            }
+        }
+
+        int received = 0;
+        for (String partitionId : partitionIds()) {
+            received += receiveFrom(partitionId, EventPosition.earliest()).size();
+        }
+        assertEquals(EVENT_COUNT, received,
+                "events sent to " + uriForm + " did not reach the partitions the SDK reads");
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    private List<String> partitionIds() {
+        List<String> partitionIds = new ArrayList<>();
+        producer.getPartitionIds().forEach(partitionIds::add);
+        return partitionIds;
+    }
+
+    private EventData event(int index) {
+        EventData event = new EventData("event-" + index);
+        event.getProperties().put("testId", testId);
+        return event;
+    }
+
+    private void send(int count) {
+        for (int i = 0; i < count; i++) {
+            var batch = producer.createBatch();
+            assertTrue(batch.tryAdd(event(i)), "the batch would not take event " + i);
+            producer.send(batch);
+        }
+    }
+
+    /** Bodies of this test's own events on one partition, from {@code position} onwards. */
+    private List<String> receiveFrom(String partitionId, EventPosition position) {
+        List<String> bodies = new ArrayList<>();
+        try (EventHubConsumerClient consumer =
+                     EmulatorConfig.eventHubClientBuilder()
+                             .consumerGroup(CONSUMER_GROUP)
+                             .buildConsumerClient()) {
+            for (PartitionEvent event :
+                    consumer.receiveFromPartition(partitionId, RECEIVE_LIMIT, position, RECEIVE_TIMEOUT)) {
+                EventData data = event.getData();
+                if (testId.equals(data.getProperties().get("testId"))) {
+                    bodies.add(data.getBodyAsString());
+                }
+            }
+        }
+        return bodies;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -272,7 +272,7 @@
                                 <replace
                                     file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/DefaultSenderController.java"
                                     token="final String sourceAddress = ParameterisedAddress.extractAddress(source.getAddress());"
-                                    value="final String sourceAddress = ServiceBusSessionSupport.normalizeEntityPath(ParameterisedAddress.extractAddress(source.getAddress())).replaceFirst(&quot;^/&quot;, &quot;&quot;);"
+                                    value="final String sourceAddress = ServiceBusSessionSupport.normalizeEntityPath(AmqpEntityAddress.toEntityPath(ParameterisedAddress.extractAddress(source.getAddress())));"
                                     failOnNoReplacements="true" />
                                 <replace
                                     file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/DefaultSenderController.java"
@@ -302,7 +302,7 @@
                                 <replace
                                     file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerReceiverContext.java"
                                     token="address = SimpleString.of(targetAddress);"
-                                    value="address = SimpleString.of(targetAddress.startsWith(&quot;/&quot;) ? targetAddress.substring(1) : targetAddress);"
+                                    value="address = SimpleString.of(AmqpEntityAddress.toEntityPath(targetAddress));"
                                     failOnNoReplacements="true" />
                                 <replace
                                     file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerReceiverContext.java"

--- a/pom.xml
+++ b/pom.xml
@@ -261,6 +261,11 @@
                                     failOnNoReplacements="true" />
                                 <replace
                                     file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/DefaultSenderController.java"
+                                    token="selector = filter.getValue().getDescribed().toString();"
+                                    value="selector = EventHubFilterSupport.rewriteSelector(filter.getValue().getDescribed().toString());"
+                                    failOnNoReplacements="true" />
+                                <replace
+                                    file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/DefaultSenderController.java"
                                     token="protonSender.setReceiverSettleMode(ReceiverSettleMode.FIRST);"
                                     value="protonSender.setReceiverSettleMode(protonSender.getRemoteReceiverSettleMode());"
                                     failOnNoReplacements="true" />

--- a/src/artemis-amqp-patch/java/org/apache/activemq/artemis/protocol/amqp/proton/AmqpEntityAddress.java
+++ b/src/artemis-amqp-patch/java/org/apache/activemq/artemis/protocol/amqp/proton/AmqpEntityAddress.java
@@ -1,0 +1,69 @@
+package org.apache.activemq.artemis.protocol.amqp.proton;
+
+/** Reduces the several ways a client can address one event hub down to the entity path itself. */
+public final class AmqpEntityAddress {
+
+   private static final String CONSUMER_GROUPS_SEGMENT = "/ConsumerGroups/";
+   private static final String PARTITIONS_SEGMENT = "/Partitions/";
+
+   private AmqpEntityAddress() {
+   }
+
+   /**
+    * Strips the scheme and host from an address that names an event hub, leaving the path.
+    *
+    * <p>There is no single form a client sends. The Java SDK names the entity alone; the Python and
+    * Rust SDKs name it under {@code {scheme}://{host}/}, with the namespace as the host, in
+    * whatever case the client was configured with. Artemis matches addresses exactly, so without
+    * this every spelling is a different address. Since {@code auto-create-addresses} is on, the
+    * spellings with no topology behind them are created empty and their messages discarded with no
+    * error anywhere — and worse, the spellings that do have topology have a private copy of it, so
+    * a producer on one and a consumer on another read and write different queues while the
+    * management node reports a single hub.
+    *
+    * <p>The scheme is dropped rather than examined: SDKs put {@code amqps} in the address whatever
+    * the transport turns out to be, so it carries no information about the connection.
+    *
+    * <p>Only event-hub-shaped paths are reduced — a bare entity, or one followed by
+    * {@code /Partitions/{id}} or {@code /ConsumerGroups/{group}/Partitions/{id}}. floci also serves
+    * addresses whose path carries the namespace ({@code amqp://host/{namespace}/{entity}}), and
+    * those name a different topology: the same path without a host is the multicast address that
+    * path-addressing clients publish to. Reducing one onto the other would merge two address
+    * families that are deliberately distinct, so anything that is not event-hub-shaped is returned
+    * exactly as it arrived.
+    */
+   public static String toEntityPath(String address) {
+      if (address == null) {
+         return null;
+      }
+      int schemeEnd = address.indexOf("://");
+      if (schemeEnd < 0) {
+         return address;
+      }
+      int hostEnd = address.indexOf('/', schemeEnd + 3);
+      if (hostEnd < 0 || hostEnd == address.length() - 1) {
+         return address;
+      }
+      String path = address.substring(hostEnd + 1);
+      while (path.startsWith("/")) {
+         path = path.substring(1);
+      }
+      return isEventHubPath(path) ? path : address;
+   }
+
+   /** True for {@code entity}, {@code entity/Partitions/n} and the consumer-group form. */
+   private static boolean isEventHubPath(String path) {
+      if (path.isEmpty()) {
+         return false;
+      }
+      int consumerGroups = path.indexOf(CONSUMER_GROUPS_SEGMENT);
+      if (consumerGroups > 0) {
+         return path.indexOf(PARTITIONS_SEGMENT, consumerGroups) > 0;
+      }
+      int partitions = path.indexOf(PARTITIONS_SEGMENT);
+      if (partitions > 0) {
+         return path.indexOf('/', partitions + PARTITIONS_SEGMENT.length()) < 0;
+      }
+      return path.indexOf('/') < 0;
+   }
+}

--- a/src/artemis-amqp-patch/java/org/apache/activemq/artemis/protocol/amqp/proton/AmqpEntityAddress.java
+++ b/src/artemis-amqp-patch/java/org/apache/activemq/artemis/protocol/amqp/proton/AmqpEntityAddress.java
@@ -36,19 +36,29 @@ public final class AmqpEntityAddress {
       if (address == null) {
          return null;
       }
-      int schemeEnd = address.indexOf("://");
+      // Unconditional, and not only for the addresses reduced below: clients send an entity path
+      // with a leading slash as readily as without one, Service Bus among them, and an address
+      // that keeps it matches nothing.
+      String path = stripLeadingSlashes(address);
+
+      int schemeEnd = path.indexOf("://");
       if (schemeEnd < 0) {
-         return address;
+         return path;
       }
-      int hostEnd = address.indexOf('/', schemeEnd + 3);
-      if (hostEnd < 0 || hostEnd == address.length() - 1) {
-         return address;
+      int hostEnd = path.indexOf('/', schemeEnd + 3);
+      if (hostEnd < 0 || hostEnd == path.length() - 1) {
+         return path;
       }
-      String path = address.substring(hostEnd + 1);
-      while (path.startsWith("/")) {
-         path = path.substring(1);
+      String afterHost = stripLeadingSlashes(path.substring(hostEnd + 1));
+      return isEventHubPath(afterHost) ? afterHost : path;
+   }
+
+   private static String stripLeadingSlashes(String value) {
+      int i = 0;
+      while (i < value.length() && value.charAt(i) == '/') {
+         i++;
       }
-      return isEventHubPath(path) ? path : address;
+      return value.substring(i);
    }
 
    /** True for {@code entity}, {@code entity/Partitions/n} and the consumer-group form. */

--- a/src/artemis-amqp-patch/java/org/apache/activemq/artemis/protocol/amqp/proton/EventHubFilterSupport.java
+++ b/src/artemis-amqp-patch/java/org/apache/activemq/artemis/protocol/amqp/proton/EventHubFilterSupport.java
@@ -1,0 +1,67 @@
+package org.apache.activemq.artemis.protocol.amqp.proton;
+
+import java.util.regex.Pattern;
+
+/** Translates an Event Hubs start position into a selector Artemis can parse. */
+public final class EventHubFilterSupport {
+
+   /**
+    * Properties the partition plugin stamps, one per annotation an Event Hubs start position can
+    * be expressed against. The names are duplicated in {@code EventHubPartitionPlugin}: the plugin
+    * and this patch are built into separate jars, so neither can see the other's constants.
+    */
+   public static final String OFFSET_PROPERTY = "floci_offset";
+   public static final String SEQUENCE_NUMBER_PROPERTY = "floci_sequence_number";
+   public static final String ENQUEUED_TIME_PROPERTY = "floci_enqueued_time";
+
+   private static final String ANNOTATION_PREFIX = "amqp.annotation.";
+
+   /** {@code amqp.annotation.x-opt-offset > '@latest'} — the start position with no numeric form. */
+   private static final Pattern LATEST =
+      Pattern.compile("amqp\\.annotation\\.x-opt-offset\\s*>=?\\s*'@latest'");
+
+   /** A quoted operand on one of the rewritten properties, e.g. {@code floci_offset > '-1'}. */
+   private static final Pattern QUOTED_OPERAND = Pattern.compile(
+      "(" + OFFSET_PROPERTY + "|" + SEQUENCE_NUMBER_PROPERTY + "|" + ENQUEUED_TIME_PROPERTY + ")"
+         + "(\\s*(?:>=|<=|<>|>|<|=)\\s*)'(-?\\d+)'");
+
+   private EventHubFilterSupport() {
+   }
+
+   /**
+    * Rewrites an Event Hubs start-position selector, and returns anything else unchanged.
+    *
+    * <p>Every start position arrives as a selector over an annotation — including "earliest",
+    * which is sent as {@code amqp.annotation.x-opt-offset > '-1'}. Artemis rejects all of them,
+    * and not for the reason it first appears: quoted operands are legal, and Artemis reads
+    * annotations in selectors under its own {@code m.} prefix, so an unrecognised name simply
+    * falls through to a property lookup. The blocker is the hyphens. {@code x-opt-offset} is not
+    * an identifier in the selector grammar — it parses as {@code x - opt - offset} — so the
+    * expression fails to parse and the receiver's attach is refused before a value is ever
+    * compared. Underscored names parse, so the annotations are mapped onto the properties the
+    * partition plugin stamps under those names.
+    *
+    * <p>Quoted numbers are unquoted with them: the stamped properties are numeric, and Artemis
+    * compares a number against a string constant only when a thread-local conversion flag happens
+    * to be set.
+    *
+    * <p>{@code @latest} has no numeric form. It means "only what arrives from now on", so it
+    * becomes a comparison against the clock — read here, as the link attaches, which is the moment
+    * "now" refers to.
+    */
+   public static String rewriteSelector(String selector) {
+      if (selector == null || !selector.contains(ANNOTATION_PREFIX)) {
+         return selector;
+      }
+
+      String rewritten = LATEST.matcher(selector)
+         .replaceAll(ENQUEUED_TIME_PROPERTY + " > " + System.currentTimeMillis());
+
+      rewritten = rewritten
+         .replace(ANNOTATION_PREFIX + "x-opt-enqueued-time", ENQUEUED_TIME_PROPERTY)
+         .replace(ANNOTATION_PREFIX + "x-opt-sequence-number", SEQUENCE_NUMBER_PROPERTY)
+         .replace(ANNOTATION_PREFIX + "x-opt-offset", OFFSET_PROPERTY);
+
+      return QUOTED_OPERAND.matcher(rewritten).replaceAll("$1$2$3");
+   }
+}

--- a/src/artemis-amqp-patch/java/org/apache/activemq/artemis/protocol/amqp/proton/EventHubFilterSupport.java
+++ b/src/artemis-amqp-patch/java/org/apache/activemq/artemis/protocol/amqp/proton/EventHubFilterSupport.java
@@ -47,7 +47,14 @@ public final class EventHubFilterSupport {
     *
     * <p>{@code @latest} has no numeric form. It means "only what arrives from now on", so it
     * becomes a comparison against the clock — read here, as the link attaches, which is the moment
-    * "now" refers to.
+    * "now" refers to. The comparison is inclusive because the clock has only millisecond
+    * resolution: an event enqueued in the same millisecond as the attach is on the wrong side of a
+    * strict {@code >} even when it genuinely arrived afterwards, and would then be excluded
+    * forever. Inclusive instead risks replaying whatever else landed in that one millisecond,
+    * which is a duplicate rather than a loss — and Event Hubs delivery is at-least-once, so a
+    * consumer already has to tolerate one. A monotonic broker-local counter would make the
+    * boundary exact, but it would restart with the broker, and messages outliving it would
+    * compare against an origin that no longer means anything.
     */
    public static String rewriteSelector(String selector) {
       if (selector == null || !selector.contains(ANNOTATION_PREFIX)) {
@@ -55,7 +62,7 @@ public final class EventHubFilterSupport {
       }
 
       String rewritten = LATEST.matcher(selector)
-         .replaceAll(ENQUEUED_TIME_PROPERTY + " > " + System.currentTimeMillis());
+         .replaceAll(ENQUEUED_TIME_PROPERTY + " >= " + System.currentTimeMillis());
 
       rewritten = rewritten
          .replace(ANNOTATION_PREFIX + "x-opt-enqueued-time", ENQUEUED_TIME_PROPERTY)

--- a/src/artemis-plugin/java/io/floci/az/artemis/EventHubPartitionPlugin.java
+++ b/src/artemis-plugin/java/io/floci/az/artemis/EventHubPartitionPlugin.java
@@ -55,6 +55,8 @@ public final class EventHubPartitionPlugin implements ActiveMQServerPlugin {
     private static final String OFFSET_PROPERTY = "floci_offset";
     private static final String SEQUENCE_NUMBER_PROPERTY = "floci_sequence_number";
     private static final String ENQUEUED_TIME_PROPERTY = "floci_enqueued_time";
+    /** Segment a producer address carries when the caller pinned a partition. */
+    private static final String PARTITIONS_SEGMENT = "/Partitions/";
     /** Plugin property: "eh1:4,eh2:2". */
     private static final String ENTITIES_PROPERTY = "entities";
 
@@ -102,14 +104,23 @@ public final class EventHubPartitionPlugin implements ActiveMQServerPlugin {
         if (address == null) {
             return;
         }
-        int partitionCount = partitionCountFor(address);
-        // Even a single-partition hub is stamped: its divert filters on this like any other.
-        int partition = partitionCount <= 1 ? 0 : choosePartition(message, address, partitionCount);
+        String hub = hubOf(address);
+        int partitionCount = partitionCounts.getOrDefault(hub, 1);
+        // A partition named in the address outranks everything: the caller pinned it, and the
+        // address is how the Java SDK says so. Otherwise pick by id, key or round-robin. Even a
+        // single-partition hub is stamped, because its divert filters on this like any other.
+        int pinnedByAddress = partitionInAddress(address);
+        int partition = pinnedByAddress >= 0 && pinnedByAddress < partitionCount ? pinnedByAddress
+                : partitionCount <= 1 ? 0
+                : choosePartition(message, hub, partitionCount);
         // Stamped as a string, and compared as one by the generated divert filters. That mirrors
         // the CBS divert, the one filter on an AMQP application property already known to work
         // here.
         message.putStringProperty(PARTITION_PROPERTY, Integer.toString(partition));
-        stampStreamPosition(message, address, partition);
+        // Keyed by the hub, not the address: a send pinned to {hub}/Partitions/{id} and one to
+        // {hub} land in the same partition queue, so they have to draw from the same counter or
+        // consumers would see the offset go backwards.
+        stampStreamPosition(message, hub, partition);
         // An AMQP message serves its properties from its encoded form, so a property set here is
         // invisible to the divert filters until the message is re-encoded.
         message.reencode();
@@ -131,9 +142,9 @@ public final class EventHubPartitionPlugin implements ActiveMQServerPlugin {
      * <p>Offsets and sequence numbers are the same counter here: Artemis keeps neither, and a
      * consumer only needs them to be monotonic per partition for a resume point to mean anything.
      */
-    private void stampStreamPosition(Message message, String address, int partition) {
+    private void stampStreamPosition(Message message, String hub, int partition) {
         long sequence = sequences
-                .computeIfAbsent(address + "#" + partition, k -> new AtomicLong())
+                .computeIfAbsent(hub + "#" + partition, k -> new AtomicLong())
                 .getAndIncrement();
         long enqueuedTime = System.currentTimeMillis();
 
@@ -147,7 +158,7 @@ public final class EventHubPartitionPlugin implements ActiveMQServerPlugin {
         message.putLongProperty(ENQUEUED_TIME_PROPERTY, enqueuedTime);
     }
 
-    private int choosePartition(Message message, String address, int partitionCount) {
+    private int choosePartition(Message message, String hub, int partitionCount) {
         Object pinned = addressingHint(message, PARTITION_ID_ANNOTATION);
         if (pinned != null) {
             try {
@@ -157,10 +168,10 @@ public final class EventHubPartitionPlugin implements ActiveMQServerPlugin {
                 }
                 LOG.log(System.Logger.Level.WARNING,
                         "Partition id " + id + " is outside 0.." + (partitionCount - 1)
-                        + " for " + address + "; falling back to the partition key");
+                        + " for " + hub + "; falling back to the partition key");
             } catch (NumberFormatException e) {
                 LOG.log(System.Logger.Level.WARNING,
-                        "Ignoring non-numeric partition id '" + pinned + "' on " + address);
+                        "Ignoring non-numeric partition id '" + pinned + "' on " + hub);
             }
         }
 
@@ -170,7 +181,7 @@ public final class EventHubPartitionPlugin implements ActiveMQServerPlugin {
         }
 
         return Math.floorMod(
-                roundRobin.computeIfAbsent(address, a -> new AtomicInteger()).getAndIncrement(),
+                roundRobin.computeIfAbsent(hub, a -> new AtomicInteger()).getAndIncrement(),
                 partitionCount);
     }
 
@@ -187,13 +198,27 @@ public final class EventHubPartitionPlugin implements ActiveMQServerPlugin {
         return annotation != null ? annotation : message.getObjectProperty(name);
     }
 
+    /** The partition a {@code {hub}/Partitions/{id}} address pins, or -1 if it pins none. */
+    private static int partitionInAddress(String address) {
+        int marker = address.lastIndexOf(PARTITIONS_SEGMENT);
+        if (marker < 0 || marker + PARTITIONS_SEGMENT.length() >= address.length()) {
+            return -1;
+        }
+        try {
+            return Integer.parseInt(address.substring(marker + PARTITIONS_SEGMENT.length()));
+        } catch (NumberFormatException e) {
+            return -1;
+        }
+    }
+
     /**
-     * The entity is the last segment of the address the sender used
-     * ({@code amqps://host/eh1} → {@code eh1}); hubs are configured by bare name.
+     * The hub an address names, whether or not it pins a partition.
+     *
+     * The AMQP layer has already reduced the address to a path, so the hub is the whole of it
+     * minus a trailing {@code /Partitions/{id}}.
      */
-    private int partitionCountFor(String address) {
-        int slash = address.lastIndexOf('/');
-        String entity = slash >= 0 ? address.substring(slash + 1) : address;
-        return partitionCounts.getOrDefault(entity, 1);
+    private static String hubOf(String address) {
+        int marker = address.lastIndexOf(PARTITIONS_SEGMENT);
+        return partitionInAddress(address) >= 0 ? address.substring(0, marker) : address;
     }
 }

--- a/src/artemis-plugin/java/io/floci/az/artemis/EventHubPartitionPlugin.java
+++ b/src/artemis-plugin/java/io/floci/az/artemis/EventHubPartitionPlugin.java
@@ -1,10 +1,12 @@
 package io.floci.az.artemis;
 
 import org.apache.activemq.artemis.api.core.Message;
+import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.server.ServerSession;
 import org.apache.activemq.artemis.core.transaction.Transaction;
 import org.apache.activemq.artemis.core.server.plugin.ActiveMQServerPlugin;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -36,14 +38,23 @@ public final class EventHubPartitionPlugin implements ActiveMQServerPlugin {
 
     /** Property the generated partition diverts filter on. */
     public static final String PARTITION_PROPERTY = "floci_partition";
-    /** Set by senders that pin a message to a partition. */
+    /** Set by senders that pin a message to a partition, and echoed back to consumers. */
     private static final String PARTITION_ID_ANNOTATION = "x-opt-partition-id";
     /** Set by senders that supply a partition key. */
     private static final String PARTITION_KEY_ANNOTATION = "x-opt-partition-key";
-    /** Names the Event Hubs start-position selectors reference. */
-    private static final String OFFSET_ANNOTATION = "amqp.annotation.x-opt-offset";
-    private static final String SEQUENCE_NUMBER_ANNOTATION = "amqp.annotation.x-opt-sequence-number";
-    private static final String ENQUEUED_TIME_ANNOTATION = "amqp.annotation.x-opt-enqueued-time";
+    /** Stream position, as consumers read it back. */
+    private static final String OFFSET_ANNOTATION = "x-opt-offset";
+    private static final String SEQUENCE_NUMBER_ANNOTATION = "x-opt-sequence-number";
+    private static final String ENQUEUED_TIME_ANNOTATION = "x-opt-enqueued-time";
+    /**
+     * Stream position, as a start-position selector matches it. The names are duplicated in
+     * {@code EventHubFilterSupport}, which rewrites the selectors onto them: that class patches
+     * the AMQP protocol jar and this one is a broker plugin, so neither can see the other's
+     * constants.
+     */
+    private static final String OFFSET_PROPERTY = "floci_offset";
+    private static final String SEQUENCE_NUMBER_PROPERTY = "floci_sequence_number";
+    private static final String ENQUEUED_TIME_PROPERTY = "floci_enqueued_time";
     /** Plugin property: "eh1:4,eh2:2". */
     private static final String ENTITIES_PROPERTY = "entities";
 
@@ -105,26 +116,35 @@ public final class EventHubPartitionPlugin implements ActiveMQServerPlugin {
     }
 
     /**
-     * Stamps the stream position a consumer's start position is expressed against.
+     * Stamps the message's position in its partition's stream, twice over.
      *
-     * <p>Every Event Hubs start position becomes an AMQP selector over an annotation — even
-     * "earliest", which is sent as {@code amqp.annotation.x-opt-offset > '-1'}. Artemis reads
-     * annotations in filters only under its own {@code m.} prefix, so those selectors fall through
-     * to an ordinary property lookup by the full name. Naming the properties exactly as the
-     * selectors reference them is therefore what makes start positions work at all.
+     * <p>The annotations are what a consumer reads back: the SDKs take the offset and sequence
+     * number of the last event they handled from {@code x-opt-offset} and
+     * {@code x-opt-sequence-number}, and store them as the checkpoint they later resume from.
      *
-     * <p>The values are strings because the selectors quote their operands, so the comparison is
-     * lexicographic. That is exact for enqueued time, whose millisecond stamps are all the same
-     * width, and for offsets only while they are — a consumer resuming from a specific offset
-     * across a digit boundary is a known limitation of this emulation.
+     * <p>The properties are what the broker matches a resume point against. A start position
+     * reaches Artemis as a selector over those same annotations, which the AMQP patch rewrites
+     * onto these names — hyphens are not legal in a selector identifier, and Artemis compares a
+     * number to a quoted constant only under a thread-local flag, so a parseable selector needs
+     * both an underscored name and a numeric value to match.
+     *
+     * <p>Offsets and sequence numbers are the same counter here: Artemis keeps neither, and a
+     * consumer only needs them to be monotonic per partition for a resume point to mean anything.
      */
     private void stampStreamPosition(Message message, String address, int partition) {
         long sequence = sequences
                 .computeIfAbsent(address + "#" + partition, k -> new AtomicLong())
                 .getAndIncrement();
-        message.putStringProperty(OFFSET_ANNOTATION, Long.toString(sequence));
-        message.putStringProperty(SEQUENCE_NUMBER_ANNOTATION, Long.toString(sequence));
-        message.putStringProperty(ENQUEUED_TIME_ANNOTATION, Long.toString(System.currentTimeMillis()));
+        long enqueuedTime = System.currentTimeMillis();
+
+        message.setAnnotation(SimpleString.of(PARTITION_ID_ANNOTATION), Integer.toString(partition));
+        message.setAnnotation(SimpleString.of(OFFSET_ANNOTATION), Long.toString(sequence));
+        message.setAnnotation(SimpleString.of(SEQUENCE_NUMBER_ANNOTATION), sequence);
+        message.setAnnotation(SimpleString.of(ENQUEUED_TIME_ANNOTATION), new Date(enqueuedTime));
+
+        message.putLongProperty(OFFSET_PROPERTY, sequence);
+        message.putLongProperty(SEQUENCE_NUMBER_PROPERTY, sequence);
+        message.putLongProperty(ENQUEUED_TIME_PROPERTY, enqueuedTime);
     }
 
     private int choosePartition(Message message, String address, int partitionCount) {

--- a/src/artemis-plugin/java/io/floci/az/artemis/EventHubPartitionPlugin.java
+++ b/src/artemis-plugin/java/io/floci/az/artemis/EventHubPartitionPlugin.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Assigns each message an Event Hubs partition as it is routed.
@@ -39,6 +40,10 @@ public final class EventHubPartitionPlugin implements ActiveMQServerPlugin {
     private static final String PARTITION_ID_ANNOTATION = "x-opt-partition-id";
     /** Set by senders that supply a partition key. */
     private static final String PARTITION_KEY_ANNOTATION = "x-opt-partition-key";
+    /** Names the Event Hubs start-position selectors reference. */
+    private static final String OFFSET_ANNOTATION = "amqp.annotation.x-opt-offset";
+    private static final String SEQUENCE_NUMBER_ANNOTATION = "amqp.annotation.x-opt-sequence-number";
+    private static final String ENQUEUED_TIME_ANNOTATION = "amqp.annotation.x-opt-enqueued-time";
     /** Plugin property: "eh1:4,eh2:2". */
     private static final String ENTITIES_PROPERTY = "entities";
 
@@ -47,6 +52,7 @@ public final class EventHubPartitionPlugin implements ActiveMQServerPlugin {
 
     private final Map<String, Integer> partitionCounts = new HashMap<>();
     private final ConcurrentHashMap<String, AtomicInteger> roundRobin = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, AtomicLong> sequences = new ConcurrentHashMap<>();
 
     @Override
     public void init(Map<String, String> properties) {
@@ -92,9 +98,33 @@ public final class EventHubPartitionPlugin implements ActiveMQServerPlugin {
         // the CBS divert, the one filter on an AMQP application property already known to work
         // here.
         message.putStringProperty(PARTITION_PROPERTY, Integer.toString(partition));
+        stampStreamPosition(message, address, partition);
         // An AMQP message serves its properties from its encoded form, so a property set here is
         // invisible to the divert filters until the message is re-encoded.
         message.reencode();
+    }
+
+    /**
+     * Stamps the stream position a consumer's start position is expressed against.
+     *
+     * <p>Every Event Hubs start position becomes an AMQP selector over an annotation — even
+     * "earliest", which is sent as {@code amqp.annotation.x-opt-offset > '-1'}. Artemis reads
+     * annotations in filters only under its own {@code m.} prefix, so those selectors fall through
+     * to an ordinary property lookup by the full name. Naming the properties exactly as the
+     * selectors reference them is therefore what makes start positions work at all.
+     *
+     * <p>The values are strings because the selectors quote their operands, so the comparison is
+     * lexicographic. That is exact for enqueued time, whose millisecond stamps are all the same
+     * width, and for offsets only while they are — a consumer resuming from a specific offset
+     * across a digit boundary is a known limitation of this emulation.
+     */
+    private void stampStreamPosition(Message message, String address, int partition) {
+        long sequence = sequences
+                .computeIfAbsent(address + "#" + partition, k -> new AtomicLong())
+                .getAndIncrement();
+        message.putStringProperty(OFFSET_ANNOTATION, Long.toString(sequence));
+        message.putStringProperty(SEQUENCE_NUMBER_ANNOTATION, Long.toString(sequence));
+        message.putStringProperty(ENQUEUED_TIME_ANNOTATION, Long.toString(System.currentTimeMillis()));
     }
 
     private int choosePartition(Message message, String address, int partitionCount) {

--- a/src/artemis-plugin/java/io/floci/az/artemis/EventHubPartitionPlugin.java
+++ b/src/artemis-plugin/java/io/floci/az/artemis/EventHubPartitionPlugin.java
@@ -1,0 +1,136 @@
+package io.floci.az.artemis;
+
+import org.apache.activemq.artemis.api.core.Message;
+import org.apache.activemq.artemis.core.server.ServerSession;
+import org.apache.activemq.artemis.core.transaction.Transaction;
+import org.apache.activemq.artemis.core.server.plugin.ActiveMQServerPlugin;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Assigns each message an Event Hubs partition as it is routed.
+ *
+ * <p>Artemis has no notion of partitions, so the emulated ones are ordinary queues selected by a
+ * filter. This plugin supplies what that filter matches on: it stamps {@value #PARTITION_PROPERTY}
+ * with the partition the message belongs to, and the generated broker.xml gives each partition a
+ * divert filtered on that value. A message therefore reaches exactly one partition per consumer
+ * group — every group sees the whole stream, each event in one partition of it.
+ *
+ * <p>Assignment follows the Event Hubs rules, in order of precedence:
+ * <ol>
+ *   <li>an explicitly addressed partition id, honoured as given;</li>
+ *   <li>a partition key, hashed so the same key always lands in the same partition;</li>
+ *   <li>neither — round-robin across the hub's partitions.</li>
+ * </ol>
+ *
+ * <p>The hash is {@link String#hashCode()}, which the Java language specification pins, so the
+ * mapping is stable across runs and JVMs. It deliberately does not reproduce Azure's own hash:
+ * that is undocumented, and client code depends on the guarantee (same key, same partition;
+ * ordering within a partition) rather than on which index a key lands in.
+ */
+public final class EventHubPartitionPlugin implements ActiveMQServerPlugin {
+
+    /** Property the generated partition diverts filter on. */
+    public static final String PARTITION_PROPERTY = "floci_partition";
+    /** Set by senders that pin a message to a partition. */
+    private static final String PARTITION_ID_ANNOTATION = "x-opt-partition-id";
+    /** Set by senders that supply a partition key. */
+    private static final String PARTITION_KEY_ANNOTATION = "x-opt-partition-key";
+    /** Plugin property: "eh1:4,eh2:2". */
+    private static final String ENTITIES_PROPERTY = "entities";
+
+    private static final System.Logger LOG =
+            System.getLogger(EventHubPartitionPlugin.class.getName());
+
+    private final Map<String, Integer> partitionCounts = new HashMap<>();
+    private final ConcurrentHashMap<String, AtomicInteger> roundRobin = new ConcurrentHashMap<>();
+
+    @Override
+    public void init(Map<String, String> properties) {
+        String entities = properties.get(ENTITIES_PROPERTY);
+        if (entities == null || entities.isBlank()) {
+            return;
+        }
+        for (String token : entities.split(",")) {
+            String[] parts = token.trim().split(":", 2);
+            if (parts.length != 2 || parts[0].isBlank()) {
+                continue;
+            }
+            try {
+                partitionCounts.put(parts[0].trim(), Integer.parseInt(parts[1].trim()));
+            } catch (NumberFormatException e) {
+                LOG.log(System.Logger.Level.WARNING,
+                        "Ignoring malformed partition count in '" + token + "'");
+            }
+        }
+    }
+
+    /**
+     * Stamps the partition before the message is routed.
+     *
+     * <p>It has to be {@code beforeSend} rather than the more obvious {@code beforeMessageRoute}.
+     * Despite the name, {@code beforeMessageRoute} fires inside {@code PostOfficeImpl.route}
+     * <em>after</em> the bindings have already been resolved — diverts and their filters are
+     * evaluated in {@code simpleRoute} further up, so a property set there is too late to steer
+     * routing and the partition diverts never match. {@code beforeSend} runs in
+     * {@code ServerSessionImpl.doSend} before {@code postOffice.route} is called at all.
+     */
+    @Override
+    public void beforeSend(ServerSession session, Transaction tx, Message message,
+                           boolean direct, boolean noAutoCreateQueue) {
+        String address = message.getAddress();
+        if (address == null) {
+            return;
+        }
+        int partitionCount = partitionCountFor(address);
+        // Even a single-partition hub is stamped: its divert filters on this like any other.
+        int partition = partitionCount <= 1 ? 0 : choosePartition(message, address, partitionCount);
+        // Stamped as a string, and compared as one by the generated divert filters. That mirrors
+        // the CBS divert, the one filter on an AMQP application property already known to work
+        // here.
+        message.putStringProperty(PARTITION_PROPERTY, Integer.toString(partition));
+        // An AMQP message serves its properties from its encoded form, so a property set here is
+        // invisible to the divert filters until the message is re-encoded.
+        message.reencode();
+    }
+
+    private int choosePartition(Message message, String address, int partitionCount) {
+        Object pinned = message.getObjectProperty(PARTITION_ID_ANNOTATION);
+        if (pinned != null) {
+            try {
+                int id = Integer.parseInt(pinned.toString().trim());
+                if (id >= 0 && id < partitionCount) {
+                    return id;
+                }
+                LOG.log(System.Logger.Level.WARNING,
+                        "Partition id " + id + " is outside 0.." + (partitionCount - 1)
+                        + " for " + address + "; falling back to the partition key");
+            } catch (NumberFormatException e) {
+                LOG.log(System.Logger.Level.WARNING,
+                        "Ignoring non-numeric partition id '" + pinned + "' on " + address);
+            }
+        }
+
+        Object key = message.getObjectProperty(PARTITION_KEY_ANNOTATION);
+        if (key != null) {
+            return Math.floorMod(key.toString().hashCode(), partitionCount);
+        }
+
+        return Math.floorMod(
+                roundRobin.computeIfAbsent(address, a -> new AtomicInteger()).getAndIncrement(),
+                partitionCount);
+    }
+
+    /**
+     * The entity is the last segment of the address the sender used
+     * ({@code amqps://host/eh1} → {@code eh1}); hubs are configured by bare name.
+     */
+    private int partitionCountFor(String address) {
+        int slash = address.lastIndexOf('/');
+        String entity = slash >= 0 ? address.substring(slash + 1) : address;
+        return partitionCounts.getOrDefault(entity, 1);
+    }
+}

--- a/src/artemis-plugin/java/io/floci/az/artemis/EventHubPartitionPlugin.java
+++ b/src/artemis-plugin/java/io/floci/az/artemis/EventHubPartitionPlugin.java
@@ -148,7 +148,7 @@ public final class EventHubPartitionPlugin implements ActiveMQServerPlugin {
     }
 
     private int choosePartition(Message message, String address, int partitionCount) {
-        Object pinned = message.getObjectProperty(PARTITION_ID_ANNOTATION);
+        Object pinned = addressingHint(message, PARTITION_ID_ANNOTATION);
         if (pinned != null) {
             try {
                 int id = Integer.parseInt(pinned.toString().trim());
@@ -164,7 +164,7 @@ public final class EventHubPartitionPlugin implements ActiveMQServerPlugin {
             }
         }
 
-        Object key = message.getObjectProperty(PARTITION_KEY_ANNOTATION);
+        Object key = addressingHint(message, PARTITION_KEY_ANNOTATION);
         if (key != null) {
             return Math.floorMod(key.toString().hashCode(), partitionCount);
         }
@@ -172,6 +172,19 @@ public final class EventHubPartitionPlugin implements ActiveMQServerPlugin {
         return Math.floorMod(
                 roundRobin.computeIfAbsent(address, a -> new AtomicInteger()).getAndIncrement(),
                 partitionCount);
+    }
+
+    /**
+     * Reads a sender's partition id or key, wherever the client put it.
+     *
+     * The Azure SDKs send both as message annotations, and an annotation is not an application
+     * property: {@code getObjectProperty} looks only at the latter, so reading it alone loses
+     * every partition key and quietly round-robins instead. Some clients do set an application
+     * property of the same name, so that stays as the fallback.
+     */
+    private static Object addressingHint(Message message, String name) {
+        Object annotation = message.getAnnotation(SimpleString.of(name));
+        return annotation != null ? annotation : message.getObjectProperty(name);
     }
 
     /**

--- a/src/main/java/io/floci/az/services/eventhub/ArtemisConfigGenerator.java
+++ b/src/main/java/io/floci/az/services/eventhub/ArtemisConfigGenerator.java
@@ -14,10 +14,14 @@ import java.util.Map;
 /**
  * Generates the Artemis broker.xml for an Event Hubs namespace.
  *
- * The broker.xml statically configures both:
- * - MULTICAST addresses for the rhea-promise (Node.js) SDK (path-only addressing)
- * - ANYCAST addresses, durable queues, and exclusive diverts for the uamqp (Python) SDK
- *   (full AMQP URI addressing: {@code amqp://hostname/namespace/entity})
+ * The broker.xml statically configures two address families, which stay apart deliberately:
+ * - the namespace-carrying one, addressed either by path ({@code {namespace}/{entity}}, MULTICAST,
+ *   one queue per consumer group, what rhea-promise publishes to) or by URI
+ *   ({@code amqp://{host}/{namespace}/{entity}}, ANYCAST, fanned out by exclusive diverts, what
+ *   uamqp sends). Both predate partitions, and neither is what an Azure SDK sends.
+ * - {@code {entity}} — the partitioned topology the Azure SDKs reach, declared once because
+ *   {@link org.apache.activemq.artemis.protocol.amqp.proton.AmqpEntityAddress} reduces every
+ *   scheme and host spelling of it to this one path.
  *
  * Pre-configuring topology in broker.xml avoids any dependency on the Jolokia management API,
  * which can take several minutes to start and would otherwise block readiness.
@@ -46,8 +50,7 @@ public class ArtemisConfigGenerator {
 
     /** Returns broker.xml for the given namespace and entities (used for dynamic namespace creation). */
     public String generate(String namespace, Map<String, EntitySpec> entities) {
-        String containerName = "floci-az-artemis-" + namespace;
-        List<String> hostnames = List.of("localhost", containerName);
+        List<String> hostnames = List.of("localhost", "floci-az-artemis-" + namespace);
 
         XmlBuilder addresses = new XmlBuilder();
         XmlBuilder diverts = new XmlBuilder();
@@ -64,13 +67,15 @@ public class ArtemisConfigGenerator {
             }
             partitionSpec.append(entityName).append(':').append(partitions);
 
+            // The namespace-carrying family, addressed by path (multicast) or by URI (anycast).
+            // Both predate partitions and neither is what an Azure SDK sends.
             appendMulticastAddress(addresses, namespace + "/" + entityName, cgs);
-
             for (String hostname : hostnames) {
                 appendAnycastTopology(addresses, diverts, hostname, namespace, entityName, cgs);
-                appendAzureAddressing(addresses, diverts, hostname, namespace, entityName, cgs);
-                appendPartitionTopology(addresses, diverts, hostname, entityName, cgs, partitions);
             }
+            // The family the Azure SDKs use, declared once: the AMQP layer reduces every scheme
+            // and host spelling of it to this one path.
+            appendPartitionTopology(addresses, diverts, entityName, cgs, partitions);
         }
         return buildBrokerXml(addresses, diverts, partitionSpec.toString());
     }
@@ -275,85 +280,92 @@ public class ArtemisConfigGenerator {
     }
 
     /**
-     * Appends the address form the Azure SDKs actually send to: {@code {scheme}://{host}/{entity}},
-     * where the namespace is the HOST and the path is only the hub — no namespace path segment.
+     * Appends the partitioned topology for one hub: the addresses a producer sends to and one
+     * durable queue per (consumer group, partition) for consumers to attach to.
      *
-     * Without this a send matches no configured address, {@code auto-create-addresses} creates one
-     * with no queues bound, and the message is discarded with no error anywhere. Both schemes are
-     * generated because SDKs put {@code amqps} in the address whatever the transport turns out to
-     * be, while some send {@code amqp}.
+     * Everything hangs off the bare entity path, once. That is what the AMQP layer reduces every
+     * address to ({@link org.apache.activemq.artemis.protocol.amqp.proton.AmqpEntityAddress}), so
+     * a Java producer naming {@code eh1} and a Rust consumer naming
+     * {@code amqps://ns.servicebus.windows.net/eh1} meet on the same queues. Generating a copy per
+     * host and scheme instead gave each spelling its own private hub — the sends were not lost, but
+     * only a client using the very same spelling could read them, while the management node
+     * reported one hub either way.
      *
-     * The diverts feed the same per-consumer-group queues the uamqp topology uses, so a consumer on
-     * either address form reads the same messages.
+     * Two kinds of sender address are declared:
+     * <ul>
+     *   <li>{@code {entity}} — the hub itself, where the partition is chosen by key or round-robin;
+     *   <li>{@code {entity}/Partitions/{id}} — a partition named outright, which is how the Java
+     *       SDK sends when the caller pins one. Without it those sends reach an auto-created
+     *       address with no queues and are discarded with no error anywhere.
+     * </ul>
+     *
+     * Each partition queue is fed by an exclusive divert filtered on the partition property that
+     * {@code EventHubPartitionPlugin} stamps as the message is routed — for the pinned address the
+     * plugin reads the partition out of the address itself, so the same filter serves both. A
+     * message therefore reaches exactly one partition per consumer group, which is the Event Hubs
+     * guarantee: every consumer group sees the whole stream, each event in one partition of it.
      */
-    private void appendAzureAddressing(XmlBuilder addresses, XmlBuilder diverts,
-                                       String hostname, String namespace, String entity,
-                                       List<String> consumerGroups) {
-        String host = hostname.toLowerCase(java.util.Locale.US);
-        for (String scheme : List.of("amqp", "amqps")) {
-            String entityAddr = scheme + "://" + host + "/" + entity;
-
-            // Non-durable queue so the sender link can attach; the exclusive diverts below take
-            // every message before it reaches this queue.
-            addresses.startAttr("address", "name", entityAddr)
-                       .start("anycast")
-                         .startAttr("queue", "name", entityAddr)
-                           .elem("durable", false)
-                         .end("queue")
-                       .end("anycast")
-                     .end("address");
-
-        }
-        // Routing out of this address belongs to appendPartitionTopology: every message goes to
-        // one partition queue per consumer group. Diverting here as well would deliver each
-        // message twice — once to a partition and once to the unpartitioned consumer-group queue.
-    }
-
-    /**
-     * Appends the partitioned consumer topology: one durable queue per (consumer group, partition)
-     * at the address SDKs attach their receiver to,
-     * {@code {scheme}://{host}/{entity}/ConsumerGroups/{group}/Partitions/{n}}.
-     *
-     * Each partition is fed by its own divert from the entity address, filtered on the partition
-     * property that {@code EventHubPartitionPlugin} stamps as the message is routed. A message
-     * therefore reaches exactly one partition per consumer group, which is the Event Hubs
-     * guarantee — every consumer group sees the whole stream, each event in one partition of it.
-     */
-    private void appendPartitionTopology(XmlBuilder addresses, XmlBuilder diverts,
-                                         String hostname, String entity,
+    private void appendPartitionTopology(XmlBuilder addresses, XmlBuilder diverts, String entity,
                                          List<String> consumerGroups, int partitionCount) {
-        String host = hostname.toLowerCase(java.util.Locale.US);
-        for (String scheme : List.of("amqp", "amqps")) {
-            String entityAddr = scheme + "://" + host + "/" + entity;
-            for (String cg : consumerGroups) {
-                for (int partition = 0; partition < partitionCount; partition++) {
-                    String partitionAddr = entityAddr + "/ConsumerGroups/" + cg + "/Partitions/" + partition;
-                    String divertName = (scheme + "-" + host + "-" + entity + "-" + cg + "-p" + partition)
-                            .replaceAll("[^A-Za-z0-9_-]", "-");
+        appendSenderAddress(addresses, entity);
+        for (int partition = 0; partition < partitionCount; partition++) {
+            appendSenderAddress(addresses, partitionSenderAddress(entity, partition));
+        }
 
-                    addresses.startAttr("address", "name", partitionAddr)
-                               .start("anycast")
-                                 .startAttr("queue", "name", partitionAddr)
-                                   .elem("durable", true)
-                                 .end("queue")
-                               .end("anycast")
-                             .end("address");
+        for (String cg : consumerGroups) {
+            for (int partition = 0; partition < partitionCount; partition++) {
+                String partitionAddr =
+                        entity + "/ConsumerGroups/" + cg + "/Partitions/" + partition;
 
-                    diverts.startAttr("divert", "name", divertName)
-                             .elem("address", entityAddr)
+                addresses.startAttr("address", "name", partitionAddr)
+                           .start("anycast")
+                             .startAttr("queue", "name", partitionAddr)
+                               .elem("durable", true)
+                             .end("queue")
+                           .end("anycast")
+                         .end("address");
+
+                // One divert per sender address: from the hub, and from the pinned-partition
+                // address for this partition. Both are exclusive, so a routed message does not
+                // also stay in the sender address's own queue — that queue exists only so the
+                // sender link has something to attach to, nothing consumes it, and a copy left
+                // there would never be drained. Each consumer group still gets its own copy,
+                // because it has its own divert and only the matching partition's filter passes.
+                for (String senderAddr :
+                        List.of(entity, partitionSenderAddress(entity, partition))) {
+                    diverts.startAttr("divert", "name",
+                                      divertName(senderAddr, cg, "p" + partition))
+                             .elem("address", senderAddr)
                              .elem("forwarding-address", partitionAddr)
                              .selfClose("filter", "string",
                                      PARTITION_PROPERTY + " = '" + partition + "'")
-                             // Exclusive, so a routed message does not also stay in the entity
-                             // address's own queue. That queue exists only so the sender link can
-                             // attach; nothing consumes it, so a copy left there is never drained.
-                             // Each consumer group still gets its own copy — one divert per
-                             // (group, partition), and only the matching partition's filter passes.
                              .elem("exclusive", true)
                            .end("divert");
                 }
             }
         }
+    }
+
+    /** The address the Java SDK sends to when the caller pins a partition. */
+    static String partitionSenderAddress(String entity, int partition) {
+        return entity + "/Partitions/" + partition;
+    }
+
+    /**
+     * Appends an address a producer attaches to.
+     *
+     * Its queue is non-durable and nothing consumes it: the exclusive partition diverts take every
+     * message before it arrives, and the queue exists only so the sender link has something to
+     * attach to.
+     */
+    private void appendSenderAddress(XmlBuilder addresses, String entityAddr) {
+        addresses.startAttr("address", "name", entityAddr)
+                   .start("anycast")
+                     .startAttr("queue", "name", entityAddr)
+                       .elem("durable", false)
+                     .end("queue")
+                   .end("anycast")
+                 .end("address");
     }
 
     /**

--- a/src/main/java/io/floci/az/services/eventhub/ArtemisConfigGenerator.java
+++ b/src/main/java/io/floci/az/services/eventhub/ArtemisConfigGenerator.java
@@ -34,6 +34,8 @@ public class ArtemisConfigGenerator {
     static final String PARTITION_PROPERTY = "floci_partition";
     private static final String CBS_ADDRESS = "$cbs";
     private static final String CBS_INTERCEPT_ADDRESS = "$cbs-intercept";
+    private static final String MANAGEMENT_ADDRESS = "$management";
+    private static final String MANAGEMENT_INTERCEPT_ADDRESS = "$management-intercept";
 
     private final EmulatorConfig config;
 
@@ -182,6 +184,14 @@ public class ArtemisConfigGenerator {
                       .selfClose("queue", "name", CBS_INTERCEPT_ADDRESS)
                     .end("anycast")
                   .end("address")
+                  .startAttr("address", "name", MANAGEMENT_ADDRESS)
+                    .selfClose("multicast")
+                  .end("address")
+                  .startAttr("address", "name", MANAGEMENT_INTERCEPT_ADDRESS)
+                    .start("anycast")
+                      .selfClose("queue", "name", MANAGEMENT_INTERCEPT_ADDRESS)
+                    .end("anycast")
+                  .end("address")
                 .end("addresses");
 
         // The CBS divert is unconditional: every Azure SDK puts a token on $cbs before
@@ -194,6 +204,14 @@ public class ArtemisConfigGenerator {
                .elem("address", CBS_ADDRESS)
                .elem("forwarding-address", CBS_INTERCEPT_ADDRESS)
                .selfClose("filter", "string", "operation = 'put-token'")
+               .elem("exclusive", true)
+             .end("divert")
+             // Requests only. Without the filter the responder's own replies, which go back on
+             // $management, would divert straight back to it in a loop.
+             .startAttr("divert", "name", "management-request-intercept")
+               .elem("address", MANAGEMENT_ADDRESS)
+               .elem("forwarding-address", MANAGEMENT_INTERCEPT_ADDRESS)
+               .selfClose("filter", "string", "operation = 'READ'")
                .elem("exclusive", true)
              .end("divert")
            .end("diverts");

--- a/src/main/java/io/floci/az/services/eventhub/ArtemisConfigGenerator.java
+++ b/src/main/java/io/floci/az/services/eventhub/ArtemisConfigGenerator.java
@@ -26,6 +26,12 @@ import java.util.Map;
 public class ArtemisConfigGenerator {
 
     private static final String DEFAULT_CONSUMER_GROUP = "$Default";
+    /** A hub configured without an explicit count is one undivided stream. */
+    static final int DEFAULT_PARTITION_COUNT = 1;
+    /** Azure's own per-hub limit outside dedicated clusters. */
+    static final int MAX_PARTITION_COUNT = 32;
+    /** Message property carrying the assigned partition; set by the broker plugin, filtered on here. */
+    static final String PARTITION_PROPERTY = "floci_partition";
     private static final String CBS_ADDRESS = "$cbs";
     private static final String CBS_INTERCEPT_ADDRESS = "$cbs-intercept";
 
@@ -37,25 +43,34 @@ public class ArtemisConfigGenerator {
     }
 
     /** Returns broker.xml for the given namespace and entities (used for dynamic namespace creation). */
-    public String generate(String namespace, Map<String, List<String>> entities) {
+    public String generate(String namespace, Map<String, EntitySpec> entities) {
         String containerName = "floci-az-artemis-" + namespace;
         List<String> hostnames = List.of("localhost", containerName);
 
         XmlBuilder addresses = new XmlBuilder();
         XmlBuilder diverts = new XmlBuilder();
+        // Passed to the partition plugin so it knows how many partitions each hub has.
+        StringBuilder partitionSpec = new StringBuilder();
 
-        for (Map.Entry<String, List<String>> entry : entities.entrySet()) {
+        for (Map.Entry<String, EntitySpec> entry : entities.entrySet()) {
             String entityName = entry.getKey();
-            List<String> cgs = entry.getValue();
+            List<String> cgs = entry.getValue().consumerGroups();
+            int partitions = entry.getValue().partitionCount();
+
+            if (!partitionSpec.isEmpty()) {
+                partitionSpec.append(',');
+            }
+            partitionSpec.append(entityName).append(':').append(partitions);
 
             appendMulticastAddress(addresses, namespace + "/" + entityName, cgs);
 
             for (String hostname : hostnames) {
                 appendAnycastTopology(addresses, diverts, hostname, namespace, entityName, cgs);
                 appendAzureAddressing(addresses, diverts, hostname, namespace, entityName, cgs);
+                appendPartitionTopology(addresses, diverts, hostname, entityName, cgs, partitions);
             }
         }
-        return buildBrokerXml(addresses, diverts);
+        return buildBrokerXml(addresses, diverts, partitionSpec.toString());
     }
 
     /** Returns broker.xml using the default namespace/entities from config. */
@@ -64,29 +79,64 @@ public class ArtemisConfigGenerator {
         return generate(eh.defaultNamespace(), parseEntities(eh.entities(), eh.consumerGroups()));
     }
 
+    /** An event hub's partition count and its consumer groups. */
+    public record EntitySpec(int partitionCount, List<String> consumerGroups) {}
+
     /**
-     * Parses "eh1:4,eh2:2" and a consumer groups string into entityName → consumer group list.
-     * The partition count in the entities string is accepted but ignored (Artemis handles routing).
+     * Parses "eh1:4,eh2:2" and a consumer groups string into entityName → {@link EntitySpec}.
+     *
+     * A hub named without a count gets {@link #DEFAULT_PARTITION_COUNT}, which keeps the single
+     * undivided stream this emulated before partitions existed. The count is now load-bearing —
+     * it decides how many queues and diverts each consumer group gets — so it is validated rather
+     * than ignored: it must be a positive number, and no larger than {@link #MAX_PARTITION_COUNT},
+     * the limit Azure applies outside dedicated clusters. Each partition costs a durable queue per
+     * consumer group, so an unbounded count multiplies quietly into thousands of queues.
      */
-    public static Map<String, List<String>> parseEntities(String entitiesStr, String consumerGroupsStr) {
-        Map<String, List<String>> result = new LinkedHashMap<>();
+    public static Map<String, EntitySpec> parseEntities(String entitiesStr, String consumerGroupsStr) {
+        Map<String, EntitySpec> result = new LinkedHashMap<>();
         List<String> groups = parseConsumerGroups(consumerGroupsStr);
         if (entitiesStr == null || entitiesStr.isBlank()) {
-            result.put("eh1", groups);
+            result.put("eh1", new EntitySpec(DEFAULT_PARTITION_COUNT, groups));
             return result;
         }
         for (String token : entitiesStr.split(",")) {
             token = token.trim();
             if (token.isEmpty()) continue;
-            String name = token.split(":")[0].trim();
-            result.put(name, groups);
+            String[] parts = token.split(":", 2);
+            String name = parts[0].trim();
+            if (name.isEmpty()) continue;
+            result.put(name, new EntitySpec(parsePartitionCount(name, parts), groups));
         }
         return result;
     }
 
+    private static int parsePartitionCount(String entityName, String[] parts) {
+        if (parts.length < 2 || parts[1].isBlank()) {
+            return DEFAULT_PARTITION_COUNT;
+        }
+        String raw = parts[1].trim();
+        int count;
+        try {
+            count = Integer.parseInt(raw);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                    "Event hub '" + entityName + "': partition count '" + raw + "' is not a number");
+        }
+        if (count < 1) {
+            throw new IllegalArgumentException(
+                    "Event hub '" + entityName + "': partition count must be at least 1, got " + count);
+        }
+        if (count > MAX_PARTITION_COUNT) {
+            throw new IllegalArgumentException(
+                    "Event hub '" + entityName + "': partition count " + count + " exceeds the maximum of "
+                    + MAX_PARTITION_COUNT);
+        }
+        return count;
+    }
+
     // ── Private helpers ──────────────────────────────────────────────────────
 
-    private String buildBrokerXml(XmlBuilder addresses, XmlBuilder diverts) {
+    private String buildBrokerXml(XmlBuilder addresses, XmlBuilder diverts, String partitionSpec) {
         XmlBuilder xml = new XmlBuilder()
             .start("configuration", "urn:activemq")
               .start("core", "urn:activemq:core")
@@ -108,6 +158,12 @@ public class ArtemisConfigGenerator {
                   .end("acceptor")
                 .end("acceptors")
                 .elem("security-enabled", false)
+                .start("broker-plugins")
+                  .startAttr("broker-plugin", "class-name",
+                          "io.floci.az.artemis.EventHubPartitionPlugin")
+                    .selfClose("property", "key", "entities", "value", partitionSpec)
+                  .end("broker-plugin")
+                .end("broker-plugins")
                 .start("address-settings")
                   .startAttr("address-setting", "match", "#")
                     .elem("auto-create-queues", true)
@@ -229,15 +285,55 @@ public class ArtemisConfigGenerator {
                        .end("anycast")
                      .end("address");
 
-            for (String cg : consumerGroups) {
-                String targetCgAddr = "amqp://" + host + "/" + namespace + "/" + entity + "/" + cg;
-                String divertName = divertName(scheme, host, entity, "to", cg);
+        }
+        // Routing out of this address belongs to appendPartitionTopology: every message goes to
+        // one partition queue per consumer group. Diverting here as well would deliver each
+        // message twice — once to a partition and once to the unpartitioned consumer-group queue.
+    }
 
-                diverts.startAttr("divert", "name", divertName)
-                         .elem("address", entityAddr)
-                         .elem("forwarding-address", targetCgAddr)
-                         .elem("exclusive", true)
-                       .end("divert");
+    /**
+     * Appends the partitioned consumer topology: one durable queue per (consumer group, partition)
+     * at the address SDKs attach their receiver to,
+     * {@code {scheme}://{host}/{entity}/ConsumerGroups/{group}/Partitions/{n}}.
+     *
+     * Each partition is fed by its own divert from the entity address, filtered on the partition
+     * property that {@code EventHubPartitionPlugin} stamps as the message is routed. A message
+     * therefore reaches exactly one partition per consumer group, which is the Event Hubs
+     * guarantee — every consumer group sees the whole stream, each event in one partition of it.
+     */
+    private void appendPartitionTopology(XmlBuilder addresses, XmlBuilder diverts,
+                                         String hostname, String entity,
+                                         List<String> consumerGroups, int partitionCount) {
+        String host = hostname.toLowerCase(java.util.Locale.US);
+        for (String scheme : List.of("amqp", "amqps")) {
+            String entityAddr = scheme + "://" + host + "/" + entity;
+            for (String cg : consumerGroups) {
+                for (int partition = 0; partition < partitionCount; partition++) {
+                    String partitionAddr = entityAddr + "/ConsumerGroups/" + cg + "/Partitions/" + partition;
+                    String divertName = (scheme + "-" + host + "-" + entity + "-" + cg + "-p" + partition)
+                            .replaceAll("[^A-Za-z0-9_-]", "-");
+
+                    addresses.startAttr("address", "name", partitionAddr)
+                               .start("anycast")
+                                 .startAttr("queue", "name", partitionAddr)
+                                   .elem("durable", true)
+                                 .end("queue")
+                               .end("anycast")
+                             .end("address");
+
+                    diverts.startAttr("divert", "name", divertName)
+                             .elem("address", entityAddr)
+                             .elem("forwarding-address", partitionAddr)
+                             .selfClose("filter", "string",
+                                     PARTITION_PROPERTY + " = '" + partition + "'")
+                             // Exclusive, so a routed message does not also stay in the entity
+                             // address's own queue. That queue exists only so the sender link can
+                             // attach; nothing consumes it, so a copy left there is never drained.
+                             // Each consumer group still gets its own copy — one divert per
+                             // (group, partition), and only the matching partition's filter passes.
+                             .elem("exclusive", true)
+                           .end("divert");
+                }
             }
         }
     }

--- a/src/main/java/io/floci/az/services/eventhub/EventHubHandler.java
+++ b/src/main/java/io/floci/az/services/eventhub/EventHubHandler.java
@@ -190,7 +190,7 @@ public class EventHubHandler implements AzureServiceHandler, Resettable {
             LOG.debugv("Could not parse namespace creation body: {0}", e.getMessage());
         }
 
-        Map<String, List<String>> entities = ArtemisConfigGenerator.parseEntities(entitiesStr, consumerGroupsStr);
+        Map<String, ArtemisConfigGenerator.EntitySpec> entities = ArtemisConfigGenerator.parseEntities(entitiesStr, consumerGroupsStr);
 
         if (eh.mocked()) {
             EventHubNamespaceManager.NamespaceState state = namespaceManager.registerMockedNamespace(namespaceName);

--- a/src/main/java/io/floci/az/services/eventhub/EventHubManagementResponder.java
+++ b/src/main/java/io/floci/az/services/eventhub/EventHubManagementResponder.java
@@ -1,0 +1,239 @@
+package io.floci.az.services.eventhub;
+
+import org.apache.qpid.proton.Proton;
+import org.apache.qpid.proton.amqp.messaging.Accepted;
+import org.apache.qpid.proton.amqp.messaging.AmqpValue;
+import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
+import org.apache.qpid.proton.amqp.messaging.Source;
+import org.apache.qpid.proton.amqp.messaging.Target;
+import org.apache.qpid.proton.engine.BaseHandler;
+import org.apache.qpid.proton.engine.Connection;
+import org.apache.qpid.proton.engine.Delivery;
+import org.apache.qpid.proton.engine.Event;
+import org.apache.qpid.proton.engine.Receiver;
+import org.apache.qpid.proton.engine.Sender;
+import org.apache.qpid.proton.engine.Session;
+import org.apache.qpid.proton.message.Message;
+import org.apache.qpid.proton.reactor.Reactor;
+import org.jboss.logging.Logger;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Daemon thread that answers the AMQP {@code $management} READ operations for a namespace.
+ *
+ * <p>Every Event Hubs consumer starts by asking the management node which partitions the hub has,
+ * and attaches its receiver per partition. Artemis has no notion of either, so nothing replies and
+ * the SDK fails before it reads anything. This answers from the namespace's own configuration,
+ * which is where the partition count already lives.
+ *
+ * <p>Built the same way as the CBS responder: the broker.xml divert routes requests to an intercept
+ * queue this attaches to, and the reply goes back on {@code $management}, which is both the address
+ * SDKs send to and the one they receive on.
+ */
+public class EventHubManagementResponder {
+
+    private static final Logger LOG = Logger.getLogger(EventHubManagementResponder.class);
+    private static final String MANAGEMENT_ADDRESS = "$management";
+    private static final String MANAGEMENT_INTERCEPT_ADDRESS = "$management-intercept";
+    private static final long RECONNECT_BACKOFF_MS = 2_000;
+
+    /** The entity type the SDKs name when asking about a hub. */
+    private static final String EVENTHUB_ENTITY_TYPE = "com.microsoft:eventhub";
+
+    private final String host;
+    private final int port;
+    private final Map<String, ArtemisConfigGenerator.EntitySpec> entities;
+    private final Date createdAt = new Date();
+
+    private volatile boolean running;
+    private volatile Reactor currentReactor;
+    private Thread thread;
+
+    public EventHubManagementResponder(String host, int port,
+                                       Map<String, ArtemisConfigGenerator.EntitySpec> entities) {
+        this.host = host;
+        this.port = port;
+        this.entities = Map.copyOf(entities);
+    }
+
+    public void start() {
+        running = true;
+        thread = new Thread(this::run, "eventhub-management-" + host + ":" + port);
+        thread.setDaemon(true);
+        thread.start();
+        LOG.infov("Management responder started for {0}:{1}", host, port);
+    }
+
+    public void stop() {
+        running = false;
+        Reactor r = currentReactor;
+        if (r != null) {
+            r.stop();
+        }
+        if (thread != null) {
+            thread.interrupt();
+        }
+    }
+
+    private void run() {
+        while (running) {
+            Reactor reactor = null;
+            try {
+                reactor = Proton.reactor(new ManagementHandler());
+                currentReactor = reactor;
+                reactor.run();
+            } catch (Exception e) {
+                if (running) {
+                    LOG.debugv("Management responder reconnecting ({0}:{1}): {2}",
+                            host, port, e.getMessage());
+                }
+            } finally {
+                currentReactor = null;
+                if (reactor != null) {
+                    try {
+                        reactor.free();
+                    } catch (Exception e) {
+                        LOG.debugv("Management responder failed to free reactor ({0}:{1}): {2}",
+                                host, port, e.getMessage());
+                    }
+                }
+            }
+
+            // Outside the catch, for the reason spelled out in ServiceBusCbsResponder: the reactor
+            // also returns normally when the broker is unreachable, so a backoff on the exception
+            // path alone never fires and the loop burns file descriptors recreating reactors.
+            if (running) {
+                try {
+                    Thread.sleep(RECONNECT_BACKOFF_MS);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
+        }
+    }
+
+    private class ManagementHandler extends BaseHandler {
+
+        private Sender responseSender;
+        private int deliveryTag = 0;
+
+        @Override
+        public void onReactorInit(Event event) {
+            Connection conn = event.getReactor().connectionToHost(host, port, this);
+            conn.setContainer("floci-az-management-responder");
+            conn.open();
+            Session session = conn.session();
+            session.setProperties(new HashMap<>());
+            session.open();
+
+            Receiver receiver = session.receiver("management-receiver");
+            Source src = new Source();
+            src.setAddress(MANAGEMENT_INTERCEPT_ADDRESS);
+            receiver.setSource(src);
+            receiver.open();
+            receiver.flow(100);
+
+            responseSender = session.sender("management-reply-sender");
+            Target tgt = new Target();
+            tgt.setAddress(MANAGEMENT_ADDRESS);
+            responseSender.setTarget(tgt);
+            responseSender.open();
+        }
+
+        @Override
+        public void onDelivery(Event event) {
+            Delivery delivery = event.getDelivery();
+            if (!(delivery.getLink() instanceof Receiver receiver)) return;
+            if (!delivery.isReadable() || delivery.isPartial()) return;
+
+            int pending = delivery.pending();
+            byte[] buf = new byte[pending];
+            int n = receiver.recv(buf, 0, buf.length);
+            receiver.advance();
+
+            Message request = Message.Factory.create();
+            request.decode(buf, 0, n);
+
+            Map<String, Object> props = applicationProperties(request);
+            String entityType = string(props.get("type"));
+            String name = string(props.get("name"));
+            LOG.debugv("Management request received: type={0}, name={1}", entityType, name);
+
+            sendResponse(request.getMessageId(), entityType, name);
+
+            delivery.disposition(Accepted.getInstance());
+            delivery.settle();
+            receiver.flow(1);
+        }
+
+        private void sendResponse(Object correlationId, String entityType, String name) {
+            ArtemisConfigGenerator.EntitySpec spec = name == null ? null : entities.get(name);
+
+            Message response = Message.Factory.create();
+            response.setCorrelationId(correlationId);
+            Map<String, Object> responseProps = new HashMap<>();
+
+            if (!EVENTHUB_ENTITY_TYPE.equals(entityType)) {
+                // Partition properties (com.microsoft:partition) would have to report sequence
+                // numbers and offsets, which Artemis does not keep. Saying so is better than
+                // inventing values a consumer may branch on.
+                responseProps.put("status-code", 501);
+                responseProps.put("status-description",
+                        "floci-az emulates " + EVENTHUB_ENTITY_TYPE + " only, not " + entityType);
+            } else if (spec == null) {
+                responseProps.put("status-code", 404);
+                responseProps.put("status-description", "Event hub '" + name + "' not found");
+            } else {
+                responseProps.put("status-code", 200);
+                responseProps.put("status-description", "OK");
+                response.setBody(new AmqpValue(hubProperties(name, spec)));
+            }
+
+            response.setApplicationProperties(new ApplicationProperties(responseProps));
+
+            byte[] encoded = new byte[4096];
+            int len = response.encode(encoded, 0, encoded.length);
+
+            byte[] tag = Integer.toString(deliveryTag++).getBytes(StandardCharsets.UTF_8);
+            Delivery resp = responseSender.delivery(tag);
+            responseSender.send(encoded, 0, len);
+            responseSender.advance();
+            resp.settle();
+        }
+
+        /**
+         * The attributes the SDKs read back. Every one is required — a missing field fails the
+         * call outright rather than degrading.
+         *
+         * <p>{@code partition_ids} is a Java array so it encodes as an AMQP array; a List would
+         * encode as an AMQP list, which the SDKs reject.
+         */
+        private Map<String, Object> hubProperties(String name, ArtemisConfigGenerator.EntitySpec spec) {
+            String[] partitionIds = new String[spec.partitionCount()];
+            for (int i = 0; i < partitionIds.length; i++) {
+                partitionIds[i] = Integer.toString(i);
+            }
+            Map<String, Object> body = new HashMap<>();
+            body.put("name", name);
+            body.put("created_at", createdAt);
+            body.put("partition_count", spec.partitionCount());
+            body.put("partition_ids", partitionIds);
+            return body;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> applicationProperties(Message message) {
+        ApplicationProperties props = message.getApplicationProperties();
+        return props == null ? Map.of() : (Map<String, Object>) props.getValue();
+    }
+
+    private static String string(Object value) {
+        return value == null ? null : value.toString();
+    }
+}

--- a/src/main/java/io/floci/az/services/eventhub/EventHubNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/eventhub/EventHubNamespaceManager.java
@@ -65,6 +65,8 @@ public class EventHubNamespaceManager {
 
     private final ConcurrentHashMap<String, NamespaceState> namespaces = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, ServiceBusCbsResponder> cbsResponders = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, EventHubManagementResponder> managementResponders =
+            new ConcurrentHashMap<>();
 
     private final EmulatorConfig config;
     private final ContainerBuilder containerBuilder;
@@ -163,6 +165,12 @@ public class EventHubNamespaceManager {
         cbs.start();
         cbsResponders.put(namespaceName, cbs);
 
+        // Answers the $management READ every consumer issues before it can attach per partition.
+        EventHubManagementResponder management =
+                new EventHubManagementResponder(amqpEndpoint.host(), amqpEndpoint.port(), entities);
+        management.start();
+        managementResponders.put(namespaceName, management);
+
         // Topology is pre-configured in broker.xml; Jolokia setup runs in background
         // to handle any dynamic additions (e.g. consumer groups created after startup).
         EndpointInfo jolokiaEndpoint = info.getEndpoint(JOLOKIA_PORT);
@@ -204,6 +212,10 @@ public class EventHubNamespaceManager {
         ServiceBusCbsResponder cbs = cbsResponders.remove(namespaceName);
         if (cbs != null) {
             cbs.stop();
+        }
+        EventHubManagementResponder management = managementResponders.remove(namespaceName);
+        if (management != null) {
+            management.stop();
         }
         if (!state.mocked() && state.containerId() != null) {
             lifecycleManager.stopAndRemove(state.containerId(), null);

--- a/src/main/java/io/floci/az/services/eventhub/EventHubNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/eventhub/EventHubNamespaceManager.java
@@ -104,7 +104,6 @@ public class EventHubNamespaceManager {
             return existing;
         }
         String containerName = containerName(namespaceName);
-        List<String> amqpHostnames = List.of("localhost", containerName);
 
         LOG.infov("Starting Artemis broker for Event Hubs namespace ''{0}'' (plain:{1}, TLS:{2})",
                 namespaceName, amqpHostPort == 0 ? "dynamic" : amqpHostPort,
@@ -171,13 +170,12 @@ public class EventHubNamespaceManager {
         management.start();
         managementResponders.put(namespaceName, management);
 
-        // Topology is pre-configured in broker.xml; Jolokia setup runs in background
-        // to handle any dynamic additions (e.g. consumer groups created after startup).
-        EndpointInfo jolokiaEndpoint = info.getEndpoint(JOLOKIA_PORT);
-        Thread.ofVirtual().name("jolokia-setup-" + namespaceName).start(() -> {
-            waitForJolokia(jolokiaEndpoint);
-            setupAmqpTopology(jolokiaEndpoint, namespaceName, entities, amqpHostnames);
-        });
+        // The topology is declared in broker.xml, written above and read as the broker starts.
+        // It used to be rebuilt over Jolokia as well, addressed per host; the AMQP layer now
+        // reduces every spelling to the entity path, so that second copy addressed nothing the
+        // broker would ever route to — and while the two copies still overlapped, any drift
+        // between how they named a divert installed a duplicate over the same route and delivered
+        // every message twice.
 
         NamespaceState state = new NamespaceState(
                 containerId, amqpEndpoint.port(), amqpsEndpoint.port(), tls.certPem(), false);
@@ -247,123 +245,6 @@ public class EventHubNamespaceManager {
 
     String containerName(String namespaceName) {
         return ContainerStorageHelper.dockerName(config, "artemis-" + namespaceName);
-    }
-
-    private void waitForJolokia(EndpointInfo endpoint) {
-        String url = "http://" + endpoint + "/console/jolokia";
-        String auth = Base64.getEncoder().encodeToString(
-                "artemis:artemis".getBytes(StandardCharsets.UTF_8));
-        long deadline = System.currentTimeMillis() + 120_000;
-        while (System.currentTimeMillis() < deadline) {
-            try {
-                HttpClient client = HttpClient.newHttpClient();
-                HttpRequest req = HttpRequest.newBuilder()
-                        .uri(URI.create(url))
-                        .timeout(Duration.ofSeconds(3))
-                        .header("Authorization", "Basic " + auth)
-                        .GET().build();
-                HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
-                if (resp.statusCode() == 200) {
-                    LOG.debugv("Artemis Jolokia ready at {0}", url);
-                    return;
-                }
-            } catch (Exception ignored) {
-            }
-            try {
-                Thread.sleep(500);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                return;
-            }
-        }
-        LOG.warnv("Artemis Jolokia did not become ready at {0} within 120s; topology setup skipped", url);
-    }
-
-    /**
-     * Creates ANYCAST addresses, durable queues, and exclusive diverts via the Artemis Jolokia API.
-     * Sender targets entity address; exclusive diverts fan out to each consumer group's durable queue.
-     */
-    private void setupAmqpTopology(EndpointInfo jolokia, String namespace,
-                                    Map<String, ArtemisConfigGenerator.EntitySpec> entities, List<String> hostnames) {
-        String baseUrl = "http://" + jolokia + "/console/jolokia";
-        String auth = Base64.getEncoder().encodeToString(
-                "artemis:artemis".getBytes(StandardCharsets.UTF_8));
-        String mbean = "org.apache.activemq.artemis:broker=\\\"floci-az-eventhubs\\\"";
-        HttpClient http = HttpClient.newHttpClient();
-
-        for (String hostname : hostnames) {
-            for (Map.Entry<String, ArtemisConfigGenerator.EntitySpec> entry : entities.entrySet()) {
-                String entityName = entry.getKey();
-                // Address and divert name both have to match what ArtemisConfigGenerator wrote
-                // into broker.xml. The diverts are exclusive, so where the two disagree the broker
-                // holds two of them over one route and delivers every message twice.
-                String entityAddr =
-                        ArtemisConfigGenerator.anycastEntityAddress(hostname, namespace, entityName);
-
-                jolokiaExec(http, baseUrl, auth, mbean,
-                        "createAddress(java.lang.String,java.lang.String)",
-                        jsonArr(entityAddr, "ANYCAST"));
-
-                for (String cg : entry.getValue().consumerGroups()) {
-                    String cgAddr = entityAddr + "/" + cg;
-                    String divertName =
-                            ArtemisConfigGenerator.anycastDivertName(hostname, entityName, cg);
-
-                    jolokiaExec(http, baseUrl, auth, mbean,
-                            "createAddress(java.lang.String,java.lang.String)",
-                            jsonArr(cgAddr, "ANYCAST"));
-
-                    jolokiaExec(http, baseUrl, auth, mbean,
-                            "createQueue(java.lang.String,java.lang.String,java.lang.String,java.lang.String,boolean,int,boolean,boolean)",
-                            jsonArr(cgAddr, "ANYCAST", cgAddr, "", true, -1, false, false));
-
-                    jolokiaExec(http, baseUrl, auth, mbean,
-                            "createDivert(java.lang.String,java.lang.String,java.lang.String,java.lang.String,boolean,java.lang.String,java.lang.String)",
-                            jsonArr(divertName, divertName, entityAddr, cgAddr, true, "", ""));
-                }
-            }
-        }
-        LOG.infov("AMQP topology configured for namespace ''{0}'': {1} entities × {2} hostnames",
-                namespace, entities.size(), hostnames.size());
-    }
-
-    private void jolokiaExec(HttpClient http, String baseUrl, String auth,
-                              String mbean, String operation, String arguments) {
-        String body = "{\"type\":\"exec\",\"mbean\":\"" + mbean + "\","
-                + "\"operation\":\"" + operation + "\","
-                + "\"arguments\":" + arguments + "}";
-        try {
-            HttpRequest req = HttpRequest.newBuilder()
-                    .uri(URI.create(baseUrl))
-                    .timeout(Duration.ofSeconds(10))
-                    .header("Content-Type", "application/json")
-                    .header("Authorization", "Basic " + auth)
-                    .POST(HttpRequest.BodyPublishers.ofString(body))
-                    .build();
-            HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString());
-            if (resp.statusCode() != 200) {
-                String err = resp.body();
-                if (!err.contains("already exists") && !err.contains("already been deployed")) {
-                    LOG.debugv("Jolokia {0}: status={1}", operation.split("\\(")[0], resp.statusCode());
-                }
-            }
-        } catch (Exception e) {
-            LOG.debugv("Jolokia call failed ({0}): {1}", operation.split("\\(")[0], e.getMessage());
-        }
-    }
-
-    private static String jsonArr(Object... values) {
-        StringBuilder sb = new StringBuilder("[");
-        for (int i = 0; i < values.length; i++) {
-            if (i > 0) sb.append(",");
-            Object v = values[i];
-            if (v instanceof String s) {
-                sb.append("\"").append(s.replace("\\", "\\\\").replace("\"", "\\\"")).append("\"");
-            } else {
-                sb.append(v);
-            }
-        }
-        return sb.append("]").toString();
     }
 
     private void waitForPort(EndpointInfo endpoint, String label) {

--- a/src/main/java/io/floci/az/services/eventhub/EventHubNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/eventhub/EventHubNamespaceManager.java
@@ -59,6 +59,9 @@ public class EventHubNamespaceManager {
     private static final String PROTON_J_PATH = "/opt/activemq-artemis/lib/proton-j-0.34.1.jar";
     private static final String ARTEMIS_AMQP_PATH =
             "/opt/activemq-artemis/lib/artemis-amqp-protocol-2.44.0.jar";
+    static final String ARTEMIS_EXTENSION_RESOURCE = "/artemis/servicebus-artemis-extension.jar";
+    private static final String ARTEMIS_EXTENSION_PATH =
+            "/var/lib/artemis-instance/lib/floci-az-artemis-extension.jar";
 
     private final ConcurrentHashMap<String, NamespaceState> namespaces = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, ServiceBusCbsResponder> cbsResponders = new ConcurrentHashMap<>();
@@ -87,7 +90,7 @@ public class EventHubNamespaceManager {
      * Host ports of {@code 0} mean "allocate dynamically".
      */
     public synchronized NamespaceState startNamespace(String namespaceName,
-                                          Map<String, List<String>> entities,
+                                          Map<String, ArtemisConfigGenerator.EntitySpec> entities,
                                           int amqpHostPort, int amqpsHostPort) {
         // Synchronized, and re-checking inside the lock, as the Service Bus manager does:
         // the handler's own existence check is not atomic with this call, so two
@@ -141,6 +144,10 @@ public class EventHubNamespaceManager {
                 PROTON_J_PATH);
         lifecycleManager.copyBytesToContainer(containerId, loadResource(ARTEMIS_AMQP_PATCH_RESOURCE),
                 ARTEMIS_AMQP_PATH);
+        // Carries EventHubPartitionPlugin, which stamps the partition each message belongs to;
+        // the generated partition diverts filter on what it sets.
+        lifecycleManager.copyBytesToContainer(containerId, loadResource(ARTEMIS_EXTENSION_RESOURCE),
+                ARTEMIS_EXTENSION_PATH);
 
         ContainerLifecycleManager.ContainerInfo info = lifecycleManager.startCreated(containerId, spec);
 
@@ -265,7 +272,7 @@ public class EventHubNamespaceManager {
      * Sender targets entity address; exclusive diverts fan out to each consumer group's durable queue.
      */
     private void setupAmqpTopology(EndpointInfo jolokia, String namespace,
-                                    Map<String, List<String>> entities, List<String> hostnames) {
+                                    Map<String, ArtemisConfigGenerator.EntitySpec> entities, List<String> hostnames) {
         String baseUrl = "http://" + jolokia + "/console/jolokia";
         String auth = Base64.getEncoder().encodeToString(
                 "artemis:artemis".getBytes(StandardCharsets.UTF_8));
@@ -273,7 +280,7 @@ public class EventHubNamespaceManager {
         HttpClient http = HttpClient.newHttpClient();
 
         for (String hostname : hostnames) {
-            for (Map.Entry<String, List<String>> entry : entities.entrySet()) {
+            for (Map.Entry<String, ArtemisConfigGenerator.EntitySpec> entry : entities.entrySet()) {
                 String entityName = entry.getKey();
                 // Address and divert name both have to match what ArtemisConfigGenerator wrote
                 // into broker.xml. The diverts are exclusive, so where the two disagree the broker
@@ -285,7 +292,7 @@ public class EventHubNamespaceManager {
                         "createAddress(java.lang.String,java.lang.String)",
                         jsonArr(entityAddr, "ANYCAST"));
 
-                for (String cg : entry.getValue()) {
+                for (String cg : entry.getValue().consumerGroups()) {
                     String cgAddr = entityAddr + "/" + cg;
                     String divertName =
                             ArtemisConfigGenerator.anycastDivertName(hostname, entityName, cg);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -140,11 +140,9 @@ floci-az:
       enabled: true
     event-hub:
       enabled: true
-      # Deliberately mocked: the Artemis sidecar starts fine, but the AMQP data plane does not yet
-      # work with the Azure SDKs (EventHubCompatibilityTest: 6/6 fail with "Connection reset").
-      # Do NOT flip this to false until that is fixed -- the compat suite self-skips on this flag,
-      # so flipping it turns a silent skip into 6 hard failures. See local/full-parity.md (C1).
-      mocked: true
+      # Real Artemis, not a mock: the AMQP data plane now works with the Azure SDKs, so both compat
+      # suites run for real against it rather than self-skipping on this flag.
+      mocked: false
       default-namespace: emulatorNs1
       entities: "eh1:4"
       amqp-port: 5672

--- a/src/test/java/io/floci/az/services/eventhub/ArtemisConfigGeneratorTest.java
+++ b/src/test/java/io/floci/az/services/eventhub/ArtemisConfigGeneratorTest.java
@@ -1,5 +1,6 @@
 package io.floci.az.services.eventhub;
 
+import io.floci.az.services.eventhub.ArtemisConfigGenerator.EntitySpec;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -16,15 +17,19 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ArtemisConfigGeneratorTest {
 
     private static final Pattern DIVERT_NAME = Pattern.compile("<divert name=\"([^\"]+)\"");
+    private static final Pattern ADDRESS_NAME = Pattern.compile("<address name=\"([^\"]+)\"");
 
-    private static List<String> divertNames(String namespace, Map<String, List<String>> entities) {
-        String brokerXml = new ArtemisConfigGenerator(null).generate(namespace, entities);
-        List<String> names = new ArrayList<>();
-        Matcher matcher = DIVERT_NAME.matcher(brokerXml);
+    private static String brokerXml(String namespace, Map<String, EntitySpec> entities) {
+        return new ArtemisConfigGenerator(null).generate(namespace, entities);
+    }
+
+    private static List<String> matches(Pattern pattern, String xml) {
+        List<String> found = new ArrayList<>();
+        Matcher matcher = pattern.matcher(xml);
         while (matcher.find()) {
-            names.add(matcher.group(1));
+            found.add(matcher.group(1));
         }
-        return names;
+        return found;
     }
 
     private static void assertAllDistinct(List<String> names) {
@@ -39,9 +44,9 @@ class ArtemisConfigGeneratorTest {
      */
     @Test
     void hubNamesThatSanitizeAlikeKeepDistinctDivertNames() {
-        assertAllDistinct(divertNames("ns", Map.of(
-                "eh.1", List.of("$Default"),
-                "eh-1", List.of("$Default"))));
+        assertAllDistinct(matches(DIVERT_NAME, brokerXml("ns", Map.of(
+                "eh.1", new EntitySpec(2, List.of("$Default")),
+                "eh-1", new EntitySpec(2, List.of("$Default"))))));
     }
 
     /**
@@ -50,36 +55,52 @@ class ArtemisConfigGeneratorTest {
      */
     @Test
     void namesThatJoinToTheSameStringKeepDistinctDivertNames() {
-        assertAllDistinct(divertNames("ns", Map.of(
-                "a-to-b", List.of("c"),
-                "a", List.of("b-to-c"))));
+        assertAllDistinct(matches(DIVERT_NAME, brokerXml("ns", Map.of(
+                "a-to-b", new EntitySpec(1, List.of("c")),
+                "a", new EntitySpec(1, List.of("b-to-c"))))));
     }
 
     /**
-     * EventHubNamespaceManager rebuilds this same topology over Jolokia, naming it through
-     * {@code anycastEntityAddress} and {@code anycastDivertName}. If the generator ever spells
-     * either one itself again the two drift apart, and because the diverts are exclusive the
-     * broker holds two of them over one route — which does not fail, it just delivers every
-     * message twice.
+     * One topology per hub, not one per spelling of its address.
+     *
+     * The AMQP layer reduces every address a client can send to down to the entity path, so the
+     * partition queues hang off that path alone. Generating a copy per host and scheme gave each
+     * spelling its own private hub: a producer on one and a consumer on another read and wrote
+     * different queues, while the management node reported a single hub either way.
      */
     @Test
-    void anycastDivertsAreNamedThroughTheSharedHelpers() {
-        String brokerXml = new ArtemisConfigGenerator(null)
-                .generate("ns", Map.of("eh1", List.of("$Default")));
+    void partitionQueuesExistOncePerHubNotOncePerAddressSpelling() {
+        List<String> partitionZero = matches(ADDRESS_NAME, brokerXml("ns",
+                Map.of("eh1", new EntitySpec(4, List.of("$Default", "other")))))
+                .stream().filter(a -> a.endsWith("/Partitions/0") && a.contains("ConsumerGroups"))
+                .toList();
 
-        String expected = "<divert name=\""
-                + ArtemisConfigGenerator.anycastDivertName("localhost", "eh1", "$Default")
-                + "\"><address>"
-                + ArtemisConfigGenerator.anycastEntityAddress("localhost", "ns", "eh1")
-                + "</address>";
-        assertTrue(brokerXml.contains(expected),
-                "the generator no longer names its diverts the way the namespace manager does");
+        assertEquals(List.of("eh1/ConsumerGroups/$Default/Partitions/0",
+                             "eh1/ConsumerGroups/other/Partitions/0"),
+                     partitionZero.stream().sorted().toList());
+    }
+
+    /**
+     * The Java SDK sends to a pinned partition by addressing it, so that address needs a queue to
+     * attach to. Without one it is auto-created empty and the sends are dropped in silence.
+     */
+    @Test
+    void everyPartitionHasASenderAddress() {
+        List<String> addresses =
+                matches(ADDRESS_NAME, brokerXml("ns", Map.of("eh1", new EntitySpec(3, List.of("$Default")))));
+
+        for (int partition = 0; partition < 3; partition++) {
+            String pinned = ArtemisConfigGenerator.partitionSenderAddress("eh1", partition);
+            assertTrue(addresses.contains(pinned), "no sender address for " + pinned);
+        }
     }
 
     /** The generated file must not change between runs, or every namespace restart rewrites it. */
     @Test
     void generatingTwiceProducesTheSameNames() {
-        Map<String, List<String>> entities = Map.of("eh1", List.of("$Default", "my-consumer-group"));
-        assertEquals(divertNames("ns", entities), divertNames("ns", entities));
+        Map<String, EntitySpec> entities =
+                Map.of("eh1", new EntitySpec(4, List.of("$Default", "my-consumer-group")));
+        assertEquals(matches(DIVERT_NAME, brokerXml("ns", entities)),
+                     matches(DIVERT_NAME, brokerXml("ns", entities)));
     }
 }

--- a/src/test/java/org/apache/activemq/artemis/protocol/amqp/proton/AmqpEntityAddressTest.java
+++ b/src/test/java/org/apache/activemq/artemis/protocol/amqp/proton/AmqpEntityAddressTest.java
@@ -1,0 +1,100 @@
+package org.apache.activemq.artemis.protocol.amqp.proton;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * The address reduction sits on the AMQP paths that Event Hubs and Service Bus both use, so these
+ * pin what it must leave alone as much as what it rewrites.
+ */
+class AmqpEntityAddressTest {
+
+    private static URLClassLoader loader;
+    private static Method toEntityPath;
+
+    @BeforeAll
+    static void loadFromPatchJar() throws Exception {
+        Path patchJar = Path.of("target", "classes", "artemis",
+                "artemis-amqp-protocol-2.44.0-floci-az-artemis-amqp-patch.jar");
+        loader = new URLClassLoader(new URL[]{patchJar.toUri().toURL()},
+                AmqpEntityAddressTest.class.getClassLoader());
+        toEntityPath = Class.forName(
+                        "org.apache.activemq.artemis.protocol.amqp.proton.AmqpEntityAddress",
+                        true, loader)
+                .getMethod("toEntityPath", String.class);
+    }
+
+    @AfterAll
+    static void close() throws Exception {
+        loader.close();
+    }
+
+    private static String reduce(String address) throws Exception {
+        return (String) toEntityPath.invoke(null, address);
+    }
+
+    /**
+     * The patched send and receive paths each stripped a leading slash before this existed, and
+     * every client that sends one — Service Bus among them — depends on it. Dropping the strip
+     * leaves the address matching nothing, which the broker reports as
+     * {@code AMQ119010: source address does not exist}.
+     */
+    @Test
+    @DisplayName("a leading slash is always stripped, scheme or no scheme")
+    void stripsLeadingSlash() throws Exception {
+        assertEquals("queue1", reduce("/queue1"));
+        assertEquals("topic1/Subscriptions/sub1", reduce("/topic1/Subscriptions/sub1"));
+        assertEquals("queue1", reduce("queue1"));
+    }
+
+    @Test
+    @DisplayName("an event hub is reduced to its entity path, whatever the scheme and host")
+    void reducesEventHubAddresses() throws Exception {
+        assertEquals("eh1", reduce("amqps://emulatorNs1.servicebus.windows.net/eh1"));
+        assertEquals("eh1", reduce("amqp://localhost/eh1"));
+        assertEquals("eh1/Partitions/2", reduce("amqps://ns.servicebus.windows.net/eh1/Partitions/2"));
+        assertEquals("eh1/ConsumerGroups/$Default/Partitions/0",
+                reduce("amqps://ns.servicebus.windows.net/eh1/ConsumerGroups/$Default/Partitions/0"));
+    }
+
+    /**
+     * {@code {namespace}/{entity}} is the multicast address path-addressing clients publish to,
+     * and {@code amqp://host/{namespace}/{entity}} is the anycast one with diverts behind it.
+     * Reducing the second onto the first merges two topologies that exist to behave differently.
+     */
+    @Test
+    @DisplayName("a namespace-carrying path keeps its host")
+    void leavesTheNamespaceFamilyAlone() throws Exception {
+        assertEquals("amqp://localhost/emulatorNs1/eh1", reduce("amqp://localhost/emulatorNs1/eh1"));
+        assertEquals("amqp://localhost/emulatorNs1/eh1/$Default",
+                reduce("amqp://localhost/emulatorNs1/eh1/$Default"));
+    }
+
+    /** Service Bus entity paths are not event-hub-shaped and must survive untouched. */
+    @Test
+    @DisplayName("a Service Bus subscription path keeps its host")
+    void leavesServiceBusAddressesAlone() throws Exception {
+        assertEquals("sb://ns.servicebus.windows.net/topic1/Subscriptions/sub1",
+                reduce("sb://ns.servicebus.windows.net/topic1/Subscriptions/sub1"));
+        assertEquals("queue1/$DeadLetterQueue", reduce("queue1/$DeadLetterQueue"));
+    }
+
+    @Test
+    @DisplayName("the broker's own addresses and a hostless address pass through")
+    void leavesBrokerAddressesAlone() throws Exception {
+        assertEquals("$cbs", reduce("$cbs"));
+        assertEquals("$management", reduce("$management"));
+        assertEquals("amqps://ns.servicebus.windows.net", reduce("amqps://ns.servicebus.windows.net"));
+        assertNull(reduce(null));
+    }
+}


### PR DESCRIPTION
Split out of #242 at your request, and held back until there was a green run to flip it on — following the Service Bus precedent you cited. #242 is green now, so here it is.

`floci.az.services.event-hub.mocked` has been `true` with a comment saying not to flip it until the Azure SDKs could use the AMQP data plane, because both compat suites self-skip on the flag and flipping it early turns a silent skip into hard failures. After #237, #241 and #242 they can.

**Stacked on #242** — one line of `application.yml` on top of it.

## What changes for a contributor

`make test` and the compat suites now start an Artemis container per Event Hubs namespace instead of skipping the data-plane assertions. That is the point of the change and also its entire risk, which is why it is on its own rather than buried in the partitions PR.

## Verified with no override set

Confirmed the shipped default is what runs — `PUT /…/namespaces/emulatorNs1` answers `"mocked":false` with no `FLOCI_AZ_SERVICES_EVENT_HUB_MOCKED` in the environment — and that the suites execute rather than self-skip (`skipped="0"` in both surefire reports, where they previously reported every test skipped):

```
883 unit tests                                   pass
EventHubSdkCompatibilityTest      (Azure SDK)    6/6   skipped=0
EventHubCompatibilityTest         (JMS)          6/6   skipped=0
EventHubNamespaceManagementTest                  9/9
sdk-test-node eventhub.test.ts                   4/4
sdk-test-dotnet ServiceBus                       9/9
```
