### PR TITLE
fix: honor X-Forwarded-Proto in /metadata/endpoints so URLs are https behind a TLS proxy

### DIFF
--- a/src/main/java/io/floci/az/core/AzureIdentityController.java
+++ b/src/main/java/io/floci/az/core/AzureIdentityController.java
@@ -4,6 +4,7 @@ import io.floci.az.config.EmulatorConfig;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.UriInfo;
@@ -30,10 +31,28 @@ public class AzureIdentityController {
     @GET
     @Path("metadata/endpoints")
     @Produces(MediaType.APPLICATION_JSON)
-    public Response metadataEndpoints(@Context UriInfo uriInfo) {
+    public Response metadataEndpoints(@Context UriInfo uriInfo, @Context HttpHeaders headers) {
         // Derive base URL from the incoming request so the returned endpoints are
         // always reachable by the caller (host-network, Docker bridge, or TLS).
         String baseUrl = uriInfo.getBaseUri().toString().replaceAll("/+$", "");
+        // Honor X-Forwarded-Proto when a TLS-terminating reverse proxy fronts the
+        // emulator: the proxy->emulator hop is plaintext, so UriInfo sees "http",
+        // but the caller reached the proxy over "https" and the advertised URLs
+        // must reflect the CLIENT's scheme. Otherwise go-azure-sdk / terraform's
+        // azurerm custom-environment bootstrap takes loginEndpoint at face value
+        // and sends a plaintext token request to the TLS-only listener, which
+        // rejects it and the apply never reaches a resource. Only the scheme is
+        // overridden; the Host-derived authority from UriInfo is kept as-is.
+        // Mirrors the X-Forwarded-Proto handling in the Cosmos/Postgres/Sql handlers.
+        String forwardedProto = headers.getHeaderString("X-Forwarded-Proto");
+        if (forwardedProto != null && !forwardedProto.isBlank()) {
+            // A proxy chain may send a comma-separated list; the first value is
+            // the scheme the original client used.
+            String scheme = forwardedProto.split(",")[0].trim().toLowerCase();
+            if (scheme.equals("http") || scheme.equals("https")) {
+                baseUrl = baseUrl.replaceFirst("^https?://", scheme + "://");
+            }
+        }
         return Response.ok(Map.of(
             "name",                     "floci-az",
             // No trailing slash: in Azure Stack mode the go-azure-sdk concatenates this

--- a/src/test/java/io/floci/az/core/AzureIdentityControllerTest.java
+++ b/src/test/java/io/floci/az/core/AzureIdentityControllerTest.java
@@ -1,0 +1,70 @@
+package io.floci.az.core;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.startsWith;
+
+/**
+ * Tests for {@link AzureIdentityController#metadataEndpoints}: the ARM environment
+ * discovery document consumed by go-azure-sdk / terraform's azurerm provider in
+ * Azure Stack (custom-environment) mode.
+ *
+ * <p>Regression coverage for issue #252: behind a TLS-terminating reverse proxy the
+ * proxy&#8594;emulator hop is plaintext, so the request arrives over {@code http}, but the
+ * self-referential URLs in this document must advertise the scheme the CLIENT used
+ * ({@code https}, signalled via {@code X-Forwarded-Proto}). Without it the SDK takes
+ * {@code loginEndpoint} at face value and sends a plaintext token request to the
+ * TLS-only listener, and the apply never reaches a resource.
+ */
+@QuarkusTest
+@DisplayName("AzureIdentityController — /metadata/endpoints scheme handling")
+class AzureIdentityControllerTest {
+
+    @Test
+    @DisplayName("without X-Forwarded-Proto, URLs use the request's own (http) scheme")
+    void defaultsToRequestScheme() {
+        given()
+                .when().get("/metadata/endpoints")
+                .then().statusCode(200)
+                .body("resourceManager", startsWith("http://"))
+                .body("authentication.loginEndpoint", startsWith("http://"));
+    }
+
+    @Test
+    @DisplayName("X-Forwarded-Proto: https makes every self-referential URL https")
+    void honorsForwardedProtoHttps() {
+        given()
+                .header("X-Forwarded-Proto", "https")
+                .when().get("/metadata/endpoints")
+                .then().statusCode(200)
+                .body("resourceManager", startsWith("https://"))
+                .body("microsoftGraphResourceId", startsWith("https://"))
+                .body("portal", startsWith("https://"))
+                .body("gallery", startsWith("https://"))
+                .body("authentication.loginEndpoint", startsWith("https://"))
+                .body("authentication.audiences[0]", startsWith("https://"));
+    }
+
+    @Test
+    @DisplayName("a proxy chain's first X-Forwarded-Proto value wins")
+    void honorsFirstValueInAForwardedProtoChain() {
+        given()
+                .header("X-Forwarded-Proto", "https, http")
+                .when().get("/metadata/endpoints")
+                .then().statusCode(200)
+                .body("resourceManager", startsWith("https://"));
+    }
+
+    @Test
+    @DisplayName("a garbage X-Forwarded-Proto is ignored, not spliced into the URL")
+    void ignoresAnUnrecognizedForwardedProto() {
+        given()
+                .header("X-Forwarded-Proto", "gopher")
+                .when().get("/metadata/endpoints")
+                .then().statusCode(200)
+                .body("resourceManager", startsWith("http://"));
+    }
+}


### PR DESCRIPTION
## Summary

`GET /metadata/endpoints` built its self-referential URLs (`resourceManager`, `loginEndpoint`, `microsoftGraphResourceId`, `portal`, `gallery`, `audiences`) from `UriInfo.getBaseUri()`, whose scheme reflects the raw socket. Behind a TLS-terminating reverse proxy — the only way to give the azurerm provider the HTTPS metadata hop it demands, since floci-az serves plain HTTP on `4577` — the proxy→emulator hop is plaintext, so `UriInfo` sees `http` and every advertised URL came back `http://` even though the client reached the proxy over `https`.

This PR honors `X-Forwarded-Proto` to override **only the scheme** of the derived base URL (the `Host`-derived authority is unchanged), matching the `X-Forwarded-Proto` + connection-secure handling already present in the Cosmos/Postgres/Sql handlers. It takes the first value of a proxy-chain list and validates it to `http`/`https` before use.

Closes #252.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

**Incorrect behavior:** terraform's `azurerm` provider with `environment = "custom"` fetches `GET /metadata/endpoints` over HTTPS unconditionally, so reaching floci-az requires a TLS-terminating reverse proxy in front. That hop then cleared, but the returned metadata advertised `loginEndpoint: "http://<host>/"`; terraform took it at face value and sent a **plaintext** OAuth token request to the TLS-only listener, which rejected it with `400 … Client sent an HTTP request to an HTTPS server`. The apply never reached a resource.

With `X-Forwarded-Proto: https` set by the proxy, the document now advertises `https://` URLs and the token hop stays on TLS. Only the scheme is affected; direct (no-proxy) callers, and floci-az's own built-in TLS proxy, are unchanged (no `X-Forwarded-Proto` → prior behavior).

Note (out of scope for this PR, worth a follow-up): `RequestUrls.resolveBaseUrl(...)` — used by `EntraServiceHandler` for the OIDC `issuer`/`audiences` and by `EmailHandler` — has the same `X-Forwarded-Proto` gap, so the OAuth token issuer claims likely mis-scheme behind a proxy the same way. Kept out of this change to stay focused on #252; happy to file it separately.

## Checklist

- [x] Tests pass locally — the full `io.floci.az.core` package (routing, identity, TLS proxy, health, CORS, registry — **46 tests, 0 failures**) plus a full project compile, on JDK 25. Full disclosure: the complete multi-service `./mvnw test` spins up docker-based service emulators (Cosmos/ServiceBus/AKS/ACR/Redis) that I couldn't run in my sandbox, so I gated on the entire `core` package instead — the change is confined to `AzureIdentityController.metadataEndpoints` and is fully covered there. Happy to confirm a clean full-suite run if a maintainer wants it before merge.
- [x] New or updated integration test added — `AzureIdentityControllerTest` (4 cases: default scheme, `X-Forwarded-Proto: https` flips every URL, proxy-chain first value wins, garbage value ignored); existing `AzureRoutingFilterTest` stays green
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
