### PR TITLE
feat(servicebus): start the default namespace on boot for a deterministic AMQP endpoint

### DIFF
--- a/docs/services/service-bus.md
+++ b/docs/services/service-bus.md
@@ -95,6 +95,23 @@ Endpoint=sb://localhost:5673;SharedAccessKeyName=RootManageSharedAccessKey;Share
 `UseDevelopmentEmulator=true` tells the SDK to use plain AMQP (no TLS). The `SharedAccessKey` value is
 ignored — Artemis runs without authentication in dev mode.
 
+## Deterministic endpoint for orchestrators
+
+The AMQP data plane always binds the configured host ports (`amqp-port`, default `5673`;
+`amqp-tls-port`, default `5674`), so an orchestrator that starts floci-az knows the Service Bus
+endpoint up front — there is no dynamic port to discover. Two more pieces complete the story:
+
+- **`start-on-boot: true`** starts the `default` namespace (and its Artemis sidecar) together with
+  the emulator, instead of on the first entity-management call. Without it, nothing listens on the
+  AMQP port until a queue, topic, or namespace is created, which breaks health checks and clients
+  that connect at startup.
+- **`GET /{account}-servicebus/namespaces`** reports each running namespace's actual
+  `amqpPort`/`amqpsPort`, for tooling that wants to verify or discover the endpoint at runtime.
+
+This is what hosting integrations (e.g. .NET Aspire) should rely on: pass
+`FLOCI_AZ_SERVICES_SERVICE_BUS_AMQP_PORT` (with `..._MOCKED=false` and `..._START_ON_BOOT=true`),
+then hand clients `Endpoint=sb://<host>:<that port>;...;UseDevelopmentEmulator=true;`.
+
 ## Python SDK
 
 ```python
@@ -145,6 +162,7 @@ services:
     environment:
       FLOCI_AZ_SERVICES_SERVICE_BUS_ENABLED: "true"
       FLOCI_AZ_SERVICES_SERVICE_BUS_MOCKED: "false"
+      FLOCI_AZ_SERVICES_SERVICE_BUS_START_ON_BOOT: "true"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
 ```
@@ -155,6 +173,7 @@ services:
 |---|---|---|
 | `FLOCI_AZ_SERVICES_SERVICE_BUS_ENABLED` | `true` | Enable/disable the service |
 | `FLOCI_AZ_SERVICES_SERVICE_BUS_MOCKED` | `true` | Mocked mode (management plane only, no Artemis) |
+| `FLOCI_AZ_SERVICES_SERVICE_BUS_START_ON_BOOT` | `false` | Start the `default` namespace (and its Artemis sidecar) with the emulator instead of on the first management call |
 | `FLOCI_AZ_SERVICES_SERVICE_BUS_AMQP_PORT` | `5673` | Host port for AMQP (Artemis) |
 | `FLOCI_AZ_SERVICES_SERVICE_BUS_AMQP_TLS_PORT` | `5674` | Host port for AMQPS |
 | `FLOCI_AZ_SERVICES_SERVICE_BUS_ARTEMIS_IMAGE` | `apache/activemq-artemis:2.44.0` | Artemis image; must match bundled protocol patches |
@@ -169,6 +188,7 @@ floci-az:
     service-bus:
       enabled: true
       mocked: true              # true = management plane only, no Docker. false = real Artemis sidecar
+      start-on-boot: false      # true = default namespace starts with the emulator (see "Deterministic endpoint")
       amqp-port: 5673
       amqp-tls-port: 5674
       artemis-image: "apache/activemq-artemis:2.44.0"

