### PR TITLE
feat(servicebus): load declarative topology from the official emulator's Config.json

### DIFF
--- a/docs/services/service-bus.md
+++ b/docs/services/service-bus.md
@@ -9,8 +9,9 @@ managed automatically by floci-az.
 | Management | HTTP | `/{account}-servicebus/` on `:4577` | `4577` |
 | Data | AMQP 1.0 | Apache ActiveMQ Artemis sidecar | `5673` (AMQP) / `5674` (AMQPS) |
 
-Unlike Event Hubs, entity topology is **not** pre-configured — queues, topics and subscriptions are
-created dynamically through the management API (or auto-created on first use by the SDK).
+Entity topology is created dynamically through the management API (or auto-created on first use by
+the SDK), and can additionally be **pre-provisioned declaratively** from a `Config.json` file in the
+official Service Bus emulator's format — see [Declarative topology](#declarative-topology-configjson).
 
 > **Mocked mode (default).** With `mocked: true` the Artemis sidecar is not started: the management
 > API responds, but the AMQP data plane is unavailable. Set `mocked: false` (and expose the AMQP
@@ -30,6 +31,40 @@ Entity CRUD is served over HTTP at `/{account}-servicebus/`:
 | `PUT` / `GET` / `DELETE` | `/{account}-servicebus/{topic}/subscriptions/{sub}` | Manage a subscription |
 | `GET` | `/{account}-servicebus/{topic}/subscriptions/{sub}/rules` | List subscription rules |
 | `PUT` / `GET` / `DELETE` | `/{account}-servicebus/{topic}/subscriptions/{sub}/rules/{rule}` | Manage a subscription rule |
+
+## Declarative topology (Config.json)
+
+At startup, floci-az applies a declarative topology file in the
+[official Service Bus emulator's `Config.json` format](https://learn.microsoft.com/azure/service-bus-messaging/test-locally-with-service-bus-emulator)
+— the same file .NET Aspire's Service Bus hosting integration writes from the AppHost model. The
+file location is resolved in order:
+
+1. `floci-az.services.service-bus.topology-file` (env `FLOCI_AZ_SERVICES_SERVICE_BUS_TOPOLOGY_FILE`)
+2. `/ServiceBus_Emulator/ConfigFiles/Config.json` — the official emulator's mount path, so a volume
+   prepared for the official emulator works unchanged
+
+```yaml
+services:
+  floci-az:
+    image: floci/floci-az:latest
+    volumes:
+      - ./Config.json:/ServiceBus_Emulator/ConfigFiles/Config.json:ro
+      - /var/run/docker.sock:/var/run/docker.sock
+```
+
+Namespaces, queues, topics, subscriptions, and rules from the file are created through the same
+code paths as the management API, before any client connects — useful for apps whose consumers
+attach to pre-provisioned entities and never create them. Semantics:
+
+- The first namespace binds the configured AMQP ports (`amqp-port`/`amqp-tls-port`); the official
+  emulator supports a single namespace, and additional namespaces get dynamic ports.
+- A subscription with declared `Rules` gets exactly those rules — the implicit `$Default`
+  TrueFilter is removed, as in the official emulator. A subscription with no rules keeps `$Default`.
+- Entity properties honor the same validation as the management API (`LockDuration` ≤ `PT5M`,
+  `MaxDeliveryCount` 1–2000, duplicate-detection window `PT20S`–`P7D`).
+- `ForwardTo`/`ForwardDeadLetteredMessagesTo` are not emulated and log a warning if present.
+- Loading is best-effort: an invalid entity is skipped with an `ERROR` log and the rest of the
+  topology still loads; a missing or unparsable file never fails startup.
 
 ## Subscription rules and filters
 
@@ -178,6 +213,7 @@ services:
 | `FLOCI_AZ_SERVICES_SERVICE_BUS_ENABLED` | `true` | Enable/disable the service |
 | `FLOCI_AZ_SERVICES_SERVICE_BUS_MOCKED` | `true` | Mocked mode (management plane only, no Artemis) |
 | `FLOCI_AZ_SERVICES_SERVICE_BUS_START_ON_BOOT` | `false` | Start the `default` namespace (and its Artemis sidecar) with the emulator instead of on the first management call |
+| `FLOCI_AZ_SERVICES_SERVICE_BUS_TOPOLOGY_FILE` | *(unset)* | Path to a declarative topology `Config.json`; when unset, `/ServiceBus_Emulator/ConfigFiles/Config.json` is probed |
 | `FLOCI_AZ_SERVICES_SERVICE_BUS_AMQP_PORT` | `5673` | Host port for AMQP (Artemis) |
 | `FLOCI_AZ_SERVICES_SERVICE_BUS_AMQP_TLS_PORT` | `5674` | Host port for AMQPS |
 | `FLOCI_AZ_SERVICES_SERVICE_BUS_ARTEMIS_IMAGE` | `apache/activemq-artemis:2.44.0` | Artemis image; must match bundled protocol patches |

--- a/docs/services/service-bus.md
+++ b/docs/services/service-bus.md
@@ -58,8 +58,12 @@ attach to pre-provisioned entities and never create them. Semantics:
 
 - The first namespace binds the configured AMQP ports (`amqp-port`/`amqp-tls-port`); the official
   emulator supports a single namespace, and additional namespaces get dynamic ports.
+- A discovered topology file takes precedence over `start-on-boot`; its first namespace owns the
+  configured ports, and no separate `default` namespace is started.
 - A subscription with declared `Rules` gets exactly those rules — the implicit `$Default`
   TrueFilter is removed, as in the official emulator. A subscription with no rules keeps `$Default`.
+- Rule replacement is atomic. If a reload of an existing subscription contains an invalid rule,
+  its previous complete rule set remains active; a new subscription keeps only valid declarations.
 - Entity properties honor the same validation as the management API (`LockDuration` ≤ `PT5M`,
   `MaxDeliveryCount` 1–2000, duplicate-detection window `PT20S`–`P7D`).
 - `ForwardTo`/`ForwardDeadLetteredMessagesTo` are not emulated and log a warning if present.
@@ -212,7 +216,7 @@ services:
 |---|---|---|
 | `FLOCI_AZ_SERVICES_SERVICE_BUS_ENABLED` | `true` | Enable/disable the service |
 | `FLOCI_AZ_SERVICES_SERVICE_BUS_MOCKED` | `true` | Mocked mode (management plane only, no Artemis) |
-| `FLOCI_AZ_SERVICES_SERVICE_BUS_START_ON_BOOT` | `false` | Start the `default` namespace (and its Artemis sidecar) with the emulator instead of on the first management call |
+| `FLOCI_AZ_SERVICES_SERVICE_BUS_START_ON_BOOT` | `false` | Start the `default` namespace with the emulator when no topology file is discovered |
 | `FLOCI_AZ_SERVICES_SERVICE_BUS_TOPOLOGY_FILE` | *(unset)* | Path to a declarative topology `Config.json`; when unset, `/ServiceBus_Emulator/ConfigFiles/Config.json` is probed |
 | `FLOCI_AZ_SERVICES_SERVICE_BUS_AMQP_PORT` | `5673` | Host port for AMQP (Artemis) |
 | `FLOCI_AZ_SERVICES_SERVICE_BUS_AMQP_TLS_PORT` | `5674` | Host port for AMQPS |
@@ -228,7 +232,7 @@ floci-az:
     service-bus:
       enabled: true
       mocked: true              # true = management plane only, no Docker. false = real Artemis sidecar
-      start-on-boot: false      # true = default namespace starts with the emulator (see "Deterministic endpoint")
+      start-on-boot: false      # true = default namespace starts when no topology file is discovered
       amqp-port: 5673
       amqp-tls-port: 5674
       artemis-image: "apache/activemq-artemis:2.44.0"

--- a/docs/services/service-bus.md
+++ b/docs/services/service-bus.md
@@ -105,6 +105,10 @@ dead-lettering).
   etc. compare with their declared type; other non-string types compare as strings.
 - Rule changes update the subscription's filter in place (messages already routed to the
   subscription stay, receivers stay attached) and, as on Azure, apply to future messages only.
+- If persisting a rule change fails, the emulator retries restoring the previous broker filter
+  and returns HTTP 500. If every rollback attempt fails, it logs the inconsistency and leaves
+  the broker running to preserve queued messages and client connections. The broker filter
+  may then differ from stored rules until a later successful rule update reconciles them.
 
 ## Message sessions
 

