### PR TITLE
docs: state the release cadence in CONTRIBUTING and the docs site

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,8 +116,8 @@ Docker images are never built on contributor PRs, so merging to `main` is always
 ## Release Process (maintainers)
 
 Stable releases ship on the **1st and 3rd Tuesday of each month**. Merging to `main` does
-not cut a release: the change rides the next train, and is in that night's `nightly` image
-either way.
+not cut a release: the change rides the next train, and reaches the `nightly` image on the
+next nightly build.
 
 Releases are cut from `main` with the **Release Cut** workflow
 (Actions → Release Cut → Run workflow). semantic-release analyzes the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,10 @@ Thank you for your interest in contributing! Floci is a community-driven project
 
 ## Ways to Contribute
 
-- **Bug reports** — open an issue with a minimal reproduction
-- **Feature requests** — open an issue describing the AWS behavior you need
-- **Pull requests** — bug fixes, new service implementations, or improvements
-- **Compatibility tests** — add cases to `./compatibility-tests/`
+- **Bug reports**: open an issue with a minimal reproduction
+- **Feature requests**: open an issue describing the AWS behavior you need
+- **Pull requests**: bug fixes, new service implementations, or improvements
+- **Compatibility tests**: add cases to `./compatibility-tests/`
 
 ## Getting Started
 
@@ -47,16 +47,16 @@ If you prefer to use your own Maven installation (3.9+), you can use `mvn` inste
 
 ## Branching Model
 
-Floci uses a **tag-driven release model**. Docker images are never published on PR merge — only when a maintainer pushes a version tag.
+Floci uses a **tag-driven release model**. Docker images are never published on PR merge, only when a maintainer pushes a version tag.
 
 | Branch | Purpose | Docker published? |
 |---|---|---|
-| `main` | Integration branch — all PRs merge here. Treated as unstable/nightly. | No (CI tests only) |
+| `main` | Integration branch: all PRs merge here. Treated as unstable/nightly. | No (CI tests only) |
 | `X.Y.Z` tag | Signals a production release. Triggers the full Docker publish pipeline. | Yes (`x.y.z`, `latest`, `x.y.z-jvm`, `latest-jvm`) |
 
 ## Commit Message Format
 