--- a/src/main/java/io/floci/az/config/EmulatorConfig.java
+++ b/src/main/java/io/floci/az/config/EmulatorConfig.java
@@ -383,6 +383,17 @@ public interface EmulatorConfig {
         @WithDefault("false")
         boolean mocked();
 
+        /**
+         * When {@code true}, the {@code default} namespace starts with the emulator instead of
+         * on the first entity-management call, so the configured AMQP port is listening as soon
+         * as floci-az is up. Lets orchestrators (Docker Compose health checks, .NET Aspire
+         * hosting integrations) treat the Service Bus endpoint as deterministic without issuing
+         * a management call first. In {@code mocked} mode the namespace is registered without a
+         * broker.
+         */
+        @WithDefault("false")
+        boolean startOnBoot();
+
         @WithDefault("5673")
         int amqpPort();
 

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusContainerManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusContainerManager.java
@@ -40,15 +40,27 @@ public class ServiceBusContainerManager {
         }
         if (sb.mocked()) {
             LOG.info("Service Bus service mocked — skipping container startup");
-        } else {
-            try {
-                int reaped = namespaceManager.reapOrphanedContainers();
-                if (reaped > 0) {
-                    LOG.infov("Removed {0} orphaned Service Bus container(s)", reaped);
-                }
-            } catch (Exception e) {
-                LOG.errorf(e, "Could not reap orphaned Service Bus containers");
+            if (sb.startOnBoot()) {
+                namespaceManager.startMockedNamespace(ServiceBusNamespaceManager.DEFAULT_NAMESPACE);
             }
+            return;
+        }
+        try {
+            int reaped = namespaceManager.reapOrphanedContainers();
+            if (reaped > 0) {
+                LOG.infov("Removed {0} orphaned Service Bus container(s)", reaped);
+            }
+        } catch (Exception e) {
+            LOG.errorf(e, "Could not reap orphaned Service Bus containers");
+        }
+        if (sb.startOnBoot()) {
+            try {
+                namespaceManager.startNamespace(
+                        ServiceBusNamespaceManager.DEFAULT_NAMESPACE, sb.amqpPort(), sb.amqpTlsPort());
+            } catch (Exception e) {
+                LOG.errorf(e, "Could not start the default Service Bus namespace on boot");
+            }
+        } else {
             LOG.info("Service Bus service enabled — namespace starts on first entity management call");
         }
     }

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
@@ -67,7 +67,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
 
     private static final String ATOM_XML_CONTENT_TYPE = "application/atom+xml;charset=utf-8";
     private static final String XML_PROLOG = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
-    private static final String DEFAULT_NAMESPACE = "default";
+    private static final String DEFAULT_NAMESPACE = ServiceBusNamespaceManager.DEFAULT_NAMESPACE;
     /** Main Service Bus namespace for entity descriptions. */
     private static final String SB_NS = "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect";
     /** Separate namespace used by MessageCountDetails child elements (per spec). */

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -37,6 +37,9 @@ import java.util.concurrent.ConcurrentHashMap;
 @ApplicationScoped
 public class ServiceBusNamespaceManager {
 
+    /** Namespace used by SDK spec paths and lazy/boot-time starts when none is named explicitly. */
+    public static final String DEFAULT_NAMESPACE = "default";
+
     private static final Logger LOG = Logger.getLogger(ServiceBusNamespaceManager.class);
 
     static final String ARTEMIS_EXTENSION_RESOURCE = "/artemis/servicebus-artemis-extension.jar";

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -175,6 +175,8 @@ floci-az:
       enabled: true
       # Keep the broker opt-in because each namespace owns an Artemis sidecar.
       mocked: true
+      # true = the default namespace starts with the emulator (deterministic AMQP endpoint at boot).
+      start-on-boot: false
       amqp-port: 5673
       amqp-tls-port: 5674
       artemis-image: "apache/activemq-artemis:2.44.0"

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusContainerManagerTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusContainerManagerTest.java
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -46,6 +48,54 @@ class ServiceBusContainerManagerTest {
     void cleanupFailureDoesNotFailApplicationStartup() {
         when(serviceBus.mocked()).thenReturn(false);
         when(namespaceManager.reapOrphanedContainers())
+                .thenThrow(new IllegalStateException("Docker unavailable"));
+
+        assertDoesNotThrow(
+                () -> new ServiceBusContainerManager(config, namespaceManager).onStart(null));
+    }
+
+    @Test
+    void namespaceStartStaysLazyByDefault() {
+        when(serviceBus.mocked()).thenReturn(false);
+
+        new ServiceBusContainerManager(config, namespaceManager).onStart(null);
+
+        verify(namespaceManager, never()).startNamespace(anyString(), anyInt(), anyInt());
+        verify(namespaceManager, never()).startMockedNamespace(anyString());
+    }
+
+    @Test
+    void startsDefaultNamespaceOnBootWhenConfigured() {
+        when(serviceBus.mocked()).thenReturn(false);
+        when(serviceBus.startOnBoot()).thenReturn(true);
+        when(serviceBus.amqpPort()).thenReturn(5673);
+        when(serviceBus.amqpTlsPort()).thenReturn(5674);
+
+        new ServiceBusContainerManager(config, namespaceManager).onStart(null);
+
+        verify(namespaceManager).startNamespace(
+                ServiceBusNamespaceManager.DEFAULT_NAMESPACE, 5673, 5674);
+    }
+
+    @Test
+    void registersMockedNamespaceOnBootWhenConfigured() {
+        when(serviceBus.mocked()).thenReturn(true);
+        when(serviceBus.startOnBoot()).thenReturn(true);
+
+        new ServiceBusContainerManager(config, namespaceManager).onStart(null);
+
+        verify(namespaceManager).startMockedNamespace(ServiceBusNamespaceManager.DEFAULT_NAMESPACE);
+        verify(namespaceManager, never()).startNamespace(anyString(), anyInt(), anyInt());
+    }
+
+    @Test
+    void bootStartFailureDoesNotFailApplicationStartup() {
+        when(serviceBus.mocked()).thenReturn(false);
+        when(serviceBus.startOnBoot()).thenReturn(true);
+        when(serviceBus.amqpPort()).thenReturn(5673);
+        when(serviceBus.amqpTlsPort()).thenReturn(5674);
+        when(namespaceManager.startNamespace(
+                ServiceBusNamespaceManager.DEFAULT_NAMESPACE, 5673, 5674))
                 .thenThrow(new IllegalStateException("Docker unavailable"));
 
         assertDoesNotThrow(


### PR DESCRIPTION
Closes #249

## What

Adds `floci-az.services.service-bus.start-on-boot` (env `FLOCI_AZ_SERVICES_SERVICE_BUS_START_ON_BOOT`, default `false`). When set, the `default` namespace — and its Artemis sidecar, unless `mocked` — starts together with the emulator instead of on the first entity-management call, so the configured AMQP port is listening as soon as floci-az is up.

## Why

Investigating #249 showed the endpoint is already *deterministic*: `amqp-port`/`amqp-tls-port` pin the sidecar's host ports (5673/5674), and `GET /{account}-servicebus/namespaces` reports them. The remaining gap for orchestrators is the **lazy namespace start** — until something calls the management API, nothing listens on the AMQP port, which breaks health checks and clients that connect at startup, and leaves a hosting integration (e.g. the CommunityToolkit Aspire `AddFlociAzure`, CommunityToolkit/Aspire#1552) with no moment at which the endpoint it advertises is actually live.

With this flag, an orchestrator can treat the Service Bus endpoint like any other fixed-port service: set `FLOCI_AZ_SERVICES_SERVICE_BUS_MOCKED=false`, `..._START_ON_BOOT=true`, and optionally `..._AMQP_PORT=<port>`, then hand clients `Endpoint=sb://<host>:<port>;...;UseDevelopmentEmulator=true;`.

## Changes

- `EmulatorConfig.ServiceBusConfig`: new `startOnBoot()` (`@WithDefault("false")`).
- `ServiceBusContainerManager.onStart`: starts the default namespace after orphan reaping when the flag is set; `mocked` mode registers a mocked namespace instead. Failures log `ERROR` and never fail startup, per the sidecar rules.
- `ServiceBusNamespaceManager.DEFAULT_NAMESPACE` extracted as the shared constant (`ServiceBusHandler` now references it).
- `application.yml` + `docs/services/service-bus.md`: flag documented; new "Deterministic endpoint for orchestrators" section explains the pinned ports + `start-on-boot` + `GET /namespaces` discovery together.

## Tests

`ServiceBusContainerManagerTest` (+4): default stays lazy; broker-mode boot start with configured ports; mocked-mode boot registration; boot-start failure is non-fatal. 7/7 green locally.

Behavior with the flag unset is unchanged.