--- a/src/main/java/io/floci/az/config/EmulatorConfig.java
+++ b/src/main/java/io/floci/az/config/EmulatorConfig.java
@@ -394,6 +394,14 @@ public interface EmulatorConfig {
         @WithDefault("false")
         boolean startOnBoot();
 
+        /**
+         * Path to a declarative topology file in the official Service Bus emulator's
+         * {@code Config.json} format, applied at startup. When unset, the official emulator's
+         * mount path ({@code /ServiceBus_Emulator/ConfigFiles/Config.json}) is probed, so a
+         * volume written for the official emulator (e.g. by .NET Aspire) works unchanged.
+         */
+        Optional<String> topologyFile();
+
         @WithDefault("5673")
         int amqpPort();
 

--- a/src/main/java/io/floci/az/core/docker/ContainerLifecycleManager.java
+++ b/src/main/java/io/floci/az/core/docker/ContainerLifecycleManager.java
@@ -419,6 +419,23 @@ public class ContainerLifecycleManager {
         tryRemoveIfExists(name);
     }
 
+    /**
+     * Force-removes a container and reports whether it is now absent. Unlike the ordinary
+     * best-effort cleanup path, callers can use this result before reusing host resources.
+     */
+    public boolean removeIfExistsAndConfirm(String name) {
+        try {
+            dockerClient.removeContainerCmd(name).withForce(true).exec();
+            LOG.infov("Removed stale container {0}", name);
+            return true;
+        } catch (NotFoundException ignored) {
+            return true;
+        } catch (Exception e) {
+            LOG.warnv("Could not confirm removal of container {0}: {1}", name, e.getMessage());
+            return false;
+        }
+    }
+
     private boolean tryRemoveIfExists(String name) {
         try {
             dockerClient.removeContainerCmd(name).withForce(true).exec();

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusContainerManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusContainerManager.java
@@ -25,12 +25,15 @@ public class ServiceBusContainerManager {
 
     private final EmulatorConfig config;
     private final ServiceBusNamespaceManager namespaceManager;
+    private final ServiceBusTopologyLoader topologyLoader;
 
     @Inject
     public ServiceBusContainerManager(EmulatorConfig config,
-                                       ServiceBusNamespaceManager namespaceManager) {
+                                       ServiceBusNamespaceManager namespaceManager,
+                                       ServiceBusTopologyLoader topologyLoader) {
         this.config = config;
         this.namespaceManager = namespaceManager;
+        this.topologyLoader = topologyLoader;
     }
 
     void onStart(@Observes StartupEvent ev) {
@@ -62,6 +65,11 @@ public class ServiceBusContainerManager {
             }
         } else {
             LOG.info("Service Bus service enabled — namespace starts on first entity management call");
+        }
+        try {
+            topologyLoader.load();
+        } catch (Exception e) {
+            LOG.errorf(e, "Could not load the Service Bus topology file");
         }
     }
 

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusContainerManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusContainerManager.java
@@ -11,7 +11,7 @@ import org.jboss.logging.Logger;
 /**
  * Lifecycle manager for Service Bus sidecar containers.
  *
- * When {@code mocked = false} (the default), a namespace starts on its first entity-management
+ * When {@code mocked = false}, a namespace starts on its first entity-management
  * call -- not on boot. Namespaces can also be started explicitly via
  * PUT /{account}-servicebus/namespaces/{ns}. All running namespaces are stopped on shutdown.
  *
@@ -41,35 +41,50 @@ public class ServiceBusContainerManager {
         if (!sb.enabled()) {
             return;
         }
-        if (sb.mocked()) {
+        boolean mocked = sb.mocked();
+        if (mocked) {
             LOG.info("Service Bus service mocked — skipping container startup");
+        } else {
+            try {
+                int reaped = namespaceManager.reapOrphanedContainers();
+                if (reaped > 0) {
+                    LOG.infov("Removed {0} orphaned Service Bus container(s)", reaped);
+                }
+            } catch (Exception e) {
+                LOG.errorf(e, "Could not reap orphaned Service Bus containers");
+            }
+        }
+
+        if (loadTopology()) {
             if (sb.startOnBoot()) {
-                namespaceManager.startMockedNamespace(ServiceBusNamespaceManager.DEFAULT_NAMESPACE);
+                LOG.info("Service Bus topology file takes precedence over start-on-boot");
             }
             return;
         }
-        try {
-            int reaped = namespaceManager.reapOrphanedContainers();
-            if (reaped > 0) {
-                LOG.infov("Removed {0} orphaned Service Bus container(s)", reaped);
-            }
-        } catch (Exception e) {
-            LOG.errorf(e, "Could not reap orphaned Service Bus containers");
-        }
+
         if (sb.startOnBoot()) {
-            try {
-                namespaceManager.startNamespace(
-                        ServiceBusNamespaceManager.DEFAULT_NAMESPACE, sb.amqpPort(), sb.amqpTlsPort());
-            } catch (Exception e) {
-                LOG.errorf(e, "Could not start the default Service Bus namespace on boot");
+            if (mocked) {
+                namespaceManager.startMockedNamespace(ServiceBusNamespaceManager.DEFAULT_NAMESPACE);
+            } else {
+                try {
+                    namespaceManager.startNamespace(
+                            ServiceBusNamespaceManager.DEFAULT_NAMESPACE,
+                            sb.amqpPort(), sb.amqpTlsPort());
+                } catch (Exception e) {
+                    LOG.errorf(e, "Could not start the default Service Bus namespace on boot");
+                }
             }
-        } else {
+        } else if (!mocked) {
             LOG.info("Service Bus service enabled — namespace starts on first entity management call");
         }
+    }
+
+    private boolean loadTopology() {
         try {
-            topologyLoader.load();
+            return topologyLoader.load();
         } catch (Exception e) {
             LOG.errorf(e, "Could not load the Service Bus topology file");
+            return false;
         }
     }
 

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusEntityXml.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusEntityXml.java
@@ -5,7 +5,12 @@ import io.floci.az.core.XmlParser;
 import java.time.Duration;
 import java.time.format.DateTimeParseException;
 
-/** Parses settings shared by Service Bus queue and topic descriptions. */
+/**
+ * Parses and validates settings shared by Service Bus queue and topic descriptions.
+ * The {@code parse*} methods take an XML description body; the {@code *Of} methods take
+ * already-extracted values and hold the validation rules, so non-XML callers (the JSON
+ * topology loader) apply exactly the same constraints as the management API.
+ */
 final class ServiceBusEntityXml {
 
     static final long DEFAULT_DUPLICATE_DETECTION_HISTORY_SECONDS = Duration.ofMinutes(10).toSeconds();
@@ -24,7 +29,15 @@ final class ServiceBusEntityXml {
                 XmlParser.extractFirst(xml, "RequiresDuplicateDetection", "false").trim());
         String rawHistory = XmlParser.extractFirst(
                 xml, "DuplicateDetectionHistoryTimeWindow",
-                DEFAULT_DUPLICATE_DETECTION_HISTORY.toString()).trim();
+                DEFAULT_DUPLICATE_DETECTION_HISTORY.toString());
+        return duplicateDetectionOf(enabled, rawHistory);
+    }
+
+    /** @param isoHistory ISO-8601 duration; {@code null} falls back to the PT10M default */
+    static DuplicateDetectionSettings duplicateDetectionOf(boolean enabled, String isoHistory) {
+        String rawHistory = isoHistory == null
+                ? DEFAULT_DUPLICATE_DETECTION_HISTORY.toString()
+                : isoHistory.trim();
         long historySeconds;
         try {
             Duration history = Duration.parse(rawHistory);
@@ -48,7 +61,15 @@ final class ServiceBusEntityXml {
     record DuplicateDetectionSettings(boolean enabled, long historySeconds) {}
 
     static MessageLifetimeSettings parseMessageLifetime(String xml) {
-        String value = XmlParser.extractFirst(xml, "DefaultMessageTimeToLive", "P14D").trim();
+        String value = XmlParser.extractFirst(xml, "DefaultMessageTimeToLive", "P14D");
+        boolean deadLetterOnExpiration = Boolean.parseBoolean(
+                XmlParser.extractFirst(xml, "DeadLetteringOnMessageExpiration", "false").trim());
+        return messageLifetimeOf(value, deadLetterOnExpiration);
+    }
+
+    /** @param isoTtl ISO-8601 duration; {@code null} falls back to the P14D default */
+    static MessageLifetimeSettings messageLifetimeOf(String isoTtl, boolean deadLetterOnExpiration) {
+        String value = isoTtl == null ? "P14D" : isoTtl.trim();
         final long ttlMillis;
         try {
             ttlMillis = Duration.parse(value).toMillis();
@@ -59,8 +80,6 @@ final class ServiceBusEntityXml {
         if (ttlMillis <= 0) {
             throw new IllegalArgumentException("DefaultMessageTimeToLive must be positive");
         }
-        boolean deadLetterOnExpiration = Boolean.parseBoolean(
-                XmlParser.extractFirst(xml, "DeadLetteringOnMessageExpiration", "false").trim());
         return new MessageLifetimeSettings(ttlMillis, deadLetterOnExpiration);
     }
 
@@ -80,17 +99,22 @@ final class ServiceBusEntityXml {
             } catch (NumberFormatException e) {
                 throw new IllegalArgumentException("MaxDeliveryCount must be an integer", e);
             }
-            if (maxDeliveryCount < 1 || maxDeliveryCount > MAX_DELIVERY_COUNT_LIMIT) {
-                throw new IllegalArgumentException(
-                        "MaxDeliveryCount must be between 1 and " + MAX_DELIVERY_COUNT_LIMIT);
-            }
+        }
+        return deliveryOf(maxDeliveryCount, XmlParser.extractFirst(xml, "LockDuration", null));
+    }
+
+    /** Null components fall back to the configured emulator-wide defaults in the handler. */
+    static DeliverySettings deliveryOf(Integer maxDeliveryCount, String isoLockDuration) {
+        if (maxDeliveryCount != null
+                && (maxDeliveryCount < 1 || maxDeliveryCount > MAX_DELIVERY_COUNT_LIMIT)) {
+            throw new IllegalArgumentException(
+                    "MaxDeliveryCount must be between 1 and " + MAX_DELIVERY_COUNT_LIMIT);
         }
         Long lockDurationSeconds = null;
-        String rawLock = XmlParser.extractFirst(xml, "LockDuration", null);
-        if (rawLock != null) {
+        if (isoLockDuration != null) {
             final Duration lock;
             try {
-                lock = Duration.parse(rawLock.trim());
+                lock = Duration.parse(isoLockDuration.trim());
             } catch (DateTimeParseException e) {
                 throw new IllegalArgumentException("LockDuration must be an ISO-8601 duration", e);
             }

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -87,6 +88,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
     private final EmulatorConfig config;
     private final ServiceBusNamespaceManager namespaceManager;
     private final StorageBackend<String, StoredObject> store;
+    private final Map<String, String> pendingTopologyReplayAccounts = new ConcurrentHashMap<>();
 
     @Inject
     public ServiceBusHandler(EmulatorConfig config,
@@ -412,7 +414,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
 
         try {
             ServiceBusNamespaceManager.NamespaceState state =
-                    namespaceManager.startNamespace(namespaceName, amqpPort, amqpTlsPort);
+                    startNamespaceWithPendingReplay(namespaceName, amqpPort, amqpTlsPort);
             StringBuilder json = new StringBuilder();
             appendNamespaceJson(json, namespaceName, state);
             return Response.status(201).entity(json.toString()).type("application/json").build();
@@ -929,7 +931,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                 LOG.errorf("Could not restore the previous broker filter for subscription '%s/%s' "
                                 + "in namespace '%s' after rule storage failed",
                         topicName, subName, namespace);
-                stopNamespaceAfterRollbackFailure(namespace, topicName, subName);
+                recoverNamespaceAfterRollbackFailure(account, namespace, topicName, subName);
             }
             return errorAtom(500, "Failed to persist the Service Bus rule state");
         }
@@ -978,7 +980,11 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         return false;
     }
 
-    private void stopNamespaceAfterRollbackFailure(String namespace, String topicName, String subName) {
+    private void recoverNamespaceAfterRollbackFailure(
+            String account, String namespace, String topicName, String subName) {
+        pendingTopologyReplayAccounts.put(namespace, account);
+        Optional<ServiceBusNamespaceManager.NamespaceState> previousState =
+                namespaceManager.getNamespace(namespace);
         try {
             if (namespaceManager.stopNamespace(namespace)) {
                 LOG.errorf("Stopped Service Bus namespace '%s' to prevent inconsistent delivery for "
@@ -993,6 +999,116 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
             LOG.errorf(e, "Failed to stop inconsistent Service Bus namespace '%s' after filter "
                             + "rollback failed for subscription '%s/%s'",
                     namespace, topicName, subName);
+            return;
+        }
+
+        if (previousState.isEmpty()) {
+            return;
+        }
+        if (previousState.get().mocked()) {
+            pendingTopologyReplayAccounts.remove(namespace, account);
+            return;
+        }
+
+        ServiceBusNamespaceManager.NamespaceState state = previousState.get();
+        try {
+            startNamespaceWithPendingReplay(
+                    namespace, state.amqpHostPort(), state.amqpsHostPort());
+            LOG.errorf("Restarted Service Bus namespace '%s' and restored persisted topology after "
+                            + "filter rollback failed for subscription '%s/%s'",
+                    namespace, topicName, subName);
+        } catch (RuntimeException e) {
+            LOG.errorf(e, "Failed to restore persisted topology for Service Bus namespace '%s' "
+                            + "after filter rollback failed for subscription '%s/%s'",
+                    namespace, topicName, subName);
+        }
+    }
+
+    private ServiceBusNamespaceManager.NamespaceState startNamespaceWithPendingReplay(
+            String namespace, int amqpPort, int amqpsPort) {
+        ServiceBusNamespaceManager.NamespaceState state =
+                namespaceManager.startNamespace(namespace, amqpPort, amqpsPort);
+        String replayAccount = pendingTopologyReplayAccounts.get(namespace);
+        if (replayAccount == null) {
+            return state;
+        }
+
+        try {
+            replayNamespaceTopology(replayAccount, namespace);
+            pendingTopologyReplayAccounts.remove(namespace, replayAccount);
+            return state;
+        } catch (RuntimeException replayFailure) {
+            stopNamespaceAfterReplayFailure(namespace, replayFailure);
+            throw replayFailure;
+        }
+    }
+
+    private void replayNamespaceTopology(String account, String namespace) {
+        List<ServiceBusModels.QueueEntity> queues = scanDirectChildren(queuePrefix(account, namespace))
+                .stream()
+                .map(obj -> requireStoredEntity(obj, ServiceBusModels.QueueEntity.class))
+                .toList();
+        List<ServiceBusModels.TopicEntity> topics = scanDirectChildren(topicPrefix(account, namespace))
+                .stream()
+                .map(obj -> requireStoredEntity(obj, ServiceBusModels.TopicEntity.class))
+                .toList();
+
+        for (ServiceBusModels.QueueEntity queue : queues) {
+            namespaceManager.jolokiaCreateQueue(
+                    namespace, queue.name(), queue.requiresSession(), queue.lockDurationSeconds(),
+                    queue.maxDeliveryCount(),
+                    new ServiceBusEntityXml.DuplicateDetectionSettings(
+                            queue.requiresDuplicateDetection(), queue.duplicateDetectionHistorySeconds()),
+                    new ServiceBusEntityXml.MessageLifetimeSettings(
+                            queue.defaultMessageTtlMillis(), queue.deadLetteringOnMessageExpiration()));
+        }
+        for (ServiceBusModels.TopicEntity topic : topics) {
+            ServiceBusEntityXml.DuplicateDetectionSettings duplicateDetection =
+                    new ServiceBusEntityXml.DuplicateDetectionSettings(
+                            topic.requiresDuplicateDetection(), topic.duplicateDetectionHistorySeconds());
+            namespaceManager.jolokiaCreateTopic(namespace, topic.name(), duplicateDetection);
+            for (StoredObject storedSubscription : scanDirectChildren(
+                    subPrefix(account, namespace, topic.name()))) {
+                ServiceBusModels.SubscriptionEntity subscription = requireStoredEntity(
+                        storedSubscription, ServiceBusModels.SubscriptionEntity.class);
+                String selector = ServiceBusRuleSelector.forRules(
+                        loadRulesForReplay(account, namespace, topic.name(), subscription.name()));
+                namespaceManager.jolokiaCreateSubscription(
+                        namespace, topic.name(), subscription.name(), selector,
+                        subscription.requiresSession(), subscription.lockDurationSeconds(),
+                        subscription.maxDeliveryCount(), duplicateDetection,
+                        new ServiceBusEntityXml.MessageLifetimeSettings(
+                                Math.min(topic.defaultMessageTtlMillis(),
+                                        subscription.defaultMessageTtlMillis()),
+                                subscription.deadLetteringOnMessageExpiration()));
+            }
+        }
+    }
+
+    private List<ServiceBusModels.RuleEntity> loadRulesForReplay(
+            String account, String namespace, String topicName, String subscriptionName) {
+        String prefix = rulePrefix(account, namespace, topicName, subscriptionName);
+        return store.scan(key -> key.startsWith(prefix)).stream()
+                .map(obj -> requireStoredEntity(obj, ServiceBusModels.RuleEntity.class))
+                .toList();
+    }
+
+    private <T> T requireStoredEntity(StoredObject storedObject, Class<T> type) {
+        T entity = fromBytes(storedObject.data(), type);
+        if (entity == null) {
+            throw new IllegalStateException(
+                    "Could not replay stored Service Bus entity " + storedObject.key());
+        }
+        return entity;
+    }
+
+    private void stopNamespaceAfterReplayFailure(String namespace, RuntimeException replayFailure) {
+        try {
+            namespaceManager.stopNamespace(namespace);
+        } catch (RuntimeException stopFailure) {
+            replayFailure.addSuppressed(stopFailure);
+            LOG.errorf(stopFailure,
+                    "Failed to stop partially restored Service Bus namespace '%s'", namespace);
         }
     }
 
@@ -1299,11 +1415,12 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         if (namespaceManager.getNamespace(name).isPresent()) return;
         EmulatorConfig.ServiceBusConfig sb = config.services().serviceBus();
         if (sb.mocked()) {
+            pendingTopologyReplayAccounts.remove(name);
             namespaceManager.startMockedNamespace(name);
             return;
         }
         try {
-            namespaceManager.startNamespace(name, sb.amqpPort(), sb.amqpTlsPort());
+            startNamespaceWithPendingReplay(name, sb.amqpPort(), sb.amqpTlsPort());
         } catch (Exception e) {
             LOG.errorf(e, "Failed to lazily start Service Bus namespace '%s'", name);
         }
@@ -1426,6 +1543,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
 
     /** Wipes all Service Bus data — used by {@code POST /_admin/reset}. */
     public void clear() {
+        pendingTopologyReplayAccounts.clear();
         store.clear();
     }
 }

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
@@ -822,7 +822,8 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
     }
 
     /** Stores a parsed rule and re-applies the compiled selector; 400 when it cannot compile. */
-    Response putRule(String account, String namespace, ServiceBusModels.RuleEntity rule) {
+    synchronized Response putRule(
+            String account, String namespace, ServiceBusModels.RuleEntity rule) {
         try {
             ServiceBusRuleSelector.forRule(rule);
         } catch (IllegalArgumentException e) {
@@ -844,8 +845,8 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         return atomEntry(previous.isPresent() ? 200 : 201, ruleEntryXml(namespace, rule));
     }
 
-    Response handleDeleteRule(String account, String namespace,
-                               String topicName, String subName, String ruleName) {
+    synchronized Response handleDeleteRule(String account, String namespace,
+                                            String topicName, String subName, String ruleName) {
         String key = ruleKey(account, namespace, topicName, subName, ruleName);
         Optional<StoredObject> previous = store.get(key);
         if (previous.isEmpty()) {
@@ -859,8 +860,9 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
     }
 
     /** Replaces a complete rule set in Artemis before committing matching management state. */
-    Response replaceRules(String account, String namespace, String topicName, String subName,
-                          List<ServiceBusModels.RuleEntity> rules) {
+    synchronized Response replaceRules(String account, String namespace,
+                                       String topicName, String subName,
+                                       List<ServiceBusModels.RuleEntity> rules) {
         Map<String, ServiceBusModels.RuleEntity> desiredByName = new LinkedHashMap<>();
         for (ServiceBusModels.RuleEntity rule : rules) {
             desiredByName.put(rule.name(), rule);
@@ -877,17 +879,17 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         }
 
         String prefix = rulePrefix(account, namespace, topicName, subName);
-        Set<String> desiredKeys = desiredRules.stream()
-                .map(rule -> ruleKey(account, namespace, topicName, subName, rule.name()))
-                .collect(Collectors.toUnmodifiableSet());
-        store.scan(key -> key.startsWith(prefix)).stream()
-                .filter(stored -> !desiredKeys.contains(stored.key()))
-                .forEach(stored -> store.delete(stored.key()));
+        Map<String, StoredObject> desiredObjects = new LinkedHashMap<>();
         for (ServiceBusModels.RuleEntity rule : desiredRules) {
             String key = ruleKey(account, namespace, topicName, subName, rule.name());
-            store.put(key, toStoredObject(key, rule));
-            warnOnActionIgnored(rule);
+            desiredObjects.put(key, toStoredObject(key, rule));
         }
+        Set<String> deletedKeys = store.scan(key -> key.startsWith(prefix)).stream()
+                .map(StoredObject::key)
+                .filter(key -> !desiredObjects.containsKey(key))
+                .collect(Collectors.toUnmodifiableSet());
+        store.applyBatch(desiredObjects, deletedKeys);
+        desiredRules.forEach(ServiceBusHandler::warnOnActionIgnored);
         return Response.ok().build();
     }
 

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
@@ -504,11 +504,11 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                 .orElseGet(() -> notFoundAtom("Queue not found: " + queueName));
     }
 
-    private Response handleCreateQueue(String account, String namespace, String queueName,
-                                        boolean requiresSession,
-                                        ServiceBusEntityXml.DuplicateDetectionSettings duplicateDetection,
-                                        ServiceBusEntityXml.MessageLifetimeSettings lifetime,
-                                        ServiceBusEntityXml.DeliverySettings delivery) {
+    Response handleCreateQueue(String account, String namespace, String queueName,
+                                boolean requiresSession,
+                                ServiceBusEntityXml.DuplicateDetectionSettings duplicateDetection,
+                                ServiceBusEntityXml.MessageLifetimeSettings lifetime,
+                                ServiceBusEntityXml.DeliverySettings delivery) {
         String key = queueKey(account, namespace, queueName);
         if (store.get(key).isPresent()) {
             ServiceBusModels.QueueEntity existing =
@@ -592,7 +592,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                 .orElseGet(() -> notFoundAtom("Topic not found: " + topicName));
     }
 
-    private Response handleCreateTopic(
+    Response handleCreateTopic(
             String account, String namespace, String topicName,
             ServiceBusEntityXml.DuplicateDetectionSettings duplicateDetection,
             ServiceBusEntityXml.MessageLifetimeSettings lifetime) {
@@ -692,11 +692,11 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                 .orElseGet(() -> notFoundAtom("Subscription not found: " + subName));
     }
 
-    private Response handleCreateSubscription(String account, String namespace,
-                                                String topicName, String subName,
-                                                boolean requiresSession, String body,
-                                                ServiceBusEntityXml.MessageLifetimeSettings lifetime,
-                                                ServiceBusEntityXml.DeliverySettings delivery) {
+    Response handleCreateSubscription(String account, String namespace,
+                                       String topicName, String subName,
+                                       boolean requiresSession, String body,
+                                       ServiceBusEntityXml.MessageLifetimeSettings lifetime,
+                                       ServiceBusEntityXml.DeliverySettings delivery) {
         Optional<StoredObject> storedTopic = store.get(topicKey(account, namespace, topicName));
         if (storedTopic.isEmpty()) {
             return notFoundAtom("Topic not found: " + topicName);
@@ -813,25 +813,29 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
     /** Creates or updates a rule, then re-applies the compiled selector to the Artemis queue. */
     private Response handlePutRule(AzureRequest req, String account, String namespace,
                                     String topicName, String subName, String ruleName) {
-        ServiceBusModels.RuleEntity rule =
-                ServiceBusRuleXml.parseRule(topicName, subName, ruleName, readBody(req));
+        return putRule(account, namespace,
+                ServiceBusRuleXml.parseRule(topicName, subName, ruleName, readBody(req)));
+    }
+
+    /** Stores a parsed rule and re-applies the compiled selector; 400 when it cannot compile. */
+    Response putRule(String account, String namespace, ServiceBusModels.RuleEntity rule) {
         try {
             ServiceBusRuleSelector.forRule(rule);
         } catch (IllegalArgumentException e) {
             return badRequestAtom(e.getMessage());
         }
 
-        String key = ruleKey(account, namespace, topicName, subName, ruleName);
+        String key = ruleKey(account, namespace, rule.topicName(), rule.subscriptionName(), rule.name());
         boolean existed = store.get(key).isPresent();
         store.put(key, toStoredObject(key, rule));
         warnOnActionIgnored(rule);
-        applySubscriptionFilter(account, namespace, topicName, subName);
+        applySubscriptionFilter(account, namespace, rule.topicName(), rule.subscriptionName());
 
         return atomEntry(existed ? 200 : 201, ruleEntryXml(namespace, rule));
     }
 
-    private Response handleDeleteRule(String account, String namespace,
-                                       String topicName, String subName, String ruleName) {
+    Response handleDeleteRule(String account, String namespace,
+                               String topicName, String subName, String ruleName) {
         String key = ruleKey(account, namespace, topicName, subName, ruleName);
         if (store.get(key).isEmpty()) {
             return notFoundAtom("Rule not found: " + ruleName);

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
@@ -22,10 +22,14 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * HTTP management handler for the Service Bus service.
@@ -827,12 +831,14 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
 
         String key = ruleKey(account, namespace, rule.topicName(), rule.subscriptionName(), rule.name());
         Optional<StoredObject> previous = store.get(key);
-        store.put(key, toStoredObject(key, rule));
-        warnOnActionIgnored(rule);
-        if (!applySubscriptionFilter(account, namespace, rule.topicName(), rule.subscriptionName())) {
-            restoreRuleMutation(key, previous, account, namespace,
-                    rule.topicName(), rule.subscriptionName());
-            return errorAtom(500, "Failed to apply rule filter to the Service Bus broker");
+        List<ServiceBusModels.RuleEntity> desiredRules = new ArrayList<>(
+                loadRules(account, namespace, rule.topicName(), rule.subscriptionName()));
+        desiredRules.removeIf(existing -> existing.name().equals(rule.name()));
+        desiredRules.add(rule);
+        Response replacement = replaceRules(
+                account, namespace, rule.topicName(), rule.subscriptionName(), desiredRules);
+        if (replacement.getStatus() / 100 != 2) {
+            return replacement;
         }
 
         return atomEntry(previous.isPresent() ? 200 : 201, ruleEntryXml(namespace, rule));
@@ -845,24 +851,44 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         if (previous.isEmpty()) {
             return notFoundAtom("Rule not found: " + ruleName);
         }
-        store.delete(key);
-        if (!applySubscriptionFilter(account, namespace, topicName, subName)) {
-            restoreRuleMutation(key, previous, account, namespace, topicName, subName);
-            return errorAtom(500, "Failed to apply rule filter to the Service Bus broker");
-        }
-        return Response.ok().build();
+        List<ServiceBusModels.RuleEntity> desiredRules = loadRules(account, namespace, topicName, subName)
+                .stream()
+                .filter(rule -> !rule.name().equals(ruleName))
+                .toList();
+        return replaceRules(account, namespace, topicName, subName, desiredRules);
     }
 
-    private void restoreRuleMutation(String key, Optional<StoredObject> previous,
-                                     String account, String namespace,
-                                     String topicName, String subName) {
-        previous.ifPresentOrElse(
-                stored -> store.put(key, stored),
-                () -> store.delete(key));
-        if (!applySubscriptionFilter(account, namespace, topicName, subName)) {
-            LOG.errorf("Failed to restore broker filter after rolling back rule mutation for '%s/%s'",
-                    topicName, subName);
+    /** Replaces a complete rule set in Artemis before committing matching management state. */
+    Response replaceRules(String account, String namespace, String topicName, String subName,
+                          List<ServiceBusModels.RuleEntity> rules) {
+        Map<String, ServiceBusModels.RuleEntity> desiredByName = new LinkedHashMap<>();
+        for (ServiceBusModels.RuleEntity rule : rules) {
+            desiredByName.put(rule.name(), rule);
         }
+        List<ServiceBusModels.RuleEntity> desiredRules = List.copyOf(desiredByName.values());
+        String selector;
+        try {
+            selector = ServiceBusRuleSelector.forRules(desiredRules);
+        } catch (IllegalArgumentException e) {
+            return badRequestAtom(e.getMessage());
+        }
+        if (!applySubscriptionFilter(namespace, topicName, subName, selector)) {
+            return errorAtom(500, "Failed to apply rule filter to the Service Bus broker");
+        }
+
+        String prefix = rulePrefix(account, namespace, topicName, subName);
+        Set<String> desiredKeys = desiredRules.stream()
+                .map(rule -> ruleKey(account, namespace, topicName, subName, rule.name()))
+                .collect(Collectors.toUnmodifiableSet());
+        store.scan(key -> key.startsWith(prefix)).stream()
+                .filter(stored -> !desiredKeys.contains(stored.key()))
+                .forEach(stored -> store.delete(stored.key()));
+        for (ServiceBusModels.RuleEntity rule : desiredRules) {
+            String key = ruleKey(account, namespace, topicName, subName, rule.name());
+            store.put(key, toStoredObject(key, rule));
+            warnOnActionIgnored(rule);
+        }
+        return Response.ok().build();
     }
 
     List<ServiceBusModels.RuleEntity> loadRules(String account, String namespace,
@@ -875,17 +901,9 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                 .toList();
     }
 
-    /** Recompiles the subscription's rules and updates its Artemis divert selector. */
-    private boolean applySubscriptionFilter(String account, String namespace,
-                                             String topicName, String subName) {
-        String selector;
-        try {
-            selector = ServiceBusRuleSelector.forRules(loadRules(account, namespace, topicName, subName));
-        } catch (IllegalArgumentException e) {
-            LOG.warnf("Cannot compile rules of subscription '%s/%s' to an Artemis filter: %s",
-                    topicName, subName, e.getMessage());
-            return false;
-        }
+    /** Updates an Artemis subscription divert before its matching management state is committed. */
+    private boolean applySubscriptionFilter(String namespace, String topicName, String subName,
+                                             String selector) {
         try {
             namespaceManager.jolokiaUpdateSubscriptionFilter(namespace, topicName, subName, selector);
             return true;

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
@@ -875,7 +875,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                 .toList();
     }
 
-    /** Recompiles the subscription's rules and re-creates its Artemis queue with the new selector. */
+    /** Recompiles the subscription's rules and updates its Artemis divert selector. */
     private boolean applySubscriptionFilter(String account, String namespace,
                                              String topicName, String subName) {
         String selector;

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
@@ -874,21 +874,43 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         } catch (IllegalArgumentException e) {
             return badRequestAtom(e.getMessage());
         }
+
+        String prefix = rulePrefix(account, namespace, topicName, subName);
+        List<StoredObject> previousObjects = store.scan(key -> key.startsWith(prefix));
+        List<ServiceBusModels.RuleEntity> previousRules = deserializeRules(previousObjects);
+        String previousSelector;
+        try {
+            previousSelector = ServiceBusRuleSelector.forRules(previousRules);
+        } catch (IllegalArgumentException e) {
+            LOG.errorf(e, "Could not compile stored rules for subscription '%s/%s' in namespace '%s'",
+                    topicName, subName, namespace);
+            return errorAtom(500, "Failed to read the existing Service Bus rule state");
+        }
         if (!applySubscriptionFilter(namespace, topicName, subName, selector)) {
             return errorAtom(500, "Failed to apply rule filter to the Service Bus broker");
         }
 
-        String prefix = rulePrefix(account, namespace, topicName, subName);
         Map<String, StoredObject> desiredObjects = new LinkedHashMap<>();
         for (ServiceBusModels.RuleEntity rule : desiredRules) {
             String key = ruleKey(account, namespace, topicName, subName, rule.name());
             desiredObjects.put(key, toStoredObject(key, rule));
         }
-        Set<String> deletedKeys = store.scan(key -> key.startsWith(prefix)).stream()
+        Set<String> deletedKeys = previousObjects.stream()
                 .map(StoredObject::key)
                 .filter(key -> !desiredObjects.containsKey(key))
                 .collect(Collectors.toUnmodifiableSet());
-        store.applyBatch(desiredObjects, deletedKeys);
+        try {
+            store.applyBatch(desiredObjects, deletedKeys);
+        } catch (RuntimeException e) {
+            LOG.errorf(e, "Failed to persist rules for subscription '%s/%s' in namespace '%s'",
+                    topicName, subName, namespace);
+            if (!applySubscriptionFilter(namespace, topicName, subName, previousSelector)) {
+                LOG.errorf("Could not restore the previous broker filter for subscription '%s/%s' "
+                                + "in namespace '%s' after rule storage failed",
+                        topicName, subName, namespace);
+            }
+            return errorAtom(500, "Failed to persist the Service Bus rule state");
+        }
         desiredRules.forEach(ServiceBusHandler::warnOnActionIgnored);
         return Response.ok().build();
     }
@@ -896,8 +918,11 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
     List<ServiceBusModels.RuleEntity> loadRules(String account, String namespace,
                                                  String topicName, String subName) {
         String prefix = rulePrefix(account, namespace, topicName, subName);
-        return store.scan(k -> k.startsWith(prefix))
-                .stream()
+        return deserializeRules(store.scan(key -> key.startsWith(prefix)));
+    }
+
+    private List<ServiceBusModels.RuleEntity> deserializeRules(List<StoredObject> objects) {
+        return objects.stream()
                 .map(obj -> fromBytes(obj.data(), ServiceBusModels.RuleEntity.class))
                 .filter(r -> r != null)
                 .toList();

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 /**
@@ -702,6 +703,29 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                                        boolean requiresSession, String body,
                                        ServiceBusEntityXml.MessageLifetimeSettings lifetime,
                                        ServiceBusEntityXml.DeliverySettings delivery) {
+        return handleCreateSubscription(account, namespace, topicName, subName,
+                requiresSession, lifetime, delivery,
+                () -> ServiceBusRuleXml.parseDefaultRule(topicName, subName, body)
+                        .orElseGet(() -> ServiceBusModels.RuleEntity.trueFilter(
+                                topicName, subName, "$Default")));
+    }
+
+    Response handleCreateSubscription(String account, String namespace,
+                                       String topicName, String subName,
+                                       boolean requiresSession,
+                                       ServiceBusEntityXml.MessageLifetimeSettings lifetime,
+                                       ServiceBusEntityXml.DeliverySettings delivery,
+                                       ServiceBusModels.RuleEntity initialRule) {
+        return handleCreateSubscription(account, namespace, topicName, subName,
+                requiresSession, lifetime, delivery, () -> initialRule);
+    }
+
+    private Response handleCreateSubscription(String account, String namespace,
+                                               String topicName, String subName,
+                                               boolean requiresSession,
+                                               ServiceBusEntityXml.MessageLifetimeSettings lifetime,
+                                               ServiceBusEntityXml.DeliverySettings delivery,
+                                               Supplier<ServiceBusModels.RuleEntity> initialRuleSupplier) {
         Optional<StoredObject> storedTopic = store.get(topicKey(account, namespace, topicName));
         if (storedTopic.isEmpty()) {
             return notFoundAtom("Topic not found: " + topicName);
@@ -716,11 +740,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
             return atomEntry(200, subscriptionEntryXml(namespace, existing));
         }
 
-        // A subscription starts with its initial rule: an explicit <DefaultRuleDescription>
-        // from the create body, or Azure's implicit $Default TrueFilter (accept everything).
-        ServiceBusModels.RuleEntity initialRule =
-                ServiceBusRuleXml.parseDefaultRule(topicName, subName, body)
-                        .orElseGet(() -> ServiceBusModels.RuleEntity.trueFilter(topicName, subName, "$Default"));
+        ServiceBusModels.RuleEntity initialRule = initialRuleSupplier.get();
         String selector;
         try {
             selector = ServiceBusRuleSelector.forRule(initialRule);
@@ -909,6 +929,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                 LOG.errorf("Could not restore the previous broker filter for subscription '%s/%s' "
                                 + "in namespace '%s' after rule storage failed",
                         topicName, subName, namespace);
+                stopNamespaceAfterRollbackFailure(namespace, topicName, subName);
             }
             return errorAtom(500, "Failed to persist the Service Bus rule state");
         }
@@ -955,6 +976,24 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
             }
         }
         return false;
+    }
+
+    private void stopNamespaceAfterRollbackFailure(String namespace, String topicName, String subName) {
+        try {
+            if (namespaceManager.stopNamespace(namespace)) {
+                LOG.errorf("Stopped Service Bus namespace '%s' to prevent inconsistent delivery for "
+                                + "subscription '%s/%s'",
+                        namespace, topicName, subName);
+            } else {
+                LOG.errorf("Service Bus namespace '%s' was already unavailable after filter rollback "
+                                + "failed for subscription '%s/%s'",
+                        namespace, topicName, subName);
+            }
+        } catch (RuntimeException e) {
+            LOG.errorf(e, "Failed to stop inconsistent Service Bus namespace '%s' after filter "
+                            + "rollback failed for subscription '%s/%s'",
+                    namespace, topicName, subName);
+        }
     }
 
     private static void warnOnActionIgnored(ServiceBusModels.RuleEntity rule) {

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
@@ -826,23 +826,43 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         }
 
         String key = ruleKey(account, namespace, rule.topicName(), rule.subscriptionName(), rule.name());
-        boolean existed = store.get(key).isPresent();
+        Optional<StoredObject> previous = store.get(key);
         store.put(key, toStoredObject(key, rule));
         warnOnActionIgnored(rule);
-        applySubscriptionFilter(account, namespace, rule.topicName(), rule.subscriptionName());
+        if (!applySubscriptionFilter(account, namespace, rule.topicName(), rule.subscriptionName())) {
+            restoreRuleMutation(key, previous, account, namespace,
+                    rule.topicName(), rule.subscriptionName());
+            return errorAtom(500, "Failed to apply rule filter to the Service Bus broker");
+        }
 
-        return atomEntry(existed ? 200 : 201, ruleEntryXml(namespace, rule));
+        return atomEntry(previous.isPresent() ? 200 : 201, ruleEntryXml(namespace, rule));
     }
 
     Response handleDeleteRule(String account, String namespace,
                                String topicName, String subName, String ruleName) {
         String key = ruleKey(account, namespace, topicName, subName, ruleName);
-        if (store.get(key).isEmpty()) {
+        Optional<StoredObject> previous = store.get(key);
+        if (previous.isEmpty()) {
             return notFoundAtom("Rule not found: " + ruleName);
         }
         store.delete(key);
-        applySubscriptionFilter(account, namespace, topicName, subName);
+        if (!applySubscriptionFilter(account, namespace, topicName, subName)) {
+            restoreRuleMutation(key, previous, account, namespace, topicName, subName);
+            return errorAtom(500, "Failed to apply rule filter to the Service Bus broker");
+        }
         return Response.ok().build();
+    }
+
+    private void restoreRuleMutation(String key, Optional<StoredObject> previous,
+                                     String account, String namespace,
+                                     String topicName, String subName) {
+        previous.ifPresentOrElse(
+                stored -> store.put(key, stored),
+                () -> store.delete(key));
+        if (!applySubscriptionFilter(account, namespace, topicName, subName)) {
+            LOG.errorf("Failed to restore broker filter after rolling back rule mutation for '%s/%s'",
+                    topicName, subName);
+        }
     }
 
     List<ServiceBusModels.RuleEntity> loadRules(String account, String namespace,
@@ -856,21 +876,23 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
     }
 
     /** Recompiles the subscription's rules and re-creates its Artemis queue with the new selector. */
-    private void applySubscriptionFilter(String account, String namespace,
-                                          String topicName, String subName) {
+    private boolean applySubscriptionFilter(String account, String namespace,
+                                             String topicName, String subName) {
         String selector;
         try {
             selector = ServiceBusRuleSelector.forRules(loadRules(account, namespace, topicName, subName));
         } catch (IllegalArgumentException e) {
             LOG.warnf("Cannot compile rules of subscription '%s/%s' to an Artemis filter: %s",
                     topicName, subName, e.getMessage());
-            return;
+            return false;
         }
         try {
             namespaceManager.jolokiaUpdateSubscriptionFilter(namespace, topicName, subName, selector);
+            return true;
         } catch (Exception e) {
             LOG.warnf(e, "Failed to update filter of subscription '%s/%s' in Artemis for namespace '%s'",
                     topicName, subName, namespace);
+            return false;
         }
     }
 

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
@@ -68,6 +68,7 @@ import java.util.stream.Collectors;
 public class ServiceBusHandler implements AzureServiceHandler, Resettable {
 
     private static final Logger LOG = Logger.getLogger(ServiceBusHandler.class);
+    private static final int BROKER_ROLLBACK_ATTEMPTS = 3;
 
     private static final String ATOM_XML_CONTENT_TYPE = "application/atom+xml;charset=utf-8";
     private static final String XML_PROLOG = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
@@ -904,7 +905,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         } catch (RuntimeException e) {
             LOG.errorf(e, "Failed to persist rules for subscription '%s/%s' in namespace '%s'",
                     topicName, subName, namespace);
-            if (!applySubscriptionFilter(namespace, topicName, subName, previousSelector)) {
+            if (!restoreSubscriptionFilter(namespace, topicName, subName, previousSelector)) {
                 LOG.errorf("Could not restore the previous broker filter for subscription '%s/%s' "
                                 + "in namespace '%s' after rule storage failed",
                         topicName, subName, namespace);
@@ -939,6 +940,21 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                     topicName, subName, namespace);
             return false;
         }
+    }
+
+    private boolean restoreSubscriptionFilter(String namespace, String topicName, String subName,
+                                              String selector) {
+        for (int attempt = 1; attempt <= BROKER_ROLLBACK_ATTEMPTS; attempt++) {
+            if (applySubscriptionFilter(namespace, topicName, subName, selector)) {
+                return true;
+            }
+            if (attempt < BROKER_ROLLBACK_ATTEMPTS) {
+                LOG.warnf("Retrying broker filter rollback for subscription '%s/%s' in namespace "
+                                + "'%s' after attempt %d of %d failed",
+                        topicName, subName, namespace, attempt, BROKER_ROLLBACK_ATTEMPTS);
+            }
+        }
+        return false;
     }
 
     private static void warnOnActionIgnored(ServiceBusModels.RuleEntity rule) {

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
@@ -845,8 +845,8 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         return Response.ok().build();
     }
 
-    private List<ServiceBusModels.RuleEntity> loadRules(String account, String namespace,
-                                                         String topicName, String subName) {
+    List<ServiceBusModels.RuleEntity> loadRules(String account, String namespace,
+                                                 String topicName, String subName) {
         String prefix = rulePrefix(account, namespace, topicName, subName);
         return store.scan(k -> k.startsWith(prefix))
                 .stream()

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusHandler.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -88,7 +87,6 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
     private final EmulatorConfig config;
     private final ServiceBusNamespaceManager namespaceManager;
     private final StorageBackend<String, StoredObject> store;
-    private final Map<String, String> pendingTopologyReplayAccounts = new ConcurrentHashMap<>();
 
     @Inject
     public ServiceBusHandler(EmulatorConfig config,
@@ -414,7 +412,7 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
 
         try {
             ServiceBusNamespaceManager.NamespaceState state =
-                    startNamespaceWithPendingReplay(namespaceName, amqpPort, amqpTlsPort);
+                    namespaceManager.startNamespace(namespaceName, amqpPort, amqpTlsPort);
             StringBuilder json = new StringBuilder();
             appendNamespaceJson(json, namespaceName, state);
             return Response.status(201).entity(json.toString()).type("application/json").build();
@@ -929,9 +927,9 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
                     topicName, subName, namespace);
             if (!restoreSubscriptionFilter(namespace, topicName, subName, previousSelector)) {
                 LOG.errorf("Could not restore the previous broker filter for subscription '%s/%s' "
-                                + "in namespace '%s' after rule storage failed",
+                                + "in namespace '%s' after rule storage failed; leaving the broker running "
+                                + "to preserve queued messages, but its filter may differ from stored rules",
                         topicName, subName, namespace);
-                recoverNamespaceAfterRollbackFailure(account, namespace, topicName, subName);
             }
             return errorAtom(500, "Failed to persist the Service Bus rule state");
         }
@@ -978,138 +976,6 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
             }
         }
         return false;
-    }
-
-    private void recoverNamespaceAfterRollbackFailure(
-            String account, String namespace, String topicName, String subName) {
-        pendingTopologyReplayAccounts.put(namespace, account);
-        Optional<ServiceBusNamespaceManager.NamespaceState> previousState =
-                namespaceManager.getNamespace(namespace);
-        try {
-            if (namespaceManager.stopNamespace(namespace)) {
-                LOG.errorf("Stopped Service Bus namespace '%s' to prevent inconsistent delivery for "
-                                + "subscription '%s/%s'",
-                        namespace, topicName, subName);
-            } else {
-                LOG.errorf("Service Bus namespace '%s' was already unavailable after filter rollback "
-                                + "failed for subscription '%s/%s'",
-                        namespace, topicName, subName);
-            }
-        } catch (RuntimeException e) {
-            LOG.errorf(e, "Failed to stop inconsistent Service Bus namespace '%s' after filter "
-                            + "rollback failed for subscription '%s/%s'",
-                    namespace, topicName, subName);
-            return;
-        }
-
-        if (previousState.isEmpty()) {
-            return;
-        }
-        if (previousState.get().mocked()) {
-            pendingTopologyReplayAccounts.remove(namespace, account);
-            return;
-        }
-
-        ServiceBusNamespaceManager.NamespaceState state = previousState.get();
-        try {
-            startNamespaceWithPendingReplay(
-                    namespace, state.amqpHostPort(), state.amqpsHostPort());
-            LOG.errorf("Restarted Service Bus namespace '%s' and restored persisted topology after "
-                            + "filter rollback failed for subscription '%s/%s'",
-                    namespace, topicName, subName);
-        } catch (RuntimeException e) {
-            LOG.errorf(e, "Failed to restore persisted topology for Service Bus namespace '%s' "
-                            + "after filter rollback failed for subscription '%s/%s'",
-                    namespace, topicName, subName);
-        }
-    }
-
-    private ServiceBusNamespaceManager.NamespaceState startNamespaceWithPendingReplay(
-            String namespace, int amqpPort, int amqpsPort) {
-        ServiceBusNamespaceManager.NamespaceState state =
-                namespaceManager.startNamespace(namespace, amqpPort, amqpsPort);
-        String replayAccount = pendingTopologyReplayAccounts.get(namespace);
-        if (replayAccount == null) {
-            return state;
-        }
-
-        try {
-            replayNamespaceTopology(replayAccount, namespace);
-            pendingTopologyReplayAccounts.remove(namespace, replayAccount);
-            return state;
-        } catch (RuntimeException replayFailure) {
-            stopNamespaceAfterReplayFailure(namespace, replayFailure);
-            throw replayFailure;
-        }
-    }
-
-    private void replayNamespaceTopology(String account, String namespace) {
-        List<ServiceBusModels.QueueEntity> queues = scanDirectChildren(queuePrefix(account, namespace))
-                .stream()
-                .map(obj -> requireStoredEntity(obj, ServiceBusModels.QueueEntity.class))
-                .toList();
-        List<ServiceBusModels.TopicEntity> topics = scanDirectChildren(topicPrefix(account, namespace))
-                .stream()
-                .map(obj -> requireStoredEntity(obj, ServiceBusModels.TopicEntity.class))
-                .toList();
-
-        for (ServiceBusModels.QueueEntity queue : queues) {
-            namespaceManager.jolokiaCreateQueue(
-                    namespace, queue.name(), queue.requiresSession(), queue.lockDurationSeconds(),
-                    queue.maxDeliveryCount(),
-                    new ServiceBusEntityXml.DuplicateDetectionSettings(
-                            queue.requiresDuplicateDetection(), queue.duplicateDetectionHistorySeconds()),
-                    new ServiceBusEntityXml.MessageLifetimeSettings(
-                            queue.defaultMessageTtlMillis(), queue.deadLetteringOnMessageExpiration()));
-        }
-        for (ServiceBusModels.TopicEntity topic : topics) {
-            ServiceBusEntityXml.DuplicateDetectionSettings duplicateDetection =
-                    new ServiceBusEntityXml.DuplicateDetectionSettings(
-                            topic.requiresDuplicateDetection(), topic.duplicateDetectionHistorySeconds());
-            namespaceManager.jolokiaCreateTopic(namespace, topic.name(), duplicateDetection);
-            for (StoredObject storedSubscription : scanDirectChildren(
-                    subPrefix(account, namespace, topic.name()))) {
-                ServiceBusModels.SubscriptionEntity subscription = requireStoredEntity(
-                        storedSubscription, ServiceBusModels.SubscriptionEntity.class);
-                String selector = ServiceBusRuleSelector.forRules(
-                        loadRulesForReplay(account, namespace, topic.name(), subscription.name()));
-                namespaceManager.jolokiaCreateSubscription(
-                        namespace, topic.name(), subscription.name(), selector,
-                        subscription.requiresSession(), subscription.lockDurationSeconds(),
-                        subscription.maxDeliveryCount(), duplicateDetection,
-                        new ServiceBusEntityXml.MessageLifetimeSettings(
-                                Math.min(topic.defaultMessageTtlMillis(),
-                                        subscription.defaultMessageTtlMillis()),
-                                subscription.deadLetteringOnMessageExpiration()));
-            }
-        }
-    }
-
-    private List<ServiceBusModels.RuleEntity> loadRulesForReplay(
-            String account, String namespace, String topicName, String subscriptionName) {
-        String prefix = rulePrefix(account, namespace, topicName, subscriptionName);
-        return store.scan(key -> key.startsWith(prefix)).stream()
-                .map(obj -> requireStoredEntity(obj, ServiceBusModels.RuleEntity.class))
-                .toList();
-    }
-
-    private <T> T requireStoredEntity(StoredObject storedObject, Class<T> type) {
-        T entity = fromBytes(storedObject.data(), type);
-        if (entity == null) {
-            throw new IllegalStateException(
-                    "Could not replay stored Service Bus entity " + storedObject.key());
-        }
-        return entity;
-    }
-
-    private void stopNamespaceAfterReplayFailure(String namespace, RuntimeException replayFailure) {
-        try {
-            namespaceManager.stopNamespace(namespace);
-        } catch (RuntimeException stopFailure) {
-            replayFailure.addSuppressed(stopFailure);
-            LOG.errorf(stopFailure,
-                    "Failed to stop partially restored Service Bus namespace '%s'", namespace);
-        }
     }
 
     private static void warnOnActionIgnored(ServiceBusModels.RuleEntity rule) {
@@ -1415,12 +1281,11 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
         if (namespaceManager.getNamespace(name).isPresent()) return;
         EmulatorConfig.ServiceBusConfig sb = config.services().serviceBus();
         if (sb.mocked()) {
-            pendingTopologyReplayAccounts.remove(name);
             namespaceManager.startMockedNamespace(name);
             return;
         }
         try {
-            startNamespaceWithPendingReplay(name, sb.amqpPort(), sb.amqpTlsPort());
+            namespaceManager.startNamespace(name, sb.amqpPort(), sb.amqpTlsPort());
         } catch (Exception e) {
             LOG.errorf(e, "Failed to lazily start Service Bus namespace '%s'", name);
         }
@@ -1543,7 +1408,6 @@ public class ServiceBusHandler implements AzureServiceHandler, Resettable {
 
     /** Wipes all Service Bus data — used by {@code POST /_admin/reset}. */
     public void clear() {
-        pendingTopologyReplayAccounts.clear();
         store.clear();
     }
 }

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -231,8 +231,28 @@ public class ServiceBusNamespaceManager {
                     namespaceName, amqpEndpoint, amqpsEndpoint);
             return state;
         } catch (RuntimeException e) {
-            cleanupFailedStart(namespaceName, containerName, containerId, cbs);
-            throw e;
+            boolean portsReleased = false;
+            try {
+                cleanupFailedStart(namespaceName, containerName, containerId, cbs);
+                portsReleased = true;
+            } catch (RuntimeException cleanupFailure) {
+                e.addSuppressed(cleanupFailure);
+            }
+            throw new NamespaceStartException(namespaceName, portsReleased, e);
+        }
+    }
+
+    static final class NamespaceStartException extends RuntimeException {
+
+        private final boolean portsReleased;
+
+        NamespaceStartException(String namespaceName, boolean portsReleased, Throwable cause) {
+            super("Failed to start Service Bus namespace '" + namespaceName + "'", cause);
+            this.portsReleased = portsReleased;
+        }
+
+        boolean portsReleased() {
+            return portsReleased;
         }
     }
 

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -187,46 +187,69 @@ public class ServiceBusNamespaceManager {
                 .withLogRotation()
                 .build();
 
-        String containerId = lifecycleManager.create(spec);
-        lifecycleManager.copyFileToContainer(containerId, brokerXml,
-                "/var/lib/artemis-instance/etc-override/broker.xml");
-        lifecycleManager.copyFileToContainer(containerId, MANAGEMENT_XML,
-                "/var/lib/artemis-instance/etc-override/management.xml");
-        lifecycleManager.copyBytesToContainer(containerId, tls.pkcs12Bytes(),
-                "/var/lib/artemis-instance/etc-override/artemis.p12");
-        lifecycleManager.copyBytesToContainer(containerId, loadArtemisExtension(),
-                ARTEMIS_EXTENSION_PATH);
-        lifecycleManager.copyBytesToContainer(containerId, loadResource(PROTON_PATCH_RESOURCE),
-                PROTON_J_PATH);
-        lifecycleManager.copyBytesToContainer(containerId, loadResource(ARTEMIS_AMQP_PATCH_RESOURCE),
-                ARTEMIS_AMQP_PATH);
+        String containerId = null;
+        ServiceBusCbsResponder cbs = null;
+        try {
+            containerId = lifecycleManager.create(spec);
+            lifecycleManager.copyFileToContainer(containerId, brokerXml,
+                    "/var/lib/artemis-instance/etc-override/broker.xml");
+            lifecycleManager.copyFileToContainer(containerId, MANAGEMENT_XML,
+                    "/var/lib/artemis-instance/etc-override/management.xml");
+            lifecycleManager.copyBytesToContainer(containerId, tls.pkcs12Bytes(),
+                    "/var/lib/artemis-instance/etc-override/artemis.p12");
+            lifecycleManager.copyBytesToContainer(containerId, loadArtemisExtension(),
+                    ARTEMIS_EXTENSION_PATH);
+            lifecycleManager.copyBytesToContainer(containerId, loadResource(PROTON_PATCH_RESOURCE),
+                    PROTON_J_PATH);
+            lifecycleManager.copyBytesToContainer(containerId, loadResource(ARTEMIS_AMQP_PATCH_RESOURCE),
+                    ARTEMIS_AMQP_PATH);
 
-        ContainerLifecycleManager.ContainerInfo info = lifecycleManager.startCreated(containerId, spec);
+            ContainerLifecycleManager.ContainerInfo info = lifecycleManager.startCreated(containerId, spec);
 
-        EndpointInfo amqpEndpoint  = info.getEndpoint(AMQP_PORT);
-        EndpointInfo amqpsEndpoint = info.getEndpoint(AMQPS_PORT);
-        EndpointInfo jolokiaEndpoint = info.getEndpoint(JOLOKIA_PORT);
+            EndpointInfo amqpEndpoint = info.getEndpoint(AMQP_PORT);
+            EndpointInfo amqpsEndpoint = info.getEndpoint(AMQPS_PORT);
+            EndpointInfo jolokiaEndpoint = info.getEndpoint(JOLOKIA_PORT);
 
-        waitForPort(amqpEndpoint, "AMQP");
-        waitForPort(amqpsEndpoint, "AMQPS");
+            waitForPort(amqpEndpoint, "AMQP");
+            waitForPort(amqpsEndpoint, "AMQPS");
 
-        ServiceBusCbsResponder cbs = new ServiceBusCbsResponder(amqpEndpoint.host(), amqpEndpoint.port());
-        cbs.start();
-        cbsResponders.put(namespaceName, cbs);
+            cbs = new ServiceBusCbsResponder(amqpEndpoint.host(), amqpEndpoint.port());
+            cbs.start();
+            cbsResponders.put(namespaceName, cbs);
 
-        NamespaceState state = new NamespaceState(
-                containerId,
-                amqpEndpoint.port(),
-                amqpsEndpoint.port(),
-                tls.certPem(),
-                jolokiaEndpoint.host(),
-                jolokiaEndpoint.port(),
-                false);
-        namespaces.put(namespaceName, state);
+            NamespaceState state = new NamespaceState(
+                    containerId,
+                    amqpEndpoint.port(),
+                    amqpsEndpoint.port(),
+                    tls.certPem(),
+                    jolokiaEndpoint.host(),
+                    jolokiaEndpoint.port(),
+                    false);
+            namespaces.put(namespaceName, state);
 
-        LOG.infov("Service Bus namespace ''{0}'' ready: amqp:{1}, amqps:{2}",
-                namespaceName, amqpEndpoint, amqpsEndpoint);
-        return state;
+            LOG.infov("Service Bus namespace ''{0}'' ready: amqp:{1}, amqps:{2}",
+                    namespaceName, amqpEndpoint, amqpsEndpoint);
+            return state;
+        } catch (RuntimeException e) {
+            cleanupFailedStart(namespaceName, containerName, containerId, cbs);
+            throw e;
+        }
+    }
+
+    private void cleanupFailedStart(String namespaceName, String containerName,
+                                    String containerId, ServiceBusCbsResponder cbs) {
+        namespaces.remove(namespaceName);
+        ServiceBusCbsResponder registeredCbs = cbsResponders.remove(namespaceName);
+        if (registeredCbs != null) {
+            registeredCbs.stop();
+        } else if (cbs != null) {
+            cbs.stop();
+        }
+        if (containerId != null) {
+            lifecycleManager.stopAndRemove(containerId, null);
+        } else {
+            lifecycleManager.removeIfExists(containerName);
+        }
     }
 
     int reapOrphanedContainers() {

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -548,11 +548,13 @@ public class ServiceBusNamespaceManager {
         String queueName = topicName + "/Subscriptions/" + subName;
         String divertName = queueName + SUBSCRIPTION_DIVERT_SUFFIX;
         withJolokia(namespaceName, (http, baseUrl, auth, mbean) -> {
-            jolokiaExec(http, baseUrl, auth, mbean,
+            jolokiaExecRequired(http, baseUrl, auth, mbean,
                     "destroyDivert(java.lang.String)",
                     jsonArr(divertName));
-            jolokiaCreateDivert(http, baseUrl, auth, mbean, divertName,
-                    topicName + TOPIC_ADDRESS_SUFFIX, queueName, filter, false);
+            jolokiaExecRequired(http, baseUrl, auth, mbean,
+                    "createDivert(java.lang.String,java.lang.String,java.lang.String,java.lang.String,boolean,java.lang.String,java.lang.String)",
+                    jsonArr(divertName, divertName, topicName + TOPIC_ADDRESS_SUFFIX,
+                            queueName, false, filter, null));
         });
     }
 
@@ -725,18 +727,9 @@ public class ServiceBusNamespaceManager {
 
     private void jolokiaExec(HttpClient http, String baseUrl, String auth,
                               String mbean, String operation, String arguments) {
-        String body = "{\"type\":\"exec\",\"mbean\":\"" + mbean + "\","
-                + "\"operation\":\"" + operation + "\","
-                + "\"arguments\":" + arguments + "}";
         try {
-            HttpRequest req = HttpRequest.newBuilder()
-                    .uri(URI.create(baseUrl))
-                    .timeout(Duration.ofSeconds(10))
-                    .header("Content-Type", "application/json")
-                    .header("Authorization", "Basic " + auth)
-                    .POST(HttpRequest.BodyPublishers.ofString(body))
-                    .build();
-            HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString());
+            HttpResponse<String> resp = sendJolokiaExec(
+                    http, baseUrl, auth, mbean, operation, arguments);
             if (resp.statusCode() != 200) {
                 String err = resp.body();
                 if (!err.contains("already exists") && !err.contains("already been deployed")) {
@@ -746,6 +739,42 @@ public class ServiceBusNamespaceManager {
         } catch (Exception e) {
             LOG.debugv("Jolokia call failed ({0}): {1}", operation.split("\\(")[0], e.getMessage());
         }
+    }
+
+    private void jolokiaExecRequired(HttpClient http, String baseUrl, String auth,
+                                     String mbean, String operation, String arguments) {
+        try {
+            HttpResponse<String> response = sendJolokiaExec(
+                    http, baseUrl, auth, mbean, operation, arguments);
+            JsonNode payload = MAPPER.readTree(response.body());
+            int jolokiaStatus = payload.path("status").asInt(-1);
+            if (response.statusCode() != 200 || jolokiaStatus != 200) {
+                throw new IllegalStateException("Jolokia " + operation.split("\\(")[0]
+                        + " failed with HTTP " + response.statusCode()
+                        + " and status " + jolokiaStatus + ": " + response.body());
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Interrupted during required Jolokia operation", e);
+        } catch (IOException e) {
+            throw new RuntimeException("Required Jolokia operation failed", e);
+        }
+    }
+
+    private HttpResponse<String> sendJolokiaExec(HttpClient http, String baseUrl, String auth,
+                                                  String mbean, String operation, String arguments)
+            throws IOException, InterruptedException {
+        String body = "{\"type\":\"exec\",\"mbean\":\"" + mbean + "\","
+                + "\"operation\":\"" + operation + "\","
+                + "\"arguments\":" + arguments + "}";
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(baseUrl))
+                .timeout(Duration.ofSeconds(10))
+                .header("Content-Type", "application/json")
+                .header("Authorization", "Basic " + auth)
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build();
+        return http.send(request, HttpResponse.BodyHandlers.ofString());
     }
 
     private static Map<String, MessageCounts> jolokiaReadMessageCounts(

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -577,7 +577,7 @@ public class ServiceBusNamespaceManager {
         withJolokia(namespaceName, (http, baseUrl, auth, mbean) -> {
             jolokiaExecRequired(http, baseUrl, auth, mbean,
                     "updateDivert(java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.util.Map,java.lang.String)",
-                    jsonArr(divertName, queueName, filter, null, Map.of(), null));
+                    jsonArr(divertName, queueName, filter, null, Map.of(), "STRIP"));
         });
     }
 

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -166,6 +166,7 @@ public class ServiceBusNamespaceManager {
 
         String containerId = null;
         ServiceBusCbsResponder cbs = null;
+        boolean containerStarted = false;
         try {
             if (!lifecycleManager.removeIfExistsAndConfirm(containerName)) {
                 throw new IllegalStateException(
@@ -209,6 +210,7 @@ public class ServiceBusNamespaceManager {
                     ARTEMIS_AMQP_PATH);
 
             ContainerLifecycleManager.ContainerInfo info = lifecycleManager.startCreated(containerId, spec);
+            containerStarted = true;
 
             EndpointInfo amqpEndpoint = info.getEndpoint(AMQP_PORT);
             EndpointInfo amqpsEndpoint = info.getEndpoint(AMQPS_PORT);
@@ -238,7 +240,8 @@ public class ServiceBusNamespaceManager {
             boolean portsReleased = false;
             try {
                 cleanupFailedStart(namespaceName, containerName, containerId, cbs);
-                portsReleased = true;
+                // A successful start proves the configured ports were bindable before cleanup.
+                portsReleased = containerStarted;
             } catch (RuntimeException cleanupFailure) {
                 e.addSuppressed(cleanupFailure);
             }

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -166,6 +166,7 @@ public class ServiceBusNamespaceManager {
 
         String containerId = null;
         ServiceBusCbsResponder cbs = null;
+        boolean startAttempted = false;
         boolean containerStarted = false;
         try {
             if (!lifecycleManager.removeIfExistsAndConfirm(containerName)) {
@@ -209,6 +210,7 @@ public class ServiceBusNamespaceManager {
             lifecycleManager.copyBytesToContainer(containerId, loadResource(ARTEMIS_AMQP_PATCH_RESOURCE),
                     ARTEMIS_AMQP_PATH);
 
+            startAttempted = true;
             ContainerLifecycleManager.ContainerInfo info = lifecycleManager.startCreated(containerId, spec);
             containerStarted = true;
 
@@ -237,12 +239,12 @@ public class ServiceBusNamespaceManager {
                     namespaceName, amqpEndpoint, amqpsEndpoint);
             return state;
         } catch (RuntimeException e) {
-            boolean portsWereBound = containerStarted
+            boolean configuredPortsReusable = !startAttempted || containerStarted
                     || (containerId != null && lifecycleManager.isContainerRunning(containerId));
             boolean portsReleased = false;
             try {
                 cleanupFailedStart(namespaceName, containerName, containerId, cbs);
-                portsReleased = portsWereBound;
+                portsReleased = configuredPortsReusable;
             } catch (RuntimeException cleanupFailure) {
                 e.addSuppressed(cleanupFailure);
             }

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -166,6 +166,7 @@ public class ServiceBusNamespaceManager {
 
         String containerId = null;
         ServiceBusCbsResponder cbs = null;
+        boolean createAttempted = false;
         boolean startAttempted = false;
         boolean containerStarted = false;
         try {
@@ -196,6 +197,7 @@ public class ServiceBusNamespaceManager {
                     .withLogRotation()
                     .build();
 
+            createAttempted = true;
             containerId = lifecycleManager.create(spec);
             lifecycleManager.copyFileToContainer(containerId, brokerXml,
                     "/var/lib/artemis-instance/etc-override/broker.xml");
@@ -239,7 +241,9 @@ public class ServiceBusNamespaceManager {
                     namespaceName, amqpEndpoint, amqpsEndpoint);
             return state;
         } catch (RuntimeException e) {
-            boolean configuredPortsReusable = !startAttempted || containerStarted
+            boolean configuredPortsReusable = !createAttempted
+                    || (containerId != null && !startAttempted)
+                    || containerStarted
                     || (containerId != null && lifecycleManager.isContainerRunning(containerId));
             boolean portsReleased = false;
             try {

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -267,8 +267,15 @@ public class ServiceBusNamespaceManager {
         }
         if (containerId != null) {
             lifecycleManager.stopAndRemove(containerId, null);
+            if (!lifecycleManager.removeIfExistsAndConfirm(containerId)) {
+                throw new IllegalStateException(
+                        "Could not confirm removal of failed container " + containerId);
+            }
         } else {
-            lifecycleManager.removeIfExists(containerName);
+            if (!lifecycleManager.removeIfExistsAndConfirm(containerName)) {
+                throw new IllegalStateException(
+                        "Could not confirm removal of failed container " + containerName);
+            }
         }
     }
 
@@ -558,25 +565,15 @@ public class ServiceBusNamespaceManager {
         });
     }
 
-    /**
-     * Replaces the filter of an existing subscription divert. The broker applies the new filter
-     * to future routing only, matching Azure's rule-change semantics: messages already routed to
-     * the subscription stay, and attached receivers stay connected to the unchanged queue.
-     */
+    /** Updates the existing subscription divert without interrupting its queue or receivers. */
     public void jolokiaUpdateSubscriptionFilter(String namespaceName, String topicName, String subName,
                                                  String filter) {
         String queueName = topicName + "/Subscriptions/" + subName;
         String divertName = queueName + SUBSCRIPTION_DIVERT_SUFFIX;
         withJolokia(namespaceName, (http, baseUrl, auth, mbean) -> {
-            // Destroy is intentionally best-effort: a failed replacement may already have
-            // removed the divert, and rollback must still be able to recreate it.
-            jolokiaExec(http, baseUrl, auth, mbean,
-                    "destroyDivert(java.lang.String)",
-                    jsonArr(divertName));
             jolokiaExecRequired(http, baseUrl, auth, mbean,
-                    "createDivert(java.lang.String,java.lang.String,java.lang.String,java.lang.String,boolean,java.lang.String,java.lang.String)",
-                    jsonArr(divertName, divertName, topicName + TOPIC_ADDRESS_SUFFIX,
-                            queueName, false, filter, null));
+                    "updateDivert(java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.util.Map,java.lang.String)",
+                    jsonArr(divertName, queueName, filter, null, Map.of(), null));
         });
     }
 

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -164,32 +164,36 @@ public class ServiceBusNamespaceManager {
                 amqpHostPort == 0 ? "dynamic" : amqpHostPort,
                 amqpsHostPort == 0 ? "dynamic" : amqpsHostPort);
 
-        ArtemisTlsGenerator.TlsBundle tls;
-        try {
-            tls = tlsGenerator.generate(containerName);
-        } catch (Exception e) {
-            throw new RuntimeException(
-                    "Failed to generate TLS certificate for Service Bus namespace '" + namespaceName
-                            + "': " + rootMessage(e), e);
-        }
-
-        String brokerXml = configGenerator.generate(namespaceName);
-        lifecycleManager.removeIfExists(containerName);
-
-        ContainerSpec spec = containerBuilder.newContainer(config.services().serviceBus().artemisImage())
-                .withName(containerName)
-                .withEnv("ANONYMOUS_LOGIN", "true")
-                .withLabels(serviceContainerLabels())
-                .withPortBinding(AMQP_PORT, amqpHostPort)
-                .withPortBinding(AMQPS_PORT, amqpsHostPort)
-                .withDynamicPort(JOLOKIA_PORT)
-                .withDockerNetwork(config.services().dockerNetwork())
-                .withLogRotation()
-                .build();
-
         String containerId = null;
         ServiceBusCbsResponder cbs = null;
         try {
+            if (!lifecycleManager.removeIfExistsAndConfirm(containerName)) {
+                throw new IllegalStateException(
+                        "Could not remove stale container " + containerName);
+            }
+
+            ArtemisTlsGenerator.TlsBundle tls;
+            try {
+                tls = tlsGenerator.generate(containerName);
+            } catch (Exception e) {
+                throw new RuntimeException(
+                        "Failed to generate TLS certificate for Service Bus namespace '"
+                                + namespaceName + "': " + rootMessage(e), e);
+            }
+
+            String brokerXml = configGenerator.generate(namespaceName);
+            ContainerSpec spec = containerBuilder.newContainer(
+                            config.services().serviceBus().artemisImage())
+                    .withName(containerName)
+                    .withEnv("ANONYMOUS_LOGIN", "true")
+                    .withLabels(serviceContainerLabels())
+                    .withPortBinding(AMQP_PORT, amqpHostPort)
+                    .withPortBinding(AMQPS_PORT, amqpsHostPort)
+                    .withDynamicPort(JOLOKIA_PORT)
+                    .withDockerNetwork(config.services().dockerNetwork())
+                    .withLogRotation()
+                    .build();
+
             containerId = lifecycleManager.create(spec);
             lifecycleManager.copyFileToContainer(containerId, brokerXml,
                     "/var/lib/artemis-instance/etc-override/broker.xml");

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -548,7 +548,9 @@ public class ServiceBusNamespaceManager {
         String queueName = topicName + "/Subscriptions/" + subName;
         String divertName = queueName + SUBSCRIPTION_DIVERT_SUFFIX;
         withJolokia(namespaceName, (http, baseUrl, auth, mbean) -> {
-            jolokiaExecRequired(http, baseUrl, auth, mbean,
+            // Destroy is intentionally best-effort: a failed replacement may already have
+            // removed the divert, and rollback must still be able to recreate it.
+            jolokiaExec(http, baseUrl, auth, mbean,
                     "destroyDivert(java.lang.String)",
                     jsonArr(divertName));
             jolokiaExecRequired(http, baseUrl, auth, mbean,

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -237,11 +237,12 @@ public class ServiceBusNamespaceManager {
                     namespaceName, amqpEndpoint, amqpsEndpoint);
             return state;
         } catch (RuntimeException e) {
+            boolean portsWereBound = containerStarted
+                    || (containerId != null && lifecycleManager.isContainerRunning(containerId));
             boolean portsReleased = false;
             try {
                 cleanupFailedStart(namespaceName, containerName, containerId, cbs);
-                // A successful start proves the configured ports were bindable before cleanup.
-                portsReleased = containerStarted;
+                portsReleased = portsWereBound;
             } catch (RuntimeException cleanupFailure) {
                 e.addSuppressed(cleanupFailure);
             }

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusTopologyFile.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusTopologyFile.java
@@ -1,0 +1,109 @@
+package io.floci.az.services.servicebus;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.quarkus.runtime.annotations.RegisterForReflection;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Jackson model of the official Service Bus emulator's declarative {@code Config.json}
+ * (<a href="https://learn.microsoft.com/azure/service-bus-messaging/test-locally-with-service-bus-emulator">
+ * format reference</a>), also written by the .NET Aspire Service Bus hosting integration.
+ * Property names are the file's PascalCase keys; unknown keys are ignored so future
+ * additions to the official format don't break loading.
+ */
+final class ServiceBusTopologyFile {
+
+    private ServiceBusTopologyFile() {}
+
+    @RegisterForReflection
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record Root(@JsonProperty("UserConfig") UserConfig userConfig) {}
+
+    @RegisterForReflection
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record UserConfig(@JsonProperty("Namespaces") List<Namespace> namespaces) {}
+
+    @RegisterForReflection
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record Namespace(
+            @JsonProperty("Name") String name,
+            @JsonProperty("Queues") List<Queue> queues,
+            @JsonProperty("Topics") List<Topic> topics) {}
+
+    @RegisterForReflection
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record Queue(
+            @JsonProperty("Name") String name,
+            @JsonProperty("Properties") EntityProperties properties) {}
+
+    @RegisterForReflection
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record Topic(
+            @JsonProperty("Name") String name,
+            @JsonProperty("Properties") EntityProperties properties,
+            @JsonProperty("Subscriptions") List<Subscription> subscriptions) {}
+
+    @RegisterForReflection
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record Subscription(
+            @JsonProperty("Name") String name,
+            @JsonProperty("Properties") EntityProperties properties,
+            @JsonProperty("Rules") List<Rule> rules) {}
+
+    /** Shared property bag — queues, topics, and subscriptions each honor their subset. */
+    @RegisterForReflection
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record EntityProperties(
+            @JsonProperty("DeadLetteringOnMessageExpiration") Boolean deadLetteringOnMessageExpiration,
+            @JsonProperty("DefaultMessageTimeToLive") String defaultMessageTimeToLive,
+            @JsonProperty("DuplicateDetectionHistoryTimeWindow") String duplicateDetectionHistoryTimeWindow,
+            @JsonProperty("ForwardDeadLetteredMessagesTo") String forwardDeadLetteredMessagesTo,
+            @JsonProperty("ForwardTo") String forwardTo,
+            @JsonProperty("LockDuration") String lockDuration,
+            @JsonProperty("MaxDeliveryCount") Integer maxDeliveryCount,
+            @JsonProperty("RequiresDuplicateDetection") Boolean requiresDuplicateDetection,
+            @JsonProperty("RequiresSession") Boolean requiresSession) {
+
+        static final EntityProperties EMPTY =
+                new EntityProperties(null, null, null, null, null, null, null, null, null);
+    }
+
+    @RegisterForReflection
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record Rule(
+            @JsonProperty("Name") String name,
+            @JsonProperty("Properties") RuleProperties properties) {}
+
+    /** {@code FilterType} is {@code Correlation} or {@code Sql} in the official format. */
+    @RegisterForReflection
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record RuleProperties(
+            @JsonProperty("FilterType") String filterType,
+            @JsonProperty("CorrelationFilter") CorrelationFilter correlationFilter,
+            @JsonProperty("SqlFilter") SqlExpressionHolder sqlFilter,
+            @JsonProperty("Action") SqlExpressionHolder action) {}
+
+    @RegisterForReflection
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record CorrelationFilter(
+            @JsonProperty("Properties") Map<String, Object> properties,
+            @JsonProperty("CorrelationId") String correlationId,
+            @JsonProperty("MessageId") String messageId,
+            @JsonProperty("To") String to,
+            @JsonProperty("ReplyTo") String replyTo,
+            @JsonProperty("Label") String label,
+            @JsonProperty("SessionId") String sessionId,
+            @JsonProperty("ReplyToSessionId") String replyToSessionId,
+            @JsonProperty("ContentType") String contentType) {
+
+        static final CorrelationFilter EMPTY =
+                new CorrelationFilter(null, null, null, null, null, null, null, null, null);
+    }
+
+    @RegisterForReflection
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record SqlExpressionHolder(@JsonProperty("SqlExpression") String sqlExpression) {}
+}

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusTopologyLoader.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusTopologyLoader.java
@@ -1,0 +1,339 @@
+package io.floci.az.services.servicebus;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.floci.az.config.EmulatorConfig;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Applies a declarative Service Bus topology at startup from the official emulator's
+ * {@code Config.json} format ({@link ServiceBusTopologyFile}). Entities are created through
+ * the same {@link ServiceBusHandler} paths the management API uses, so validation, storage,
+ * and Artemis provisioning behave exactly as if an SDK had created them.
+ *
+ * <p>Rule semantics match the official emulator: a subscription with declared rules gets
+ * exactly those rules (the implicit {@code $Default} TrueFilter is removed); one without
+ * rules keeps {@code $Default}.
+ *
+ * <p>Loading is best-effort and never fails startup: an unreadable file is skipped with an
+ * {@code ERROR}, an invalid entity is skipped with an {@code ERROR} while the rest of the
+ * topology still loads.
+ */
+@ApplicationScoped
+public class ServiceBusTopologyLoader {
+
+    /** Mount path used by the official Service Bus emulator (and targeted by .NET Aspire). */
+    static final String OFFICIAL_CONFIG_PATH = "/ServiceBus_Emulator/ConfigFiles/Config.json";
+
+    /** Account the SDK spec paths dispatch under (see {@code AzureRoutingFilter}). */
+    private static final String ACCOUNT = "devstoreaccount1";
+    private static final String DEFAULT_RULE = "$Default";
+
+    private static final Logger LOG = Logger.getLogger(ServiceBusTopologyLoader.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /** Per-load application counters, local to one {@link #load()} call. */
+    private static final class Tally {
+        int queues;
+        int topics;
+        int subscriptions;
+        int rules;
+    }
+
+    private final EmulatorConfig config;
+    private final ServiceBusHandler handler;
+    private final ServiceBusNamespaceManager namespaceManager;
+
+    @Inject
+    public ServiceBusTopologyLoader(EmulatorConfig config,
+                                     ServiceBusHandler handler,
+                                     ServiceBusNamespaceManager namespaceManager) {
+        this.config = config;
+        this.handler = handler;
+        this.namespaceManager = namespaceManager;
+    }
+
+    public void load() {
+        Path file = resolveFile();
+        if (file == null) {
+            return;
+        }
+        ServiceBusTopologyFile.Root root;
+        try {
+            root = MAPPER.readValue(Files.readAllBytes(file), ServiceBusTopologyFile.Root.class);
+        } catch (Exception e) {
+            LOG.errorf(e, "Could not parse Service Bus topology file '%s' — no topology loaded", file);
+            return;
+        }
+        List<ServiceBusTopologyFile.Namespace> namespaces =
+                root == null || root.userConfig() == null || root.userConfig().namespaces() == null
+                        ? List.of()
+                        : root.userConfig().namespaces();
+        if (namespaces.isEmpty()) {
+            LOG.warnf("Service Bus topology file '%s' declares no namespaces", file);
+            return;
+        }
+
+        Tally tally = new Tally();
+        boolean first = true;
+        for (ServiceBusTopologyFile.Namespace namespace : namespaces) {
+            if (namespace == null || namespace.name() == null || namespace.name().isBlank()) {
+                LOG.error("Skipping a Service Bus topology namespace without a Name");
+                continue;
+            }
+            startNamespace(namespace.name(), first);
+            first = false;
+            applyNamespace(namespace, tally);
+        }
+        LOG.infov("Loaded Service Bus topology from {0}: {1} namespace(s), {2} queue(s), "
+                        + "{3} topic(s), {4} subscription(s), {5} rule(s)",
+                file, namespaces.size(), tally.queues, tally.topics, tally.subscriptions, tally.rules);
+    }
+
+    private Path resolveFile() {
+        Optional<String> configured = config.services().serviceBus().topologyFile();
+        if (configured.isPresent() && !configured.get().isBlank()) {
+            Path path = Path.of(configured.get());
+            if (!Files.isRegularFile(path)) {
+                LOG.errorf("Configured Service Bus topology file '%s' does not exist", path);
+                return null;
+            }
+            return path;
+        }
+        Path official = Path.of(OFFICIAL_CONFIG_PATH);
+        return Files.isRegularFile(official) ? official : null;
+    }
+
+    /**
+     * The first namespace binds the configured AMQP host ports; further namespaces (the
+     * official emulator supports only one) get dynamic ports so they don't collide.
+     */
+    private void startNamespace(String name, boolean useConfiguredPorts) {
+        if (namespaceManager.getNamespace(name).isPresent()) {
+            return;
+        }
+        EmulatorConfig.ServiceBusConfig sb = config.services().serviceBus();
+        if (sb.mocked()) {
+            namespaceManager.startMockedNamespace(name);
+            return;
+        }
+        try {
+            namespaceManager.startNamespace(name,
+                    useConfiguredPorts ? sb.amqpPort() : 0,
+                    useConfiguredPorts ? sb.amqpTlsPort() : 0);
+        } catch (Exception e) {
+            LOG.errorf(e, "Could not start Service Bus namespace '%s' from the topology file", name);
+        }
+    }
+
+    private void applyNamespace(ServiceBusTopologyFile.Namespace namespace, Tally tally) {
+        for (ServiceBusTopologyFile.Queue queue : orEmpty(namespace.queues())) {
+            if (hasName("queue", queue == null ? null : queue.name()) && applyQueue(namespace.name(), queue)) {
+                tally.queues++;
+            }
+        }
+        for (ServiceBusTopologyFile.Topic topic : orEmpty(namespace.topics())) {
+            if (!hasName("topic", topic == null ? null : topic.name())) {
+                continue;
+            }
+            if (applyTopic(namespace.name(), topic)) {
+                tally.topics++;
+                for (ServiceBusTopologyFile.Subscription subscription : orEmpty(topic.subscriptions())) {
+                    if (hasName("subscription", subscription == null ? null : subscription.name())
+                            && applySubscription(namespace.name(), topic.name(), subscription, tally)) {
+                        tally.subscriptions++;
+                    }
+                }
+            }
+        }
+    }
+
+    private boolean applyQueue(String namespace, ServiceBusTopologyFile.Queue queue) {
+        ServiceBusTopologyFile.EntityProperties p = properties(queue.properties());
+        warnOnForwarding("queue", queue.name(), p);
+        try {
+            Response response = handler.handleCreateQueue(ACCOUNT, namespace, queue.name(),
+                    Boolean.TRUE.equals(p.requiresSession()),
+                    duplicateDetection(p), lifetime(p), delivery(p));
+            return succeeded("queue", queue.name(), response);
+        } catch (IllegalArgumentException e) {
+            LOG.errorf("Skipping topology queue '%s': %s", queue.name(), e.getMessage());
+            return false;
+        }
+    }
+
+    private boolean applyTopic(String namespace, ServiceBusTopologyFile.Topic topic) {
+        ServiceBusTopologyFile.EntityProperties p = properties(topic.properties());
+        try {
+            Response response = handler.handleCreateTopic(ACCOUNT, namespace, topic.name(),
+                    duplicateDetection(p), lifetime(p));
+            return succeeded("topic", topic.name(), response);
+        } catch (IllegalArgumentException e) {
+            LOG.errorf("Skipping topology topic '%s': %s", topic.name(), e.getMessage());
+            return false;
+        }
+    }
+
+    private boolean applySubscription(String namespace, String topicName,
+                                       ServiceBusTopologyFile.Subscription subscription, Tally tally) {
+        ServiceBusTopologyFile.EntityProperties p = properties(subscription.properties());
+        String path = topicName + "/" + subscription.name();
+        warnOnForwarding("subscription", path, p);
+        try {
+            Response response = handler.handleCreateSubscription(ACCOUNT, namespace,
+                    topicName, subscription.name(), Boolean.TRUE.equals(p.requiresSession()),
+                    "", lifetime(p), delivery(p));
+            if (!succeeded("subscription", path, response)) {
+                return false;
+            }
+        } catch (IllegalArgumentException e) {
+            LOG.errorf("Skipping topology subscription '%s': %s", path, e.getMessage());
+            return false;
+        }
+
+        int applied = 0;
+        for (ServiceBusTopologyFile.Rule rule : orEmpty(subscription.rules())) {
+            if (hasName("rule", rule == null ? null : rule.name())
+                    && applyRule(namespace, topicName, subscription.name(), rule)) {
+                applied++;
+            }
+        }
+        if (applied > 0) {
+            // Declared rules define the complete rule set, as in the official emulator:
+            // drop the implicit $Default TrueFilter so the declared filters actually apply.
+            handler.handleDeleteRule(ACCOUNT, namespace, topicName, subscription.name(), DEFAULT_RULE);
+        }
+        tally.rules += applied;
+        return true;
+    }
+
+    private boolean applyRule(String namespace, String topicName, String subName,
+                               ServiceBusTopologyFile.Rule rule) {
+        String path = topicName + "/" + subName + "/" + rule.name();
+        ServiceBusModels.RuleEntity entity;
+        try {
+            entity = toRuleEntity(topicName, subName, rule);
+        } catch (IllegalArgumentException e) {
+            LOG.errorf("Skipping topology rule '%s': %s", path, e.getMessage());
+            return false;
+        }
+        return succeeded("rule", path, handler.putRule(ACCOUNT, namespace, entity));
+    }
+
+    static ServiceBusModels.RuleEntity toRuleEntity(String topicName, String subName,
+                                                     ServiceBusTopologyFile.Rule rule) {
+        ServiceBusTopologyFile.RuleProperties p = rule.properties();
+        if (p == null || p.filterType() == null || p.filterType().isBlank()) {
+            throw new IllegalArgumentException("FilterType is required");
+        }
+        String type = p.filterType().trim();
+        String actionSql = p.action() == null ? null : p.action().sqlExpression();
+
+        if ("Correlation".equalsIgnoreCase(type) || "CorrelationFilter".equalsIgnoreCase(type)) {
+            ServiceBusTopologyFile.CorrelationFilter filter = p.correlationFilter() == null
+                    ? ServiceBusTopologyFile.CorrelationFilter.EMPTY
+                    : p.correlationFilter();
+            Map<String, String> properties = new LinkedHashMap<>();
+            Map<String, String> propertyTypes = new LinkedHashMap<>();
+            if (filter.properties() != null) {
+                filter.properties().forEach((key, value) -> {
+                    properties.put(key, String.valueOf(value));
+                    // Mirror the XML path's xsi:type tagging so typed application
+                    // properties compare with their declared type in the selector.
+                    if (value instanceof Boolean) {
+                        propertyTypes.put(key, "boolean");
+                    } else if (value instanceof Integer || value instanceof Long) {
+                        propertyTypes.put(key, "long");
+                    } else if (value instanceof Number) {
+                        propertyTypes.put(key, "double");
+                    }
+                });
+            }
+            return new ServiceBusModels.RuleEntity(topicName, subName, rule.name(),
+                    "CorrelationFilter", null, filter.correlationId(), filter.messageId(),
+                    filter.to(), filter.replyTo(), filter.label(), filter.sessionId(),
+                    filter.replyToSessionId(), filter.contentType(), properties, propertyTypes,
+                    actionSql, Instant.now());
+        }
+        if ("Sql".equalsIgnoreCase(type) || "SqlFilter".equalsIgnoreCase(type)) {
+            String expression = p.sqlFilter() == null ? null : p.sqlFilter().sqlExpression();
+            if (expression == null || expression.isBlank()) {
+                throw new IllegalArgumentException(
+                        "SqlFilter.SqlExpression is required for FilterType 'Sql'");
+            }
+            return new ServiceBusModels.RuleEntity(topicName, subName, rule.name(),
+                    "SqlFilter", expression, null, null, null, null, null, null, null, null,
+                    Map.of(), Map.of(), actionSql, Instant.now());
+        }
+        throw new IllegalArgumentException("Unsupported FilterType '" + type + "'");
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private static ServiceBusTopologyFile.EntityProperties properties(
+            ServiceBusTopologyFile.EntityProperties properties) {
+        return properties == null ? ServiceBusTopologyFile.EntityProperties.EMPTY : properties;
+    }
+
+    private static ServiceBusEntityXml.DuplicateDetectionSettings duplicateDetection(
+            ServiceBusTopologyFile.EntityProperties p) {
+        return ServiceBusEntityXml.duplicateDetectionOf(
+                Boolean.TRUE.equals(p.requiresDuplicateDetection()),
+                p.duplicateDetectionHistoryTimeWindow());
+    }
+
+    private static ServiceBusEntityXml.MessageLifetimeSettings lifetime(
+            ServiceBusTopologyFile.EntityProperties p) {
+        return ServiceBusEntityXml.messageLifetimeOf(
+                p.defaultMessageTimeToLive(),
+                Boolean.TRUE.equals(p.deadLetteringOnMessageExpiration()));
+    }
+
+    private static ServiceBusEntityXml.DeliverySettings delivery(
+            ServiceBusTopologyFile.EntityProperties p) {
+        return ServiceBusEntityXml.deliveryOf(p.maxDeliveryCount(), p.lockDuration());
+    }
+
+    private static void warnOnForwarding(String kind, String name,
+                                          ServiceBusTopologyFile.EntityProperties p) {
+        if (hasValue(p.forwardTo()) || hasValue(p.forwardDeadLetteredMessagesTo())) {
+            LOG.warnf("Topology %s '%s' declares ForwardTo/ForwardDeadLetteredMessagesTo; "
+                    + "auto-forwarding is not emulated and the setting is ignored", kind, name);
+        }
+    }
+
+    private static boolean hasValue(String value) {
+        return value != null && !value.isBlank();
+    }
+
+    private static boolean hasName(String kind, String name) {
+        if (name == null || name.isBlank()) {
+            LOG.errorf("Skipping a Service Bus topology %s without a Name", kind);
+            return false;
+        }
+        return true;
+    }
+
+    private static boolean succeeded(String kind, String name, Response response) {
+        if (response.getStatus() / 100 == 2) {
+            return true;
+        }
+        LOG.errorf("Could not apply topology %s '%s' (HTTP %d): %s",
+                kind, name, response.getStatus(), response.getEntity());
+        return false;
+    }
+
+    private static <T> List<T> orEmpty(List<T> list) {
+        return list == null ? List.of() : list;
+    }
+}

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusTopologyLoader.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusTopologyLoader.java
@@ -255,8 +255,9 @@ public class ServiceBusTopologyLoader {
         for (ServiceBusModels.RuleEntity existing :
                 handler.loadRules(ACCOUNT, namespace, topicName, subscription.name())) {
             if (!retainedRuleNames.contains(existing.name())) {
-                handler.handleDeleteRule(
-                        ACCOUNT, namespace, topicName, subscription.name(), existing.name());
+                succeeded("rule", topicName + "/" + subscription.name() + "/" + existing.name(),
+                        handler.handleDeleteRule(
+                                ACCOUNT, namespace, topicName, subscription.name(), existing.name()));
             }
         }
         return applied;

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusTopologyLoader.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusTopologyLoader.java
@@ -23,9 +23,9 @@ import java.util.Set;
  * the same {@link ServiceBusHandler} paths the management API uses, so validation, storage,
  * and Artemis provisioning behave exactly as if an SDK had created them.
  *
- * <p>Rule semantics match the official emulator: a subscription with declared rules gets
- * exactly those rules (the implicit {@code $Default} TrueFilter is removed); one without
- * rules keeps {@code $Default}.
+ * <p>Rule semantics match the official emulator: valid declarations reconcile exactly and
+ * remove the implicit {@code $Default} TrueFilter; a rejected replacement preserves the last
+ * valid same-named rule, while a subscription without declarations keeps {@code $Default}.
  *
  * <p>Loading is best-effort and never fails startup: an unreadable file is skipped with an
  * {@code ERROR}, an invalid entity is skipped with an {@code ERROR} while the rest of the
@@ -218,6 +218,11 @@ public class ServiceBusTopologyLoader {
     private int reconcileRules(String namespace, String topicName,
                                ServiceBusTopologyFile.Subscription subscription) {
         List<ServiceBusTopologyFile.Rule> declaredRules = orEmpty(subscription.rules());
+        Set<String> existingRuleNames = new HashSet<>();
+        for (ServiceBusModels.RuleEntity existing :
+                handler.loadRules(ACCOUNT, namespace, topicName, subscription.name())) {
+            existingRuleNames.add(existing.name());
+        }
         Set<String> retainedRuleNames = new HashSet<>();
         int applied = 0;
 
@@ -227,13 +232,22 @@ public class ServiceBusTopologyLoader {
             if (succeeded("rule", topicName + "/" + subscription.name() + "/" + DEFAULT_RULE,
                     handler.putRule(ACCOUNT, namespace, defaultRule))) {
                 retainedRuleNames.add(DEFAULT_RULE);
+            } else if (existingRuleNames.contains(DEFAULT_RULE)) {
+                retainedRuleNames.add(DEFAULT_RULE);
             }
         } else {
             for (ServiceBusTopologyFile.Rule rule : declaredRules) {
-                if (hasName("rule", rule == null ? null : rule.name())
-                        && applyRule(namespace, topicName, subscription.name(), rule)) {
+                if (!hasName("rule", rule == null ? null : rule.name())) {
+                    continue;
+                }
+                if (applyRule(namespace, topicName, subscription.name(), rule)) {
                     retainedRuleNames.add(rule.name());
                     applied++;
+                } else if (existingRuleNames.contains(rule.name())) {
+                    LOG.warnf("Keeping existing topology rule '%s/%s/%s' because its replacement "
+                                    + "was rejected",
+                            topicName, subscription.name(), rule.name());
+                    retainedRuleNames.add(rule.name());
                 }
             }
         }

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusTopologyLoader.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusTopologyLoader.java
@@ -88,16 +88,17 @@ public class ServiceBusTopologyLoader {
         }
 
         Tally tally = new Tally();
-        boolean first = true;
+        boolean configuredPortsAvailable = true;
         for (ServiceBusTopologyFile.Namespace namespace : namespaces) {
             if (namespace == null || namespace.name() == null || namespace.name().isBlank()) {
                 LOG.error("Skipping a Service Bus topology namespace without a Name");
                 continue;
             }
-            if (!startNamespace(namespace.name(), first)) {
+            boolean useConfiguredPorts = configuredPortsAvailable;
+            configuredPortsAvailable = false;
+            if (!startNamespace(namespace.name(), useConfiguredPorts)) {
                 continue;
             }
-            first = false;
             tally.namespaces++;
             applyNamespace(namespace, tally);
         }

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusTopologyLoader.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusTopologyLoader.java
@@ -10,12 +10,11 @@ import org.jboss.logging.Logger;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
-import java.util.HashSet;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 /**
  * Applies a declarative Service Bus topology at startup from the official emulator's
@@ -23,9 +22,9 @@ import java.util.Set;
  * the same {@link ServiceBusHandler} paths the management API uses, so validation, storage,
  * and Artemis provisioning behave exactly as if an SDK had created them.
  *
- * <p>Rule semantics match the official emulator: valid declarations reconcile exactly and
- * remove the implicit {@code $Default} TrueFilter; a rejected replacement preserves the last
- * valid same-named rule, while a subscription without declarations keeps {@code $Default}.
+ * <p>Rule semantics match the official emulator: valid declarations replace the full rule set
+ * atomically and remove the implicit {@code $Default} TrueFilter. A rejected reload leaves an
+ * existing subscription unchanged, while a new subscription keeps only valid declarations.
  *
  * <p>Loading is best-effort and never fails startup: an unreadable file is skipped with an
  * {@code ERROR}, an invalid entity is skipped with an {@code ERROR} while the rest of the
@@ -66,17 +65,23 @@ public class ServiceBusTopologyLoader {
         this.namespaceManager = namespaceManager;
     }
 
-    public void load() {
+    /**
+     * Loads configured topology when present.
+     *
+     * @return {@code true} when a topology file was discovered, including an invalid file that
+     *         was logged and skipped; {@code false} when no file was discovered
+     */
+    public boolean load() {
         Path file = resolveFile();
         if (file == null) {
-            return;
+            return false;
         }
         ServiceBusTopologyFile.Root root;
         try {
             root = MAPPER.readValue(Files.readAllBytes(file), ServiceBusTopologyFile.Root.class);
         } catch (Exception e) {
             LOG.errorf(e, "Could not parse Service Bus topology file '%s' — no topology loaded", file);
-            return;
+            return true;
         }
         List<ServiceBusTopologyFile.Namespace> namespaces =
                 root == null || root.userConfig() == null || root.userConfig().namespaces() == null
@@ -84,7 +89,7 @@ public class ServiceBusTopologyLoader {
                         : root.userConfig().namespaces();
         if (namespaces.isEmpty()) {
             LOG.warnf("Service Bus topology file '%s' declares no namespaces", file);
-            return;
+            return true;
         }
 
         Tally tally = new Tally();
@@ -109,6 +114,7 @@ public class ServiceBusTopologyLoader {
         LOG.infov("Loaded Service Bus topology from {0}: {1} namespace(s), {2} queue(s), "
                         + "{3} topic(s), {4} subscription(s), {5} rule(s)",
                 file, tally.namespaces, tally.queues, tally.topics, tally.subscriptions, tally.rules);
+        return true;
     }
 
     private Path resolveFile() {
@@ -206,6 +212,7 @@ public class ServiceBusTopologyLoader {
         ServiceBusTopologyFile.EntityProperties p = properties(subscription.properties());
         String path = topicName + "/" + subscription.name();
         warnOnForwarding("subscription", path, p);
+        boolean created;
         try {
             Response response = handler.handleCreateSubscription(ACCOUNT, namespace,
                     topicName, subscription.name(), Boolean.TRUE.equals(p.requiresSession()),
@@ -213,86 +220,59 @@ public class ServiceBusTopologyLoader {
             if (!succeeded("subscription", path, response)) {
                 return false;
             }
+            created = response.getStatus() == 201;
         } catch (IllegalArgumentException e) {
             LOG.errorf("Skipping topology subscription '%s': %s", path, e.getMessage());
             return false;
         }
 
-        int applied = reconcileRules(namespace, topicName, subscription);
+        int applied = reconcileRules(namespace, topicName, subscription, created);
         tally.rules += applied;
         return true;
     }
 
     private int reconcileRules(String namespace, String topicName,
-                               ServiceBusTopologyFile.Subscription subscription) {
+                               ServiceBusTopologyFile.Subscription subscription,
+                               boolean subscriptionCreated) {
         List<ServiceBusTopologyFile.Rule> declaredRules = orEmpty(subscription.rules());
-        Set<String> existingRuleNames = new HashSet<>();
-        for (ServiceBusModels.RuleEntity existing :
-                handler.loadRules(ACCOUNT, namespace, topicName, subscription.name())) {
-            existingRuleNames.add(existing.name());
-        }
-        Set<String> retainedRuleNames = new HashSet<>();
-        int applied = 0;
-        boolean ruleRejected = false;
+        List<ServiceBusModels.RuleEntity> desiredRules = new ArrayList<>();
+        boolean rejected = false;
 
         if (declaredRules.isEmpty()) {
-            ServiceBusModels.RuleEntity defaultRule = ServiceBusModels.RuleEntity.trueFilter(
-                    topicName, subscription.name(), DEFAULT_RULE);
-            if (succeeded("rule", topicName + "/" + subscription.name() + "/" + DEFAULT_RULE,
-                    handler.putRule(ACCOUNT, namespace, defaultRule))) {
-                retainedRuleNames.add(DEFAULT_RULE);
-            } else if (existingRuleNames.contains(DEFAULT_RULE)) {
-                retainedRuleNames.add(DEFAULT_RULE);
-            }
+            desiredRules.add(ServiceBusModels.RuleEntity.trueFilter(
+                    topicName, subscription.name(), DEFAULT_RULE));
         } else {
             for (ServiceBusTopologyFile.Rule rule : declaredRules) {
                 if (!hasName("rule", rule == null ? null : rule.name())) {
-                    ruleRejected = true;
+                    rejected = true;
                     continue;
                 }
-                if (applyRule(namespace, topicName, subscription.name(), rule)) {
-                    retainedRuleNames.add(rule.name());
-                    applied++;
-                } else {
-                    ruleRejected = true;
-                    if (!DEFAULT_RULE.equals(rule.name())
-                            && existingRuleNames.contains(rule.name())) {
-                        retainedRuleNames.add(rule.name());
-                    }
+                String path = topicName + "/" + subscription.name() + "/" + rule.name();
+                try {
+                    ServiceBusModels.RuleEntity entity = toRuleEntity(
+                            topicName, subscription.name(), rule);
+                    ServiceBusRuleSelector.forRule(entity);
+                    desiredRules.add(entity);
+                } catch (IllegalArgumentException e) {
+                    rejected = true;
+                    LOG.errorf("Skipping topology rule '%s': %s", path, e.getMessage());
                 }
             }
-            if (ruleRejected && applied == 0) {
-                // The official emulator drops invalid declarations before seeding, leaving the
-                // subscription's implicit $Default rule (or its previous valid rule set) intact.
-                retainedRuleNames.addAll(existingRuleNames);
-                LOG.warnf("Keeping existing topology rules for '%s/%s' because at least one "
-                                + "declared rule was rejected",
+            if (rejected && !subscriptionCreated) {
+                LOG.warnf("Keeping existing topology rules for '%s/%s' because its replacement "
+                                + "contains a rejected rule",
                         topicName, subscription.name());
+                return 0;
             }
         }
 
-        for (ServiceBusModels.RuleEntity existing :
-                handler.loadRules(ACCOUNT, namespace, topicName, subscription.name())) {
-            if (!retainedRuleNames.contains(existing.name())) {
-                succeeded("rule", topicName + "/" + subscription.name() + "/" + existing.name(),
-                        handler.handleDeleteRule(
-                                ACCOUNT, namespace, topicName, subscription.name(), existing.name()));
-            }
+        String path = topicName + "/" + subscription.name();
+        Response response = handler.replaceRules(
+                ACCOUNT, namespace, topicName, subscription.name(), desiredRules);
+        if (!succeeded("rules", path, response)) {
+            return 0;
         }
-        return applied;
-    }
-
-    private boolean applyRule(String namespace, String topicName, String subName,
-                               ServiceBusTopologyFile.Rule rule) {
-        String path = topicName + "/" + subName + "/" + rule.name();
-        ServiceBusModels.RuleEntity entity;
-        try {
-            entity = toRuleEntity(topicName, subName, rule);
-        } catch (IllegalArgumentException e) {
-            LOG.errorf("Skipping topology rule '%s': %s", path, e.getMessage());
-            return false;
-        }
-        return succeeded("rule", path, handler.putRule(ACCOUNT, namespace, entity));
+        return declaredRules.isEmpty() ? 0 : desiredRules.size();
     }
 
     static ServiceBusModels.RuleEntity toRuleEntity(String topicName, String subName,

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusTopologyLoader.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusTopologyLoader.java
@@ -255,9 +255,12 @@ public class ServiceBusTopologyLoader {
                     applied++;
                 } else {
                     ruleRejected = true;
+                    if (existingRuleNames.contains(rule.name())) {
+                        retainedRuleNames.add(rule.name());
+                    }
                 }
             }
-            if (ruleRejected) {
+            if (ruleRejected && applied == 0) {
                 existingRuleNames.stream()
                         .filter(name -> !DEFAULT_RULE.equals(name))
                         .forEach(retainedRuleNames::add);

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusTopologyLoader.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusTopologyLoader.java
@@ -277,23 +277,25 @@ public class ServiceBusTopologyLoader {
                     topicName, subscriptionName);
             return RuleReconcileResult.success(0);
         }
-        if (rulePlan.rejected() && rulePlan.desiredRules().isEmpty()) {
+        boolean keepingImplicitDefault = rulePlan.rejected() && rulePlan.desiredRules().isEmpty();
+        List<ServiceBusModels.RuleEntity> desiredRules = rulePlan.desiredRules();
+        if (keepingImplicitDefault) {
             LOG.warnf("Keeping the implicit $Default rule for new subscription '%s/%s' because "
                             + "every declared rule was rejected",
                     topicName, subscriptionName);
-            return RuleReconcileResult.success(0);
-        }
-        if (subscriptionCreated && rulePlan.desiredRules().size() == 1) {
-            return RuleReconcileResult.success(rulePlan.declaredRulesEmpty() ? 0 : 1);
+            desiredRules = List.of(ServiceBusModels.RuleEntity.trueFilter(
+                    topicName, subscriptionName, DEFAULT_RULE));
         }
 
         String path = topicName + "/" + subscriptionName;
         Response response = handler.replaceRules(
-                ACCOUNT, namespace, topicName, subscriptionName, rulePlan.desiredRules());
+                ACCOUNT, namespace, topicName, subscriptionName, desiredRules);
         if (!succeeded("rules", path, response)) {
             return RuleReconcileResult.failure();
         }
-        int appliedRules = rulePlan.declaredRulesEmpty() ? 0 : rulePlan.desiredRules().size();
+        int appliedRules = rulePlan.declaredRulesEmpty() || keepingImplicitDefault
+                ? 0
+                : rulePlan.desiredRules().size();
         return RuleReconcileResult.success(appliedRules);
     }
 

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusTopologyLoader.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusTopologyLoader.java
@@ -255,7 +255,8 @@ public class ServiceBusTopologyLoader {
                     applied++;
                 } else {
                     ruleRejected = true;
-                    if (existingRuleNames.contains(rule.name())) {
+                    if (!DEFAULT_RULE.equals(rule.name())
+                            && existingRuleNames.contains(rule.name())) {
                         retainedRuleNames.add(rule.name());
                     }
                 }

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusTopologyLoader.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusTopologyLoader.java
@@ -95,10 +95,14 @@ public class ServiceBusTopologyLoader {
                 continue;
             }
             boolean useConfiguredPorts = configuredPortsAvailable;
-            configuredPortsAvailable = false;
-            if (!startNamespace(namespace.name(), useConfiguredPorts)) {
+            NamespaceStartResult startResult = startNamespace(namespace.name(), useConfiguredPorts);
+            if (!startResult.started()) {
+                if (useConfiguredPorts && !startResult.portsReleased()) {
+                    configuredPortsAvailable = false;
+                }
                 continue;
             }
+            configuredPortsAvailable = false;
             tally.namespaces++;
             applyNamespace(namespace, tally);
         }
@@ -125,25 +129,29 @@ public class ServiceBusTopologyLoader {
      * The first namespace binds the configured AMQP host ports; further namespaces (the
      * official emulator supports only one) get dynamic ports so they don't collide.
      */
-    private boolean startNamespace(String name, boolean useConfiguredPorts) {
+    private NamespaceStartResult startNamespace(String name, boolean useConfiguredPorts) {
         if (namespaceManager.getNamespace(name).isPresent()) {
-            return true;
+            return new NamespaceStartResult(true, false);
         }
         EmulatorConfig.ServiceBusConfig sb = config.services().serviceBus();
         if (sb.mocked()) {
             namespaceManager.startMockedNamespace(name);
-            return true;
+            return new NamespaceStartResult(true, false);
         }
         try {
             namespaceManager.startNamespace(name,
                     useConfiguredPorts ? sb.amqpPort() : 0,
                     useConfiguredPorts ? sb.amqpTlsPort() : 0);
-            return true;
+            return new NamespaceStartResult(true, false);
         } catch (Exception e) {
             LOG.errorf(e, "Could not start Service Bus namespace '%s' from the topology file", name);
-            return false;
+            boolean portsReleased = e instanceof ServiceBusNamespaceManager.NamespaceStartException startError
+                    && startError.portsReleased();
+            return new NamespaceStartResult(false, portsReleased);
         }
     }
+
+    private record NamespaceStartResult(boolean started, boolean portsReleased) {}
 
     private void applyNamespace(ServiceBusTopologyFile.Namespace namespace, Tally tally) {
         for (ServiceBusTopologyFile.Queue queue : orEmpty(namespace.queues())) {

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusTopologyLoader.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusTopologyLoader.java
@@ -10,10 +10,12 @@ import org.jboss.logging.Logger;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Applies a declarative Service Bus topology at startup from the official emulator's
@@ -44,6 +46,7 @@ public class ServiceBusTopologyLoader {
 
     /** Per-load application counters, local to one {@link #load()} call. */
     private static final class Tally {
+        int namespaces;
         int queues;
         int topics;
         int subscriptions;
@@ -91,13 +94,16 @@ public class ServiceBusTopologyLoader {
                 LOG.error("Skipping a Service Bus topology namespace without a Name");
                 continue;
             }
-            startNamespace(namespace.name(), first);
+            if (!startNamespace(namespace.name(), first)) {
+                continue;
+            }
             first = false;
+            tally.namespaces++;
             applyNamespace(namespace, tally);
         }
         LOG.infov("Loaded Service Bus topology from {0}: {1} namespace(s), {2} queue(s), "
                         + "{3} topic(s), {4} subscription(s), {5} rule(s)",
-                file, namespaces.size(), tally.queues, tally.topics, tally.subscriptions, tally.rules);
+                file, tally.namespaces, tally.queues, tally.topics, tally.subscriptions, tally.rules);
     }
 
     private Path resolveFile() {
@@ -118,21 +124,23 @@ public class ServiceBusTopologyLoader {
      * The first namespace binds the configured AMQP host ports; further namespaces (the
      * official emulator supports only one) get dynamic ports so they don't collide.
      */
-    private void startNamespace(String name, boolean useConfiguredPorts) {
+    private boolean startNamespace(String name, boolean useConfiguredPorts) {
         if (namespaceManager.getNamespace(name).isPresent()) {
-            return;
+            return true;
         }
         EmulatorConfig.ServiceBusConfig sb = config.services().serviceBus();
         if (sb.mocked()) {
             namespaceManager.startMockedNamespace(name);
-            return;
+            return true;
         }
         try {
             namespaceManager.startNamespace(name,
                     useConfiguredPorts ? sb.amqpPort() : 0,
                     useConfiguredPorts ? sb.amqpTlsPort() : 0);
+            return true;
         } catch (Exception e) {
             LOG.errorf(e, "Could not start Service Bus namespace '%s' from the topology file", name);
+            return false;
         }
     }
 
@@ -201,20 +209,42 @@ public class ServiceBusTopologyLoader {
             return false;
         }
 
-        int applied = 0;
-        for (ServiceBusTopologyFile.Rule rule : orEmpty(subscription.rules())) {
-            if (hasName("rule", rule == null ? null : rule.name())
-                    && applyRule(namespace, topicName, subscription.name(), rule)) {
-                applied++;
-            }
-        }
-        if (applied > 0) {
-            // Declared rules define the complete rule set, as in the official emulator:
-            // drop the implicit $Default TrueFilter so the declared filters actually apply.
-            handler.handleDeleteRule(ACCOUNT, namespace, topicName, subscription.name(), DEFAULT_RULE);
-        }
+        int applied = reconcileRules(namespace, topicName, subscription);
         tally.rules += applied;
         return true;
+    }
+
+    private int reconcileRules(String namespace, String topicName,
+                               ServiceBusTopologyFile.Subscription subscription) {
+        List<ServiceBusTopologyFile.Rule> declaredRules = orEmpty(subscription.rules());
+        Set<String> retainedRuleNames = new HashSet<>();
+        int applied = 0;
+
+        if (declaredRules.isEmpty()) {
+            ServiceBusModels.RuleEntity defaultRule = ServiceBusModels.RuleEntity.trueFilter(
+                    topicName, subscription.name(), DEFAULT_RULE);
+            if (succeeded("rule", topicName + "/" + subscription.name() + "/" + DEFAULT_RULE,
+                    handler.putRule(ACCOUNT, namespace, defaultRule))) {
+                retainedRuleNames.add(DEFAULT_RULE);
+            }
+        } else {
+            for (ServiceBusTopologyFile.Rule rule : declaredRules) {
+                if (hasName("rule", rule == null ? null : rule.name())
+                        && applyRule(namespace, topicName, subscription.name(), rule)) {
+                    retainedRuleNames.add(rule.name());
+                    applied++;
+                }
+            }
+        }
+
+        for (ServiceBusModels.RuleEntity existing :
+                handler.loadRules(ACCOUNT, namespace, topicName, subscription.name())) {
+            if (!retainedRuleNames.contains(existing.name())) {
+                handler.handleDeleteRule(
+                        ACCOUNT, namespace, topicName, subscription.name(), existing.name());
+            }
+        }
+        return applied;
     }
 
     private boolean applyRule(String namespace, String topicName, String subName,

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusTopologyLoader.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusTopologyLoader.java
@@ -264,6 +264,12 @@ public class ServiceBusTopologyLoader {
                         topicName, subscription.name());
                 return 0;
             }
+            if (rejected && desiredRules.isEmpty()) {
+                LOG.warnf("Keeping the implicit $Default rule for new subscription '%s/%s' because "
+                                + "every declared rule was rejected",
+                        topicName, subscription.name());
+                return 0;
+            }
         }
 
         String path = topicName + "/" + subscription.name();

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusTopologyLoader.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusTopologyLoader.java
@@ -212,11 +212,15 @@ public class ServiceBusTopologyLoader {
         ServiceBusTopologyFile.EntityProperties p = properties(subscription.properties());
         String path = topicName + "/" + subscription.name();
         warnOnForwarding("subscription", path, p);
+        RulePlan rulePlan = prepareRules(topicName, subscription);
+        ServiceBusModels.RuleEntity initialRule = rulePlan.desiredRules().isEmpty()
+                ? ServiceBusModels.RuleEntity.trueFilter(topicName, subscription.name(), DEFAULT_RULE)
+                : rulePlan.desiredRules().getFirst();
         boolean created;
         try {
             Response response = handler.handleCreateSubscription(ACCOUNT, namespace,
                     topicName, subscription.name(), Boolean.TRUE.equals(p.requiresSession()),
-                    "", lifetime(p), delivery(p));
+                    lifetime(p), delivery(p), initialRule);
             if (!succeeded("subscription", path, response)) {
                 return false;
             }
@@ -226,14 +230,14 @@ public class ServiceBusTopologyLoader {
             return false;
         }
 
-        int applied = reconcileRules(namespace, topicName, subscription, created);
-        tally.rules += applied;
-        return true;
+        RuleReconcileResult result = reconcileRules(
+                namespace, topicName, subscription.name(), created, rulePlan);
+        tally.rules += result.appliedRules();
+        return result.succeeded();
     }
 
-    private int reconcileRules(String namespace, String topicName,
-                               ServiceBusTopologyFile.Subscription subscription,
-                               boolean subscriptionCreated) {
+    private RulePlan prepareRules(String topicName,
+                                  ServiceBusTopologyFile.Subscription subscription) {
         List<ServiceBusTopologyFile.Rule> declaredRules = orEmpty(subscription.rules());
         List<ServiceBusModels.RuleEntity> desiredRules = new ArrayList<>();
         boolean rejected = false;
@@ -258,27 +262,54 @@ public class ServiceBusTopologyLoader {
                     LOG.errorf("Skipping topology rule '%s': %s", path, e.getMessage());
                 }
             }
-            if (rejected && !subscriptionCreated) {
-                LOG.warnf("Keeping existing topology rules for '%s/%s' because its replacement "
-                                + "contains a rejected rule",
-                        topicName, subscription.name());
-                return 0;
-            }
-            if (rejected && desiredRules.isEmpty()) {
-                LOG.warnf("Keeping the implicit $Default rule for new subscription '%s/%s' because "
-                                + "every declared rule was rejected",
-                        topicName, subscription.name());
-                return 0;
-            }
         }
 
-        String path = topicName + "/" + subscription.name();
-        Response response = handler.replaceRules(
-                ACCOUNT, namespace, topicName, subscription.name(), desiredRules);
-        if (!succeeded("rules", path, response)) {
-            return 0;
+        return new RulePlan(declaredRules.isEmpty(), List.copyOf(desiredRules), rejected);
+    }
+
+    private RuleReconcileResult reconcileRules(String namespace, String topicName,
+                                                String subscriptionName,
+                                                boolean subscriptionCreated,
+                                                RulePlan rulePlan) {
+        if (rulePlan.rejected() && !subscriptionCreated) {
+            LOG.warnf("Keeping existing topology rules for '%s/%s' because its replacement "
+                            + "contains a rejected rule",
+                    topicName, subscriptionName);
+            return RuleReconcileResult.success(0);
         }
-        return declaredRules.isEmpty() ? 0 : desiredRules.size();
+        if (rulePlan.rejected() && rulePlan.desiredRules().isEmpty()) {
+            LOG.warnf("Keeping the implicit $Default rule for new subscription '%s/%s' because "
+                            + "every declared rule was rejected",
+                    topicName, subscriptionName);
+            return RuleReconcileResult.success(0);
+        }
+        if (subscriptionCreated && rulePlan.desiredRules().size() == 1) {
+            return RuleReconcileResult.success(rulePlan.declaredRulesEmpty() ? 0 : 1);
+        }
+
+        String path = topicName + "/" + subscriptionName;
+        Response response = handler.replaceRules(
+                ACCOUNT, namespace, topicName, subscriptionName, rulePlan.desiredRules());
+        if (!succeeded("rules", path, response)) {
+            return RuleReconcileResult.failure();
+        }
+        int appliedRules = rulePlan.declaredRulesEmpty() ? 0 : rulePlan.desiredRules().size();
+        return RuleReconcileResult.success(appliedRules);
+    }
+
+    private record RulePlan(boolean declaredRulesEmpty,
+                            List<ServiceBusModels.RuleEntity> desiredRules,
+                            boolean rejected) {}
+
+    private record RuleReconcileResult(boolean succeeded, int appliedRules) {
+
+        private static RuleReconcileResult success(int appliedRules) {
+            return new RuleReconcileResult(true, appliedRules);
+        }
+
+        private static RuleReconcileResult failure() {
+            return new RuleReconcileResult(false, 0);
+        }
     }
 
     static ServiceBusModels.RuleEntity toRuleEntity(String topicName, String subName,

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusTopologyLoader.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusTopologyLoader.java
@@ -233,6 +233,7 @@ public class ServiceBusTopologyLoader {
         }
         Set<String> retainedRuleNames = new HashSet<>();
         int applied = 0;
+        boolean ruleRejected = false;
 
         if (declaredRules.isEmpty()) {
             ServiceBusModels.RuleEntity defaultRule = ServiceBusModels.RuleEntity.trueFilter(
@@ -246,17 +247,23 @@ public class ServiceBusTopologyLoader {
         } else {
             for (ServiceBusTopologyFile.Rule rule : declaredRules) {
                 if (!hasName("rule", rule == null ? null : rule.name())) {
+                    ruleRejected = true;
                     continue;
                 }
                 if (applyRule(namespace, topicName, subscription.name(), rule)) {
                     retainedRuleNames.add(rule.name());
                     applied++;
-                } else if (existingRuleNames.contains(rule.name())) {
-                    LOG.warnf("Keeping existing topology rule '%s/%s/%s' because its replacement "
-                                    + "was rejected",
-                            topicName, subscription.name(), rule.name());
-                    retainedRuleNames.add(rule.name());
+                } else {
+                    ruleRejected = true;
                 }
+            }
+            if (ruleRejected) {
+                existingRuleNames.stream()
+                        .filter(name -> !DEFAULT_RULE.equals(name))
+                        .forEach(retainedRuleNames::add);
+                LOG.warnf("Keeping existing topology rules for '%s/%s' because at least one "
+                                + "declared rule was rejected",
+                        topicName, subscription.name());
             }
         }
 

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusTopologyLoader.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusTopologyLoader.java
@@ -261,9 +261,9 @@ public class ServiceBusTopologyLoader {
                 }
             }
             if (ruleRejected && applied == 0) {
-                existingRuleNames.stream()
-                        .filter(name -> !DEFAULT_RULE.equals(name))
-                        .forEach(retainedRuleNames::add);
+                // The official emulator drops invalid declarations before seeding, leaving the
+                // subscription's implicit $Default rule (or its previous valid rule set) intact.
+                retainedRuleNames.addAll(existingRuleNames);
                 LOG.warnf("Keeping existing topology rules for '%s/%s' because at least one "
                                 + "declared rule was rejected",
                         topicName, subscription.name());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -177,6 +177,9 @@ floci-az:
       mocked: true
       # true = the default namespace starts with the emulator (deterministic AMQP endpoint at boot).
       start-on-boot: false
+      # Optional path to a declarative topology file (official emulator Config.json format);
+      # when unset, /ServiceBus_Emulator/ConfigFiles/Config.json is probed.
+      # topology-file: /path/to/Config.json
       amqp-port: 5673
       amqp-tls-port: 5674
       artemis-image: "apache/activemq-artemis:2.44.0"

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusContainerManagerTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusContainerManagerTest.java
@@ -95,7 +95,7 @@ class ServiceBusContainerManagerTest {
     void namespaceStartStaysLazyByDefault() {
         when(serviceBus.mocked()).thenReturn(false);
 
-        new ServiceBusContainerManager(config, namespaceManager).onStart(null);
+        new ServiceBusContainerManager(config, namespaceManager, topologyLoader).onStart(null);
 
         verify(namespaceManager, never()).startNamespace(anyString(), anyInt(), anyInt());
         verify(namespaceManager, never()).startMockedNamespace(anyString());
@@ -108,10 +108,21 @@ class ServiceBusContainerManagerTest {
         when(serviceBus.amqpPort()).thenReturn(5673);
         when(serviceBus.amqpTlsPort()).thenReturn(5674);
 
-        new ServiceBusContainerManager(config, namespaceManager).onStart(null);
+        new ServiceBusContainerManager(config, namespaceManager, topologyLoader).onStart(null);
 
         verify(namespaceManager).startNamespace(
                 ServiceBusNamespaceManager.DEFAULT_NAMESPACE, 5673, 5674);
+    }
+
+    @Test
+    void topologyTakesPrecedenceOverBrokerStartOnBoot() {
+        when(serviceBus.mocked()).thenReturn(false);
+        when(serviceBus.startOnBoot()).thenReturn(true);
+        when(topologyLoader.load()).thenReturn(true);
+
+        new ServiceBusContainerManager(config, namespaceManager, topologyLoader).onStart(null);
+
+        verify(namespaceManager, never()).startNamespace(anyString(), anyInt(), anyInt());
     }
 
     @Test
@@ -119,10 +130,21 @@ class ServiceBusContainerManagerTest {
         when(serviceBus.mocked()).thenReturn(true);
         when(serviceBus.startOnBoot()).thenReturn(true);
 
-        new ServiceBusContainerManager(config, namespaceManager).onStart(null);
+        new ServiceBusContainerManager(config, namespaceManager, topologyLoader).onStart(null);
 
         verify(namespaceManager).startMockedNamespace(ServiceBusNamespaceManager.DEFAULT_NAMESPACE);
         verify(namespaceManager, never()).startNamespace(anyString(), anyInt(), anyInt());
+    }
+
+    @Test
+    void topologyTakesPrecedenceOverMockedStartOnBoot() {
+        when(serviceBus.mocked()).thenReturn(true);
+        when(serviceBus.startOnBoot()).thenReturn(true);
+        when(topologyLoader.load()).thenReturn(true);
+
+        new ServiceBusContainerManager(config, namespaceManager, topologyLoader).onStart(null);
+
+        verify(namespaceManager, never()).startMockedNamespace(anyString());
     }
 
     @Test
@@ -136,6 +158,7 @@ class ServiceBusContainerManagerTest {
                 .thenThrow(new IllegalStateException("Docker unavailable"));
 
         assertDoesNotThrow(
-                () -> new ServiceBusContainerManager(config, namespaceManager).onStart(null));
+                () -> new ServiceBusContainerManager(
+                        config, namespaceManager, topologyLoader).onStart(null));
     }
 }

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusContainerManagerTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusContainerManagerTest.java
@@ -18,6 +18,7 @@ class ServiceBusContainerManagerTest {
     private final EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
     private final EmulatorConfig.ServiceBusConfig serviceBus = mock(EmulatorConfig.ServiceBusConfig.class);
     private final ServiceBusNamespaceManager namespaceManager = mock(ServiceBusNamespaceManager.class);
+    private final ServiceBusTopologyLoader topologyLoader = mock(ServiceBusTopologyLoader.class);
 
     @BeforeEach
     void setUp() {
@@ -30,7 +31,7 @@ class ServiceBusContainerManagerTest {
     void reapsOrphanedContainersWhenBrokerModeStarts() {
         when(serviceBus.mocked()).thenReturn(false);
 
-        new ServiceBusContainerManager(config, namespaceManager).onStart(null);
+        new ServiceBusContainerManager(config, namespaceManager, topologyLoader).onStart(null);
 
         verify(namespaceManager).reapOrphanedContainers();
     }
@@ -39,7 +40,7 @@ class ServiceBusContainerManagerTest {
     void skipsCleanupInMockedMode() {
         when(serviceBus.mocked()).thenReturn(true);
 
-        new ServiceBusContainerManager(config, namespaceManager).onStart(null);
+        new ServiceBusContainerManager(config, namespaceManager, topologyLoader).onStart(null);
 
         verify(namespaceManager, never()).reapOrphanedContainers();
     }
@@ -51,7 +52,43 @@ class ServiceBusContainerManagerTest {
                 .thenThrow(new IllegalStateException("Docker unavailable"));
 
         assertDoesNotThrow(
-                () -> new ServiceBusContainerManager(config, namespaceManager).onStart(null));
+                () -> new ServiceBusContainerManager(config, namespaceManager, topologyLoader).onStart(null));
+    }
+
+    @Test
+    void loadsTopologyInBrokerMode() {
+        when(serviceBus.mocked()).thenReturn(false);
+
+        new ServiceBusContainerManager(config, namespaceManager, topologyLoader).onStart(null);
+
+        verify(topologyLoader).load();
+    }
+
+    @Test
+    void loadsTopologyInMockedMode() {
+        when(serviceBus.mocked()).thenReturn(true);
+
+        new ServiceBusContainerManager(config, namespaceManager, topologyLoader).onStart(null);
+
+        verify(topologyLoader).load();
+    }
+
+    @Test
+    void skipsTopologyWhenServiceDisabled() {
+        when(serviceBus.enabled()).thenReturn(false);
+
+        new ServiceBusContainerManager(config, namespaceManager, topologyLoader).onStart(null);
+
+        verify(topologyLoader, never()).load();
+    }
+
+    @Test
+    void topologyLoadFailureDoesNotFailApplicationStartup() {
+        when(serviceBus.mocked()).thenReturn(true);
+        org.mockito.Mockito.doThrow(new IllegalStateException("boom")).when(topologyLoader).load();
+
+        assertDoesNotThrow(
+                () -> new ServiceBusContainerManager(config, namespaceManager, topologyLoader).onStart(null));
     }
 
     @Test

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusHandlerRuleConsistencyTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusHandlerRuleConsistencyTest.java
@@ -93,4 +93,38 @@ class ServiceBusHandlerRuleConsistencyTest {
         mutation.verify(store).applyBatch(
                 argThat(puts -> puts.keySet().equals(Set.of(newKey))), eq(Set.of(oldKey)));
     }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void failedStorageBatchRestoresPreviousBrokerFilter() throws Exception {
+        String oldKey = "sb/account/namespace/topics/topic/subscriptions/subscription/rules/old";
+        ServiceBusModels.RuleEntity oldRule = new ServiceBusModels.RuleEntity(
+                "topic", "subscription", "old", "FalseFilter",
+                null, null, null, null, null, null, null, null, null,
+                Map.of(), Map.of(), null, Instant.EPOCH);
+        ServiceBusModels.RuleEntity newRule = ServiceBusModels.RuleEntity.trueFilter(
+                "topic", "subscription", "new");
+        StoredObject stored = new StoredObject(
+                oldKey, MAPPER.writeValueAsBytes(oldRule), Map.of(), Instant.now(), oldKey);
+        StorageBackend<String, StoredObject> store = mock(StorageBackend.class);
+        StorageFactory storageFactory = mock(StorageFactory.class);
+        ServiceBusNamespaceManager namespaceManager = mock(ServiceBusNamespaceManager.class);
+        when(storageFactory.create("servicebus")).thenReturn(store);
+        when(store.scan(any())).thenReturn(List.of(stored));
+        doThrow(new IllegalStateException("storage unavailable"))
+                .when(store).applyBatch(any(), any());
+        ServiceBusHandler handler = new ServiceBusHandler(
+                mock(EmulatorConfig.class), namespaceManager, storageFactory);
+
+        Response response = handler.replaceRules(
+                "account", "namespace", "topic", "subscription", List.of(newRule));
+
+        assertEquals(500, response.getStatus());
+        InOrder mutation = inOrder(namespaceManager, store);
+        mutation.verify(namespaceManager).jolokiaUpdateSubscriptionFilter(
+                "namespace", "topic", "subscription", ServiceBusRuleSelector.MATCH_ALL);
+        mutation.verify(store).applyBatch(any(), any());
+        mutation.verify(namespaceManager).jolokiaUpdateSubscriptionFilter(
+                "namespace", "topic", "subscription", ServiceBusRuleSelector.MATCH_NONE);
+    }
 }

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusHandlerRuleConsistencyTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusHandlerRuleConsistencyTest.java
@@ -134,4 +134,42 @@ class ServiceBusHandlerRuleConsistencyTest {
         mutation.verify(namespaceManager, times(2)).jolokiaUpdateSubscriptionFilter(
                 "namespace", "topic", "subscription", ServiceBusRuleSelector.MATCH_NONE);
     }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void exhaustedBrokerRollbackStopsNamespace() throws Exception {
+        String oldKey = "sb/account/namespace/topics/topic/subscriptions/subscription/rules/old";
+        ServiceBusModels.RuleEntity oldRule = new ServiceBusModels.RuleEntity(
+                "topic", "subscription", "old", "FalseFilter",
+                null, null, null, null, null, null, null, null, null,
+                Map.of(), Map.of(), null, Instant.EPOCH);
+        ServiceBusModels.RuleEntity newRule = ServiceBusModels.RuleEntity.trueFilter(
+                "topic", "subscription", "new");
+        StoredObject stored = new StoredObject(
+                oldKey, MAPPER.writeValueAsBytes(oldRule), Map.of(), Instant.now(), oldKey);
+        StorageBackend<String, StoredObject> store = mock(StorageBackend.class);
+        StorageFactory storageFactory = mock(StorageFactory.class);
+        ServiceBusNamespaceManager namespaceManager = mock(ServiceBusNamespaceManager.class);
+        when(storageFactory.create("servicebus")).thenReturn(store);
+        when(store.scan(any())).thenReturn(List.of(stored));
+        doThrow(new IllegalStateException("storage unavailable"))
+                .when(store).applyBatch(any(), any());
+        doNothing()
+                .doThrow(new IllegalStateException("rollback failed"))
+                .doThrow(new IllegalStateException("rollback failed"))
+                .doThrow(new IllegalStateException("rollback failed"))
+                .when(namespaceManager).jolokiaUpdateSubscriptionFilter(
+                        anyString(), anyString(), anyString(), anyString());
+        when(namespaceManager.stopNamespace("namespace")).thenReturn(true);
+        ServiceBusHandler handler = new ServiceBusHandler(
+                mock(EmulatorConfig.class), namespaceManager, storageFactory);
+
+        Response response = handler.replaceRules(
+                "account", "namespace", "topic", "subscription", List.of(newRule));
+
+        assertEquals(500, response.getStatus());
+        verify(namespaceManager, times(4)).jolokiaUpdateSubscriptionFilter(
+                anyString(), anyString(), anyString(), anyString());
+        verify(namespaceManager).stopNamespace("namespace");
+    }
 }

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusHandlerRuleConsistencyTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusHandlerRuleConsistencyTest.java
@@ -18,9 +18,11 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -30,7 +32,7 @@ class ServiceBusHandlerRuleConsistencyTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    void failedBrokerUpdateRestoresDeletedRule() throws Exception {
+    void failedBrokerUpdateDoesNotDeleteStoredRule() throws Exception {
         String key = "sb/account/namespace/topics/topic/subscriptions/subscription/rules/existing";
         ServiceBusModels.RuleEntity rule = ServiceBusModels.RuleEntity.trueFilter(
                 "topic", "subscription", "existing");
@@ -41,9 +43,8 @@ class ServiceBusHandlerRuleConsistencyTest {
         ServiceBusNamespaceManager namespaceManager = mock(ServiceBusNamespaceManager.class);
         when(storageFactory.create("servicebus")).thenReturn(store);
         when(store.get(key)).thenReturn(Optional.of(stored));
-        when(store.scan(any())).thenReturn(List.of(), List.of(stored));
+        when(store.scan(any())).thenReturn(List.of(stored));
         doThrow(new IllegalStateException("Jolokia unavailable"))
-                .doNothing()
                 .when(namespaceManager)
                 .jolokiaUpdateSubscriptionFilter(
                         anyString(), anyString(), anyString(), anyString());
@@ -54,11 +55,39 @@ class ServiceBusHandlerRuleConsistencyTest {
                 "account", "namespace", "topic", "subscription", "existing");
 
         assertEquals(500, response.getStatus());
-        verify(store).put(key, stored);
-        InOrder updates = inOrder(namespaceManager);
-        updates.verify(namespaceManager).jolokiaUpdateSubscriptionFilter(
+        verify(store, never()).delete(key);
+        verify(store, never()).put(anyString(), any());
+        verify(namespaceManager).jolokiaUpdateSubscriptionFilter(
                 "namespace", "topic", "subscription", ServiceBusRuleSelector.MATCH_NONE);
-        updates.verify(namespaceManager).jolokiaUpdateSubscriptionFilter(
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void replacementCommitsStorageAfterBrokerUpdate() throws Exception {
+        String oldKey = "sb/account/namespace/topics/topic/subscriptions/subscription/rules/old";
+        String newKey = "sb/account/namespace/topics/topic/subscriptions/subscription/rules/new";
+        ServiceBusModels.RuleEntity oldRule = ServiceBusModels.RuleEntity.trueFilter(
+                "topic", "subscription", "old");
+        ServiceBusModels.RuleEntity newRule = ServiceBusModels.RuleEntity.trueFilter(
+                "topic", "subscription", "new");
+        StoredObject stored = new StoredObject(
+                oldKey, MAPPER.writeValueAsBytes(oldRule), Map.of(), Instant.now(), oldKey);
+        StorageBackend<String, StoredObject> store = mock(StorageBackend.class);
+        StorageFactory storageFactory = mock(StorageFactory.class);
+        ServiceBusNamespaceManager namespaceManager = mock(ServiceBusNamespaceManager.class);
+        when(storageFactory.create("servicebus")).thenReturn(store);
+        when(store.scan(any())).thenReturn(List.of(stored));
+        ServiceBusHandler handler = new ServiceBusHandler(
+                mock(EmulatorConfig.class), namespaceManager, storageFactory);
+
+        Response response = handler.replaceRules(
+                "account", "namespace", "topic", "subscription", List.of(newRule));
+
+        assertEquals(200, response.getStatus());
+        InOrder mutation = inOrder(namespaceManager, store);
+        mutation.verify(namespaceManager).jolokiaUpdateSubscriptionFilter(
                 "namespace", "topic", "subscription", ServiceBusRuleSelector.MATCH_ALL);
+        mutation.verify(store).delete(oldKey);
+        mutation.verify(store).put(eq(newKey), any());
     }
 }

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusHandlerRuleConsistencyTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusHandlerRuleConsistencyTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -137,21 +138,42 @@ class ServiceBusHandlerRuleConsistencyTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    void exhaustedBrokerRollbackStopsNamespace() throws Exception {
+    void exhaustedBrokerRollbackRestartsNamespaceWithPersistedTopology() throws Exception {
+        String queueKey = "sb/account/namespace/queues/queue";
+        String topicKey = "sb/account/namespace/topics/topic";
+        String subscriptionKey = "sb/account/namespace/topics/topic/subscriptions/subscription";
         String oldKey = "sb/account/namespace/topics/topic/subscriptions/subscription/rules/old";
+        ServiceBusModels.QueueEntity queue = new ServiceBusModels.QueueEntity(
+                "queue", 10, 60, 1024, false, false, 600,
+                86_400_000, false, Instant.EPOCH, Instant.EPOCH);
+        ServiceBusModels.TopicEntity topic = new ServiceBusModels.TopicEntity(
+                "topic", 1024, false, 600, 86_400_000, Instant.EPOCH, Instant.EPOCH);
+        ServiceBusModels.SubscriptionEntity subscription = new ServiceBusModels.SubscriptionEntity(
+                "topic", "subscription", 10, 60, false, 86_400_000,
+                false, Instant.EPOCH, Instant.EPOCH);
         ServiceBusModels.RuleEntity oldRule = new ServiceBusModels.RuleEntity(
                 "topic", "subscription", "old", "FalseFilter",
                 null, null, null, null, null, null, null, null, null,
                 Map.of(), Map.of(), null, Instant.EPOCH);
         ServiceBusModels.RuleEntity newRule = ServiceBusModels.RuleEntity.trueFilter(
                 "topic", "subscription", "new");
-        StoredObject stored = new StoredObject(
-                oldKey, MAPPER.writeValueAsBytes(oldRule), Map.of(), Instant.now(), oldKey);
+        List<StoredObject> storedObjects = List.of(
+                new StoredObject(queueKey, MAPPER.writeValueAsBytes(queue),
+                        Map.of(), Instant.now(), queueKey),
+                new StoredObject(topicKey, MAPPER.writeValueAsBytes(topic),
+                        Map.of(), Instant.now(), topicKey),
+                new StoredObject(subscriptionKey, MAPPER.writeValueAsBytes(subscription),
+                        Map.of(), Instant.now(), subscriptionKey),
+                new StoredObject(oldKey, MAPPER.writeValueAsBytes(oldRule),
+                        Map.of(), Instant.now(), oldKey));
         StorageBackend<String, StoredObject> store = mock(StorageBackend.class);
         StorageFactory storageFactory = mock(StorageFactory.class);
         ServiceBusNamespaceManager namespaceManager = mock(ServiceBusNamespaceManager.class);
         when(storageFactory.create("servicebus")).thenReturn(store);
-        when(store.scan(any())).thenReturn(List.of(stored));
+        when(store.scan(any())).thenAnswer(invocation -> {
+            Predicate<String> predicate = invocation.getArgument(0);
+            return storedObjects.stream().filter(obj -> predicate.test(obj.key())).toList();
+        });
         doThrow(new IllegalStateException("storage unavailable"))
                 .when(store).applyBatch(any(), any());
         doNothing()
@@ -160,7 +182,12 @@ class ServiceBusHandlerRuleConsistencyTest {
                 .doThrow(new IllegalStateException("rollback failed"))
                 .when(namespaceManager).jolokiaUpdateSubscriptionFilter(
                         anyString(), anyString(), anyString(), anyString());
+        ServiceBusNamespaceManager.NamespaceState namespaceState =
+                new ServiceBusNamespaceManager.NamespaceState(
+                        "container", 5672, 5671, "certificate", "localhost", 8161, false);
+        when(namespaceManager.getNamespace("namespace")).thenReturn(Optional.of(namespaceState));
         when(namespaceManager.stopNamespace("namespace")).thenReturn(true);
+        when(namespaceManager.startNamespace("namespace", 5672, 5671)).thenReturn(namespaceState);
         ServiceBusHandler handler = new ServiceBusHandler(
                 mock(EmulatorConfig.class), namespaceManager, storageFactory);
 
@@ -171,5 +198,12 @@ class ServiceBusHandlerRuleConsistencyTest {
         verify(namespaceManager, times(4)).jolokiaUpdateSubscriptionFilter(
                 anyString(), anyString(), anyString(), anyString());
         verify(namespaceManager).stopNamespace("namespace");
+        verify(namespaceManager).startNamespace("namespace", 5672, 5671);
+        verify(namespaceManager).jolokiaCreateQueue(
+                eq("namespace"), eq("queue"), eq(false), eq(60L), eq(10), any(), any());
+        verify(namespaceManager).jolokiaCreateTopic(eq("namespace"), eq("topic"), any());
+        verify(namespaceManager).jolokiaCreateSubscription(
+                eq("namespace"), eq("topic"), eq("subscription"),
+                eq(ServiceBusRuleSelector.MATCH_NONE), eq(false), eq(60L), eq(10), any(), any());
     }
 }

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusHandlerRuleConsistencyTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusHandlerRuleConsistencyTest.java
@@ -14,10 +14,12 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
@@ -57,6 +59,7 @@ class ServiceBusHandlerRuleConsistencyTest {
         assertEquals(500, response.getStatus());
         verify(store, never()).delete(key);
         verify(store, never()).put(anyString(), any());
+        verify(store, never()).applyBatch(any(), any());
         verify(namespaceManager).jolokiaUpdateSubscriptionFilter(
                 "namespace", "topic", "subscription", ServiceBusRuleSelector.MATCH_NONE);
     }
@@ -87,7 +90,7 @@ class ServiceBusHandlerRuleConsistencyTest {
         InOrder mutation = inOrder(namespaceManager, store);
         mutation.verify(namespaceManager).jolokiaUpdateSubscriptionFilter(
                 "namespace", "topic", "subscription", ServiceBusRuleSelector.MATCH_ALL);
-        mutation.verify(store).delete(oldKey);
-        mutation.verify(store).put(eq(newKey), any());
+        mutation.verify(store).applyBatch(
+                argThat(puts -> puts.keySet().equals(Set.of(newKey))), eq(Set.of(oldKey)));
     }
 }

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusHandlerRuleConsistencyTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusHandlerRuleConsistencyTest.java
@@ -1,0 +1,56 @@
+package io.floci.az.services.servicebus;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.floci.az.config.EmulatorConfig;
+import io.floci.az.core.StoredObject;
+import io.floci.az.core.storage.StorageBackend;
+import io.floci.az.core.storage.StorageFactory;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ServiceBusHandlerRuleConsistencyTest {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper().registerModule(new JavaTimeModule());
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void failedBrokerUpdateRestoresDeletedRule() throws Exception {
+        String key = "sb/account/namespace/topics/topic/subscriptions/subscription/rules/existing";
+        ServiceBusModels.RuleEntity rule = ServiceBusModels.RuleEntity.trueFilter(
+                "topic", "subscription", "existing");
+        StoredObject stored = new StoredObject(
+                key, MAPPER.writeValueAsBytes(rule), Map.of(), Instant.now(), key);
+        StorageBackend<String, StoredObject> store = mock(StorageBackend.class);
+        StorageFactory storageFactory = mock(StorageFactory.class);
+        ServiceBusNamespaceManager namespaceManager = mock(ServiceBusNamespaceManager.class);
+        when(storageFactory.create("servicebus")).thenReturn(store);
+        when(store.get(key)).thenReturn(Optional.of(stored));
+        when(store.scan(any())).thenReturn(List.of());
+        doThrow(new IllegalStateException("Jolokia unavailable"))
+                .when(namespaceManager)
+                .jolokiaUpdateSubscriptionFilter(
+                        anyString(), anyString(), anyString(), anyString());
+        ServiceBusHandler handler = new ServiceBusHandler(
+                mock(EmulatorConfig.class), namespaceManager, storageFactory);
+
+        Response response = handler.handleDeleteRule(
+                "account", "namespace", "topic", "subscription", "existing");
+
+        assertEquals(500, response.getStatus());
+        verify(store).put(key, stored);
+    }
+}

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusHandlerRuleConsistencyTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusHandlerRuleConsistencyTest.java
@@ -8,6 +8,7 @@ import io.floci.az.core.storage.StorageBackend;
 import io.floci.az.core.storage.StorageFactory;
 import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 
 import java.time.Instant;
 import java.util.List;
@@ -18,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -39,8 +41,9 @@ class ServiceBusHandlerRuleConsistencyTest {
         ServiceBusNamespaceManager namespaceManager = mock(ServiceBusNamespaceManager.class);
         when(storageFactory.create("servicebus")).thenReturn(store);
         when(store.get(key)).thenReturn(Optional.of(stored));
-        when(store.scan(any())).thenReturn(List.of());
+        when(store.scan(any())).thenReturn(List.of(), List.of(stored));
         doThrow(new IllegalStateException("Jolokia unavailable"))
+                .doNothing()
                 .when(namespaceManager)
                 .jolokiaUpdateSubscriptionFilter(
                         anyString(), anyString(), anyString(), anyString());
@@ -52,5 +55,10 @@ class ServiceBusHandlerRuleConsistencyTest {
 
         assertEquals(500, response.getStatus());
         verify(store).put(key, stored);
+        InOrder updates = inOrder(namespaceManager);
+        updates.verify(namespaceManager).jolokiaUpdateSubscriptionFilter(
+                "namespace", "topic", "subscription", ServiceBusRuleSelector.MATCH_NONE);
+        updates.verify(namespaceManager).jolokiaUpdateSubscriptionFilter(
+                "namespace", "topic", "subscription", ServiceBusRuleSelector.MATCH_ALL);
     }
 }

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusHandlerRuleConsistencyTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusHandlerRuleConsistencyTest.java
@@ -21,10 +21,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -96,7 +98,7 @@ class ServiceBusHandlerRuleConsistencyTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    void failedStorageBatchRestoresPreviousBrokerFilter() throws Exception {
+    void failedStorageBatchRetriesPreviousBrokerFilter() throws Exception {
         String oldKey = "sb/account/namespace/topics/topic/subscriptions/subscription/rules/old";
         ServiceBusModels.RuleEntity oldRule = new ServiceBusModels.RuleEntity(
                 "topic", "subscription", "old", "FalseFilter",
@@ -113,6 +115,11 @@ class ServiceBusHandlerRuleConsistencyTest {
         when(store.scan(any())).thenReturn(List.of(stored));
         doThrow(new IllegalStateException("storage unavailable"))
                 .when(store).applyBatch(any(), any());
+        doNothing()
+                .doThrow(new IllegalStateException("first rollback failed"))
+                .doNothing()
+                .when(namespaceManager).jolokiaUpdateSubscriptionFilter(
+                        anyString(), anyString(), anyString(), anyString());
         ServiceBusHandler handler = new ServiceBusHandler(
                 mock(EmulatorConfig.class), namespaceManager, storageFactory);
 
@@ -124,7 +131,7 @@ class ServiceBusHandlerRuleConsistencyTest {
         mutation.verify(namespaceManager).jolokiaUpdateSubscriptionFilter(
                 "namespace", "topic", "subscription", ServiceBusRuleSelector.MATCH_ALL);
         mutation.verify(store).applyBatch(any(), any());
-        mutation.verify(namespaceManager).jolokiaUpdateSubscriptionFilter(
+        mutation.verify(namespaceManager, times(2)).jolokiaUpdateSubscriptionFilter(
                 "namespace", "topic", "subscription", ServiceBusRuleSelector.MATCH_NONE);
     }
 }

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusHandlerRuleConsistencyTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusHandlerRuleConsistencyTest.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Predicate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -29,6 +28,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 class ServiceBusHandlerRuleConsistencyTest {
@@ -138,42 +138,21 @@ class ServiceBusHandlerRuleConsistencyTest {
 
     @Test
     @SuppressWarnings("unchecked")
-    void exhaustedBrokerRollbackRestartsNamespaceWithPersistedTopology() throws Exception {
-        String queueKey = "sb/account/namespace/queues/queue";
-        String topicKey = "sb/account/namespace/topics/topic";
-        String subscriptionKey = "sb/account/namespace/topics/topic/subscriptions/subscription";
+    void exhaustedBrokerRollbackLeavesNamespaceRunning() throws Exception {
         String oldKey = "sb/account/namespace/topics/topic/subscriptions/subscription/rules/old";
-        ServiceBusModels.QueueEntity queue = new ServiceBusModels.QueueEntity(
-                "queue", 10, 60, 1024, false, false, 600,
-                86_400_000, false, Instant.EPOCH, Instant.EPOCH);
-        ServiceBusModels.TopicEntity topic = new ServiceBusModels.TopicEntity(
-                "topic", 1024, false, 600, 86_400_000, Instant.EPOCH, Instant.EPOCH);
-        ServiceBusModels.SubscriptionEntity subscription = new ServiceBusModels.SubscriptionEntity(
-                "topic", "subscription", 10, 60, false, 86_400_000,
-                false, Instant.EPOCH, Instant.EPOCH);
         ServiceBusModels.RuleEntity oldRule = new ServiceBusModels.RuleEntity(
                 "topic", "subscription", "old", "FalseFilter",
                 null, null, null, null, null, null, null, null, null,
                 Map.of(), Map.of(), null, Instant.EPOCH);
         ServiceBusModels.RuleEntity newRule = ServiceBusModels.RuleEntity.trueFilter(
                 "topic", "subscription", "new");
-        List<StoredObject> storedObjects = List.of(
-                new StoredObject(queueKey, MAPPER.writeValueAsBytes(queue),
-                        Map.of(), Instant.now(), queueKey),
-                new StoredObject(topicKey, MAPPER.writeValueAsBytes(topic),
-                        Map.of(), Instant.now(), topicKey),
-                new StoredObject(subscriptionKey, MAPPER.writeValueAsBytes(subscription),
-                        Map.of(), Instant.now(), subscriptionKey),
-                new StoredObject(oldKey, MAPPER.writeValueAsBytes(oldRule),
-                        Map.of(), Instant.now(), oldKey));
+        StoredObject stored = new StoredObject(
+                oldKey, MAPPER.writeValueAsBytes(oldRule), Map.of(), Instant.now(), oldKey);
         StorageBackend<String, StoredObject> store = mock(StorageBackend.class);
         StorageFactory storageFactory = mock(StorageFactory.class);
         ServiceBusNamespaceManager namespaceManager = mock(ServiceBusNamespaceManager.class);
         when(storageFactory.create("servicebus")).thenReturn(store);
-        when(store.scan(any())).thenAnswer(invocation -> {
-            Predicate<String> predicate = invocation.getArgument(0);
-            return storedObjects.stream().filter(obj -> predicate.test(obj.key())).toList();
-        });
+        when(store.scan(any())).thenReturn(List.of(stored));
         doThrow(new IllegalStateException("storage unavailable"))
                 .when(store).applyBatch(any(), any());
         doNothing()
@@ -182,12 +161,6 @@ class ServiceBusHandlerRuleConsistencyTest {
                 .doThrow(new IllegalStateException("rollback failed"))
                 .when(namespaceManager).jolokiaUpdateSubscriptionFilter(
                         anyString(), anyString(), anyString(), anyString());
-        ServiceBusNamespaceManager.NamespaceState namespaceState =
-                new ServiceBusNamespaceManager.NamespaceState(
-                        "container", 5672, 5671, "certificate", "localhost", 8161, false);
-        when(namespaceManager.getNamespace("namespace")).thenReturn(Optional.of(namespaceState));
-        when(namespaceManager.stopNamespace("namespace")).thenReturn(true);
-        when(namespaceManager.startNamespace("namespace", 5672, 5671)).thenReturn(namespaceState);
         ServiceBusHandler handler = new ServiceBusHandler(
                 mock(EmulatorConfig.class), namespaceManager, storageFactory);
 
@@ -195,15 +168,14 @@ class ServiceBusHandlerRuleConsistencyTest {
                 "account", "namespace", "topic", "subscription", List.of(newRule));
 
         assertEquals(500, response.getStatus());
-        verify(namespaceManager, times(4)).jolokiaUpdateSubscriptionFilter(
-                anyString(), anyString(), anyString(), anyString());
-        verify(namespaceManager).stopNamespace("namespace");
-        verify(namespaceManager).startNamespace("namespace", 5672, 5671);
-        verify(namespaceManager).jolokiaCreateQueue(
-                eq("namespace"), eq("queue"), eq(false), eq(60L), eq(10), any(), any());
-        verify(namespaceManager).jolokiaCreateTopic(eq("namespace"), eq("topic"), any());
-        verify(namespaceManager).jolokiaCreateSubscription(
-                eq("namespace"), eq("topic"), eq("subscription"),
-                eq(ServiceBusRuleSelector.MATCH_NONE), eq(false), eq(60L), eq(10), any(), any());
+        InOrder mutation = inOrder(namespaceManager, store);
+        mutation.verify(namespaceManager).jolokiaUpdateSubscriptionFilter(
+                "namespace", "topic", "subscription", ServiceBusRuleSelector.MATCH_ALL);
+        mutation.verify(store).applyBatch(any(), any());
+        mutation.verify(namespaceManager, times(3)).jolokiaUpdateSubscriptionFilter(
+                "namespace", "topic", "subscription", ServiceBusRuleSelector.MATCH_NONE);
+        verifyNoMoreInteractions(namespaceManager);
+        verify(store, never()).delete(anyString());
+        verify(store, never()).put(anyString(), any());
     }
 }

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusNamespaceManagerStartupTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusNamespaceManagerStartupTest.java
@@ -93,6 +93,50 @@ class ServiceBusNamespaceManagerStartupTest {
     }
 
     @Test
+    void failedContainerCreationDoesNotReportConfiguredPortsReleased() throws Exception {
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
+        EmulatorConfig.ServiceBusConfig serviceBus = mock(EmulatorConfig.ServiceBusConfig.class);
+        ContainerBuilder containerBuilder = mock(ContainerBuilder.class);
+        ContainerBuilder.Builder builder = mock(ContainerBuilder.Builder.class);
+        ContainerLifecycleManager lifecycleManager = mock(ContainerLifecycleManager.class);
+        ServiceBusConfigGenerator configGenerator = mock(ServiceBusConfigGenerator.class);
+        ArtemisTlsGenerator tlsGenerator = mock(ArtemisTlsGenerator.class);
+        ContainerSpec spec = new ContainerSpec("artemis");
+        String containerName = "floci-az-servicebus-failed";
+
+        when(config.services()).thenReturn(services);
+        when(services.serviceBus()).thenReturn(serviceBus);
+        when(services.dockerNetwork()).thenReturn(Optional.empty());
+        when(serviceBus.artemisImage()).thenReturn("artemis");
+        when(configGenerator.generate("failed")).thenReturn("<configuration/>");
+        when(tlsGenerator.generate(containerName))
+                .thenReturn(new ArtemisTlsGenerator.TlsBundle(new byte[0], "certificate"));
+        when(containerBuilder.newContainer("artemis")).thenReturn(builder);
+        when(builder.withName(anyString())).thenReturn(builder);
+        when(builder.withEnv(anyString(), anyString())).thenReturn(builder);
+        when(builder.withLabels(anyMap())).thenReturn(builder);
+        when(builder.withPortBinding(anyInt(), anyInt())).thenReturn(builder);
+        when(builder.withDynamicPort(anyInt())).thenReturn(builder);
+        when(builder.withDockerNetwork(any())).thenReturn(builder);
+        when(builder.withLogRotation()).thenReturn(builder);
+        when(builder.build()).thenReturn(spec);
+        when(lifecycleManager.create(spec))
+                .thenThrow(new IllegalStateException("configured port is already allocated"));
+        when(lifecycleManager.removeIfExistsAndConfirm(containerName)).thenReturn(true);
+
+        ServiceBusNamespaceManager manager = new ServiceBusNamespaceManager(
+                config, containerBuilder, lifecycleManager, configGenerator, tlsGenerator);
+
+        ServiceBusNamespaceManager.NamespaceStartException error = assertThrows(
+                ServiceBusNamespaceManager.NamespaceStartException.class,
+                () -> manager.startNamespace("failed", 5672, 5671));
+
+        assertFalse(error.portsReleased());
+        verify(lifecycleManager, times(2)).removeIfExistsAndConfirm(containerName);
+    }
+
+    @Test
     void endpointResolutionFailureReportsReleasedPortsAfterCleanup() throws Exception {
         EmulatorConfig config = mock(EmulatorConfig.class);
         EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusNamespaceManagerStartupTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusNamespaceManagerStartupTest.java
@@ -1,0 +1,65 @@
+package io.floci.az.services.servicebus;
+
+import io.floci.az.config.EmulatorConfig;
+import io.floci.az.core.docker.ContainerBuilder;
+import io.floci.az.core.docker.ContainerLifecycleManager;
+import io.floci.az.core.docker.ContainerSpec;
+import io.floci.az.services.eventhub.ArtemisTlsGenerator;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ServiceBusNamespaceManagerStartupTest {
+
+    @Test
+    void failedStartRemovesPartiallyCreatedContainer() throws Exception {
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
+        EmulatorConfig.ServiceBusConfig serviceBus = mock(EmulatorConfig.ServiceBusConfig.class);
+        ContainerBuilder containerBuilder = mock(ContainerBuilder.class);
+        ContainerBuilder.Builder builder = mock(ContainerBuilder.Builder.class);
+        ContainerLifecycleManager lifecycleManager = mock(ContainerLifecycleManager.class);
+        ServiceBusConfigGenerator configGenerator = mock(ServiceBusConfigGenerator.class);
+        ArtemisTlsGenerator tlsGenerator = mock(ArtemisTlsGenerator.class);
+        ContainerSpec spec = new ContainerSpec("artemis");
+
+        when(config.services()).thenReturn(services);
+        when(services.serviceBus()).thenReturn(serviceBus);
+        when(services.dockerNetwork()).thenReturn(Optional.empty());
+        when(serviceBus.artemisImage()).thenReturn("artemis");
+        when(configGenerator.generate("failed")).thenReturn("<configuration/>");
+        when(tlsGenerator.generate("floci-az-servicebus-failed"))
+                .thenReturn(new ArtemisTlsGenerator.TlsBundle(new byte[0], "certificate"));
+        when(containerBuilder.newContainer("artemis")).thenReturn(builder);
+        when(builder.withName(anyString())).thenReturn(builder);
+        when(builder.withEnv(anyString(), anyString())).thenReturn(builder);
+        when(builder.withLabels(anyMap())).thenReturn(builder);
+        when(builder.withPortBinding(anyInt(), anyInt())).thenReturn(builder);
+        when(builder.withDynamicPort(anyInt())).thenReturn(builder);
+        when(builder.withDockerNetwork(any())).thenReturn(builder);
+        when(builder.withLogRotation()).thenReturn(builder);
+        when(builder.build()).thenReturn(spec);
+        when(lifecycleManager.create(spec)).thenReturn("container-id");
+        when(lifecycleManager.startCreated("container-id", spec))
+                .thenThrow(new IllegalStateException("readiness failed"));
+
+        ServiceBusNamespaceManager manager = new ServiceBusNamespaceManager(
+                config, containerBuilder, lifecycleManager, configGenerator, tlsGenerator);
+
+        assertThrows(IllegalStateException.class,
+                () -> manager.startNamespace("failed", 5672, 5671));
+
+        verify(lifecycleManager).stopAndRemove("container-id", null);
+        assertTrue(manager.listNamespaces().isEmpty());
+    }
+}

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusNamespaceManagerStartupTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusNamespaceManagerStartupTest.java
@@ -72,7 +72,7 @@ class ServiceBusNamespaceManagerStartupTest {
     }
 
     @Test
-    void earlyFailureDoesNotReportUnprovenPortsReleased() throws Exception {
+    void cleanedPreStartFailureReportsPortsReleased() throws Exception {
         EmulatorConfig config = mock(EmulatorConfig.class);
         ContainerLifecycleManager lifecycleManager = mock(ContainerLifecycleManager.class);
         ArtemisTlsGenerator tlsGenerator = mock(ArtemisTlsGenerator.class);
@@ -88,7 +88,7 @@ class ServiceBusNamespaceManagerStartupTest {
                 ServiceBusNamespaceManager.NamespaceStartException.class,
                 () -> manager.startNamespace("failed", 5672, 5671));
 
-        assertFalse(error.portsReleased());
+        assertTrue(error.portsReleased());
         verify(lifecycleManager, times(2)).removeIfExistsAndConfirm(containerName);
     }
 

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusNamespaceManagerStartupTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusNamespaceManagerStartupTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -23,7 +24,7 @@ import static org.mockito.Mockito.when;
 class ServiceBusNamespaceManagerStartupTest {
 
     @Test
-    void failedStartRemovesPartiallyCreatedContainer() throws Exception {
+    void failedDockerStartRemovesContainerWithoutReportingPortsReleased() throws Exception {
         EmulatorConfig config = mock(EmulatorConfig.class);
         EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
         EmulatorConfig.ServiceBusConfig serviceBus = mock(EmulatorConfig.ServiceBusConfig.class);
@@ -66,12 +67,12 @@ class ServiceBusNamespaceManagerStartupTest {
 
         verify(lifecycleManager).stopAndRemove("container-id", null);
         verify(lifecycleManager).removeIfExistsAndConfirm("container-id");
-        assertTrue(error.portsReleased());
+        assertFalse(error.portsReleased());
         assertTrue(manager.listNamespaces().isEmpty());
     }
 
     @Test
-    void earlyFailureReportsPortsReleasedAfterConfirmedCleanup() throws Exception {
+    void earlyFailureDoesNotReportUnprovenPortsReleased() throws Exception {
         EmulatorConfig config = mock(EmulatorConfig.class);
         ContainerLifecycleManager lifecycleManager = mock(ContainerLifecycleManager.class);
         ArtemisTlsGenerator tlsGenerator = mock(ArtemisTlsGenerator.class);
@@ -87,7 +88,7 @@ class ServiceBusNamespaceManagerStartupTest {
                 ServiceBusNamespaceManager.NamespaceStartException.class,
                 () -> manager.startNamespace("failed", 5672, 5671));
 
-        assertTrue(error.portsReleased());
+        assertFalse(error.portsReleased());
         verify(lifecycleManager, times(2)).removeIfExistsAndConfirm(containerName);
     }
 }

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusNamespaceManagerStartupTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusNamespaceManagerStartupTest.java
@@ -91,4 +91,51 @@ class ServiceBusNamespaceManagerStartupTest {
         assertFalse(error.portsReleased());
         verify(lifecycleManager, times(2)).removeIfExistsAndConfirm(containerName);
     }
+
+    @Test
+    void endpointResolutionFailureReportsReleasedPortsAfterCleanup() throws Exception {
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
+        EmulatorConfig.ServiceBusConfig serviceBus = mock(EmulatorConfig.ServiceBusConfig.class);
+        ContainerBuilder containerBuilder = mock(ContainerBuilder.class);
+        ContainerBuilder.Builder builder = mock(ContainerBuilder.Builder.class);
+        ContainerLifecycleManager lifecycleManager = mock(ContainerLifecycleManager.class);
+        ServiceBusConfigGenerator configGenerator = mock(ServiceBusConfigGenerator.class);
+        ArtemisTlsGenerator tlsGenerator = mock(ArtemisTlsGenerator.class);
+        ContainerSpec spec = new ContainerSpec("artemis");
+
+        when(config.services()).thenReturn(services);
+        when(services.serviceBus()).thenReturn(serviceBus);
+        when(services.dockerNetwork()).thenReturn(Optional.empty());
+        when(serviceBus.artemisImage()).thenReturn("artemis");
+        when(configGenerator.generate("failed")).thenReturn("<configuration/>");
+        when(tlsGenerator.generate("floci-az-servicebus-failed"))
+                .thenReturn(new ArtemisTlsGenerator.TlsBundle(new byte[0], "certificate"));
+        when(containerBuilder.newContainer("artemis")).thenReturn(builder);
+        when(builder.withName(anyString())).thenReturn(builder);
+        when(builder.withEnv(anyString(), anyString())).thenReturn(builder);
+        when(builder.withLabels(anyMap())).thenReturn(builder);
+        when(builder.withPortBinding(anyInt(), anyInt())).thenReturn(builder);
+        when(builder.withDynamicPort(anyInt())).thenReturn(builder);
+        when(builder.withDockerNetwork(any())).thenReturn(builder);
+        when(builder.withLogRotation()).thenReturn(builder);
+        when(builder.build()).thenReturn(spec);
+        when(lifecycleManager.create(spec)).thenReturn("container-id");
+        when(lifecycleManager.startCreated("container-id", spec))
+                .thenThrow(new IllegalStateException("endpoint resolution failed"));
+        when(lifecycleManager.isContainerRunning("container-id")).thenReturn(true);
+        when(lifecycleManager.removeIfExistsAndConfirm("floci-az-servicebus-failed"))
+                .thenReturn(true);
+        when(lifecycleManager.removeIfExistsAndConfirm("container-id")).thenReturn(true);
+
+        ServiceBusNamespaceManager manager = new ServiceBusNamespaceManager(
+                config, containerBuilder, lifecycleManager, configGenerator, tlsGenerator);
+
+        ServiceBusNamespaceManager.NamespaceStartException error = assertThrows(
+                ServiceBusNamespaceManager.NamespaceStartException.class,
+                () -> manager.startNamespace("failed", 5672, 5671));
+
+        assertTrue(error.portsReleased());
+        verify(lifecycleManager).stopAndRemove("container-id", null);
+    }
 }

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusNamespaceManagerStartupTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusNamespaceManagerStartupTest.java
@@ -16,6 +16,7 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -52,6 +53,8 @@ class ServiceBusNamespaceManagerStartupTest {
         when(lifecycleManager.create(spec)).thenReturn("container-id");
         when(lifecycleManager.startCreated("container-id", spec))
                 .thenThrow(new IllegalStateException("readiness failed"));
+        when(lifecycleManager.removeIfExistsAndConfirm("floci-az-servicebus-failed"))
+                .thenReturn(true);
         when(lifecycleManager.removeIfExistsAndConfirm("container-id")).thenReturn(true);
 
         ServiceBusNamespaceManager manager = new ServiceBusNamespaceManager(
@@ -65,5 +68,26 @@ class ServiceBusNamespaceManagerStartupTest {
         verify(lifecycleManager).removeIfExistsAndConfirm("container-id");
         assertTrue(error.portsReleased());
         assertTrue(manager.listNamespaces().isEmpty());
+    }
+
+    @Test
+    void earlyFailureReportsPortsReleasedAfterConfirmedCleanup() throws Exception {
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        ContainerLifecycleManager lifecycleManager = mock(ContainerLifecycleManager.class);
+        ArtemisTlsGenerator tlsGenerator = mock(ArtemisTlsGenerator.class);
+        String containerName = "floci-az-servicebus-failed";
+        when(lifecycleManager.removeIfExistsAndConfirm(containerName)).thenReturn(true);
+        when(tlsGenerator.generate(containerName))
+                .thenThrow(new IllegalStateException("certificate unavailable"));
+        ServiceBusNamespaceManager manager = new ServiceBusNamespaceManager(
+                config, mock(ContainerBuilder.class), lifecycleManager,
+                mock(ServiceBusConfigGenerator.class), tlsGenerator);
+
+        ServiceBusNamespaceManager.NamespaceStartException error = assertThrows(
+                ServiceBusNamespaceManager.NamespaceStartException.class,
+                () -> manager.startNamespace("failed", 5672, 5671));
+
+        assertTrue(error.portsReleased());
+        verify(lifecycleManager, times(2)).removeIfExistsAndConfirm(containerName);
     }
 }

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusNamespaceManagerStartupTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusNamespaceManagerStartupTest.java
@@ -52,6 +52,7 @@ class ServiceBusNamespaceManagerStartupTest {
         when(lifecycleManager.create(spec)).thenReturn("container-id");
         when(lifecycleManager.startCreated("container-id", spec))
                 .thenThrow(new IllegalStateException("readiness failed"));
+        when(lifecycleManager.removeIfExistsAndConfirm("container-id")).thenReturn(true);
 
         ServiceBusNamespaceManager manager = new ServiceBusNamespaceManager(
                 config, containerBuilder, lifecycleManager, configGenerator, tlsGenerator);
@@ -61,6 +62,7 @@ class ServiceBusNamespaceManagerStartupTest {
                 () -> manager.startNamespace("failed", 5672, 5671));
 
         verify(lifecycleManager).stopAndRemove("container-id", null);
+        verify(lifecycleManager).removeIfExistsAndConfirm("container-id");
         assertTrue(error.portsReleased());
         assertTrue(manager.listNamespaces().isEmpty());
     }

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusNamespaceManagerStartupTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusNamespaceManagerStartupTest.java
@@ -56,10 +56,12 @@ class ServiceBusNamespaceManagerStartupTest {
         ServiceBusNamespaceManager manager = new ServiceBusNamespaceManager(
                 config, containerBuilder, lifecycleManager, configGenerator, tlsGenerator);
 
-        assertThrows(IllegalStateException.class,
+        ServiceBusNamespaceManager.NamespaceStartException error = assertThrows(
+                ServiceBusNamespaceManager.NamespaceStartException.class,
                 () -> manager.startNamespace("failed", 5672, 5671));
 
         verify(lifecycleManager).stopAndRemove("container-id", null);
+        assertTrue(error.portsReleased());
         assertTrue(manager.listNamespaces().isEmpty());
     }
 }

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusTopologyLoaderTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusTopologyLoaderTest.java
@@ -130,10 +130,10 @@ class ServiceBusTopologyLoaderTest {
     }
 
     @Test
-    void rejectedDeclaredRulesRetainDefault() {
+    void rejectedDeclaredRulesDoNotRetainMatchAllDefault() {
         given().when().get(BASE + "/topic.orders/subscriptions/rejected/rules")
                 .then().statusCode(200)
-                .body(containsString("$Default"))
+                .body(not(containsString("$Default")))
                 .body(not(containsString("unsupported")));
     }
 

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusTopologyLoaderTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusTopologyLoaderTest.java
@@ -3,6 +3,7 @@ package io.floci.az.services.servicebus;
 import io.quarkus.test.junit.QuarkusTest;
 import io.quarkus.test.junit.QuarkusTestProfile;
 import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -30,6 +31,12 @@ import static org.hamcrest.Matchers.not;
 class ServiceBusTopologyLoaderTest {
 
     private static final String BASE = "/devstoreaccount1-servicebus";
+    private static final String SB_NS =
+            "http://schemas.microsoft.com/netservices/2010/10/servicebus/connect";
+    private static final String XSI_NS = "http://www.w3.org/2001/XMLSchema-instance";
+
+    @Inject
+    ServiceBusTopologyLoader topologyLoader;
 
     public static class TopologyProfile implements QuarkusTestProfile {
         @Override
@@ -86,7 +93,8 @@ class ServiceBusTopologyLoaderTest {
                 .then().statusCode(200)
                 .body(containsString("<title type=\"text\">all</title>"))
                 .body(containsString("<title type=\"text\">filtered</title>"))
-                .body(containsString("<title type=\"text\">sql</title>"));
+                .body(containsString("<title type=\"text\">sql</title>"))
+                .body(containsString("<title type=\"text\">rejected</title>"));
 
         given().when().get(BASE + "/topic.orders/subscriptions/filtered")
                 .then().statusCode(200)
@@ -119,5 +127,33 @@ class ServiceBusTopologyLoaderTest {
                 .body(not(containsString("$Default")))
                 .body(containsString("SqlFilter"))
                 .body(containsString("priority"));
+    }
+
+    @Test
+    void rejectedDeclaredRulesDoNotRetainDefault() {
+        given().when().get(BASE + "/topic.orders/subscriptions/rejected/rules")
+                .then().statusCode(200)
+                .body(not(containsString("$Default")))
+                .body(not(containsString("unsupported")));
+    }
+
+    @Test
+    void reloadRemovesRulesAbsentFromTopology() {
+        String staleRule = "<entry xmlns=\"http://www.w3.org/2005/Atom\">"
+                + "<content type=\"application/xml\">"
+                + "<RuleDescription xmlns:i=\"" + XSI_NS + "\" xmlns=\"" + SB_NS + "\">"
+                + "<Filter i:type=\"SqlFilter\"><SqlExpression>priority = 1</SqlExpression></Filter>"
+                + "<Name>stale</Name></RuleDescription></content></entry>";
+        String rules = BASE + "/topic.orders/subscriptions/filtered/rules";
+
+        given().body(staleRule).when().put(rules + "/stale").then().statusCode(201);
+
+        topologyLoader.load();
+
+        given().when().get(rules)
+                .then().statusCode(200)
+                .body(containsString("by-subject"))
+                .body(not(containsString("stale")))
+                .body(not(containsString("$Default")));
     }
 }

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusTopologyLoaderTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusTopologyLoaderTest.java
@@ -130,10 +130,10 @@ class ServiceBusTopologyLoaderTest {
     }
 
     @Test
-    void rejectedDeclaredRulesDoNotRetainMatchAllDefault() {
+    void rejectedDeclaredRulesPreserveMatchAllDefault() {
         given().when().get(BASE + "/topic.orders/subscriptions/rejected/rules")
                 .then().statusCode(200)
-                .body(not(containsString("$Default")))
+                .body(containsString("$Default"))
                 .body(not(containsString("unsupported")));
     }
 

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusTopologyLoaderTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusTopologyLoaderTest.java
@@ -130,10 +130,10 @@ class ServiceBusTopologyLoaderTest {
     }
 
     @Test
-    void rejectedDeclaredRulesDoNotRetainDefault() {
+    void rejectedDeclaredRulesRetainDefault() {
         given().when().get(BASE + "/topic.orders/subscriptions/rejected/rules")
                 .then().statusCode(200)
-                .body(not(containsString("$Default")))
+                .body(containsString("$Default"))
                 .body(not(containsString("unsupported")));
     }
 

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusTopologyLoaderTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusTopologyLoaderTest.java
@@ -1,0 +1,123 @@
+package io.floci.az.services.servicebus;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * End-to-end check of the declarative topology loader: a Config.json in the official
+ * emulator's format is applied at startup, and the resulting entities are visible (with
+ * their properties) through the same management API the SDKs use. Runs in mocked mode,
+ * so it verifies the management-plane state without Docker.
+ */
+@QuarkusTest
+@TestProfile(ServiceBusTopologyLoaderTest.TopologyProfile.class)
+@DisplayName("Service Bus — declarative topology loaded from Config.json at startup")
+class ServiceBusTopologyLoaderTest {
+
+    private static final String BASE = "/devstoreaccount1-servicebus";
+
+    public static class TopologyProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            try (InputStream in = TopologyProfile.class.getResourceAsStream(
+                    "/servicebus/topology-config.json")) {
+                Path file = Files.createTempFile("floci-az-sb-topology", ".json");
+                Files.copy(in, file, StandardCopyOption.REPLACE_EXISTING);
+                file.toFile().deleteOnExit();
+                return Map.of("floci-az.services.service-bus.topology-file", file.toString());
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+    }
+
+    @Test
+    void loadsQueuesAndSkipsInvalidOnes() {
+        given().when().get(BASE + "/$Resources/queues")
+                .then().statusCode(200)
+                .body(containsString("queue.plain"))
+                .body(containsString("queue.sessions"))
+                .body(not(containsString("queue.invalid")));
+    }
+
+    @Test
+    void queuePropertiesRoundTrip() {
+        given().when().get(BASE + "/queue.sessions")
+                .then().statusCode(200)
+                .body(containsString("<RequiresSession>true</RequiresSession>"))
+                .body(containsString("<MaxDeliveryCount>3</MaxDeliveryCount>"))
+                .body(containsString("<LockDuration>PT1M</LockDuration>"))
+                .body(containsString("<DeadLetteringOnMessageExpiration>true"
+                        + "</DeadLetteringOnMessageExpiration>"))
+                .body(containsString("<DefaultMessageTimeToLive>PT1H</DefaultMessageTimeToLive>"));
+    }
+
+    @Test
+    void loadsTopicWithDuplicateDetection() {
+        given().when().get(BASE + "/$Resources/topics")
+                .then().statusCode(200)
+                .body(containsString("topic.orders"));
+
+        given().when().get(BASE + "/topic.orders")
+                .then().statusCode(200)
+                .body(containsString("<RequiresDuplicateDetection>true</RequiresDuplicateDetection>"))
+                .body(containsString(
+                        "<DuplicateDetectionHistoryTimeWindow>PT30S</DuplicateDetectionHistoryTimeWindow>"));
+    }
+
+    @Test
+    void loadsSubscriptions() {
+        given().when().get(BASE + "/topic.orders/subscriptions")
+                .then().statusCode(200)
+                .body(containsString("<title type=\"text\">all</title>"))
+                .body(containsString("<title type=\"text\">filtered</title>"))
+                .body(containsString("<title type=\"text\">sql</title>"));
+
+        given().when().get(BASE + "/topic.orders/subscriptions/filtered")
+                .then().statusCode(200)
+                .body(containsString("<MaxDeliveryCount>5</MaxDeliveryCount>"));
+    }
+
+    @Test
+    void subscriptionWithoutRulesKeepsDefaultTrueFilter() {
+        given().when().get(BASE + "/topic.orders/subscriptions/all/rules")
+                .then().statusCode(200)
+                .body(containsString("$Default"))
+                .body(containsString("TrueFilter"));
+    }
+
+    @Test
+    void declaredCorrelationRuleReplacesDefault() {
+        given().when().get(BASE + "/topic.orders/subscriptions/filtered/rules")
+                .then().statusCode(200)
+                .body(containsString("by-subject"))
+                .body(not(containsString("$Default")))
+                .body(containsString("order-created"))
+                .body(containsString("region"));
+    }
+
+    @Test
+    void declaredSqlRuleReplacesDefault() {
+        given().when().get(BASE + "/topic.orders/subscriptions/sql/rules")
+                .then().statusCode(200)
+                .body(containsString("sql-rule"))
+                .body(not(containsString("$Default")))
+                .body(containsString("SqlFilter"))
+                .body(containsString("priority"));
+    }
+}

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusTopologyLoaderUnitTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusTopologyLoaderUnitTest.java
@@ -51,13 +51,52 @@ class ServiceBusTopologyLoaderUnitTest {
         when(serviceBus.amqpTlsPort()).thenReturn(5671);
         when(namespaceManager.getNamespace(anyString())).thenReturn(Optional.empty());
         when(namespaceManager.startNamespace("failed", 5672, 5671))
-                .thenThrow(new IllegalStateException("Docker unavailable"));
+                .thenThrow(new ServiceBusNamespaceManager.NamespaceStartException(
+                        "failed", false, new IllegalStateException("Docker unavailable")));
 
         new ServiceBusTopologyLoader(config, handler, namespaceManager).load();
 
         verify(namespaceManager).startNamespace("failed", 5672, 5671);
         verify(namespaceManager).startNamespace("working", 0, 0);
         verify(namespaceManager, never()).startNamespace("working", 5672, 5671);
+        verifyNoInteractions(handler);
+    }
+
+    @Test
+    void cleanedFailedNamespaceReusesConfiguredPorts() throws Exception {
+        Path topologyFile = tempDir.resolve("cleaned.json");
+        Files.writeString(topologyFile, """
+                {
+                  "UserConfig": {
+                    "Namespaces": [
+                      { "Name": "failed" },
+                      { "Name": "working" }
+                    ]
+                  }
+                }
+                """);
+
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
+        EmulatorConfig.ServiceBusConfig serviceBus = mock(EmulatorConfig.ServiceBusConfig.class);
+        ServiceBusHandler handler = mock(ServiceBusHandler.class);
+        ServiceBusNamespaceManager namespaceManager = mock(ServiceBusNamespaceManager.class);
+        when(config.services()).thenReturn(services);
+        when(services.serviceBus()).thenReturn(serviceBus);
+        when(serviceBus.topologyFile()).thenReturn(Optional.of(topologyFile.toString()));
+        when(serviceBus.mocked()).thenReturn(false);
+        when(serviceBus.amqpPort()).thenReturn(5672);
+        when(serviceBus.amqpTlsPort()).thenReturn(5671);
+        when(namespaceManager.getNamespace(anyString())).thenReturn(Optional.empty());
+        when(namespaceManager.startNamespace("failed", 5672, 5671))
+                .thenThrow(new ServiceBusNamespaceManager.NamespaceStartException(
+                        "failed", true, new IllegalStateException("Readiness failed")));
+
+        new ServiceBusTopologyLoader(config, handler, namespaceManager).load();
+
+        verify(namespaceManager).startNamespace("failed", 5672, 5671);
+        verify(namespaceManager).startNamespace("working", 5672, 5671);
+        verify(namespaceManager, never()).startNamespace("working", 0, 0);
         verifyNoInteractions(handler);
     }
 

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusTopologyLoaderUnitTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusTopologyLoaderUnitTest.java
@@ -21,7 +21,7 @@ class ServiceBusTopologyLoaderUnitTest {
     Path tempDir;
 
     @Test
-    void failedNamespaceIsSkippedWithoutConsumingConfiguredPorts() throws Exception {
+    void failedNamespaceIsSkippedWithoutReusingConfiguredPorts() throws Exception {
         Path topologyFile = tempDir.resolve("Config.json");
         Files.writeString(topologyFile, """
                 {
@@ -52,8 +52,8 @@ class ServiceBusTopologyLoaderUnitTest {
         new ServiceBusTopologyLoader(config, handler, namespaceManager).load();
 
         verify(namespaceManager).startNamespace("failed", 5672, 5671);
-        verify(namespaceManager).startNamespace("working", 5672, 5671);
-        verify(namespaceManager, never()).startNamespace("working", 0, 0);
+        verify(namespaceManager).startNamespace("working", 0, 0);
+        verify(namespaceManager, never()).startNamespace("working", 5672, 5671);
         verifyNoInteractions(handler);
     }
 }

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusTopologyLoaderUnitTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusTopologyLoaderUnitTest.java
@@ -1,14 +1,18 @@
 package io.floci.az.services.servicebus;
 
 import io.floci.az.config.EmulatorConfig;
+import jakarta.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Optional;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -55,5 +59,61 @@ class ServiceBusTopologyLoaderUnitTest {
         verify(namespaceManager).startNamespace("working", 0, 0);
         verify(namespaceManager, never()).startNamespace("working", 5672, 5671);
         verifyNoInteractions(handler);
+    }
+
+    @Test
+    void rejectedReplacementPreservesExistingRule() throws Exception {
+        Path topologyFile = tempDir.resolve("replacement.json");
+        Files.writeString(topologyFile, """
+                {
+                  "UserConfig": {
+                    "Namespaces": [{
+                      "Name": "namespace",
+                      "Topics": [{
+                        "Name": "topic",
+                        "Subscriptions": [{
+                          "Name": "subscription",
+                          "Rules": [{
+                            "Name": "existing",
+                            "Properties": {
+                              "FilterType": "Sql",
+                              "SqlFilter": { "SqlExpression": "priority % 2 = 0" }
+                            }
+                          }]
+                        }]
+                      }]
+                    }]
+                  }
+                }
+                """);
+
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
+        EmulatorConfig.ServiceBusConfig serviceBus = mock(EmulatorConfig.ServiceBusConfig.class);
+        ServiceBusHandler handler = mock(ServiceBusHandler.class);
+        ServiceBusNamespaceManager namespaceManager = mock(ServiceBusNamespaceManager.class);
+        ServiceBusModels.RuleEntity existing = ServiceBusModels.RuleEntity.trueFilter(
+                "topic", "subscription", "existing");
+        when(config.services()).thenReturn(services);
+        when(services.serviceBus()).thenReturn(serviceBus);
+        when(serviceBus.topologyFile()).thenReturn(Optional.of(topologyFile.toString()));
+        when(serviceBus.mocked()).thenReturn(true);
+        when(namespaceManager.getNamespace(anyString())).thenReturn(Optional.empty());
+        when(handler.handleCreateTopic(
+                eq("devstoreaccount1"), eq("namespace"), eq("topic"), any(), any()))
+                .thenReturn(Response.status(201).build());
+        when(handler.handleCreateSubscription(
+                eq("devstoreaccount1"), eq("namespace"), eq("topic"), eq("subscription"),
+                eq(false), anyString(), any(), any()))
+                .thenReturn(Response.status(201).build());
+        when(handler.putRule(eq("devstoreaccount1"), eq("namespace"), any()))
+                .thenReturn(Response.status(400).build());
+        when(handler.loadRules("devstoreaccount1", "namespace", "topic", "subscription"))
+                .thenReturn(List.of(existing));
+
+        new ServiceBusTopologyLoader(config, handler, namespaceManager).load();
+
+        verify(handler, never()).handleDeleteRule(
+                "devstoreaccount1", "namespace", "topic", "subscription", "existing");
     }
 }

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusTopologyLoaderUnitTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusTopologyLoaderUnitTest.java
@@ -154,7 +154,7 @@ class ServiceBusTopologyLoaderUnitTest {
     }
 
     @Test
-    void newSubscriptionStartsWithOnlyValidDeclaredRule() throws Exception {
+    void newSubscriptionVerifiesOnlyValidDeclaredRule() throws Exception {
         Path topologyFile = tempDir.resolve("partial-replacement.json");
         Files.writeString(topologyFile, """
                 {
@@ -207,6 +207,9 @@ class ServiceBusTopologyLoaderUnitTest {
                 any(ServiceBusEntityXml.DeliverySettings.class),
                 any(ServiceBusModels.RuleEntity.class)))
                 .thenReturn(Response.status(201).build());
+        when(handler.replaceRules(
+                eq("devstoreaccount1"), eq("namespace"), eq("topic"), eq("subscription"), any()))
+                .thenReturn(Response.ok().build());
         new ServiceBusTopologyLoader(config, handler, namespaceManager).load();
 
         verify(handler).handleCreateSubscription(
@@ -214,8 +217,9 @@ class ServiceBusTopologyLoaderUnitTest {
                 eq(false), any(ServiceBusEntityXml.MessageLifetimeSettings.class),
                 any(ServiceBusEntityXml.DeliverySettings.class),
                 argThat(rule -> "valid".equals(rule.name())));
-        verify(handler, never()).replaceRules(
-                eq("devstoreaccount1"), eq("namespace"), eq("topic"), eq("subscription"), any());
+        verify(handler).replaceRules(
+                eq("devstoreaccount1"), eq("namespace"), eq("topic"), eq("subscription"),
+                argThat(rules -> rules.size() == 1 && "valid".equals(rules.getFirst().name())));
     }
 
     @Test
@@ -263,11 +267,15 @@ class ServiceBusTopologyLoaderUnitTest {
                 any(ServiceBusEntityXml.DeliverySettings.class),
                 any(ServiceBusModels.RuleEntity.class)))
                 .thenReturn(Response.status(201).build());
+        when(handler.replaceRules(
+                eq("devstoreaccount1"), eq("namespace"), eq("topic"), eq("subscription"), any()))
+                .thenReturn(Response.ok().build());
 
         new ServiceBusTopologyLoader(config, handler, namespaceManager).load();
 
-        verify(handler, never()).replaceRules(
-                eq("devstoreaccount1"), eq("namespace"), eq("topic"), eq("subscription"), any());
+        verify(handler).replaceRules(
+                eq("devstoreaccount1"), eq("namespace"), eq("topic"), eq("subscription"),
+                argThat(rules -> rules.size() == 1 && "$Default".equals(rules.getFirst().name())));
     }
 
     @Test
@@ -282,22 +290,13 @@ class ServiceBusTopologyLoaderUnitTest {
                         "Name": "topic",
                         "Subscriptions": [{
                           "Name": "subscription",
-                          "Rules": [
-                            {
+                          "Rules": [{
                               "Name": "first",
                               "Properties": {
                                 "FilterType": "Sql",
                                 "SqlFilter": { "SqlExpression": "priority > 2" }
                               }
-                            },
-                            {
-                              "Name": "second",
-                              "Properties": {
-                                "FilterType": "Sql",
-                                "SqlFilter": { "SqlExpression": "region = 'eu'" }
-                              }
-                            }
-                          ]
+                            }]
                         }]
                       }]
                     }]
@@ -338,6 +337,6 @@ class ServiceBusTopologyLoaderUnitTest {
                         && "priority > 2".equals(rule.sqlExpression())));
         verify(handler).replaceRules(
                 eq("devstoreaccount1"), eq("namespace"), eq("topic"), eq("subscription"),
-                argThat(rules -> rules.size() == 2));
+                argThat(rules -> rules.size() == 1 && "first".equals(rules.getFirst().name())));
     }
 }

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusTopologyLoaderUnitTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusTopologyLoaderUnitTest.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -131,8 +132,6 @@ class ServiceBusTopologyLoaderUnitTest {
         EmulatorConfig.ServiceBusConfig serviceBus = mock(EmulatorConfig.ServiceBusConfig.class);
         ServiceBusHandler handler = mock(ServiceBusHandler.class);
         ServiceBusNamespaceManager namespaceManager = mock(ServiceBusNamespaceManager.class);
-        ServiceBusModels.RuleEntity existing = ServiceBusModels.RuleEntity.trueFilter(
-                "topic", "subscription", "existing");
         when(config.services()).thenReturn(services);
         when(services.serviceBus()).thenReturn(serviceBus);
         when(serviceBus.topologyFile()).thenReturn(Optional.of(topologyFile.toString()));
@@ -144,20 +143,16 @@ class ServiceBusTopologyLoaderUnitTest {
         when(handler.handleCreateSubscription(
                 eq("devstoreaccount1"), eq("namespace"), eq("topic"), eq("subscription"),
                 eq(false), anyString(), any(), any()))
-                .thenReturn(Response.status(201).build());
-        when(handler.putRule(eq("devstoreaccount1"), eq("namespace"), any()))
-                .thenReturn(Response.status(400).build());
-        when(handler.loadRules("devstoreaccount1", "namespace", "topic", "subscription"))
-                .thenReturn(List.of(existing));
+                .thenReturn(Response.ok().build());
 
         new ServiceBusTopologyLoader(config, handler, namespaceManager).load();
 
-        verify(handler, never()).handleDeleteRule(
-                "devstoreaccount1", "namespace", "topic", "subscription", "existing");
+        verify(handler, never()).replaceRules(
+                eq("devstoreaccount1"), eq("namespace"), eq("topic"), eq("subscription"), any());
     }
 
     @Test
-    void validRuleRemovesStaleAndRejectedDefaultRules() throws Exception {
+    void newSubscriptionAppliesOnlyValidDeclaredRules() throws Exception {
         Path topologyFile = tempDir.resolve("partial-replacement.json");
         Files.writeString(topologyFile, """
                 {
@@ -196,10 +191,6 @@ class ServiceBusTopologyLoaderUnitTest {
         EmulatorConfig.ServiceBusConfig serviceBus = mock(EmulatorConfig.ServiceBusConfig.class);
         ServiceBusHandler handler = mock(ServiceBusHandler.class);
         ServiceBusNamespaceManager namespaceManager = mock(ServiceBusNamespaceManager.class);
-        ServiceBusModels.RuleEntity stale = ServiceBusModels.RuleEntity.trueFilter(
-                "topic", "subscription", "stale");
-        ServiceBusModels.RuleEntity defaultRule = ServiceBusModels.RuleEntity.trueFilter(
-                "topic", "subscription", "$Default");
         when(config.services()).thenReturn(services);
         when(services.serviceBus()).thenReturn(serviceBus);
         when(serviceBus.topologyFile()).thenReturn(Optional.of(topologyFile.toString()));
@@ -212,25 +203,14 @@ class ServiceBusTopologyLoaderUnitTest {
                 eq("devstoreaccount1"), eq("namespace"), eq("topic"), eq("subscription"),
                 eq(false), anyString(), any(), any()))
                 .thenReturn(Response.status(201).build());
-        when(handler.putRule(eq("devstoreaccount1"), eq("namespace"), any()))
-                .thenAnswer(invocation -> {
-                    ServiceBusModels.RuleEntity rule = invocation.getArgument(2);
-                    return Response.status("valid".equals(rule.name()) ? 201 : 400).build();
-                });
-        when(handler.loadRules("devstoreaccount1", "namespace", "topic", "subscription"))
-                .thenReturn(List.of(stale, defaultRule));
-        when(handler.handleDeleteRule(
-                "devstoreaccount1", "namespace", "topic", "subscription", "stale"))
-                .thenReturn(Response.ok().build());
-        when(handler.handleDeleteRule(
-                "devstoreaccount1", "namespace", "topic", "subscription", "$Default"))
+        when(handler.replaceRules(
+                eq("devstoreaccount1"), eq("namespace"), eq("topic"), eq("subscription"), any()))
                 .thenReturn(Response.ok().build());
 
         new ServiceBusTopologyLoader(config, handler, namespaceManager).load();
 
-        verify(handler).handleDeleteRule(
-                "devstoreaccount1", "namespace", "topic", "subscription", "stale");
-        verify(handler).handleDeleteRule(
-                "devstoreaccount1", "namespace", "topic", "subscription", "$Default");
+        verify(handler).replaceRules(
+                eq("devstoreaccount1"), eq("namespace"), eq("topic"), eq("subscription"),
+                argThat(rules -> rules.size() == 1 && "valid".equals(rules.getFirst().name())));
     }
 }

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusTopologyLoaderUnitTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusTopologyLoaderUnitTest.java
@@ -213,4 +213,54 @@ class ServiceBusTopologyLoaderUnitTest {
                 eq("devstoreaccount1"), eq("namespace"), eq("topic"), eq("subscription"),
                 argThat(rules -> rules.size() == 1 && "valid".equals(rules.getFirst().name())));
     }
+
+    @Test
+    void newSubscriptionWithOnlyRejectedRulesKeepsDefault() throws Exception {
+        Path topologyFile = tempDir.resolve("rejected-rules.json");
+        Files.writeString(topologyFile, """
+                {
+                  "UserConfig": {
+                    "Namespaces": [{
+                      "Name": "namespace",
+                      "Topics": [{
+                        "Name": "topic",
+                        "Subscriptions": [{
+                          "Name": "subscription",
+                          "Rules": [{
+                            "Name": "invalid",
+                            "Properties": {
+                              "FilterType": "Sql",
+                              "SqlFilter": { "SqlExpression": "priority % 2 = 0" }
+                            }
+                          }]
+                        }]
+                      }]
+                    }]
+                  }
+                }
+                """);
+
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
+        EmulatorConfig.ServiceBusConfig serviceBus = mock(EmulatorConfig.ServiceBusConfig.class);
+        ServiceBusHandler handler = mock(ServiceBusHandler.class);
+        ServiceBusNamespaceManager namespaceManager = mock(ServiceBusNamespaceManager.class);
+        when(config.services()).thenReturn(services);
+        when(services.serviceBus()).thenReturn(serviceBus);
+        when(serviceBus.topologyFile()).thenReturn(Optional.of(topologyFile.toString()));
+        when(serviceBus.mocked()).thenReturn(true);
+        when(namespaceManager.getNamespace(anyString())).thenReturn(Optional.empty());
+        when(handler.handleCreateTopic(
+                eq("devstoreaccount1"), eq("namespace"), eq("topic"), any(), any()))
+                .thenReturn(Response.status(201).build());
+        when(handler.handleCreateSubscription(
+                eq("devstoreaccount1"), eq("namespace"), eq("topic"), eq("subscription"),
+                eq(false), anyString(), any(), any()))
+                .thenReturn(Response.status(201).build());
+
+        new ServiceBusTopologyLoader(config, handler, namespaceManager).load();
+
+        verify(handler, never()).replaceRules(
+                eq("devstoreaccount1"), eq("namespace"), eq("topic"), eq("subscription"), any());
+    }
 }

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusTopologyLoaderUnitTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusTopologyLoaderUnitTest.java
@@ -155,4 +155,75 @@ class ServiceBusTopologyLoaderUnitTest {
         verify(handler, never()).handleDeleteRule(
                 "devstoreaccount1", "namespace", "topic", "subscription", "existing");
     }
+
+    @Test
+    void validRuleAllowsUnrelatedStaleRuleRemovalWhenAnotherRuleIsRejected() throws Exception {
+        Path topologyFile = tempDir.resolve("partial-replacement.json");
+        Files.writeString(topologyFile, """
+                {
+                  "UserConfig": {
+                    "Namespaces": [{
+                      "Name": "namespace",
+                      "Topics": [{
+                        "Name": "topic",
+                        "Subscriptions": [{
+                          "Name": "subscription",
+                          "Rules": [
+                            {
+                              "Name": "valid",
+                              "Properties": {
+                                "FilterType": "Sql",
+                                "SqlFilter": { "SqlExpression": "priority > 2" }
+                              }
+                            },
+                            {
+                              "Name": "rejected",
+                              "Properties": {
+                                "FilterType": "Sql",
+                                "SqlFilter": { "SqlExpression": "priority % 2 = 0" }
+                              }
+                            }
+                          ]
+                        }]
+                      }]
+                    }]
+                  }
+                }
+                """);
+
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
+        EmulatorConfig.ServiceBusConfig serviceBus = mock(EmulatorConfig.ServiceBusConfig.class);
+        ServiceBusHandler handler = mock(ServiceBusHandler.class);
+        ServiceBusNamespaceManager namespaceManager = mock(ServiceBusNamespaceManager.class);
+        ServiceBusModels.RuleEntity stale = ServiceBusModels.RuleEntity.trueFilter(
+                "topic", "subscription", "stale");
+        when(config.services()).thenReturn(services);
+        when(services.serviceBus()).thenReturn(serviceBus);
+        when(serviceBus.topologyFile()).thenReturn(Optional.of(topologyFile.toString()));
+        when(serviceBus.mocked()).thenReturn(true);
+        when(namespaceManager.getNamespace(anyString())).thenReturn(Optional.empty());
+        when(handler.handleCreateTopic(
+                eq("devstoreaccount1"), eq("namespace"), eq("topic"), any(), any()))
+                .thenReturn(Response.status(201).build());
+        when(handler.handleCreateSubscription(
+                eq("devstoreaccount1"), eq("namespace"), eq("topic"), eq("subscription"),
+                eq(false), anyString(), any(), any()))
+                .thenReturn(Response.status(201).build());
+        when(handler.putRule(eq("devstoreaccount1"), eq("namespace"), any()))
+                .thenAnswer(invocation -> {
+                    ServiceBusModels.RuleEntity rule = invocation.getArgument(2);
+                    return Response.status("valid".equals(rule.name()) ? 201 : 400).build();
+                });
+        when(handler.loadRules("devstoreaccount1", "namespace", "topic", "subscription"))
+                .thenReturn(List.of(stale));
+        when(handler.handleDeleteRule(
+                "devstoreaccount1", "namespace", "topic", "subscription", "stale"))
+                .thenReturn(Response.ok().build());
+
+        new ServiceBusTopologyLoader(config, handler, namespaceManager).load();
+
+        verify(handler).handleDeleteRule(
+                "devstoreaccount1", "namespace", "topic", "subscription", "stale");
+    }
 }

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusTopologyLoaderUnitTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusTopologyLoaderUnitTest.java
@@ -1,0 +1,59 @@
+package io.floci.az.services.servicebus;
+
+import io.floci.az.config.EmulatorConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class ServiceBusTopologyLoaderUnitTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void failedNamespaceIsSkippedWithoutConsumingConfiguredPorts() throws Exception {
+        Path topologyFile = tempDir.resolve("Config.json");
+        Files.writeString(topologyFile, """
+                {
+                  "UserConfig": {
+                    "Namespaces": [
+                      { "Name": "failed", "Queues": [{ "Name": "orphan" }] },
+                      { "Name": "working" }
+                    ]
+                  }
+                }
+                """);
+
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
+        EmulatorConfig.ServiceBusConfig serviceBus = mock(EmulatorConfig.ServiceBusConfig.class);
+        ServiceBusHandler handler = mock(ServiceBusHandler.class);
+        ServiceBusNamespaceManager namespaceManager = mock(ServiceBusNamespaceManager.class);
+        when(config.services()).thenReturn(services);
+        when(services.serviceBus()).thenReturn(serviceBus);
+        when(serviceBus.topologyFile()).thenReturn(Optional.of(topologyFile.toString()));
+        when(serviceBus.mocked()).thenReturn(false);
+        when(serviceBus.amqpPort()).thenReturn(5672);
+        when(serviceBus.amqpTlsPort()).thenReturn(5671);
+        when(namespaceManager.getNamespace(anyString())).thenReturn(Optional.empty());
+        when(namespaceManager.startNamespace("failed", 5672, 5671))
+                .thenThrow(new IllegalStateException("Docker unavailable"));
+
+        new ServiceBusTopologyLoader(config, handler, namespaceManager).load();
+
+        verify(namespaceManager).startNamespace("failed", 5672, 5671);
+        verify(namespaceManager).startNamespace("working", 5672, 5671);
+        verify(namespaceManager, never()).startNamespace("working", 0, 0);
+        verifyNoInteractions(handler);
+    }
+}

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusTopologyLoaderUnitTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusTopologyLoaderUnitTest.java
@@ -101,7 +101,7 @@ class ServiceBusTopologyLoaderUnitTest {
     }
 
     @Test
-    void rejectedReplacementPreservesExistingRule() throws Exception {
+    void rejectedRenamePreservesExistingRule() throws Exception {
         Path topologyFile = tempDir.resolve("replacement.json");
         Files.writeString(topologyFile, """
                 {
@@ -113,7 +113,7 @@ class ServiceBusTopologyLoaderUnitTest {
                         "Subscriptions": [{
                           "Name": "subscription",
                           "Rules": [{
-                            "Name": "existing",
+                            "Name": "replacement",
                             "Properties": {
                               "FilterType": "Sql",
                               "SqlFilter": { "SqlExpression": "priority % 2 = 0" }

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusTopologyLoaderUnitTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusTopologyLoaderUnitTest.java
@@ -142,7 +142,9 @@ class ServiceBusTopologyLoaderUnitTest {
                 .thenReturn(Response.status(201).build());
         when(handler.handleCreateSubscription(
                 eq("devstoreaccount1"), eq("namespace"), eq("topic"), eq("subscription"),
-                eq(false), anyString(), any(), any()))
+                eq(false), any(ServiceBusEntityXml.MessageLifetimeSettings.class),
+                any(ServiceBusEntityXml.DeliverySettings.class),
+                any(ServiceBusModels.RuleEntity.class)))
                 .thenReturn(Response.ok().build());
 
         new ServiceBusTopologyLoader(config, handler, namespaceManager).load();
@@ -152,7 +154,7 @@ class ServiceBusTopologyLoaderUnitTest {
     }
 
     @Test
-    void newSubscriptionAppliesOnlyValidDeclaredRules() throws Exception {
+    void newSubscriptionStartsWithOnlyValidDeclaredRule() throws Exception {
         Path topologyFile = tempDir.resolve("partial-replacement.json");
         Files.writeString(topologyFile, """
                 {
@@ -201,17 +203,19 @@ class ServiceBusTopologyLoaderUnitTest {
                 .thenReturn(Response.status(201).build());
         when(handler.handleCreateSubscription(
                 eq("devstoreaccount1"), eq("namespace"), eq("topic"), eq("subscription"),
-                eq(false), anyString(), any(), any()))
+                eq(false), any(ServiceBusEntityXml.MessageLifetimeSettings.class),
+                any(ServiceBusEntityXml.DeliverySettings.class),
+                any(ServiceBusModels.RuleEntity.class)))
                 .thenReturn(Response.status(201).build());
-        when(handler.replaceRules(
-                eq("devstoreaccount1"), eq("namespace"), eq("topic"), eq("subscription"), any()))
-                .thenReturn(Response.ok().build());
-
         new ServiceBusTopologyLoader(config, handler, namespaceManager).load();
 
-        verify(handler).replaceRules(
+        verify(handler).handleCreateSubscription(
                 eq("devstoreaccount1"), eq("namespace"), eq("topic"), eq("subscription"),
-                argThat(rules -> rules.size() == 1 && "valid".equals(rules.getFirst().name())));
+                eq(false), any(ServiceBusEntityXml.MessageLifetimeSettings.class),
+                any(ServiceBusEntityXml.DeliverySettings.class),
+                argThat(rule -> "valid".equals(rule.name())));
+        verify(handler, never()).replaceRules(
+                eq("devstoreaccount1"), eq("namespace"), eq("topic"), eq("subscription"), any());
     }
 
     @Test
@@ -255,12 +259,85 @@ class ServiceBusTopologyLoaderUnitTest {
                 .thenReturn(Response.status(201).build());
         when(handler.handleCreateSubscription(
                 eq("devstoreaccount1"), eq("namespace"), eq("topic"), eq("subscription"),
-                eq(false), anyString(), any(), any()))
+                eq(false), any(ServiceBusEntityXml.MessageLifetimeSettings.class),
+                any(ServiceBusEntityXml.DeliverySettings.class),
+                any(ServiceBusModels.RuleEntity.class)))
                 .thenReturn(Response.status(201).build());
 
         new ServiceBusTopologyLoader(config, handler, namespaceManager).load();
 
         verify(handler, never()).replaceRules(
                 eq("devstoreaccount1"), eq("namespace"), eq("topic"), eq("subscription"), any());
+    }
+
+    @Test
+    void failedRuleReplacementStartsWithRestrictiveDeclaredRule() throws Exception {
+        Path topologyFile = tempDir.resolve("failed-replacement.json");
+        Files.writeString(topologyFile, """
+                {
+                  "UserConfig": {
+                    "Namespaces": [{
+                      "Name": "namespace",
+                      "Topics": [{
+                        "Name": "topic",
+                        "Subscriptions": [{
+                          "Name": "subscription",
+                          "Rules": [
+                            {
+                              "Name": "first",
+                              "Properties": {
+                                "FilterType": "Sql",
+                                "SqlFilter": { "SqlExpression": "priority > 2" }
+                              }
+                            },
+                            {
+                              "Name": "second",
+                              "Properties": {
+                                "FilterType": "Sql",
+                                "SqlFilter": { "SqlExpression": "region = 'eu'" }
+                              }
+                            }
+                          ]
+                        }]
+                      }]
+                    }]
+                  }
+                }
+                """);
+
+        EmulatorConfig config = mock(EmulatorConfig.class);
+        EmulatorConfig.ServicesConfig services = mock(EmulatorConfig.ServicesConfig.class);
+        EmulatorConfig.ServiceBusConfig serviceBus = mock(EmulatorConfig.ServiceBusConfig.class);
+        ServiceBusHandler handler = mock(ServiceBusHandler.class);
+        ServiceBusNamespaceManager namespaceManager = mock(ServiceBusNamespaceManager.class);
+        when(config.services()).thenReturn(services);
+        when(services.serviceBus()).thenReturn(serviceBus);
+        when(serviceBus.topologyFile()).thenReturn(Optional.of(topologyFile.toString()));
+        when(serviceBus.mocked()).thenReturn(true);
+        when(namespaceManager.getNamespace(anyString())).thenReturn(Optional.empty());
+        when(handler.handleCreateTopic(
+                eq("devstoreaccount1"), eq("namespace"), eq("topic"), any(), any()))
+                .thenReturn(Response.status(201).build());
+        when(handler.handleCreateSubscription(
+                eq("devstoreaccount1"), eq("namespace"), eq("topic"), eq("subscription"),
+                eq(false), any(ServiceBusEntityXml.MessageLifetimeSettings.class),
+                any(ServiceBusEntityXml.DeliverySettings.class),
+                any(ServiceBusModels.RuleEntity.class)))
+                .thenReturn(Response.status(201).build());
+        when(handler.replaceRules(
+                eq("devstoreaccount1"), eq("namespace"), eq("topic"), eq("subscription"), any()))
+                .thenReturn(Response.serverError().build());
+
+        new ServiceBusTopologyLoader(config, handler, namespaceManager).load();
+
+        verify(handler).handleCreateSubscription(
+                eq("devstoreaccount1"), eq("namespace"), eq("topic"), eq("subscription"),
+                eq(false), any(ServiceBusEntityXml.MessageLifetimeSettings.class),
+                any(ServiceBusEntityXml.DeliverySettings.class),
+                argThat(rule -> "first".equals(rule.name())
+                        && "priority > 2".equals(rule.sqlExpression())));
+        verify(handler).replaceRules(
+                eq("devstoreaccount1"), eq("namespace"), eq("topic"), eq("subscription"),
+                argThat(rules -> rules.size() == 2));
     }
 }

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusTopologyLoaderUnitTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusTopologyLoaderUnitTest.java
@@ -157,7 +157,7 @@ class ServiceBusTopologyLoaderUnitTest {
     }
 
     @Test
-    void validRuleAllowsUnrelatedStaleRuleRemovalWhenAnotherRuleIsRejected() throws Exception {
+    void validRuleRemovesStaleAndRejectedDefaultRules() throws Exception {
         Path topologyFile = tempDir.resolve("partial-replacement.json");
         Files.writeString(topologyFile, """
                 {
@@ -177,7 +177,7 @@ class ServiceBusTopologyLoaderUnitTest {
                               }
                             },
                             {
-                              "Name": "rejected",
+                              "Name": "$Default",
                               "Properties": {
                                 "FilterType": "Sql",
                                 "SqlFilter": { "SqlExpression": "priority % 2 = 0" }
@@ -198,6 +198,8 @@ class ServiceBusTopologyLoaderUnitTest {
         ServiceBusNamespaceManager namespaceManager = mock(ServiceBusNamespaceManager.class);
         ServiceBusModels.RuleEntity stale = ServiceBusModels.RuleEntity.trueFilter(
                 "topic", "subscription", "stale");
+        ServiceBusModels.RuleEntity defaultRule = ServiceBusModels.RuleEntity.trueFilter(
+                "topic", "subscription", "$Default");
         when(config.services()).thenReturn(services);
         when(services.serviceBus()).thenReturn(serviceBus);
         when(serviceBus.topologyFile()).thenReturn(Optional.of(topologyFile.toString()));
@@ -216,14 +218,19 @@ class ServiceBusTopologyLoaderUnitTest {
                     return Response.status("valid".equals(rule.name()) ? 201 : 400).build();
                 });
         when(handler.loadRules("devstoreaccount1", "namespace", "topic", "subscription"))
-                .thenReturn(List.of(stale));
+                .thenReturn(List.of(stale, defaultRule));
         when(handler.handleDeleteRule(
                 "devstoreaccount1", "namespace", "topic", "subscription", "stale"))
+                .thenReturn(Response.ok().build());
+        when(handler.handleDeleteRule(
+                "devstoreaccount1", "namespace", "topic", "subscription", "$Default"))
                 .thenReturn(Response.ok().build());
 
         new ServiceBusTopologyLoader(config, handler, namespaceManager).load();
 
         verify(handler).handleDeleteRule(
                 "devstoreaccount1", "namespace", "topic", "subscription", "stale");
+        verify(handler).handleDeleteRule(
+                "devstoreaccount1", "namespace", "topic", "subscription", "$Default");
     }
 }

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusTopologyRuleMappingTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusTopologyRuleMappingTest.java
@@ -1,0 +1,73 @@
+package io.floci.az.services.servicebus;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ServiceBusTopologyRuleMappingTest {
+
+    private static ServiceBusTopologyFile.Rule rule(String name,
+                                                     ServiceBusTopologyFile.RuleProperties properties) {
+        return new ServiceBusTopologyFile.Rule(name, properties);
+    }
+
+    @Test
+    void mapsCorrelationFilterWithTypedProperties() {
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("region", "eu");
+        properties.put("priority", 3);
+        properties.put("score", 1.5);
+        properties.put("vip", true);
+        var filter = new ServiceBusTopologyFile.CorrelationFilter(
+                properties, "corr-1", null, null, null, "order-created", "session-1", null, null);
+        var entity = ServiceBusTopologyLoader.toRuleEntity("t", "s",
+                rule("r1", new ServiceBusTopologyFile.RuleProperties("Correlation", filter, null, null)));
+
+        assertEquals("CorrelationFilter", entity.filterType());
+        assertEquals("corr-1", entity.correlationId());
+        assertEquals("order-created", entity.label());
+        assertEquals("session-1", entity.sessionId());
+        assertEquals("eu", entity.correlationProperties().get("region"));
+        assertEquals("3", entity.correlationProperties().get("priority"));
+        assertNull(entity.correlationPropertyTypes().get("region"));
+        assertEquals("long", entity.correlationPropertyTypes().get("priority"));
+        assertEquals("double", entity.correlationPropertyTypes().get("score"));
+        assertEquals("boolean", entity.correlationPropertyTypes().get("vip"));
+    }
+
+    @Test
+    void mapsSqlFilterWithAction() {
+        var entity = ServiceBusTopologyLoader.toRuleEntity("t", "s",
+                rule("r2", new ServiceBusTopologyFile.RuleProperties("Sql",
+                        null,
+                        new ServiceBusTopologyFile.SqlExpressionHolder("priority > 2"),
+                        new ServiceBusTopologyFile.SqlExpressionHolder("SET x = 1"))));
+
+        assertEquals("SqlFilter", entity.filterType());
+        assertEquals("priority > 2", entity.sqlExpression());
+        assertEquals("SET x = 1", entity.actionSqlExpression());
+    }
+
+    @Test
+    void rejectsMissingFilterType() {
+        assertThrows(IllegalArgumentException.class, () -> ServiceBusTopologyLoader.toRuleEntity(
+                "t", "s", rule("r", new ServiceBusTopologyFile.RuleProperties(null, null, null, null))));
+    }
+
+    @Test
+    void rejectsSqlFilterWithoutExpression() {
+        assertThrows(IllegalArgumentException.class, () -> ServiceBusTopologyLoader.toRuleEntity(
+                "t", "s", rule("r", new ServiceBusTopologyFile.RuleProperties("Sql", null, null, null))));
+    }
+
+    @Test
+    void rejectsUnknownFilterType() {
+        assertThrows(IllegalArgumentException.class, () -> ServiceBusTopologyLoader.toRuleEntity(
+                "t", "s", rule("r", new ServiceBusTopologyFile.RuleProperties("Fancy", null, null, null))));
+    }
+}

--- a/src/test/resources/servicebus/topology-config.json
+++ b/src/test/resources/servicebus/topology-config.json
@@ -73,6 +73,21 @@
                     }
                   }
                 ]
+              },
+              {
+                "Name": "rejected",
+                "Properties": {},
+                "Rules": [
+                  {
+                    "Name": "unsupported",
+                    "Properties": {
+                      "FilterType": "Sql",
+                      "SqlFilter": {
+                        "SqlExpression": "priority % 2 = 0"
+                      }
+                    }
+                  }
+                ]
               }
             ]
           }

--- a/src/test/resources/servicebus/topology-config.json
+++ b/src/test/resources/servicebus/topology-config.json
@@ -1,0 +1,86 @@
+{
+  "UserConfig": {
+    "Namespaces": [
+      {
+        "Name": "sbemulatorns",
+        "Queues": [
+          {
+            "Name": "queue.plain",
+            "Properties": {}
+          },
+          {
+            "Name": "queue.sessions",
+            "Properties": {
+              "DeadLetteringOnMessageExpiration": true,
+              "DefaultMessageTimeToLive": "PT1H",
+              "LockDuration": "PT1M",
+              "MaxDeliveryCount": 3,
+              "RequiresSession": true
+            }
+          },
+          {
+            "Name": "queue.invalid",
+            "Properties": {
+              "LockDuration": "PT99M"
+            }
+          }
+        ],
+        "Topics": [
+          {
+            "Name": "topic.orders",
+            "Properties": {
+              "RequiresDuplicateDetection": true,
+              "DuplicateDetectionHistoryTimeWindow": "PT30S"
+            },
+            "Subscriptions": [
+              {
+                "Name": "all",
+                "Properties": {},
+                "Rules": []
+              },
+              {
+                "Name": "filtered",
+                "Properties": {
+                  "MaxDeliveryCount": 5
+                },
+                "Rules": [
+                  {
+                    "Name": "by-subject",
+                    "Properties": {
+                      "FilterType": "Correlation",
+                      "CorrelationFilter": {
+                        "Properties": {
+                          "region": "eu",
+                          "priority": 3
+                        },
+                        "Label": "order-created"
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "Name": "sql",
+                "Properties": {},
+                "Rules": [
+                  {
+                    "Name": "sql-rule",
+                    "Properties": {
+                      "FilterType": "Sql",
+                      "SqlFilter": {
+                        "SqlExpression": "priority > 2"
+                      }
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "Logging": {
+      "Type": "File"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #248.

Load Service Bus namespaces, queues, topics, subscriptions, and rules at startup from the official emulator's `Config.json` format. Read `floci-az.services.service-bus.topology-file` (`FLOCI_AZ_SERVICES_SERVICE_BUS_TOPOLOGY_FILE`) first, then the official `/ServiceBus_Emulator/ConfigFiles/Config.json` mount path. This accepts topology files produced by .NET Aspire.

Apply entities through the existing management paths, sharing validation, storage, and Artemis provisioning. A discovered topology file takes precedence over `start-on-boot`. The first namespace uses configured AMQP ports; later namespaces use dynamic ports. Failed startup releases configured ports for reuse only after container removal is confirmed. Invalid entities are logged and skipped without failing application startup.

Rule reconciliation validates the complete desired rule set, updates the broker selector, then commits one atomic storage batch. A failed storage batch retries the previous selector. If every rollback attempt fails, the request returns HTTP 500 and logs the inconsistency while leaving the broker running. There is no namespace restart or deferred topology replay: repairing a stale filter must not discard queued messages or disconnect clients across the namespace. A later successful rule update reconciles the filter with stored rules.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

The reflection-safe JSON model accepts the official emulator's PascalCase format, correlation and SQL rules, and typed correlation properties. XML and JSON configuration share entity validation. Valid declared rules replace the implicit `$Default` rule. Invalid replacements preserve an existing subscription's complete rule set; a new subscription retains `$Default` if all declarations are rejected.

Unsupported forwarding properties and rule actions are logged. After an exhausted rollback, the broker filter may differ from stored rules; this limitation is documented in `docs/services/service-bus.md`.

## Validation

- `./mvnw test -Dtest=ServiceBus*Test`: 166 tests passed locally.
- The exhausted-rollback regression failed before the fix and passes afterward. It verifies HTTP 500, bounded selector rollback, and no namespace lifecycle or topology recreation calls.
- Topology loading, typed rule mapping, atomic rule replacement, startup wiring, and failed-start cleanup have automated coverage.
- CI runs the complete unit and native SDK compatibility suites on the pushed commit.

## Checklist

- [ ] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