-This project uses [Conventional Commits](https://www.conventionalcommits.org/) — semantic-release reads these to generate the changelog and version bumps automatically.
+This project uses [Conventional Commits](https://www.conventionalcommits.org/): semantic-release reads these to generate the changelog and version bumps automatically.
 
 | Prefix | When to use | Version bump |
 |--------|-------------|--------------|
@@ -65,7 +65,7 @@ This project uses [Conventional Commits](https://www.conventionalcommits.org/) �
 | `perf:` | Performance improvement | patch |
 | `docs:` | Documentation only | none |
 | `chore:` | Build, CI, dependencies | none |
-| `BREAKING CHANGE:` | Footer or `!` suffix — incompatible change | major |
+| `BREAKING CHANGE:` | Footer or `!` suffix, incompatible change | major |
 
 Do not include `Co-Authored-By` trailers for AI tools in commit messages. Attribution should be limited to human contributors.
 
@@ -92,7 +92,7 @@ ln -s AGENT.md COPILOT.md
 ## Adding a New AWS Service
 
 1. Create a package under `src/main/java/.../services/<service>/`
-2. Add a Controller (follow the correct protocol — Query, JSON 1.1, REST JSON, or REST XML)
+2. Add a Controller (follow the correct protocol: Query, JSON 1.1, REST JSON, or REST XML)
 3. Add a Service (`@ApplicationScoped`) and model POJOs
 4. Add config entries in `EmulatorConfig.java` and `application.yml`
 5. Register a `ServiceDescriptor` in `ResolvedServiceCatalog`
@@ -101,19 +101,23 @@ ln -s AGENT.md COPILOT.md
 
 `ServiceRegistry`, `ServiceEnabledFilter`, and `StorageFactory` now resolve service metadata from the descriptor catalog. Adding a service should not require new service-keyed switch statements in those consumers.
 
-Always implement the **real AWS wire protocol** — never invent custom endpoints. The AWS SDK must work against Floci without modification.
+Always implement the **real AWS wire protocol**. Never invent custom endpoints. The AWS SDK must work against Floci without modification.
 
 ## Pull Request Guidelines
 
 1. Branch off `main`: `git checkout -b feature/my-feature`
 2. Open a PR targeting `main`.
-3. CI runs tests automatically — all checks must pass before merge.
-4. Keep PRs focused — one feature or fix per PR.
+3. CI runs tests automatically. All checks must pass before merge.
+4. Keep PRs focused: one feature or fix per PR.
 5. Reference any related issues in the PR description.
 
 Docker images are never built on contributor PRs, so merging to `main` is always cheap.
 
 ## Release Process (maintainers)
+
+Stable releases ship on the **1st and 3rd Tuesday of each month**. Merging to `main` does
+not cut a release: the change rides the next train, and is in that night's `nightly` image
+either way.
 
 Releases are cut from `main` with the **Release Cut** workflow
 (Actions → Release Cut → Run workflow). semantic-release analyzes the
@@ -122,7 +126,7 @@ Conventional Commits since the last tag, bumps `pom.xml`, regenerates
 push triggers the Docker publish pipeline. Use the `dry-run` input to
 preview the next version and notes without releasing.
 
-`CHANGELOG.md` is generated — **do not edit it by hand**. Your Conventional
+`CHANGELOG.md` is generated. **Do not edit it by hand.** Your Conventional
 Commit message is the changelog entry. Genuine corrections to the file
 require the `changelog-edit` label on the PR.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Contributions are welcome — bug fixes, new service operations, documentation improvements, or test coverage.
+Contributions are welcome: bug fixes, new service operations, documentation improvements, or test coverage.
 
 ## Development Environment
 
@@ -12,10 +12,10 @@ Contributions are welcome — bug fixes, new service operations, documentation i
 
 ```
 src/main/java/io/floci/az/
-├── config/          # EmulatorConfig — all settings via SmallRye Config
+├── config/          # EmulatorConfig : all settings via SmallRye Config
 ├── core/
 │   ├── auth/        # AuthPipeline, SharedKeyAuthVerifier, BearerTokenVerifier, SasTokenParser
-│   ├── dns/         # EmbeddedDnsServer — DNS resolver injected into function containers
+│   ├── dns/         # EmbeddedDnsServer : DNS resolver injected into function containers
 │   ├── docker/      # DockerClientProducer, DockerHostResolver, ContainerDetector
 │   └── storage/     # StorageBackend, StorageFactory, InMemoryStorage, HybridStorage, WalStorage
 └── services/
@@ -39,7 +39,7 @@ compatibility-tests/
 ./mvnw test
 ```
 
-### Compatibility tests — local (requires running emulator)
+### Compatibility tests: local (requires running emulator)
 
 Start the emulator first:
 ```bash
@@ -54,7 +54,7 @@ make test-node-compat   # Node.js SDK (npm)
 make test-cpp-compat    # C++ SDK (Docker only: the toolchain lives in the image)
 ```
 
-### Compatibility tests — Docker (matches CI)
+### Compatibility tests: Docker (matches CI)
 
 ```bash
 make compat-docker
@@ -66,7 +66,13 @@ Azure Functions invocation tests.
 
 ## Code Style
 
-- Follow existing patterns — controllers stay thin, logic lives in service classes.
+- Follow existing patterns: controllers stay thin, logic lives in service classes.
 - Errors returned to clients must use `AzureErrorResponse` (never raw strings or arbitrary JSON).
 - New config keys belong in `EmulatorConfig`; document them in `docs/configuration/application-yml.md`.
 - New service operations should have a corresponding compatibility test.
+
+## Releases
+
+Stable releases ship on the **1st and 3rd Tuesday of each month**. Merging to `main` does not cut a release: the change rides the next train, and is in that night's `nightly` image either way.
+
+Maintainers cut releases from `main` with the Release Cut workflow, which runs semantic-release over the Conventional Commits since the last tag. That is why the commit type matters: `feat:` and `fix:` move the version, `docs:` and `chore:` do not. `CHANGELOG.md` is generated from those messages and is never edited by hand.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -73,6 +73,6 @@ Azure Functions invocation tests.
 
 ## Releases
 
-Stable releases ship on the **1st and 3rd Tuesday of each month**. Merging to `main` does not cut a release: the change rides the next train, and is in that night's `nightly` image either way.
+Stable releases ship on the **1st and 3rd Tuesday of each month**. Merging to `main` does not cut a release: the change rides the next train, and reaches the `nightly` image on the next nightly build.
 
-Maintainers cut releases from `main` with the Release Cut workflow, which runs semantic-release over the Conventional Commits since the last tag. That is why the commit type matters: `feat:` and `fix:` move the version, `docs:` and `chore:` do not. `CHANGELOG.md` is generated from those messages and is never edited by hand.
+Maintainers cut releases from `main` with the Release Cut workflow, which runs semantic-release over the Conventional Commits since the last tag. That is why the commit type matters: `feat:` and `fix:` move the version, `docs:` and `chore:` do not. `CHANGELOG.md` is generated from those messages and is not edited by hand; a genuine correction goes in a PR carrying the `changelog-edit` label.


### PR DESCRIPTION
## Summary

Follow-up to #254, which documented the release train in the README. The cadence was still missing everywhere a contributor or maintainer would actually look for it.

- **`CONTRIBUTING.md`** described how a release is cut but never when. The 1st and 3rd Tuesday train now leads the release section, and merging to `main` is stated not to cut a release.
- **`docs/contributing.md`**, the published contributing page, said nothing about releases at all. It gains a `## Releases` section, including why the commit type matters, since semantic-release derives the version from it.

Em-dashes in the touched files are replaced with ordinary punctuation, per the `## Documentation Style` rule added to `AGENTS.md` in #254.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## Azure Compatibility

Not applicable. No source, wire protocol, or workflow is touched.

## Checklist

- [x] Tests pass locally (not run: no source changed, docs only)
- [ ] New or updated integration test added (not applicable, documentation only)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

<sub>`mkdocs build --strict` exits 0 with no warnings.</sub>
