### PR TITLE
ci: align the nightly schedule on 23:00 America/Chicago

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,7 +1,9 @@
 name: Nightly
 
 # Builds and publishes native images from the tip of main as nightly Docker tags.
-# Runs every night at 23:00 CT (04:00 UTC, approximate — shifts 1 h in CST winter).
+# Runs every night at 23:00 America/Chicago (04:00 UTC in CDT, 05:00 UTC in CST).
+# GitHub may delay scheduled runs on low-activity repositories; observed delays on this
+# org have reached several hours. The schedule is a target, not a guarantee.
 # Can also be triggered manually.
 #
 # Published tags:
@@ -12,7 +14,8 @@ name: Nightly
 
 on:
   schedule:
-    - cron: '0 4 * * *'   # 23:00 CT (CDT/UTC-5); shifts to 23:00 CST in winter
+    - cron: '0 23 * * *'
+      timezone: 'America/Chicago'
   workflow_dispatch:        # Allow maintainers to trigger manually
 
 permissions:
@@ -35,7 +38,7 @@ jobs:
         id: date
         run: echo "version=$(TZ='America/Chicago' date +'%m%d%Y')" >> "$GITHUB_OUTPUT"
 
-  # ── Build native artifact — amd64 ────────────────────────────────────────
+  # ── Build native artifact: amd64 ─────────────────────────────────────────
   build-native-amd64:
     name: Build native artifact (amd64)
     needs: prepare
@@ -83,7 +86,7 @@ jobs:
           if-no-files-found: warn
           retention-days: 1
 
-  # ── Build native artifact — arm64 ────────────────────────────────────────
+  # ── Build native artifact: arm64 ─────────────────────────────────────────
   build-native-arm64:
     name: Build native artifact (arm64)
     needs: prepare


### PR DESCRIPTION
## Summary

All four emulators now carry a byte-identical schedule block:

```yaml
schedule:
  - cron: '0 23 * * *'
    timezone: 'America/Chicago'
```

**This repo's schedule changes.** It used a fixed `cron: '0 4 * * *'` in UTC, which is 23:00 CT only while CDT is in effect and slips to 22:00 CT once CST starts. It now fires at 23:00 America/Chicago year-round. No change in summer; one hour later in winter.

The gcp and az inline comment also had the DST direction backwards: it read "shifts to 23:00 CST in winter", but a fixed 04:00 UTC shifts to **22:00** CST.

### The caveat, stated in the workflow comment as well

Aligning the cron does not make the four build together. They already targeted the same instant, and GitHub delays scheduled runs on low-activity repositories. Observed `schedule` start times:

| Date (UTC) | aws | gcp | az | oci |
|---|---|---|---|---|
| Aug 26 | 04:12 | 04:38 | 04:27 | 04:33 |
| Aug 29 | 04:03 | 10:50 | 10:30 | 10:39 |
| Aug 31 | 04:04 | 10:36 | 10:10 | 10:22 |

floci-oci has floci-aws's exact configuration and still lands six hours late. This PR makes the four **configured** identically, which is worth having on its own; it does not make them **run** together. A single scheduler fanning out via `repository_dispatch` would, and is deliberately not in this PR.

**Worth a maintainer's eye:** `timezone` is not in GitHub's documented `schedule` syntax. The evidence it is honored is observational: floci-aws's `'0 23 * * *'` fires at 04:0xZ, which is 23:00 CDT, not the 23:00Z a plain cron would give. Please confirm this repo's nightly still shows as active after merge.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## Azure Compatibility

Not applicable. Workflow scheduling only; no source, wire protocol, or published artifact changes.

## Checklist

- [x] Tests pass locally (not run: no source changed)
- [ ] New or updated integration test added (not applicable)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
