### PR TITLE
feat(blob): add ADLS Gen2 DFS support for Hadoop ABFS

### DIFF
--- a/.github/workflows/compatibility.yml
+++ b/.github/workflows/compatibility.yml
@@ -100,6 +100,8 @@ jobs:
               -e FLOCI_AZ_SERVICES_SERVICE_BUS_MOCKED=false
               -e FLOCI_AZ_SERVICES_SERVICE_BUS_LOCK_DURATION_SECONDS=5
             extra_env: >-
+              --add-host devstoreaccount1.dfs.core.windows.net:127.0.0.1
+              -e FLOCI_AZ_ABFS_LOOPBACK=true
               -e SERVICEBUS_HOST=floci-az-servicebus-default
               -e SERVICEBUS_AMQPS_PORT=5671
               -e SERVICEBUS_NAMESPACE=default

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,8 @@ AZCLI_IMAGE     = compat-azcli
 POD_IDENTITY_ENV = -e AZURE_POD_IDENTITY_AUTHORITY_HOST=http://floci-az:4577
 SUITE_ENV_PYTHON = $(POD_IDENTITY_ENV)
 SUITE_ENV_JAVA   = $(POD_IDENTITY_ENV) \
+	--add-host devstoreaccount1.dfs.core.windows.net:127.0.0.1 \
+	-e FLOCI_AZ_ABFS_LOOPBACK=true \
 	-e SERVICEBUS_HOST=floci-az-servicebus-default \
 	-e SERVICEBUS_AMQPS_PORT=5671 \
 	-e SERVICEBUS_NAMESPACE=default

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ flowchart LR
 
 | Service                 | Routing                      | Notable operations                                                                                                                                                                                                    |
 |-------------------------|------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Blob Storage**        | `/{account}/`                | Create/delete containers, upload/download/delete blobs, list blobs; ADLS Gen2 DFS host alias, user delegation key vending, user delegation SAS enforcement, Path - List                                               |
+| **Blob Storage**        | `/{account}/`                | Create/delete containers, upload/download/delete blobs, list blobs; ADLS Gen2 DFS filesystem/path operations with Hadoop ABFS 3.3.4 compatibility; user delegation key/SAS |
 | **Queue Storage**       | `/{account}-queue/`          | Create/delete queues, send/receive/peek/delete messages, visibility timeout                                                                                                                                           |
 | **Table Storage**       | `/{account}-table/`          | Create/delete tables, insert/get/update/upsert/delete entities; OData `$filter` / `$select` / `$top`; server-side pagination (continuation tokens); ETag optimistic concurrency; Entity Group Transactions (`$batch`) |
 | **Azure Functions**     | `/{account}-functions/`      | Deploy & invoke HTTP-triggered functions (node, python, java, dotnet); warm-container pool                                                                                                                            |
@@ -433,7 +433,7 @@ Floci AZ uses path-style routing:
 | Service           | Endpoint                                              | Notes |
 |-------------------|-------------------------------------------------------|-------|
 | Blob              | `http://localhost:4577/{accountName}`                 | |
-| Data Lake Storage Gen2 | `http://localhost:4577/{accountName}`            | Use the `{accountName}.dfs.core.windows.net` Host header; maps to the Blob backend and supports Java DataLake SDK path flows, including `listPaths` |
+| Data Lake Storage Gen2 | `http://localhost:4577/{accountName}`            | Use the `{accountName}.dfs.core.windows.net` Host header; maps to the Blob backend and supports Hadoop ABFS 3.3.4 filesystem/path flows, including HNS detection, conditional create/overwrite, properties/XAttrs, ACL metadata, leases, append/flush, listing, status, rename, and delete |
 | Queue             | `http://localhost:4577/{accountName}-queue`           | |
 | Table             | `http://localhost:4577/{accountName}-table`           | |
 | Functions         | `http://localhost:4577/{accountName}-functions`       | |

--- a/compatibility-tests/sdk-test-java/pom.xml
+++ b/compatibility-tests/sdk-test-java/pom.xml
@@ -14,6 +14,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <azure.sdk.bom.version>1.2.28</azure.sdk.bom.version>
         <junit.version>5.10.2</junit.version>
+        <hadoop.version>3.3.4</hadoop.version>
     </properties>
 
     <dependencyManagement>
@@ -76,6 +77,18 @@
         <dependency>
             <groupId>com.azure</groupId>
             <artifactId>azure-communication-email</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>${hadoop.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-azure</artifactId>
+            <version>${hadoop.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/DataLakeCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/DataLakeCompatibilityTest.java
@@ -65,6 +65,31 @@ class DataLakeCompatibilityTest {
     }
 
     @Test
+    @DisplayName("rename: moves a directory tree through dfs endpoint")
+    void renameDirectoryMovesDescendants() {
+        String name = "test-" + UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+        DataLakeFileSystemClient fileSystem = client.createFileSystem(name);
+        try {
+            DataLakeDirectoryClient source = fileSystem.createDirectory("source-dir");
+            source.createFile("part.parquet");
+
+            DataLakeDirectoryClient renamed = source.rename(name, "destination-dir");
+
+            // DataLakePathClient.exists() is implemented through the SDK's BlockBlobClient.
+            // Use DFS-native access-control requests here so this compatibility test validates
+            // the renamed path through the Data Lake endpoint rather than the Blob endpoint.
+            assertNotNull(renamed.getAccessControl());
+            assertNotNull(renamed.getFileClient("part.parquet").getAccessControl());
+
+            DataLakeStorageException sourceMissing = assertThrows(
+                    DataLakeStorageException.class, source::getAccessControl);
+            assertEquals(404, sourceMissing.getStatusCode());
+        } finally {
+            client.deleteFileSystem(name);
+        }
+    }
+
+    @Test
     @DisplayName("user delegation key: SDK-generated SAS can create path through dfs endpoint")
     void userDelegationKeyCanGenerateUsableDfsSas() throws Exception {
         OffsetDateTime start = OffsetDateTime.now().minusMinutes(5);

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/HadoopAbfsCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/HadoopAbfsCompatibilityTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.TestInstance;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.URI;
@@ -149,7 +150,10 @@ class HadoopAbfsCompatibilityTest {
         }
 
         void start() throws IOException {
-            serverSocket = new ServerSocket(listenPort);
+            serverSocket = new ServerSocket(
+                    listenPort,
+                    50,
+                    InetAddress.getByName("127.0.0.1"));
             running.set(true);
             executor.submit(this::acceptLoop);
         }

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/HadoopAbfsCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/HadoopAbfsCompatibilityTest.java
@@ -1,0 +1,214 @@
+package io.floci.az.compat;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.util.VersionInfo;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * Compatibility smoke using the real Apache Hadoop ABFS 3.3.4 implementation.
+ *
+ * <p>The Docker compatibility harness maps {@code devstoreaccount1.dfs.core.windows.net}
+ * to this test container's loopback address. A transparent TCP forwarder on port 80
+ * relays the original HTTP stream to floci-az:4577, preserving Hadoop's DFS Host header
+ * and wire shape without adding emulator-only request headers or routing heuristics.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("Hadoop ABFS 3.3.4 Compatibility")
+class HadoopAbfsCompatibilityTest {
+
+    private static final String ACCOUNT_HOST = EmulatorConfig.ACCOUNT + ".dfs.core.windows.net";
+    private TcpForwarder forwarder;
+
+    @BeforeAll
+    void setup() throws Exception {
+        assumeTrue("true".equalsIgnoreCase(System.getenv("FLOCI_AZ_ABFS_LOOPBACK")),
+                "Hadoop ABFS compatibility test requires the Docker loopback host mapping");
+        EmulatorConfig.assumeEmulatorRunning();
+
+        URI emulator = URI.create(EmulatorConfig.httpBase());
+        int targetPort = emulator.getPort() > 0 ? emulator.getPort() : 80;
+        forwarder = new TcpForwarder(80, emulator.getHost(), targetPort);
+        forwarder.start();
+    }
+
+    @AfterAll
+    void teardown() throws Exception {
+        if (forwarder != null) {
+            forwarder.close();
+        }
+    }
+
+    @Test
+    @DisplayName("filesystem: real Hadoop 3.3.4 ABFS client exercises DFS path semantics")
+    void hadoopAbfs334FilesystemSmoke() throws Exception {
+        String filesystem = "hadoop-" + UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+        URI uri = URI.create("abfs://" + filesystem + "@" + ACCOUNT_HOST);
+
+        assertEquals("3.3.4", VersionInfo.getVersion());
+
+        Configuration conf = new Configuration();
+        conf.set("fs.abfs.impl", "org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem");
+        conf.set("fs.azure.account.key." + ACCOUNT_HOST, EmulatorConfig.DEV_KEY);
+        // Hadoop 3.3.4 defaults fs.azure.always.use.https=true even for abfs://.
+        // This Docker-only compatibility harness deliberately forwards plaintext HTTP
+        // from ACCOUNT_HOST:80 to floci-az:4577 so the original DFS Host header is preserved.
+        conf.setBoolean("fs.azure.always.use.https", false);
+        conf.setBoolean("fs.azure.createRemoteFileSystemDuringInitialization", true);
+        conf.setBoolean("fs.azure.enable.conditional.create.overwrite", true);
+        conf.unset("fs.azure.account.hns.enabled." + ACCOUNT_HOST);
+        conf.unset("fs.azure.account.hns.enabled");
+
+        try (FileSystem fs = FileSystem.newInstance(uri, conf)) {
+            assertEquals("org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem", fs.getClass().getName());
+            assertTrue(fs.getFileStatus(new Path("/")).isDirectory());
+
+            Path dir = new Path("/compat");
+            Path file = new Path(dir, "file.txt");
+            assertTrue(fs.mkdirs(dir));
+
+            write(fs, file, "first");
+            write(fs, file, "second"); // Hadoop's default conditional overwrite flow.
+            assertEquals("second", read(fs, file));
+
+            byte[] xattr = "v8".getBytes(StandardCharsets.UTF_8);
+            fs.setXAttr(file, "user.floci_smoke", xattr);
+            assertArrayEquals(xattr, fs.getXAttr(file, "user.floci_smoke"));
+            assertEquals("second", read(fs, file), "setting an XAttr must not truncate file content");
+
+            FileStatus[] exact = fs.listStatus(file);
+            assertEquals(1, exact.length);
+            assertFalse(exact[0].isDirectory());
+            assertEquals("file.txt", exact[0].getPath().getName());
+
+            Path renamed = new Path(dir, "renamed.txt");
+            assertTrue(fs.rename(file, renamed));
+            assertEquals("second", read(fs, renamed));
+
+            assertFalse(fs.delete(new Path(dir, "missing.txt"), true));
+            assertTrue(fs.delete(dir, true));
+        }
+    }
+
+    private static void write(FileSystem fs, Path path, String value) throws IOException {
+        try (OutputStream out = fs.create(path, true)) {
+            out.write(value.getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    private static String read(FileSystem fs, Path path) throws IOException {
+        try (InputStream in = fs.open(path)) {
+            return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    /** Simple byte-for-byte TCP relay used only by this compatibility test. */
+    private static final class TcpForwarder implements AutoCloseable {
+        private final int listenPort;
+        private final String targetHost;
+        private final int targetPort;
+        private final ExecutorService executor = Executors.newCachedThreadPool(runnable -> {
+            Thread thread = new Thread(runnable, "hadoop-abfs-tcp-forwarder");
+            thread.setDaemon(true);
+            return thread;
+        });
+        private final Set<Socket> sockets = ConcurrentHashMap.newKeySet();
+        private final AtomicBoolean running = new AtomicBoolean();
+        private ServerSocket serverSocket;
+
+        private TcpForwarder(int listenPort, String targetHost, int targetPort) {
+            this.listenPort = listenPort;
+            this.targetHost = targetHost;
+            this.targetPort = targetPort;
+        }
+
+        void start() throws IOException {
+            serverSocket = new ServerSocket(listenPort);
+            running.set(true);
+            executor.submit(this::acceptLoop);
+        }
+
+        private void acceptLoop() {
+            while (running.get()) {
+                try {
+                    Socket client = serverSocket.accept();
+                    Socket upstream = new Socket(targetHost, targetPort);
+                    sockets.add(client);
+                    sockets.add(upstream);
+                    executor.submit(() -> relay(client, upstream));
+                } catch (IOException e) {
+                    if (running.get()) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        }
+
+        private void relay(Socket client, Socket upstream) {
+            AtomicBoolean closed = new AtomicBoolean();
+            executor.submit(() -> copyAndClose(client, upstream, closed));
+            executor.submit(() -> copyAndClose(upstream, client, closed));
+        }
+
+        private void copyAndClose(Socket source, Socket destination, AtomicBoolean closed) {
+            try {
+                source.getInputStream().transferTo(destination.getOutputStream());
+                destination.getOutputStream().flush();
+            } catch (IOException ignored) {
+                // Connection shutdown races are expected when either side closes an HTTP keep-alive socket.
+            } finally {
+                if (closed.compareAndSet(false, true)) {
+                    sockets.remove(source);
+                    sockets.remove(destination);
+                    closeQuietly(source);
+                    closeQuietly(destination);
+                }
+            }
+        }
+
+        @Override
+        public void close() throws Exception {
+            running.set(false);
+            if (serverSocket != null) {
+                serverSocket.close();
+            }
+            sockets.forEach(TcpForwarder::closeQuietly);
+            sockets.clear();
+            executor.shutdownNow();
+        }
+
+        private static void closeQuietly(Socket socket) {
+            try {
+                socket.close();
+            } catch (IOException ignored) {
+                // Best-effort test cleanup.
+            }
+        }
+    }
+}

--- a/docs/services/blob.md
+++ b/docs/services/blob.md
@@ -25,9 +25,19 @@ Blob XML responses, and the Data Lake Storage Gen2 DFS host alias.
 - **User delegation SAS enforcement** — validates SDK-generated user delegation SAS signatures,
   expiry, signed key validity, permissions, and container/blob/directory resource scope for Blob
   and ADLS path operations
-- **ADLS Path - List** — supports Java DataLake SDK `listPaths` over the DFS endpoint, including
-  recursive and non-recursive listing, directory filters, deterministic continuation tokens, and
-  user delegation SAS list-scope checks
+- **ADLS Gen2 / Hadoop ABFS 3.3.4 path operations** - supports the DFS wire shapes used by
+  `org.apache.hadoop:hadoop-azure:3.3.4`: conditional file/directory create, path status and
+  properties, append/flush, recursive delete, file/directory rename, POSIX owner/group/permission/ACL
+  metadata, `checkAccess`, and the ADLS Path Lease POST API. Hadoop's default conditional-create
+  overwrite flow (`409` -> status/ETag -> `If-Match`) is modeled explicitly.
+- **ADLS filesystem operations** - create/delete a filesystem and get/set filesystem properties via
+  `?resource=filesystem`. Root `getAccessControl` is supported so Hadoop can auto-detect HNS and
+  resolve `getFileStatus("/")` without forcing `fs.azure.account.hns.enabled=true`.
+- **ADLS Path - List** - supports Java DataLake SDK `listPaths` and Hadoop `listStatus`, including
+  recursive/non-recursive listing, directory filters, exact-file singleton results, server pagination,
+  and Hadoop 3.3.4's Base64 HNS `startFrom` continuation token.
+- **ADLS AppendBlob mode** - recognizes Hadoop's `blobType=AppendBlob` create mode and enforces
+  sequential append positions, including append requests carrying `flush=true` / `close=true`.
 - **Range download** — `Range: bytes=…` returns `206 Partial Content`
 - **Conditional download** — `If-Match` / `If-None-Match` honored; a stale ETag is rejected
 - **Metadata** — `x-ms-meta-*` set on upload and returned on Get, round-tripped exactly
@@ -98,15 +108,24 @@ floci-az:
 
 - **Shared Key signatures are accepted but not cryptographically verified** — the emulator is a
   local dev target; any well-formed `Authorization` header (or the Azurite key) is honored.
+- **ADLS large-operation behavior is simplified** - directory rename and recursive delete complete
+  atomically in the local backend rather than reproducing Azure's server-side multi-request batching.
+  Hadoop observes a completed operation with no continuation token, which is protocol-compatible for
+  the caller. The full Azure source/destination lease-transfer and time-condition matrix is not modeled.
+- **ADLS access control is metadata-compatible, not a full POSIX authorization engine** - owner,
+  group, permissions and ACLs round-trip through the Hadoop/DFS wire protocol, and `checkAccess`
+  validates path existence and request shape. It does not deny requests based on emulated POSIX ACLs;
+  authentication/SAS authorization remains the emulator's access-control boundary.
+- **ADLS close/event semantics are storage-only** - `close=true` is accepted and committed data is
+  immediately visible, but Azure Event Grid/change-notification side effects are not emulated.
 - **SAS enforcement is scoped to user delegation SAS** — SDK-generated user delegation SAS tokens
   for container (`sr=c`), blob (`sr=b`), and ADLS directory (`sr=d`) resources are validated.
   Account SAS, stored access policies, IP/protocol restrictions, and the full SAS feature matrix
   are not fully modeled. User delegation keys are protected by a process-local secret, so SAS
   tokens issued by a previous emulator process are invalid after restart.
-- **Snapshots, versioning, leases, and tiering are not modeled.** `Get Blob` and
-  `Get Container Properties` still report the lease headers Azure always returns, fixed at the
-  unleased values (`x-ms-lease-status: unlocked`, `x-ms-lease-state: available`), because strict SDK
-  clients require them. There is no way to acquire a lease, so these values never change.
+- **Snapshots, versioning, and tiering are not modeled.** Blob leases and ADLS Path leases share
+  the emulator's in-memory lease state and support acquire/renew/change/release/break. Lease state is
+  intentionally process-local and is lost when the emulator restarts.
 - **`x-ms-server-encrypted: true` is reported although no encryption is performed** — blob data is
   stored as-is by the configured storage backend. The header mirrors the
   `x-ms-request-server-encrypted` already returned on upload and exists for SDK compatibility.

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -5,7 +5,7 @@ Floci-AZ provides emulation for several core Azure services.
 | Service | Endpoint | Implementation Status |
 |---|---|---|
 | **Azure Resource Manager** | `/subscriptions/...` + `/providers/...` | ✅ Subscriptions, resource groups, resource/provider listing; management-plane fallthrough for the `Microsoft.*` providers |
-| **Blob Storage** | `/{account}/` | ✅ Full CRUD; ADLS Gen2 DFS host alias, user delegation key vending, user delegation SAS enforcement, Path - List |
+| **Blob Storage** | `/{account}/` | ✅ Full CRUD; ADLS Gen2 DFS filesystem/path operations with Hadoop ABFS 3.3.4 compatibility; user delegation key/SAS |
 | **Queue Storage** | `/{account}-queue/` | ✅ Full CRUD |
 | **Table Storage** | `/{account}-table/` | ✅ Full CRUD |
 | **Azure Functions** | `/{account}-functions/` | ✅ HTTP Triggers, Docker runtimes |

--- a/src/main/java/io/floci/az/core/AzureErrorResponse.java
+++ b/src/main/java/io/floci/az/core/AzureErrorResponse.java
@@ -29,6 +29,23 @@ public record AzureErrorResponse(
             .build();
     }
 
+    /**
+     * Azure Data Lake Storage Gen2 data-plane errors use the DataLakeStorageError
+     * envelope: {"error":{"code":"...","message":"..."}}. Hadoop ABFS
+     * 3.3.x parses this JSON body to obtain the service error code; returning
+     * only the x-ms-error-code header or a Blob-style XML body leaves the ABFS
+     * storageErrorCode empty.
+     */
+    public Response toDataLakeJsonResponse(int httpStatus) {
+        return Response.status(httpStatus)
+            .type(MediaType.APPLICATION_JSON)
+            .header("x-ms-error-code", Code)
+            .entity(Map.of("error", Map.of(
+                "code", Code,
+                "message", Message)))
+            .build();
+    }
+
     // The Table service wraps errors in the OData envelope; SDKs (notably .NET
     // Azure.Data.Tables) parse the body, not just the x-ms-error-code header.
     public Response toODataResponse(int httpStatus) {

--- a/src/main/java/io/floci/az/core/AzureRequest.java
+++ b/src/main/java/io/floci/az/core/AzureRequest.java
@@ -15,7 +15,8 @@ public record AzureRequest(
     Map<String, String> queryParams,
     Map<String, List<String>> queryParamsMulti, // repeated query params preserved (e.g. App Config `tags`)
     AuthContext authContext,
-    boolean secure           // true when the request arrived over HTTPS
+    boolean secure,          // true when the request arrived over HTTPS
+    String host              // host captured before async/blocking dispatch; may be null for direct/internal requests
 ) {
 
     /**
@@ -27,16 +28,38 @@ public record AzureRequest(
                         HttpHeaders headers, InputStream bodyStream, Map<String, String> queryParams,
                         AuthContext authContext, boolean secure) {
         this(method, accountName, serviceType, resourcePath, headers, bodyStream,
-             queryParams, Map.of(), authContext, secure);
+             queryParams, Map.of(), authContext, secure, null);
+    }
+
+    /**
+     * Constructor used by the routing layer when it has already captured the request host before
+     * switching to a blocking thread. Keeping the host on the immutable request avoids reading
+     * request-scoped JAX-RS headers after the thread switch.
+     */
+    public AzureRequest(String method, String accountName, String serviceType, String resourcePath,
+                        HttpHeaders headers, InputStream bodyStream, Map<String, String> queryParams,
+                        Map<String, List<String>> queryParamsMulti, AuthContext authContext, boolean secure,
+                        String host) {
+        this.method = method;
+        this.accountName = accountName;
+        this.serviceType = serviceType;
+        this.resourcePath = resourcePath;
+        this.headers = headers;
+        this.bodyStream = bodyStream;
+        this.queryParams = queryParams;
+        this.queryParamsMulti = queryParamsMulti;
+        this.authContext = authContext;
+        this.secure = secure;
+        this.host = host;
     }
 
     /**
      * Returns a copy of this request carrying the resolved {@link AuthContext}. The routing filter
      * builds a request with a {@code null} auth context, feeds it to the auth pipeline, then rebuilds
-     * it with the result; this keeps that rebuild from restating all ten components positionally.
+     * it with the result; this keeps that rebuild from restating all components positionally.
      */
     public AzureRequest withAuthContext(AuthContext resolved) {
         return new AzureRequest(method, accountName, serviceType, resourcePath, headers, bodyStream,
-             queryParams, queryParamsMulti, resolved, secure);
+             queryParams, queryParamsMulti, resolved, secure, host);
     }
 }

--- a/src/main/java/io/floci/az/core/AzureRoutingFilter.java
+++ b/src/main/java/io/floci/az/core/AzureRoutingFilter.java
@@ -290,11 +290,16 @@ public class AzureRoutingFilter {
         // Capture context before switching threads
         String path0 = requestContext.getUriInfo().getPath();
         HttpHeaders headers = httpHeaders;
-        // Capture Host header now (JAX-RS request scope may not propagate to the blocking thread).
-        // Try both canonical and lowercase forms since HTTP header names are case-insensitive.
-        String h = requestContext.getHeaders().getFirst("Host");
-        if (h == null) {
-            h = requestContext.getHeaders().getFirst("host");
+        // Capture the request authority/host now (JAX-RS request scope may not propagate to the
+        // blocking thread). Under HTTP/2 the wire protocol uses :authority instead of a Host
+        // header, while UriInfo exposes the resolved authority for both HTTP/1.1 and HTTP/2.
+        String h = requestContext.getUriInfo().getRequestUri().getHost();
+        if (h == null || h.isBlank()) {
+            // Fallback for servlet/JAX-RS implementations that do not expose an absolute request URI.
+            h = requestContext.getHeaders().getFirst("Host");
+            if (h == null) {
+                h = requestContext.getHeaders().getFirst("host");
+            }
         }
         final String capturedHost = h;
 
@@ -656,7 +661,7 @@ public class AzureRoutingFilter {
         }
         AzureRequest request = new AzureRequest(ctx.method(), serviceType, serviceType, ctx.path(),
             ctx.headers(), ctx.requestContext().getEntityStream(), singleValueQueryParams(ctx.requestContext()),
-            null, ctx.secure());
+            Map.of(), null, ctx.secure(), ctx.host());
         LOGGER.infof("Dispatching %s request to %s: %s %s", label,
             handler.get().getClass().getSimpleName(), ctx.method(), ctx.path());
         return new Handled(handler.get().handle(request));
@@ -672,7 +677,7 @@ public class AzureRoutingFilter {
         });
 
         AzureRequest request = new AzureRequest(ctx.method(), account, serviceType, path, ctx.headers(),
-            ctx.requestContext().getEntityStream(), queryParams, queryParamsMulti, null, ctx.secure());
+            ctx.requestContext().getEntityStream(), queryParams, queryParamsMulti, null, ctx.secure(), ctx.host());
         return request.withAuthContext(authPipeline.resolve(request));
     }
 

--- a/src/main/java/io/floci/az/services/blob/BlobLeaseService.java
+++ b/src/main/java/io/floci/az/services/blob/BlobLeaseService.java
@@ -11,9 +11,14 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Blob lease state and the Lease Blob operation (comp=lease).
+ * Shared Blob Storage and ADLS Gen2 Path lease state.
  *
- * <p>Leases are the coordination primitive of the Azure Functions host:
+ * <p>The Blob endpoint uses {@code PUT ?comp=lease}; the DFS endpoint used by
+ * Hadoop ABFS uses {@code POST /filesystem/path} with {@code x-ms-lease-action}.
+ * Both wire protocols share the same in-memory lease state so a path cannot be
+ * leased independently through the Blob and DFS aliases.
+ *
+ * <p>Leases are also the coordination primitive of the Azure Functions host:
  * WebJobs singleton/timer locks and Durable Functions partition management
  * are blob leases. Lease state is kept in memory only — like a real lease it
  * is transient runtime state, and an emulator restart is equivalent to every
@@ -34,14 +39,7 @@ public class BlobLeaseService {
         String action = header(request, "x-ms-lease-action");
         Instant now = Instant.now();
         BlobLease lease = leases.get(blobKey);
-        Response response = switch (action == null ? "" : action.toLowerCase()) {
-            case "acquire" -> acquire(request, blobKey, lease, now);
-            case "renew" -> renew(request, blobKey, lease, now);
-            case "change" -> change(request, blobKey, lease, now);
-            case "release" -> release(request, blobKey, lease, now);
-            case "break" -> breakLease(request, blobKey, lease, now);
-            default -> invalidHeaderValue();
-        };
+        Response response = dispatchLeaseOperation(request, blobKey, lease, now, false);
         if (response.getStatus() >= 400) {
             return response;
         }
@@ -51,7 +49,39 @@ public class BlobLeaseService {
                 .build();
     }
 
-    private Response acquire(AzureRequest request, String blobKey, BlobLease lease, Instant now) {
+
+    /**
+     * ADLS Gen2 Path Lease operation. Hadoop ABFS uses POST directly on the DFS path
+     * rather than Blob Storage's PUT ?comp=lease wire shape. Lease state is shared
+     * with Blob leases so both endpoints observe one coherent emulator lease.
+     */
+    public synchronized Response handleDataLakeLeaseOp(AzureRequest request, String blobKey,
+                                                       String etag, String lastModifiedRfc1123) {
+        Response response = dispatchLeaseOperation(request, blobKey, leases.get(blobKey), Instant.now(), true);
+        if (response.getStatus() >= 400) {
+            return response;
+        }
+        return Response.fromResponse(response)
+                .header("ETag", etag)
+                .header("Last-Modified", lastModifiedRfc1123)
+                .build();
+    }
+
+    private Response dispatchLeaseOperation(AzureRequest request, String blobKey, BlobLease lease,
+                                            Instant now, boolean dataLake) {
+        String action = header(request, "x-ms-lease-action");
+        return switch (action == null ? "" : action.toLowerCase()) {
+            case "acquire" -> acquire(request, blobKey, lease, now, dataLake);
+            case "renew" -> renew(request, blobKey, lease, now, dataLake);
+            case "change" -> change(request, blobKey, lease, now, dataLake);
+            case "release" -> release(request, blobKey, lease, now, dataLake);
+            case "break" -> breakLease(request, blobKey, lease, now, dataLake);
+            default -> error("InvalidHeaderValue",
+                    "The value for one of the HTTP headers is not in the correct format.", 400, dataLake);
+        };
+    }
+
+    private Response acquire(AzureRequest request, String blobKey, BlobLease lease, Instant now, boolean dataLake) {
         int duration;
         try {
             duration = Integer.parseInt(header(request, "x-ms-lease-duration") == null
@@ -60,19 +90,20 @@ public class BlobLeaseService {
             duration = 0;
         }
         if (duration != -1 && (duration < 15 || duration > 60)) {
-            return invalidHeaderValue();
+            return error("InvalidHeaderValue",
+                    "The value for one of the HTTP headers is not in the correct format.", 400, dataLake);
         }
         String proposed = header(request, "x-ms-proposed-lease-id");
         if (proposed != null && !isGuid(proposed)) {
-            return invalidHeaderValue();
+            return error("InvalidHeaderValue",
+                    "The value for one of the HTTP headers is not in the correct format.", 400, dataLake);
         }
 
         if (lease != null && lease.activeAt(now)) {
             boolean reacquireSameId = lease.stateAt(now) == BlobLease.State.LEASED
                     && proposed != null && proposed.equalsIgnoreCase(lease.leaseId());
             if (!reacquireSameId) {
-                return new AzureErrorResponse("LeaseAlreadyPresent",
-                        "There is already a lease present.").toXmlResponse(409);
+                return error("LeaseAlreadyPresent", "There is already a lease present.", 409, dataLake);
             }
         }
 
@@ -83,71 +114,75 @@ public class BlobLeaseService {
                 .build();
     }
 
-    private Response renew(AzureRequest request, String blobKey, BlobLease lease, Instant now) {
+    private Response renew(AzureRequest request, String blobKey, BlobLease lease, Instant now, boolean dataLake) {
         String leaseId = header(request, "x-ms-lease-id");
         if (leaseId == null || leaseId.isBlank()) {
-            return missingRequiredHeader();
+            return error("MissingRequiredHeader",
+                    "An HTTP header that's mandatory for this request is not specified.", 400, dataLake);
         }
         if (lease == null) {
-            return leaseNotPresent();
+            return error("LeaseNotPresentWithLeaseOperation",
+                    "There is currently no lease on the blob.", 409, dataLake);
         }
         if (!lease.leaseId().equalsIgnoreCase(leaseId)) {
-            return new AzureErrorResponse("LeaseIdMismatchWithLeaseOperation",
-                    "The lease ID specified did not match the lease ID for the blob.")
-                    .toXmlResponse(409);
+            return error("LeaseIdMismatchWithLeaseOperation",
+                    "The lease ID specified did not match the lease ID for the blob.", 409, dataLake);
         }
         BlobLease.State state = lease.stateAt(now);
         if (state == BlobLease.State.BREAKING || state == BlobLease.State.BROKEN) {
-            return new AzureErrorResponse("LeaseIsBrokenAndCannotBeRenewed",
-                    "The lease ID matched, but the lease has been broken explicitly and cannot be renewed.")
-                    .toXmlResponse(409);
+            return error("LeaseIsBrokenAndCannotBeRenewed",
+                    "The lease ID matched, but the lease has been broken explicitly and cannot be renewed.", 409, dataLake);
         }
         leases.put(blobKey, lease.renewed(now));
         return Response.ok().header("x-ms-lease-id", lease.leaseId()).build();
     }
 
-    private Response change(AzureRequest request, String blobKey, BlobLease lease, Instant now) {
+    private Response change(AzureRequest request, String blobKey, BlobLease lease, Instant now, boolean dataLake) {
         String leaseId = header(request, "x-ms-lease-id");
         String proposed = header(request, "x-ms-proposed-lease-id");
         if (leaseId == null || leaseId.isBlank() || proposed == null || proposed.isBlank()) {
-            return missingRequiredHeader();
+            return error("MissingRequiredHeader",
+                    "An HTTP header that's mandatory for this request is not specified.", 400, dataLake);
         }
         if (!isGuid(proposed)) {
-            return invalidHeaderValue();
+            return error("InvalidHeaderValue",
+                    "The value for one of the HTTP headers is not in the correct format.", 400, dataLake);
         }
         if (lease == null || !lease.activeAt(now)) {
-            return leaseNotPresent();
+            return error("LeaseNotPresentWithLeaseOperation",
+                    "There is currently no lease on the blob.", 409, dataLake);
         }
         if (!lease.leaseId().equalsIgnoreCase(leaseId)) {
-            return new AzureErrorResponse("LeaseIdMismatchWithLeaseOperation",
-                    "The lease ID specified did not match the lease ID for the blob.")
-                    .toXmlResponse(409);
+            return error("LeaseIdMismatchWithLeaseOperation",
+                    "The lease ID specified did not match the lease ID for the blob.", 409, dataLake);
         }
         BlobLease changed = lease.changed(proposed);
         leases.put(blobKey, changed);
         return Response.ok().header("x-ms-lease-id", changed.leaseId()).build();
     }
 
-    private Response release(AzureRequest request, String blobKey, BlobLease lease, Instant now) {
+    private Response release(AzureRequest request, String blobKey, BlobLease lease, Instant now, boolean dataLake) {
         String leaseId = header(request, "x-ms-lease-id");
         if (leaseId == null || leaseId.isBlank()) {
-            return missingRequiredHeader();
+            return error("MissingRequiredHeader",
+                    "An HTTP header that's mandatory for this request is not specified.", 400, dataLake);
         }
         if (lease == null) {
-            return leaseNotPresent();
+            return error("LeaseNotPresentWithLeaseOperation",
+                    "There is currently no lease on the blob.", 409, dataLake);
         }
         if (!lease.leaseId().equalsIgnoreCase(leaseId)) {
-            return new AzureErrorResponse("LeaseIdMismatchWithLeaseOperation",
-                    "The lease ID specified did not match the lease ID for the blob.")
-                    .toXmlResponse(409);
+            return error("LeaseIdMismatchWithLeaseOperation",
+                    "The lease ID specified did not match the lease ID for the blob.", 409, dataLake);
         }
         leases.remove(blobKey);
         return Response.ok().build();
     }
 
-    private Response breakLease(AzureRequest request, String blobKey, BlobLease lease, Instant now) {
+    private Response breakLease(AzureRequest request, String blobKey, BlobLease lease, Instant now, boolean dataLake) {
         if (lease == null || !lease.activeAt(now)) {
-            return leaseNotPresent();
+            return error("LeaseNotPresentWithLeaseOperation",
+                    "There is currently no lease on the blob.", 409, dataLake);
         }
         int breakPeriod;
         String breakPeriodHeader = header(request, "x-ms-lease-break-period");
@@ -155,10 +190,12 @@ public class BlobLeaseService {
             try {
                 breakPeriod = Integer.parseInt(breakPeriodHeader);
             } catch (NumberFormatException e) {
-                return invalidHeaderValue();
+                return error("InvalidHeaderValue",
+                    "The value for one of the HTTP headers is not in the correct format.", 400, dataLake);
             }
             if (breakPeriod < 0 || breakPeriod > 60) {
-                return invalidHeaderValue();
+                return error("InvalidHeaderValue",
+                    "The value for one of the HTTP headers is not in the correct format.", 400, dataLake);
             }
         } else {
             // Default: infinite leases break immediately, fixed leases run out their term.
@@ -173,21 +210,9 @@ public class BlobLeaseService {
                 .build();
     }
 
-    private static Response leaseNotPresent() {
-        return new AzureErrorResponse("LeaseNotPresentWithLeaseOperation",
-                "There is currently no lease on the blob.").toXmlResponse(409);
-    }
-
-    private static Response missingRequiredHeader() {
-        return new AzureErrorResponse("MissingRequiredHeader",
-                "An HTTP header that's mandatory for this request is not specified.")
-                .toXmlResponse(400);
-    }
-
-    private static Response invalidHeaderValue() {
-        return new AzureErrorResponse("InvalidHeaderValue",
-                "The value for one of the HTTP headers is not in the correct format.")
-                .toXmlResponse(400);
+    private static Response error(String code, String message, int status, boolean dataLake) {
+        AzureErrorResponse error = new AzureErrorResponse(code, message);
+        return dataLake ? error.toDataLakeJsonResponse(status) : error.toXmlResponse(status);
     }
 
     private static boolean isGuid(String value) {
@@ -240,6 +265,28 @@ public class BlobLeaseService {
         } else if (requestLeaseId != null) {
             return new AzureErrorResponse("LeaseNotPresentWithBlobOperation",
                     "There is currently no lease on the blob.").toXmlResponse(412);
+        }
+        return null;
+    }
+
+    /** Data Lake variant of {@link #validateWrite} using the DFS JSON error envelope. */
+    Response validateDataLakeWrite(AzureRequest request, String blobKey) {
+        String requestLeaseId = header(request, "x-ms-lease-id");
+        BlobLease lease = leases.get(blobKey);
+        Instant now = Instant.now();
+        if (lease != null && lease.activeAt(now)) {
+            if (requestLeaseId == null) {
+                return error("LeaseIdMissing",
+                        "There is currently a lease on the path and no lease ID was specified in the request.",
+                        412, true);
+            }
+            if (!lease.leaseId().equalsIgnoreCase(requestLeaseId)) {
+                return error("LeaseIdMismatchWithBlobOperation",
+                        "The lease ID specified did not match the lease ID for the path.", 412, true);
+            }
+        } else if (requestLeaseId != null) {
+            return error("LeaseNotPresentWithBlobOperation",
+                    "There is currently no lease on the path.", 412, true);
         }
         return null;
     }

--- a/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
+++ b/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
@@ -22,6 +22,7 @@ import jakarta.ws.rs.core.Response;
 import org.jboss.logging.Logger;
 
 import java.io.IOException;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.ZoneId;
@@ -43,6 +44,20 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
     private static final String BLK_PREFIX = "__blk__:";
     private static final String USER_METADATA_PREFIX = "UserMeta:";
     private static final String CREATION_TIME_KEY = "CreationTime";
+    private static final String DATALAKE_APPEND_PREFIX = "__abfs_append__:";
+    private static final String DATALAKE_OWNER = DataLakePathOperations.DEFAULT_OWNER;
+    private static final String DATALAKE_GROUP = DataLakePathOperations.DEFAULT_GROUP;
+    private static final String DATALAKE_FILE_PERMISSIONS = DataLakePathOperations.DEFAULT_FILE_PERMISSIONS;
+    private static final String DATALAKE_DIRECTORY_PERMISSIONS = DataLakePathOperations.DEFAULT_DIRECTORY_PERMISSIONS;
+    private static final String DATALAKE_RESOURCE_TYPE_KEY = DataLakePathOperations.RESOURCE_TYPE;
+    private static final String DATALAKE_OWNER_KEY = DataLakePathOperations.OWNER_KEY;
+    private static final String DATALAKE_GROUP_KEY = DataLakePathOperations.GROUP_KEY;
+    private static final String DATALAKE_PERMISSIONS_KEY = DataLakePathOperations.PERMISSIONS_KEY;
+    private static final String DATALAKE_ACL_KEY = DataLakePathOperations.ACL_KEY;
+    private static final String DATALAKE_PROPERTIES_KEY = DataLakePathOperations.PROPERTIES_KEY;
+    private static final String DATALAKE_FILESYSTEM_PROPERTIES_KEY = "DataLakeFilesystemProperties";
+    private static final String DATALAKE_DEFAULT_FILE_ACL = "user::rw-,group::r--,other::---";
+    private static final String DATALAKE_DEFAULT_DIRECTORY_ACL = "user::rwx,group::r-x,other::---";
     private static final Map<String, String> BLOB_HTTP_PROPERTY_HEADERS = Map.of(
             "x-ms-blob-cache-control", HttpHeaders.CACHE_CONTROL,
             "x-ms-blob-content-disposition", "Content-Disposition",
@@ -145,11 +160,46 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
             String blobName = parts.length > 1 ? parts[1] : "";
 
             String comp = query.get("comp");
+            String action = query.get("action");
+            boolean dataLakeRequest = isDataLakeRequest(request);
 
             if (blobName.isEmpty()) {
-                if ("GET".equalsIgnoreCase(method) && comp == null
-                        && "filesystem".equals(query.get("resource"))) {
-                    response = listDataLakePaths(request, containerName);
+                if (dataLakeRequest && "filesystem".equals(query.get("resource"))
+                        && (comp != null || action != null)) {
+                    // ADLS filesystem operations do not use Blob-style `comp` or path `action`
+                    // dispatch. Fail closed so unsupported query shapes cannot be mistaken for
+                    // List Paths or another filesystem operation.
+                    response = dataLakeNotImplemented();
+                } else if (dataLakeRequest && "filesystem".equals(query.get("resource"))) {
+                    if ("GET".equalsIgnoreCase(method)) {
+                        response = listDataLakePaths(request, containerName);
+                    } else if ("HEAD".equalsIgnoreCase(method)) {
+                        response = getDataLakeFilesystemProperties(request, containerName);
+                    } else if ("PUT".equalsIgnoreCase(method)
+                            && "PATCH".equalsIgnoreCase(request.headers().getHeaderString("X-Http-Method-Override"))) {
+                        response = setDataLakeFilesystemProperties(request, containerName);
+                    } else if ("PUT".equalsIgnoreCase(method)) {
+                        response = createDataLakeFilesystem(request, containerName);
+                    } else if ("DELETE".equalsIgnoreCase(method)) {
+                        response = deleteDataLakeFilesystem(request, containerName);
+                    } else {
+                        response = dataLakeNotImplemented();
+                    }
+                } else if (dataLakeRequest && "HEAD".equalsIgnoreCase(method)
+                        && (action == null || "getStatus".equals(action))) {
+                    response = getDataLakeRootPathStatus(request, containerName);
+                } else if (dataLakeRequest && "HEAD".equalsIgnoreCase(method)
+                        && "getAccessControl".equals(action)) {
+                    response = getDataLakeAccessControl(request, containerName, null);
+                } else if (dataLakeRequest && "HEAD".equalsIgnoreCase(method)
+                        && "checkAccess".equals(action)) {
+                    response = checkDataLakeAccess(request, containerName, null);
+                } else if (dataLakeRequest && "PUT".equalsIgnoreCase(method)
+                        && "setAccessControl".equals(action)) {
+                    response = setDataLakeAccessControl(request, containerName, null);
+                } else if (dataLakeRequest && "PUT".equalsIgnoreCase(method)
+                        && "setProperties".equals(action)) {
+                    response = setDataLakePathProperties(request, containerName, null);
                 } else if ("GET".equalsIgnoreCase(method) && "list".equals(comp)) {
                     response = listBlobs(request, containerName);
                 } else if (comp != null) {
@@ -165,10 +215,48 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
                 } else if (("GET".equalsIgnoreCase(method) || "HEAD".equalsIgnoreCase(method)) && "container".equals(query.get("restype"))) {
                     response = getContainer(request, containerName, "HEAD".equalsIgnoreCase(method));
                 } else {
-                    response = notImplemented();
+                    response = dataLakeRequest ? dataLakeNotImplemented() : notImplemented();
                 }
             } else {
-                if ("PUT".equalsIgnoreCase(method) && "lease".equals(comp)) {
+                String renameSource = request.headers().getHeaderString("x-ms-rename-source");
+
+                if (dataLakeRequest && "PUT".equalsIgnoreCase(method) && renameSource != null) {
+                    response = renameDataLakePath(request, containerName, blobName, renameSource);
+                } else if (dataLakeRequest && "HEAD".equalsIgnoreCase(method)
+                        && (action == null || "getStatus".equals(action))) {
+                    response = getDataLakePathStatus(request, containerName, blobName);
+                } else if (dataLakeRequest && "HEAD".equalsIgnoreCase(method)
+                        && "getAccessControl".equals(action)) {
+                    response = getDataLakeAccessControl(request, containerName, blobName);
+                } else if (dataLakeRequest && "HEAD".equalsIgnoreCase(method)
+                        && "checkAccess".equals(action)) {
+                    response = checkDataLakeAccess(request, containerName, blobName);
+                } else if (dataLakeRequest && "PUT".equalsIgnoreCase(method) && "append".equals(action)) {
+                    response = appendDataLakePath(request, containerName, blobName);
+                } else if (dataLakeRequest && "PUT".equalsIgnoreCase(method) && "flush".equals(action)) {
+                    response = flushDataLakePath(request, containerName, blobName);
+                } else if (dataLakeRequest && "PUT".equalsIgnoreCase(method) && "setProperties".equals(action)) {
+                    response = setDataLakePathProperties(request, containerName, blobName);
+                } else if (dataLakeRequest && "PUT".equalsIgnoreCase(method) && "setAccessControl".equals(action)) {
+                    response = setDataLakeAccessControl(request, containerName, blobName);
+                } else if (dataLakeRequest && "POST".equalsIgnoreCase(method)
+                        && request.headers().getHeaderString("x-ms-lease-action") != null) {
+                    response = leaseDataLakePath(request, containerName, blobName);
+                } else if (dataLakeRequest && "PUT".equalsIgnoreCase(method)
+                        && action == null && ("file".equals(query.get("resource"))
+                        || "directory".equals(query.get("resource")))) {
+                    response = createDataLakePath(request, containerName, blobName);
+                } else if (dataLakeRequest && action != null) {
+                    // Never allow an ADLS Path Update action to fall through into PutBlob:
+                    // Hadoop setProperties/setAccessControl requests have empty bodies and a
+                    // generic blob write would silently truncate the file.
+                    response = dataLakeNotImplemented();
+                } else if (dataLakeRequest && "PUT".equalsIgnoreCase(method)) {
+                    // Every Hadoop ABFS 3.3.4 DFS PUT shape is explicitly handled above
+                    // (create, rename, append/flush, properties, ACL). An unknown DFS PUT
+                    // must fail closed rather than being mistaken for a Blob Put operation.
+                    response = dataLakeNotImplemented();
+                } else if ("PUT".equalsIgnoreCase(method) && "lease".equals(comp)) {
                     response = leaseBlob(request, containerName, blobName);
                 } else if ("PUT".equalsIgnoreCase(method) && "metadata".equals(comp)) {
                     response = setBlobMetadata(request, containerName, blobName);
@@ -184,14 +272,22 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
                     response = getBlockList(request, containerName, blobName);
                 } else if ("PUT".equalsIgnoreCase(method) && isPutBlob(request, comp)) {
                     response = putBlob(request, containerName, blobName);
+                } else if (dataLakeRequest && "GET".equalsIgnoreCase(method)) {
+                    response = readDataLakePath(request, containerName, blobName);
                 } else if ("GET".equalsIgnoreCase(method) || "HEAD".equalsIgnoreCase(method)) {
                     response = getBlob(request, containerName, blobName, "HEAD".equalsIgnoreCase(method));
                 } else if ("DELETE".equalsIgnoreCase(method)) {
-                    response = deleteBlob(request, containerName, blobName);
+                    response = dataLakeRequest
+                            ? deleteDataLakePath(request, containerName, blobName)
+                            : deleteBlob(request, containerName, blobName);
                 } else {
-                    response = notImplemented();
+                    response = dataLakeRequest ? dataLakeNotImplemented() : notImplemented();
                 }
             }
+        }
+
+        if (isDataLakeRequest(request) && response.getStatus() >= 400) {
+            response = normalizeDataLakeErrorResponse(response);
         }
 
         return Response.fromResponse(response)
@@ -214,6 +310,29 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
     private Response notImplemented() {
         return new AzureErrorResponse("NotImplemented", "The requested operation is not implemented.")
                 .toXmlResponse(501);
+    }
+
+    private Response dataLakeNotImplemented() {
+        return new AzureErrorResponse("NotImplemented", "The requested Data Lake operation is not implemented.")
+                .toDataLakeJsonResponse(501);
+    }
+
+    private static Response normalizeDataLakeErrorResponse(Response response) {
+        if (response.getMediaType() != null
+                && response.getMediaType().isCompatible(MediaType.APPLICATION_JSON_TYPE)) {
+            return response;
+        }
+        String code = response.getHeaderString("x-ms-error-code");
+        if (code == null || code.isBlank()) {
+            code = response.getStatus() == 404 ? "PathNotFound" : "OperationFailed";
+        }
+        return Response.fromResponse(response)
+                .type(MediaType.APPLICATION_JSON_TYPE)
+                .header("x-ms-error-code", code)
+                .entity(Map.of("error", Map.of(
+                        "code", code,
+                        "message", "The requested Data Lake operation failed.")))
+                .build();
     }
 
     /** PUT /{container}/{blob}?comp=lease — Lease Blob (acquire/renew/change/release/break). */
@@ -328,8 +447,9 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
             store.delete(nsKey(request.accountName(), containerName));
             String objPrefix = request.accountName() + "/" + containerName + "/";
             String blkPrefix = BLK_PREFIX + objPrefix;
+            String appendPrefix = DATALAKE_APPEND_PREFIX + objPrefix;
             store.keys().stream()
-                    .filter(k -> k.startsWith(objPrefix) || k.startsWith(blkPrefix))
+                    .filter(k -> k.startsWith(objPrefix) || k.startsWith(blkPrefix) || k.startsWith(appendPrefix))
                     .toList()
                     .forEach(store::delete);
             leaseService.onContainerDeleted(objPrefix);
@@ -407,6 +527,9 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
                 String etag = UUID.randomUUID().toString();
                 store.put(objKey(request.accountName(), containerName, blobName),
                         new StoredObject(blobName, data, metadata, Instant.now(), etag));
+                if ("file".equals(dataLakeResourceType)) {
+                    clearDataLakeAppendChunks(request.accountName(), containerName, blobName);
+                }
 
                 return Response.status(Response.Status.CREATED)
                         .header("Last-Modified", RFC1123_DATE_TIME.format(Instant.now()))
@@ -418,6 +541,1307 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
         } catch (IOException e) {
             return Response.serverError().build();
         }
+    }
+
+
+    // ── ADLS Gen2 filesystem/path compatibility for Hadoop ABFS 3.3.4 ───────
+
+    private Response createDataLakeFilesystem(AzureRequest request, String filesystem) {
+        Response authFailure = authorizeCreate(request, filesystem, null);
+        if (authFailure != null) {
+            return authFailure;
+        }
+        return leaseService.exclusively(() -> {
+            String key = nsKey(request.accountName(), filesystem);
+            if (store.get(key).isPresent()) {
+                return new AzureErrorResponse("FilesystemAlreadyExists",
+                        "The specified filesystem already exists.")
+                        .toDataLakeJsonResponse(Response.Status.CONFLICT.getStatusCode());
+            }
+            Instant now = Instant.now();
+            Map<String, String> metadata = defaultDataLakeMetadata("", true, null);
+            metadata.put(DATALAKE_FILESYSTEM_PROPERTIES_KEY,
+                    headerOrEmpty(request, "x-ms-properties"));
+            metadata.put(CREATION_TIME_KEY, now.toString());
+            String etag = UUID.randomUUID().toString();
+            store.put(key, new StoredObject("", new byte[0], metadata, now, etag));
+            return Response.status(Response.Status.CREATED)
+                    .header("Last-Modified", RFC1123_DATE_TIME.format(now))
+                    .header("ETag", etag)
+                    .build();
+        });
+    }
+
+    private Response getDataLakeRootPathStatus(AzureRequest request, String filesystem) {
+        Response authFailure = authorizeRead(request, filesystem, null);
+        if (authFailure != null) {
+            return authFailure;
+        }
+        Optional<StoredObject> sentinel = store.get(nsKey(request.accountName(), filesystem));
+        if (sentinel.isEmpty()) {
+            return new AzureErrorResponse("FilesystemNotFound", "The specified filesystem does not exist.")
+                    .toDataLakeJsonResponse(Response.Status.NOT_FOUND.getStatusCode());
+        }
+        StoredObject object = sentinel.get();
+        Map<String, String> metadata = object.metadata();
+        Response.ResponseBuilder builder = Response.ok()
+                .header("Last-Modified", RFC1123_DATE_TIME.format(effectiveLastModified(object)))
+                .header("ETag", effectiveEtag(object, nsKey(request.accountName(), filesystem)))
+                .header(HttpHeaders.CONTENT_LENGTH, 0)
+                .header("x-ms-resource-type", "directory")
+                .header("x-ms-owner", metadata.getOrDefault(DATALAKE_OWNER_KEY, DATALAKE_OWNER))
+                .header("x-ms-group", metadata.getOrDefault(DATALAKE_GROUP_KEY, DATALAKE_GROUP))
+                .header("x-ms-permissions", metadata.getOrDefault(
+                        DATALAKE_PERMISSIONS_KEY, DATALAKE_DIRECTORY_PERMISSIONS))
+                .header("x-ms-request-server-encrypted", "true");
+        if (request.queryParams().get("action") == null) {
+            builder.header("x-ms-properties", metadata.getOrDefault(DATALAKE_PROPERTIES_KEY, ""));
+        }
+        return builder.build();
+    }
+
+    private Response getDataLakeFilesystemProperties(AzureRequest request, String filesystem) {
+        Response authFailure = authorizeRead(request, filesystem, null);
+        if (authFailure != null) {
+            return authFailure;
+        }
+        Optional<StoredObject> sentinel = store.get(nsKey(request.accountName(), filesystem));
+        if (sentinel.isEmpty()) {
+            return new AzureErrorResponse("FilesystemNotFound", "The specified filesystem does not exist.")
+                    .toDataLakeJsonResponse(Response.Status.NOT_FOUND.getStatusCode());
+        }
+        StoredObject so = sentinel.get();
+        Instant modified = effectiveLastModified(so);
+        return Response.ok()
+                .header("Last-Modified", RFC1123_DATE_TIME.format(modified))
+                .header("ETag", effectiveEtag(so, nsKey(request.accountName(), filesystem)))
+                .header("x-ms-properties", so.metadata().getOrDefault(DATALAKE_FILESYSTEM_PROPERTIES_KEY, ""))
+                .build();
+    }
+
+    private Response setDataLakeFilesystemProperties(AzureRequest request, String filesystem) {
+        Response authFailure = authorizeWrite(request, filesystem, null);
+        if (authFailure != null) {
+            return authFailure;
+        }
+        return leaseService.exclusively(() -> {
+            String key = nsKey(request.accountName(), filesystem);
+            Optional<StoredObject> sentinel = store.get(key);
+            if (sentinel.isEmpty()) {
+                return new AzureErrorResponse("FilesystemNotFound", "The specified filesystem does not exist.")
+                        .toDataLakeJsonResponse(Response.Status.NOT_FOUND.getStatusCode());
+            }
+            StoredObject current = sentinel.get();
+            Map<String, String> metadata = new HashMap<>(current.metadata());
+            metadata.put(DATALAKE_FILESYSTEM_PROPERTIES_KEY, headerOrEmpty(request, "x-ms-properties"));
+            ensureDataLakeDefaults(metadata, true);
+            Instant now = Instant.now();
+            String etag = UUID.randomUUID().toString();
+            store.put(key, new StoredObject(current.key(), current.data(), metadata, now, etag));
+            return Response.ok()
+                    .header("Last-Modified", RFC1123_DATE_TIME.format(now))
+                    .header("ETag", etag)
+                    .build();
+        });
+    }
+
+    private Response deleteDataLakeFilesystem(AzureRequest request, String filesystem) {
+        Response authFailure = authorizeDelete(request, filesystem, null);
+        if (authFailure != null) {
+            return authFailure;
+        }
+        return leaseService.exclusively(() -> {
+            String nsKey = nsKey(request.accountName(), filesystem);
+            if (store.get(nsKey).isEmpty()) {
+                return new AzureErrorResponse("FilesystemNotFound", "The specified filesystem does not exist.")
+                        .toDataLakeJsonResponse(Response.Status.NOT_FOUND.getStatusCode());
+            }
+            store.delete(nsKey);
+            String objectPrefix = request.accountName() + "/" + filesystem + "/";
+            String blockPrefix = BLK_PREFIX + objectPrefix;
+            String appendPrefix = DATALAKE_APPEND_PREFIX + objectPrefix;
+            store.keys().stream()
+                    .filter(key -> key.startsWith(objectPrefix)
+                            || key.startsWith(blockPrefix)
+                            || key.startsWith(appendPrefix))
+                    .toList()
+                    .forEach(store::delete);
+            leaseService.onContainerDeleted(objectPrefix);
+            return Response.status(Response.Status.ACCEPTED).build();
+        });
+    }
+
+    /** Hadoop createPath(), including its default conditional-overwrite flow. */
+    private Response createDataLakePath(AzureRequest request, String filesystem, String path) {
+        String contentLengthHeader = request.headers().getHeaderString(HttpHeaders.CONTENT_LENGTH);
+        if (contentLengthHeader != null) {
+            try {
+                if (Long.parseLong(contentLengthHeader) != 0L) {
+                    return new AzureErrorResponse("ContentLengthMustBeZero",
+                            "The Content-Length request header must be zero.")
+                            .toDataLakeJsonResponse(Response.Status.BAD_REQUEST.getStatusCode());
+                }
+            } catch (NumberFormatException e) {
+                return new AzureErrorResponse("InvalidHeaderValue",
+                        "The value for one of the HTTP headers is not in the correct format.")
+                        .toDataLakeJsonResponse(Response.Status.BAD_REQUEST.getStatusCode());
+            }
+        }
+
+        boolean directory = "directory".equals(request.queryParams().get("resource"));
+        String key = objKey(request.accountName(), filesystem, path);
+        return leaseService.exclusively(() -> {
+            if (store.get(nsKey(request.accountName(), filesystem)).isEmpty()) {
+                return new AzureErrorResponse("FilesystemNotFound", "The specified filesystem does not exist.")
+                        .toDataLakeJsonResponse(Response.Status.NOT_FOUND.getStatusCode());
+            }
+
+            DataLakePathState state = resolveDataLakePath(request.accountName(), filesystem, path);
+            boolean exists = state != null;
+            Response authFailure = exists
+                    ? authorizeWrite(request, filesystem, path)
+                    : authorizeCreate(request, filesystem, path);
+            if (authFailure != null) {
+                return authFailure;
+            }
+
+            String ifNoneMatch = request.headers().getHeaderString(HttpHeaders.IF_NONE_MATCH);
+            if (exists && ifNoneMatch != null && "*".equals(ifNoneMatch.trim())) {
+                Response error = new AzureErrorResponse("PathAlreadyExists",
+                        "The specified path already exists.")
+                        .toDataLakeJsonResponse(Response.Status.CONFLICT.getStatusCode());
+                return Response.fromResponse(error)
+                        .header("x-ms-existing-resource-type", state.directory() ? "directory" : "file")
+                        .build();
+            }
+
+            String ifMatch = request.headers().getHeaderString(HttpHeaders.IF_MATCH);
+            if (ifMatch != null && (state == null || !etagMatches(ifMatch, state.object().etag()))) {
+                return new AzureErrorResponse("ConditionNotMet",
+                        "The condition specified using HTTP conditional header(s) is not met.")
+                        .toDataLakeJsonResponse(Response.Status.PRECONDITION_FAILED.getStatusCode());
+            }
+
+            if (state != null && state.directory() != directory) {
+                return new AzureErrorResponse("PathConflict",
+                        "The path conflicts with an existing resource of a different type.")
+                        .toDataLakeJsonResponse(Response.Status.CONFLICT.getStatusCode());
+            }
+
+            Response leaseFailure = state != null && !state.implicit()
+                    ? leaseService.validateDataLakeWrite(request, key)
+                    : null;
+            if (leaseFailure != null) {
+                return leaseFailure;
+            }
+
+            Optional<StoredObject> existing = store.get(key);
+            Map<String, String> metadata = defaultDataLakeMetadata(path, directory, request);
+            metadata.put(CREATION_TIME_KEY, createdOn(existing).toString());
+            if (existing.isPresent()) {
+                // Conditional overwrite replaces file content but keeps path identity and user
+                // properties. Hadoop supplies x-ms-permissions/x-ms-umask on create; when it does
+                // not, preserve the existing POSIX mode/ACL rather than resetting them to defaults.
+                Map<String, String> currentMetadata = existing.get().metadata();
+                copyIfPresent(currentMetadata, metadata, DATALAKE_PROPERTIES_KEY);
+                copyIfPresent(currentMetadata, metadata, DATALAKE_OWNER_KEY);
+                copyIfPresent(currentMetadata, metadata, DATALAKE_GROUP_KEY);
+                String requestedPermissions = request.headers().getHeaderString("x-ms-permissions");
+                if (requestedPermissions == null || requestedPermissions.isBlank()) {
+                    copyIfPresent(currentMetadata, metadata, DATALAKE_PERMISSIONS_KEY);
+                    copyIfPresent(currentMetadata, metadata, DATALAKE_ACL_KEY);
+                } else {
+                    metadata.put(DATALAKE_ACL_KEY, applyPermissionsToAcl(
+                            currentMetadata.get(DATALAKE_ACL_KEY), metadata.get(DATALAKE_PERMISSIONS_KEY)));
+                }
+            }
+
+            String requestedBlobType = request.queryParams().get("blobType");
+            metadata.put("BlobType", "AppendBlob".equalsIgnoreCase(requestedBlobType)
+                    ? "AppendBlob" : "BlockBlob");
+            String etag = UUID.randomUUID().toString();
+            Instant now = Instant.now();
+            store.put(key, new StoredObject(path, new byte[0], metadata, now, etag));
+            if (!directory) {
+                clearDataLakeAppendChunks(request.accountName(), filesystem, path);
+            }
+            return Response.status(Response.Status.CREATED)
+                    .header("Last-Modified", RFC1123_DATE_TIME.format(now))
+                    .header("ETag", etag)
+                    .header("x-ms-request-server-encrypted", "true")
+                    .header(HttpHeaders.CONTENT_LENGTH, 0)
+                    .build();
+        });
+    }
+
+    private Response setDataLakePathProperties(AzureRequest request, String filesystem, String path) {
+        Response authFailure = authorizeWrite(request, filesystem, path);
+        if (authFailure != null) {
+            return authFailure;
+        }
+        return leaseService.exclusively(() -> {
+            DataLakePathState state = resolveDataLakePath(request.accountName(), filesystem, path);
+            if (state == null) {
+                return new AzureErrorResponse("PathNotFound", "The specified path does not exist.")
+                        .toDataLakeJsonResponse(Response.Status.NOT_FOUND.getStatusCode());
+            }
+            boolean root = path == null || path.isBlank() || "/".equals(path);
+            // Validate against the visible ETag first. Implicit directories expose a
+            // deterministic synthetic ETag; materializing a marker before this check
+            // would replace it and make Hadoop getAclStatus -> setAcl If-Match fail.
+            Response conditionFailure = validateDataLakeConditions(request, Optional.of(state.object()));
+            if (conditionFailure != null) {
+                return conditionFailure;
+            }
+            StoredObject current = root
+                    ? state.object()
+                    : materializeIfImplicitDirectory(request.accountName(), filesystem, path, state);
+            if (!root) {
+                Response leaseFailure = leaseService.validateDataLakeWrite(request,
+                        objKey(request.accountName(), filesystem, path));
+                if (leaseFailure != null) {
+                    return leaseFailure;
+                }
+            }
+            Map<String, String> metadata = new HashMap<>(current.metadata());
+            metadata.put(DATALAKE_PROPERTIES_KEY, headerOrEmpty(request, "x-ms-properties"));
+            ensureDataLakeDefaults(metadata, state.directory());
+            String etag = UUID.randomUUID().toString();
+            Instant now = Instant.now();
+            String storageKey = root ? nsKey(request.accountName(), filesystem)
+                    : objKey(request.accountName(), filesystem, path);
+            String objectName = root ? current.key() : path;
+            store.put(storageKey,
+                    new StoredObject(objectName, current.data(), metadata, now, etag));
+            return Response.ok()
+                    .header("Last-Modified", RFC1123_DATE_TIME.format(now))
+                    .header("ETag", etag)
+                    .build();
+        });
+    }
+
+    private Response getDataLakeAccessControl(AzureRequest request, String filesystem, String path) {
+        Response authFailure = authorizeRead(request, filesystem, path);
+        if (authFailure != null) {
+            return authFailure;
+        }
+        if (store.get(nsKey(request.accountName(), filesystem)).isEmpty()) {
+            return new AzureErrorResponse("FilesystemNotFound", "The specified filesystem does not exist.")
+                    .toDataLakeJsonResponse(Response.Status.NOT_FOUND.getStatusCode());
+        }
+        DataLakePathState state = resolveDataLakePath(request.accountName(), filesystem, path);
+        if (state == null) {
+            return new AzureErrorResponse("PathNotFound", "The specified path does not exist.")
+                    .toDataLakeJsonResponse(Response.Status.NOT_FOUND.getStatusCode());
+        }
+        StoredObject object = state.object();
+        Map<String, String> metadata = object.metadata();
+        String permissions = metadata.getOrDefault(DATALAKE_PERMISSIONS_KEY,
+                state.directory() ? DATALAKE_DIRECTORY_PERMISSIONS : DATALAKE_FILE_PERMISSIONS);
+        String acl = metadata.getOrDefault(DATALAKE_ACL_KEY,
+                state.directory() ? DATALAKE_DEFAULT_DIRECTORY_ACL : DATALAKE_DEFAULT_FILE_ACL);
+        return Response.ok()
+                .header("Last-Modified", RFC1123_DATE_TIME.format(effectiveLastModified(object)))
+                .header("ETag", effectiveEtag(object, state.key()))
+                .header("x-ms-owner", metadata.getOrDefault(DATALAKE_OWNER_KEY, DATALAKE_OWNER))
+                .header("x-ms-group", metadata.getOrDefault(DATALAKE_GROUP_KEY, DATALAKE_GROUP))
+                .header("x-ms-permissions", permissions)
+                .header("x-ms-acl", acl)
+                .build();
+    }
+
+    private Response setDataLakeAccessControl(AzureRequest request, String filesystem, String path) {
+        Response authFailure = authorizeWrite(request, filesystem, path);
+        if (authFailure != null) {
+            return authFailure;
+        }
+        return leaseService.exclusively(() -> {
+            if (store.get(nsKey(request.accountName(), filesystem)).isEmpty()) {
+                return new AzureErrorResponse("FilesystemNotFound", "The specified filesystem does not exist.")
+                        .toDataLakeJsonResponse(Response.Status.NOT_FOUND.getStatusCode());
+            }
+            DataLakePathState state = resolveDataLakePath(request.accountName(), filesystem, path);
+            if (state == null) {
+                return new AzureErrorResponse("PathNotFound", "The specified path does not exist.")
+                        .toDataLakeJsonResponse(Response.Status.NOT_FOUND.getStatusCode());
+            }
+
+            boolean root = path == null || path.isBlank() || "/".equals(path);
+            // Validate against the visible ETag first. Implicit directories expose a
+            // deterministic synthetic ETag; materializing a marker before this check
+            // would replace it and make Hadoop getAclStatus -> setAcl If-Match fail.
+            Response conditionFailure = validateDataLakeConditions(request, Optional.of(state.object()));
+            if (conditionFailure != null) {
+                return conditionFailure;
+            }
+            StoredObject current = root
+                    ? state.object()
+                    : materializeIfImplicitDirectory(request.accountName(), filesystem, path, state);
+            if (!root) {
+                Response leaseFailure = leaseService.validateDataLakeWrite(request,
+                        objKey(request.accountName(), filesystem, path));
+                if (leaseFailure != null) {
+                    return leaseFailure;
+                }
+            }
+
+            Map<String, String> metadata = new HashMap<>(current.metadata());
+            ensureDataLakeDefaults(metadata, state.directory());
+            putIfHeaderPresent(request, metadata, "x-ms-owner", DATALAKE_OWNER_KEY);
+            putIfHeaderPresent(request, metadata, "x-ms-group", DATALAKE_GROUP_KEY);
+
+            String permissionHeader = request.headers().getHeaderString("x-ms-permissions");
+            if (permissionHeader != null && !permissionHeader.isBlank()) {
+                String permissions = normalizeDataLakePermissions(permissionHeader, null, state.directory());
+                String updatedAcl = applyPermissionsToAcl(metadata.get(DATALAKE_ACL_KEY), permissions);
+                metadata.put(DATALAKE_ACL_KEY, updatedAcl);
+                // Hadoop derives FileStatus.hasAcl from the trailing '+' in x-ms-permissions.
+                // chmod/setPermission must not make an existing extended ACL disappear; the
+                // group mode bits update mask:: while named ACL entries stay intact.
+                metadata.put(DATALAKE_PERMISSIONS_KEY,
+                        isExtendedAcl(updatedAcl) && !permissions.endsWith("+")
+                                ? permissions + "+" : permissions);
+            }
+
+            String aclHeader = request.headers().getHeaderString("x-ms-acl");
+            if (aclHeader != null) {
+                metadata.put(DATALAKE_ACL_KEY, aclHeader);
+                if (permissionHeader == null || permissionHeader.isBlank()) {
+                    String derived = permissionsFromAcl(aclHeader, state.directory());
+                    if (isExtendedAcl(aclHeader) && !derived.endsWith("+")) {
+                        derived += "+";
+                    }
+                    metadata.put(DATALAKE_PERMISSIONS_KEY, derived);
+                }
+            }
+
+            Instant now = Instant.now();
+            String etag = UUID.randomUUID().toString();
+            String storageKey = root ? nsKey(request.accountName(), filesystem)
+                    : objKey(request.accountName(), filesystem, path);
+            store.put(storageKey, new StoredObject(current.key(), current.data(), metadata, now, etag));
+            return Response.ok()
+                    .header("Last-Modified", RFC1123_DATE_TIME.format(now))
+                    .header("ETag", etag)
+                    .build();
+        });
+    }
+
+    private Response checkDataLakeAccess(AzureRequest request, String filesystem, String path) {
+        Response authFailure = authorizeRead(request, filesystem, path);
+        if (authFailure != null) {
+            return authFailure;
+        }
+        if (store.get(nsKey(request.accountName(), filesystem)).isEmpty()) {
+            return new AzureErrorResponse("FilesystemNotFound", "The specified filesystem does not exist.")
+                    .toDataLakeJsonResponse(Response.Status.NOT_FOUND.getStatusCode());
+        }
+        String fsAction = request.queryParams().get("fsAction");
+        if (fsAction == null || fsAction.isBlank() || !fsAction.matches("[rwx-]{1,3}")) {
+            return new AzureErrorResponse("InvalidQueryParameterValue",
+                    "Value for one of the query parameters specified in the request URI is invalid.")
+                    .toDataLakeJsonResponse(Response.Status.BAD_REQUEST.getStatusCode());
+        }
+        if (resolveDataLakePath(request.accountName(), filesystem, path) == null) {
+            return new AzureErrorResponse("PathNotFound", "The specified path does not exist.")
+                    .toDataLakeJsonResponse(Response.Status.NOT_FOUND.getStatusCode());
+        }
+        // Authentication/authorization is already handled by the emulator. Hadoop only needs
+        // the HNS access-check wire contract here; a full POSIX authorization engine is outside
+        // the storage emulator scope.
+        return Response.ok().build();
+    }
+
+    private Response leaseDataLakePath(AzureRequest request, String filesystem, String path) {
+        Response authFailure = authorizeWrite(request, filesystem, path);
+        if (authFailure != null) {
+            return authFailure;
+        }
+        return leaseService.exclusively(() -> {
+            DataLakePathState state = resolveDataLakePath(request.accountName(), filesystem, path);
+            if (state == null) {
+                return new AzureErrorResponse("PathNotFound", "The specified path does not exist.")
+                        .toDataLakeJsonResponse(Response.Status.NOT_FOUND.getStatusCode());
+            }
+            StoredObject object = materializeIfImplicitDirectory(request.accountName(), filesystem, path, state);
+            return leaseService.handleDataLakeLeaseOp(request,
+                    objKey(request.accountName(), filesystem, path),
+                    object.etag(), RFC1123_DATE_TIME.format(object.lastModified()));
+        });
+    }
+
+    private DataLakePathState resolveDataLakePath(String account, String filesystem, String path) {
+        if (path == null || path.isBlank() || "/".equals(path)) {
+            String key = nsKey(account, filesystem);
+            return store.get(key).map(object -> new DataLakePathState(key, object, true, false, true)).orElse(null);
+        }
+        String normalized = normalizeDataLakePath(path);
+        if (normalized == null) {
+            return null;
+        }
+        String key = objKey(account, filesystem, normalized);
+        Optional<StoredObject> exact = store.get(key);
+        if (exact.isPresent()) {
+            boolean directory = "directory".equals(exact.get().metadata().get(DATALAKE_RESOURCE_TYPE_KEY));
+            return new DataLakePathState(key, exact.get(), directory, false, false);
+        }
+        String prefix = key + "/";
+        List<StoredObject> descendants = store.scan(candidate -> candidate.startsWith(prefix)).stream()
+                .filter(object -> !isDataLakeInternalStoredObject(object))
+                .toList();
+        if (descendants.isEmpty()) {
+            return null;
+        }
+        StoredObject latest = descendants.stream()
+                .max(Comparator.comparing(StoredObject::lastModified))
+                .orElse(NS_SENTINEL);
+        Map<String, String> metadata = defaultDataLakeMetadata(normalized, true, null);
+        String etag = "implicit-" + Integer.toHexString(key.hashCode());
+        StoredObject synthetic = new StoredObject(normalized, new byte[0], metadata,
+                effectiveLastModified(latest), etag);
+        return new DataLakePathState(key, synthetic, true, true, false);
+    }
+
+    private StoredObject materializeIfImplicitDirectory(
+            String account, String filesystem, String path, DataLakePathState state) {
+        if (!state.implicit()) {
+            return state.object();
+        }
+        String normalized = normalizeDataLakePath(path);
+        Map<String, String> metadata = new HashMap<>(state.object().metadata());
+        metadata.put("Name", normalized);
+        metadata.put(DATALAKE_RESOURCE_TYPE_KEY, "directory");
+        metadata.put(CREATION_TIME_KEY, state.object().lastModified().toString());
+        ensureDataLakeDefaults(metadata, true);
+        String etag = UUID.randomUUID().toString();
+        StoredObject marker = new StoredObject(normalized, new byte[0], metadata,
+                Instant.now(), etag);
+        store.put(objKey(account, filesystem, normalized), marker);
+        return marker;
+    }
+
+    private static Map<String, String> defaultDataLakeMetadata(
+            String path, boolean directory, AzureRequest request) {
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put("Name", path == null ? "" : path);
+        metadata.put(DATALAKE_RESOURCE_TYPE_KEY, directory ? "directory" : "file");
+        metadata.put(DATALAKE_OWNER_KEY, DATALAKE_OWNER);
+        metadata.put(DATALAKE_GROUP_KEY, DATALAKE_GROUP);
+        String requestedPermissions = request == null ? null
+                : request.headers().getHeaderString("x-ms-permissions");
+        String umask = request == null ? null : request.headers().getHeaderString("x-ms-umask");
+        String permissions = normalizeDataLakePermissions(requestedPermissions, umask, directory);
+        metadata.put(DATALAKE_PERMISSIONS_KEY, permissions);
+        metadata.put(DATALAKE_ACL_KEY, aclFromPermissions(permissions));
+        return metadata;
+    }
+
+    private static void ensureDataLakeDefaults(Map<String, String> metadata, boolean directory) {
+        metadata.putIfAbsent(DATALAKE_RESOURCE_TYPE_KEY, directory ? "directory" : "file");
+        metadata.putIfAbsent(DATALAKE_OWNER_KEY, DATALAKE_OWNER);
+        metadata.putIfAbsent(DATALAKE_GROUP_KEY, DATALAKE_GROUP);
+        String permissions = metadata.getOrDefault(DATALAKE_PERMISSIONS_KEY,
+                directory ? DATALAKE_DIRECTORY_PERMISSIONS : DATALAKE_FILE_PERMISSIONS);
+        metadata.put(DATALAKE_PERMISSIONS_KEY, permissions);
+        metadata.putIfAbsent(DATALAKE_ACL_KEY, aclFromPermissions(permissions));
+    }
+
+    private static String normalizeDataLakePermissions(String permissions, String umask, boolean directory) {
+        if (permissions == null || permissions.isBlank()) {
+            return directory ? DATALAKE_DIRECTORY_PERMISSIONS : DATALAKE_FILE_PERMISSIONS;
+        }
+        String value = permissions.trim();
+        if (value.matches("[0-7]{3,4}")) {
+            int mode = Integer.parseInt(value, 8);
+            if (umask != null && umask.trim().matches("[0-7]{3,4}")) {
+                mode &= ~Integer.parseInt(umask.trim(), 8);
+            }
+            return symbolicPermissions(mode);
+        }
+        return value;
+    }
+
+    private static String symbolicPermissions(int mode) {
+        StringBuilder result = new StringBuilder(9);
+        int[] bits = {0400, 0200, 0100, 0040, 0020, 0010, 0004, 0002, 0001};
+        char[] chars = {'r','w','x','r','w','x','r','w','x'};
+        for (int i = 0; i < bits.length; i++) {
+            result.append((mode & bits[i]) != 0 ? chars[i] : '-');
+        }
+        if ((mode & 01000) != 0) {
+            result.setCharAt(8, result.charAt(8) == 'x' ? 't' : 'T');
+        }
+        return result.toString();
+    }
+
+    private static String aclFromPermissions(String permissionString) {
+        String permissions = permissionString == null ? "---------" : permissionString.replace("+", "");
+        if (permissions.length() < 9) {
+            permissions = "---------";
+        }
+        return "user::" + permissions.substring(0, 3)
+                + ",group::" + permissions.substring(3, 6)
+                + ",other::" + permissions.substring(6, 9);
+    }
+
+    private static String permissionsFromAcl(String acl, boolean directory) {
+        if (acl == null || acl.isBlank()) {
+            return directory ? DATALAKE_DIRECTORY_PERMISSIONS : DATALAKE_FILE_PERMISSIONS;
+        }
+        String user = null, group = null, mask = null, other = null;
+        for (String entry : acl.split(",")) {
+            String trimmed = entry.trim();
+            if (trimmed.startsWith("user::")) user = trimmed.substring("user::".length());
+            if (trimmed.startsWith("group::")) group = trimmed.substring("group::".length());
+            if (trimmed.startsWith("mask::")) mask = trimmed.substring("mask::".length());
+            if (trimmed.startsWith("other::")) other = trimmed.substring("other::".length());
+        }
+        if (user == null || group == null || other == null) {
+            return directory ? DATALAKE_DIRECTORY_PERMISSIONS : DATALAKE_FILE_PERMISSIONS;
+        }
+        return user + (mask != null ? mask : group) + other;
+    }
+
+    /**
+     * chmod/setPermission changes the POSIX mode without deleting named ACL
+     * entries. For an extended ACL the mode's group bits represent the ACL
+     * mask; for a basic ACL they represent group:: directly.
+     */
+    private static String applyPermissionsToAcl(String existingAcl, String permissionString) {
+        String permissions = permissionString == null ? "---------" : permissionString.replace("+", "");
+        if (permissions.length() < 9 || existingAcl == null || existingAcl.isBlank()) {
+            return aclFromPermissions(permissionString);
+        }
+        boolean extended = isExtendedAcl(existingAcl);
+        List<String> entries = new ArrayList<>();
+        boolean userSeen = false, groupSeen = false, maskSeen = false, otherSeen = false;
+        for (String entry : existingAcl.split(",")) {
+            String trimmed = entry.trim();
+            if (trimmed.startsWith("user::")) {
+                entries.add("user::" + permissions.substring(0, 3));
+                userSeen = true;
+            } else if (trimmed.startsWith("group::") && !extended) {
+                entries.add("group::" + permissions.substring(3, 6));
+                groupSeen = true;
+            } else if (trimmed.startsWith("mask::") && extended) {
+                entries.add("mask::" + permissions.substring(3, 6));
+                maskSeen = true;
+            } else if (trimmed.startsWith("other::")) {
+                entries.add("other::" + permissions.substring(6, 9));
+                otherSeen = true;
+            } else {
+                entries.add(trimmed);
+                if (trimmed.startsWith("group::")) groupSeen = true;
+            }
+        }
+        if (!userSeen) entries.add("user::" + permissions.substring(0, 3));
+        if (!groupSeen) entries.add("group::" + permissions.substring(3, 6));
+        if (extended && !maskSeen) entries.add("mask::" + permissions.substring(3, 6));
+        if (!otherSeen) entries.add("other::" + permissions.substring(6, 9));
+        return String.join(",", entries);
+    }
+
+    private static boolean isExtendedAcl(String acl) {
+        if (acl == null || acl.isBlank()) {
+            return false;
+        }
+        for (String entry : acl.split(",")) {
+            String value = entry.trim();
+            if (value.startsWith("default:") || value.startsWith("mask::")) {
+                return true;
+            }
+            if ((value.startsWith("user:") && !value.startsWith("user::"))
+                    || (value.startsWith("group:") && !value.startsWith("group::"))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static Response validateDataLakeConditions(AzureRequest request, Optional<StoredObject> object) {
+        String ifMatch = request.headers().getHeaderString(HttpHeaders.IF_MATCH);
+        if (ifMatch != null && object.map(StoredObject::etag)
+                .filter(etag -> etagMatches(ifMatch, etag)).isEmpty()) {
+            return new AzureErrorResponse("ConditionNotMet",
+                    "The condition specified using HTTP conditional header(s) is not met.")
+                    .toDataLakeJsonResponse(Response.Status.PRECONDITION_FAILED.getStatusCode());
+        }
+        String ifNoneMatch = request.headers().getHeaderString(HttpHeaders.IF_NONE_MATCH);
+        if (ifNoneMatch != null && object.map(StoredObject::etag)
+                .filter(etag -> etagMatches(ifNoneMatch, etag)).isPresent()) {
+            return new AzureErrorResponse("ConditionNotMet",
+                    "The condition specified using HTTP conditional header(s) is not met.")
+                    .toDataLakeJsonResponse(Response.Status.PRECONDITION_FAILED.getStatusCode());
+        }
+        return null;
+    }
+
+    private static void putIfHeaderPresent(
+            AzureRequest request, Map<String, String> metadata, String header, String metadataKey) {
+        String value = request.headers().getHeaderString(header);
+        if (value != null && !value.isBlank()) {
+            metadata.put(metadataKey, value);
+        }
+    }
+
+    private static void copyIfPresent(Map<String, String> source, Map<String, String> target, String key) {
+        if (source.containsKey(key)) {
+            target.put(key, source.get(key));
+        }
+    }
+
+    private static String headerOrEmpty(AzureRequest request, String name) {
+        String value = request.headers().getHeaderString(name);
+        return value == null ? "" : value;
+    }
+
+    private static Instant effectiveLastModified(StoredObject object) {
+        return object.lastModified() == null || object.lastModified().equals(Instant.EPOCH)
+                ? Instant.now() : object.lastModified();
+    }
+
+    private static String effectiveEtag(StoredObject object, String key) {
+        return object.etag() == null || object.etag().isBlank()
+                ? "implicit-" + Integer.toHexString(key.hashCode()) : object.etag();
+    }
+
+    private record DataLakePathState(
+            String key, StoredObject object, boolean directory, boolean implicit, boolean root) {}
+
+    /**
+     * ADLS Gen2 Path Rename (Path - Create with x-ms-rename-source).
+     *
+     * <p>Hadoop ABFS 3.3.4 sends a PUT to the destination path with a URL-encoded
+     * {@code x-ms-rename-source: /{filesystem}/{sourcePath}} header and
+     * {@code If-None-Match: *}. Spark's FileOutputCommitter uses directory renames
+     * extensively, and its source task directory may be implicit (only descendant
+     * objects exist). The move therefore operates on the complete storage-key prefix
+     * and applies all puts/deletes in one storage batch.
+     */
+    private Response renameDataLakePath(
+            AzureRequest request,
+            String destinationFilesystem,
+            String destinationPath,
+            String renameSourceHeader
+    ) {
+        String contentLengthHeader = request.headers().getHeaderString(HttpHeaders.CONTENT_LENGTH);
+        if (contentLengthHeader != null) {
+            try {
+                if (Long.parseLong(contentLengthHeader) != 0L) {
+                    return new AzureErrorResponse("ContentLengthMustBeZero",
+                            "The Content-Length request header must be zero.")
+                            .toDataLakeJsonResponse(Response.Status.BAD_REQUEST.getStatusCode());
+                }
+            } catch (NumberFormatException e) {
+                return new AzureErrorResponse("InvalidHeaderValue",
+                        "The value for one of the HTTP headers is not in the correct format.")
+                        .toDataLakeJsonResponse(Response.Status.BAD_REQUEST.getStatusCode());
+            }
+        }
+
+        RenameSource source = parseDataLakeRenameSource(renameSourceHeader);
+        if (source == null) {
+            return new AzureErrorResponse("InvalidSourceUri", "The source URI is invalid.")
+                    .toDataLakeJsonResponse(Response.Status.BAD_REQUEST.getStatusCode());
+        }
+
+        String renameMode = request.queryParams().get("mode");
+        if (renameMode != null && !"posix".equals(renameMode) && !"legacy".equals(renameMode)) {
+            return new AzureErrorResponse("InvalidQueryParameterValue",
+                    "Value for one of the query parameters specified in the request URI is invalid.")
+                    .toDataLakeJsonResponse(Response.Status.BAD_REQUEST.getStatusCode());
+        }
+
+        String normalizedDestination = normalizeDataLakePath(destinationPath);
+        if (normalizedDestination == null) {
+            return new AzureErrorResponse("InvalidDestinationPath",
+                    "The specified path, or an element of the path, exists and its resource type is invalid for this operation.")
+                    .toDataLakeJsonResponse(Response.Status.CONFLICT.getStatusCode());
+        }
+
+        if (source.filesystem().equals(destinationFilesystem)
+                && (source.path().equals(normalizedDestination)
+                || normalizedDestination.startsWith(source.path() + "/"))) {
+            return new AzureErrorResponse("InvalidRenameSourcePath",
+                    "The source directory cannot be the same as the destination directory, nor can the destination be a subdirectory of the source directory.")
+                    .toDataLakeJsonResponse(Response.Status.CONFLICT.getStatusCode());
+        }
+
+        return leaseService.exclusively(() -> renameDataLakePathLocked(
+                request, source, destinationFilesystem, normalizedDestination));
+    }
+
+    private Response renameDataLakePathLocked(
+            AzureRequest request,
+            RenameSource source,
+            String destinationFilesystem,
+            String destinationPath
+    ) {
+        if (store.get(nsKey(request.accountName(), destinationFilesystem)).isEmpty()
+                || store.get(nsKey(request.accountName(), source.filesystem())).isEmpty()) {
+            return new AzureErrorResponse("FilesystemNotFound", "The specified filesystem does not exist.")
+                    .toDataLakeJsonResponse(Response.Status.NOT_FOUND.getStatusCode());
+        }
+
+        String destinationParent = parentDataLakePath(destinationPath);
+        if (destinationParent != null) {
+            DataLakePathOperations.DeletePlan parent = dataLakePathOperations.planDelete(
+                    request.accountName(), destinationFilesystem, destinationParent);
+            if (!parent.exists()) {
+                return new AzureErrorResponse("RenameDestinationParentPathNotFound",
+                        "The parent directory of the destination path does not exist.")
+                        .toDataLakeJsonResponse(Response.Status.NOT_FOUND.getStatusCode());
+            }
+            if (!parent.directory()) {
+                return new AzureErrorResponse("InvalidDestinationPath",
+                        "The specified path, or an element of the path, exists and its resource type is invalid for this operation.")
+                        .toDataLakeJsonResponse(Response.Status.CONFLICT.getStatusCode());
+            }
+        }
+
+        DataLakePathOperations.RenamePlan plan = dataLakePathOperations.planRename(
+                request.accountName(),
+                source.filesystem(),
+                source.path(),
+                destinationFilesystem,
+                destinationPath);
+
+        if (!plan.exists()) {
+            return new AzureErrorResponse("SourcePathNotFound",
+                    "The source path for a rename operation does not exist.")
+                    .toDataLakeJsonResponse(Response.Status.NOT_FOUND.getStatusCode());
+        }
+
+        Response sourceConditionFailure = validateDataLakeRenameSourceConditions(request, plan);
+        if (sourceConditionFailure != null) {
+            return sourceConditionFailure;
+        }
+
+        DataLakePathOperations.DeletePlan destination = dataLakePathOperations.planDelete(
+                request.accountName(), destinationFilesystem, destinationPath);
+
+        Response conditionFailure = validateDataLakeRenameDestinationConditions(request, destination);
+        if (conditionFailure != null) {
+            return conditionFailure;
+        }
+
+        if (destination.exists()) {
+            if (plan.directory() != destination.directory()) {
+                return new AzureErrorResponse("InvalidSourceOrDestinationResourceType",
+                        "The source and destination resource type must be identical.")
+                        .toDataLakeJsonResponse(Response.Status.CONFLICT.getStatusCode());
+            }
+            if (destination.nonEmptyDirectory()) {
+                return new AzureErrorResponse("DirectoryNotEmpty",
+                        "The destination directory is not empty.")
+                        .toDataLakeJsonResponse(Response.Status.CONFLICT.getStatusCode());
+            }
+        }
+
+        Map<String, StoredObject> puts = new LinkedHashMap<>();
+        Set<String> deletes = new LinkedHashSet<>();
+        Instant renamedAt = Instant.now();
+        String destinationObjectPrefix = request.accountName() + "/" + destinationFilesystem + "/";
+
+        for (String sourceKey : plan.sourceKeys()) {
+            StoredObject sourceObject = store.get(sourceKey).orElse(null);
+            if (sourceObject == null) {
+                return new AzureErrorResponse("SourcePathNotFound",
+                        "The source path for a rename operation does not exist.")
+                        .toDataLakeJsonResponse(Response.Status.NOT_FOUND.getStatusCode());
+            }
+
+            String destinationKey = plan.destinationKeyFor(sourceKey);
+            String movedPath = destinationKey.substring(destinationObjectPrefix.length());
+            Map<String, String> metadata = new HashMap<>(sourceObject.metadata());
+            metadata.put("Name", movedPath);
+            String etag = UUID.randomUUID().toString();
+
+            puts.put(destinationKey,
+                    new StoredObject(movedPath, sourceObject.data(), metadata, renamedAt, etag));
+            deletes.add(sourceKey);
+        }
+
+        // A non-conditional rename overwrites an existing file or empty directory.
+        if (destination.exists()) {
+            if (destination.exactKey() != null && destination.exactObject() != null) {
+                deletes.add(destination.exactKey());
+            }
+            deletes.addAll(destination.descendantKeys());
+            String destinationAppendBase = DATALAKE_APPEND_PREFIX + request.accountName() + "/"
+                    + destinationFilesystem + "/" + destinationPath;
+            store.keys().stream()
+                    .filter(key -> key.startsWith(destinationAppendBase + ":pos:")
+                            || key.startsWith(destinationAppendBase + "/"))
+                    .forEach(deletes::add);
+        }
+
+        // Preserve any staged ADLS append data if a file/directory is renamed while
+        // uncommitted chunks exist. Spark normally flushes before rename, but moving the
+        // staging namespace keeps the emulator's path state internally coherent.
+        String sourceAppendBase = DATALAKE_APPEND_PREFIX + request.accountName() + "/"
+                + source.filesystem() + "/" + source.path();
+        String destinationAppendBase = DATALAKE_APPEND_PREFIX + request.accountName() + "/"
+                + destinationFilesystem + "/" + destinationPath;
+        for (String appendKey : store.keys().stream()
+                .filter(key -> key.startsWith(sourceAppendBase + ":pos:") || key.startsWith(sourceAppendBase + "/"))
+                .sorted()
+                .toList()) {
+            StoredObject chunk = store.get(appendKey).orElse(null);
+            if (chunk == null) {
+                continue;
+            }
+            String movedAppendKey = destinationAppendBase + appendKey.substring(sourceAppendBase.length());
+            puts.put(movedAppendKey, chunk);
+            deletes.add(appendKey);
+        }
+
+        store.applyBatch(puts, deletes);
+
+        StoredObject destinationRoot = puts.get(plan.destinationKey());
+        String etag = destinationRoot != null
+                ? destinationRoot.etag()
+                : "implicit-" + Integer.toHexString(plan.destinationKey().hashCode());
+
+        return Response.status(Response.Status.CREATED)
+                .header("Last-Modified", RFC1123_DATE_TIME.format(renamedAt))
+                .header("ETag", etag)
+                .header("x-ms-request-server-encrypted", "true")
+                .header(HttpHeaders.CONTENT_LENGTH, 0)
+                .build();
+    }
+
+    private Response validateDataLakeRenameSourceConditions(
+            AzureRequest request,
+            DataLakePathOperations.RenamePlan source
+    ) {
+        StoredObject exact = source.exactObject();
+        String ifNoneMatch = request.headers().getHeaderString("x-ms-source-if-none-match");
+        if (ifNoneMatch != null) {
+            if ("*".equals(ifNoneMatch.trim()) && source.exists()) {
+                return new AzureErrorResponse("SourceConditionNotMet",
+                        "The source condition specified using HTTP conditional header(s) is not met.")
+                        .toDataLakeJsonResponse(Response.Status.PRECONDITION_FAILED.getStatusCode());
+            }
+            if (exact != null && etagMatches(ifNoneMatch, exact.etag())) {
+                return new AzureErrorResponse("SourceConditionNotMet",
+                        "The source condition specified using HTTP conditional header(s) is not met.")
+                        .toDataLakeJsonResponse(Response.Status.PRECONDITION_FAILED.getStatusCode());
+            }
+        }
+
+        String ifMatch = request.headers().getHeaderString("x-ms-source-if-match");
+        if (ifMatch != null && (exact == null || !etagMatches(ifMatch, exact.etag()))) {
+            return new AzureErrorResponse("SourceConditionNotMet",
+                    "The source condition specified using HTTP conditional header(s) is not met.")
+                    .toDataLakeJsonResponse(Response.Status.PRECONDITION_FAILED.getStatusCode());
+        }
+        return null;
+    }
+
+    private Response validateDataLakeRenameDestinationConditions(
+            AzureRequest request,
+            DataLakePathOperations.DeletePlan destination
+    ) {
+        String ifNoneMatch = request.headers().getHeaderString(HttpHeaders.IF_NONE_MATCH);
+        if (ifNoneMatch != null) {
+            if ("*".equals(ifNoneMatch.trim()) && destination.exists()) {
+                return new AzureErrorResponse("ConditionNotMet",
+                        "The condition specified using HTTP conditional header(s) is not met.")
+                        .toDataLakeJsonResponse(Response.Status.PRECONDITION_FAILED.getStatusCode());
+            }
+            if (destination.exactObject() != null
+                    && etagMatches(ifNoneMatch, destination.exactObject().etag())) {
+                return new AzureErrorResponse("ConditionNotMet",
+                        "The condition specified using HTTP conditional header(s) is not met.")
+                        .toDataLakeJsonResponse(Response.Status.PRECONDITION_FAILED.getStatusCode());
+            }
+        }
+
+        String ifMatch = request.headers().getHeaderString(HttpHeaders.IF_MATCH);
+        if (ifMatch != null && (destination.exactObject() == null
+                || !etagMatches(ifMatch, destination.exactObject().etag()))) {
+            return new AzureErrorResponse("ConditionNotMet",
+                    "The condition specified using HTTP conditional header(s) is not met.")
+                    .toDataLakeJsonResponse(Response.Status.PRECONDITION_FAILED.getStatusCode());
+        }
+        return null;
+    }
+
+    private static RenameSource parseDataLakeRenameSource(String header) {
+        if (header == null || header.isBlank()) {
+            return null;
+        }
+        try {
+            int queryStart = header.indexOf('?');
+            String encodedPath = queryStart >= 0 ? header.substring(0, queryStart) : header;
+            String decoded = URLDecoder.decode(encodedPath, StandardCharsets.UTF_8);
+            while (decoded.startsWith("/")) {
+                decoded = decoded.substring(1);
+            }
+            String[] parts = decoded.split("/", 2);
+            if (parts.length != 2 || parts[0].isBlank()) {
+                return null;
+            }
+            String normalizedPath = normalizeDataLakePath(parts[1]);
+            return normalizedPath == null ? null : new RenameSource(parts[0], normalizedPath);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
+
+    private static String normalizeDataLakePath(String path) {
+        if (path == null) {
+            return null;
+        }
+        String normalized = path;
+        while (normalized.startsWith("/")) {
+            normalized = normalized.substring(1);
+        }
+        while (normalized.endsWith("/") && !normalized.isEmpty()) {
+            normalized = normalized.substring(0, normalized.length() - 1);
+        }
+        return normalized.isEmpty() ? null : normalized;
+    }
+
+    private static String parentDataLakePath(String path) {
+        int slash = path.lastIndexOf('/');
+        return slash < 0 ? null : path.substring(0, slash);
+    }
+
+    private record RenameSource(String filesystem, String path) {}
+
+    /**
+     * ADLS Gen2 Get Path Properties / Get Status.
+     *
+     * Hadoop ABFS uses HEAD ?action=getStatus for FileSystem.exists()/getFileStatus().
+     * A directory may be implicit (no marker object) as long as descendants exist, so this
+     * cannot be implemented as a plain Blob HEAD lookup.
+     */
+    private Response getDataLakePathStatus(AzureRequest request, String filesystem, String path) {
+        Response authFailure = authorizeRead(request, filesystem, path);
+        if (authFailure != null) {
+            return authFailure;
+        }
+        if (store.get(nsKey(request.accountName(), filesystem)).isEmpty()) {
+            return new AzureErrorResponse("FilesystemNotFound", "The specified filesystem does not exist.")
+                    .toDataLakeJsonResponse(Response.Status.NOT_FOUND.getStatusCode());
+        }
+
+        String key = objKey(request.accountName(), filesystem, path);
+        Optional<StoredObject> exact = store.get(key);
+        List<StoredObject> descendants = List.of();
+        boolean directory;
+        StoredObject source;
+
+        if (exact.isPresent()) {
+            source = exact.get();
+            directory = "directory".equals(source.metadata().get("DataLakeResourceType"));
+        } else {
+            String prefix = key + "/";
+            descendants = store.scan(candidate -> candidate.startsWith(prefix));
+            descendants = descendants.stream()
+                    .filter(object -> !isDataLakeInternalStoredObject(object))
+                    .toList();
+            if (descendants.isEmpty()) {
+                return new AzureErrorResponse("PathNotFound", "The specified path does not exist.")
+                        .toDataLakeJsonResponse(Response.Status.NOT_FOUND.getStatusCode());
+            }
+            directory = true;
+            source = descendants.stream()
+                    .max(Comparator.comparing(StoredObject::lastModified))
+                    .orElse(NS_SENTINEL);
+        }
+
+        long contentLength = directory ? 0 : source.data().length;
+        String etag = exact.map(StoredObject::etag)
+                .orElseGet(() -> "implicit-" + Integer.toHexString(key.hashCode()));
+        Instant lastModified = source.lastModified().equals(Instant.EPOCH) ? Instant.now() : source.lastModified();
+
+        boolean implicitDirectory = directory && exact.isEmpty();
+        Map<String, String> metadata = implicitDirectory ? Map.of() : source.metadata();
+        Response.ResponseBuilder builder = Response.ok()
+                .header("Last-Modified", RFC1123_DATE_TIME.format(lastModified))
+                .header("ETag", etag)
+                .header(HttpHeaders.CONTENT_LENGTH, contentLength)
+                .header("x-ms-resource-type", directory ? "directory" : "file")
+                .header("x-ms-owner", metadata.getOrDefault(DATALAKE_OWNER_KEY, DATALAKE_OWNER))
+                .header("x-ms-group", metadata.getOrDefault(DATALAKE_GROUP_KEY, DATALAKE_GROUP))
+                .header("x-ms-permissions", metadata.getOrDefault(DATALAKE_PERMISSIONS_KEY, directory
+                        ? DATALAKE_DIRECTORY_PERMISSIONS
+                        : DATALAKE_FILE_PERMISSIONS))
+                .header("x-ms-request-server-encrypted", "true");
+        if (request.queryParams().get("action") == null) {
+            builder.header("x-ms-properties", metadata.getOrDefault(DATALAKE_PROPERTIES_KEY, ""));
+        }
+        leaseService.addLeaseHeaders(builder, key);
+
+        return builder.build();
+    }
+
+    /**
+     * ADLS Gen2 Append Data. Hadoop 3.3.x sends this as HTTP PUT with
+     * X-Http-Method-Override: PATCH and action=append.
+     *
+     * Chunks are staged under an internal key so asynchronous/out-of-order ABFS uploads do not
+     * become visible until Flush commits a contiguous byte range.
+     */
+    private Response appendDataLakePath(AzureRequest request, String filesystem, String path) {
+        Response authFailure = authorizeWrite(request, filesystem, path);
+        if (authFailure != null) {
+            return authFailure;
+        }
+        if (store.get(nsKey(request.accountName(), filesystem)).isEmpty()) {
+            return new AzureErrorResponse("FilesystemNotFound", "The specified filesystem does not exist.")
+                    .toDataLakeJsonResponse(Response.Status.NOT_FOUND.getStatusCode());
+        }
+
+        Long position = parseNonNegativeLong(request.queryParams().get("position"));
+        if (position == null) {
+            return new AzureErrorResponse("InvalidQueryParameterValue",
+                    "Value for one of the query parameters specified in the request URI is invalid.")
+                    .toDataLakeJsonResponse(Response.Status.BAD_REQUEST.getStatusCode());
+        }
+
+        try {
+            byte[] data = request.bodyStream().readAllBytes();
+            return leaseService.exclusively(() -> {
+                String key = objKey(request.accountName(), filesystem, path);
+                Optional<StoredObject> existing = store.get(key);
+                if (existing.isEmpty()) {
+                    return new AzureErrorResponse("PathNotFound", "The specified path does not exist.")
+                            .toDataLakeJsonResponse(Response.Status.NOT_FOUND.getStatusCode());
+                }
+                if ("directory".equals(existing.get().metadata().get("DataLakeResourceType"))) {
+                    return new AzureErrorResponse("InvalidSourceOrDestinationResourceType",
+                            "The source and destination resource type must be identical.")
+                            .toDataLakeJsonResponse(Response.Status.CONFLICT.getStatusCode());
+                }
+
+                Response conditionFailure = validateBlobConditions(request, existing);
+                if (conditionFailure != null) {
+                    return conditionFailure;
+                }
+                Response leaseFailure = leaseService.validateDataLakeWrite(request, key);
+                if (leaseFailure != null) {
+                    return leaseFailure;
+                }
+
+                if ("AppendBlob".equalsIgnoreCase(existing.get().metadata().get("BlobType"))) {
+                    if (position != existing.get().data().length) {
+                        return new AzureErrorResponse("InvalidQueryParameterValue",
+                                "The append position does not match the current length of the append blob.")
+                                .toDataLakeJsonResponse(Response.Status.BAD_REQUEST.getStatusCode());
+                    }
+                    byte[] committed = Arrays.copyOf(existing.get().data(), existing.get().data().length + data.length);
+                    System.arraycopy(data, 0, committed, existing.get().data().length, data.length);
+                    Map<String, String> metadata = new HashMap<>(existing.get().metadata());
+                    metadata.put(DATALAKE_RESOURCE_TYPE_KEY, "file");
+                    metadata.put("Name", path);
+                    String etag = UUID.randomUUID().toString();
+                    Instant now = Instant.now();
+                    store.put(key, new StoredObject(path, committed, metadata, now, etag));
+                    boolean flush = Boolean.parseBoolean(request.queryParams().getOrDefault("flush", "false"));
+                    return Response.status(flush ? Response.Status.OK : Response.Status.ACCEPTED)
+                            .header("Last-Modified", RFC1123_DATE_TIME.format(now))
+                            .header("ETag", etag)
+                            .header("Content-Length", 0)
+                            .build();
+                }
+
+                String stageKey = dataLakeAppendChunkKey(request.accountName(), filesystem, path, position);
+                Map<String, String> metadata = Map.of(
+                        "DataLakeAppendPosition", Long.toString(position),
+                        "Name", path);
+                store.put(stageKey, new StoredObject(path, data, metadata, Instant.now(), UUID.randomUUID().toString()));
+
+                if (Boolean.parseBoolean(request.queryParams().getOrDefault("flush", "false"))) {
+                    return flushDataLakePathLocked(request, filesystem, path, position + data.length);
+                }
+
+                return Response.status(Response.Status.ACCEPTED)
+                        .header("Content-Length", 0)
+                        .build();
+            });
+        } catch (IOException e) {
+            return Response.serverError().build();
+        }
+    }
+
+    /** ADLS Gen2 Flush Data (HTTP PUT + X-Http-Method-Override: PATCH, action=flush). */
+    private Response flushDataLakePath(AzureRequest request, String filesystem, String path) {
+        Response authFailure = authorizeWrite(request, filesystem, path);
+        if (authFailure != null) {
+            return authFailure;
+        }
+        if (store.get(nsKey(request.accountName(), filesystem)).isEmpty()) {
+            return new AzureErrorResponse("FilesystemNotFound", "The specified filesystem does not exist.")
+                    .toDataLakeJsonResponse(Response.Status.NOT_FOUND.getStatusCode());
+        }
+
+        Long position = parseNonNegativeLong(request.queryParams().get("position"));
+        if (position == null) {
+            return new AzureErrorResponse("InvalidQueryParameterValue",
+                    "Value for one of the query parameters specified in the request URI is invalid.")
+                    .toDataLakeJsonResponse(Response.Status.BAD_REQUEST.getStatusCode());
+        }
+
+        return leaseService.exclusively(() -> flushDataLakePathLocked(request, filesystem, path, position));
+    }
+
+    private Response flushDataLakePathLocked(AzureRequest request, String filesystem, String path, long position) {
+        String key = objKey(request.accountName(), filesystem, path);
+        Optional<StoredObject> existing = store.get(key);
+        if (existing.isEmpty()) {
+            return new AzureErrorResponse("PathNotFound", "The specified path does not exist.")
+                    .toDataLakeJsonResponse(Response.Status.NOT_FOUND.getStatusCode());
+        }
+        StoredObject current = existing.get();
+        if ("directory".equals(current.metadata().get("DataLakeResourceType"))) {
+            return new AzureErrorResponse("InvalidFlushOperation",
+                    "The specified resource cannot be flushed as a file.")
+                    .toDataLakeJsonResponse(Response.Status.CONFLICT.getStatusCode());
+        }
+
+        Response conditionFailure = validateBlobConditions(request, existing);
+        if (conditionFailure != null) {
+            return conditionFailure;
+        }
+        Response leaseFailure = leaseService.validateDataLakeWrite(request, key);
+        if (leaseFailure != null) {
+            return leaseFailure;
+        }
+
+        if ("AppendBlob".equalsIgnoreCase(current.metadata().get("BlobType"))) {
+            if (position != current.data().length) {
+                return new AzureErrorResponse("InvalidFlushPosition",
+                        "The position query parameter value must equal the current append blob length.")
+                        .toDataLakeJsonResponse(Response.Status.BAD_REQUEST.getStatusCode());
+            }
+            return Response.ok()
+                    .header("Last-Modified", RFC1123_DATE_TIME.format(current.lastModified()))
+                    .header("ETag", current.etag())
+                    .header("x-ms-request-server-encrypted", "true")
+                    .header("Content-Length", 0)
+                    .build();
+        }
+
+        String stagePrefix = dataLakeAppendChunkPrefix(request.accountName(), filesystem, path);
+        List<StoredObject> chunks = store.scan(candidate -> candidate.startsWith(stagePrefix)).stream()
+                .sorted(Comparator.comparingLong(BlobServiceHandler::dataLakeAppendPosition))
+                .toList();
+
+        long committedLength = current.data().length;
+        long coveredThrough = Math.min(committedLength, position);
+        for (StoredObject chunk : chunks) {
+            long start = dataLakeAppendPosition(chunk);
+            long end = start + chunk.data().length;
+            if (start > coveredThrough && start < position) {
+                return new AzureErrorResponse("InvalidFlushPosition",
+                        "The uploaded data is not contiguous or the position query parameter value is not equal "
+                                + "to the length of the file after appending the uploaded data.")
+                        .toDataLakeJsonResponse(Response.Status.BAD_REQUEST.getStatusCode());
+            }
+            if (start <= coveredThrough) {
+                coveredThrough = Math.max(coveredThrough, Math.min(end, position));
+            }
+        }
+        if (coveredThrough < position) {
+            return new AzureErrorResponse("InvalidFlushPosition",
+                    "The uploaded data is not contiguous or the position query parameter value is not equal "
+                            + "to the length of the file after appending the uploaded data.")
+                    .toDataLakeJsonResponse(Response.Status.BAD_REQUEST.getStatusCode());
+        }
+
+        if (position > Integer.MAX_VALUE) {
+            return new AzureErrorResponse("OutOfRangeQueryParameterValue",
+                    "One of the query parameters specified in the request URI is outside the permissible range.")
+                    .toDataLakeJsonResponse(Response.Status.BAD_REQUEST.getStatusCode());
+        }
+
+        byte[] committed = Arrays.copyOf(current.data(), Math.toIntExact(position));
+        for (StoredObject chunk : chunks) {
+            long start = dataLakeAppendPosition(chunk);
+            if (start >= position) {
+                continue;
+            }
+            int copyLength = Math.toIntExact(Math.min((long) chunk.data().length, position - start));
+            System.arraycopy(chunk.data(), 0, committed, Math.toIntExact(start), copyLength);
+        }
+
+        Map<String, String> metadata = new HashMap<>(current.metadata());
+        metadata.put("DataLakeResourceType", "file");
+        metadata.put("Name", path);
+        String etag = UUID.randomUUID().toString();
+        store.put(key, new StoredObject(path, committed, metadata, Instant.now(), etag));
+
+        boolean retainUncommitted = Boolean.parseBoolean(
+                request.queryParams().getOrDefault("retainUncommittedData", "false"));
+        if (!retainUncommitted) {
+            store.keys().stream()
+                    .filter(candidate -> candidate.startsWith(stagePrefix))
+                    .toList()
+                    .forEach(store::delete);
+        } else {
+            store.scan(candidate -> candidate.startsWith(stagePrefix)).stream()
+                    .filter(chunk -> dataLakeAppendPosition(chunk) + chunk.data().length <= position)
+                    .map(chunk -> dataLakeAppendChunkKey(request.accountName(), filesystem, path,
+                            dataLakeAppendPosition(chunk)))
+                    .toList()
+                    .forEach(store::delete);
+        }
+
+        return Response.ok()
+                .header("Last-Modified", RFC1123_DATE_TIME.format(Instant.now()))
+                .header("ETag", etag)
+                .header("x-ms-request-server-encrypted", "true")
+                .header("Content-Length", 0)
+                .build();
+    }
+
+    private static Long parseNonNegativeLong(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            long parsed = Long.parseLong(value);
+            return parsed >= 0 ? parsed : null;
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private static long dataLakeAppendPosition(StoredObject chunk) {
+        return Long.parseLong(chunk.metadata().get("DataLakeAppendPosition"));
+    }
+
+    private static String dataLakeAppendChunkPrefix(String account, String filesystem, String path) {
+        return DATALAKE_APPEND_PREFIX + account + "/" + filesystem + "/" + path + ":pos:";
+    }
+
+    private static String dataLakeAppendChunkKey(
+            String account, String filesystem, String path, long position) {
+        return dataLakeAppendChunkPrefix(account, filesystem, path) + String.format(Locale.ROOT, "%020d", position);
+    }
+
+    private void clearDataLakeAppendChunks(String account, String filesystem, String path) {
+        String prefix = dataLakeAppendChunkPrefix(account, filesystem, path);
+        store.keys().stream()
+                .filter(candidate -> candidate.startsWith(prefix))
+                .toList()
+                .forEach(store::delete);
+    }
+
+    private void clearDataLakeAppendChunksUnderPath(String account, String filesystem, String path) {
+        String base = DATALAKE_APPEND_PREFIX + account + "/" + filesystem + "/" + path;
+        store.keys().stream()
+                .filter(candidate -> candidate.startsWith(base + ":pos:") || candidate.startsWith(base + "/"))
+                .toList()
+                .forEach(store::delete);
+    }
+
+    private static boolean isDataLakeInternalStoredObject(StoredObject object) {
+        return object.metadata().containsKey("DataLakeAppendPosition");
     }
 
     private Response getBlob(AzureRequest request, String containerName, String blobName, boolean headOnly) {
@@ -503,6 +1927,75 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
         }
 
         return rb.build();
+    }
+
+    /** GET /{filesystem}/{path} through the DFS endpoint (ADLS Path - Read). */
+    private Response readDataLakePath(AzureRequest request, String filesystem, String path) {
+        Response authFailure = authorizeRead(request, filesystem, path);
+        if (authFailure != null) {
+            return authFailure;
+        }
+        if (store.get(nsKey(request.accountName(), filesystem)).isEmpty()) {
+            return new AzureErrorResponse("FilesystemNotFound", "The specified filesystem does not exist.")
+                    .toDataLakeJsonResponse(Response.Status.NOT_FOUND.getStatusCode());
+        }
+        if (store.get(objKey(request.accountName(), filesystem, path)).isEmpty()) {
+            return new AzureErrorResponse("PathNotFound", "The specified path does not exist.")
+                    .toDataLakeJsonResponse(Response.Status.NOT_FOUND.getStatusCode());
+        }
+        // Reuse Blob read/range/condition handling once DFS namespace semantics have been resolved.
+        return getBlob(request, filesystem, path, false);
+    }
+
+    private Response deleteDataLakePath(AzureRequest request, String filesystem, String path) {
+        Response authFailure = authorizeDelete(request, filesystem, path);
+        if (authFailure != null) {
+            return authFailure;
+        }
+        if (store.get(nsKey(request.accountName(), filesystem)).isEmpty()) {
+            return new AzureErrorResponse("FilesystemNotFound", "The specified filesystem does not exist.")
+                    .toDataLakeJsonResponse(Response.Status.NOT_FOUND.getStatusCode());
+        }
+
+        return leaseService.exclusively(() -> {
+            DataLakePathOperations.DeletePlan plan =
+                    dataLakePathOperations.planDelete(request.accountName(), filesystem, path);
+
+            if (!plan.exists()) {
+                return new AzureErrorResponse("PathNotFound", "The specified path does not exist.")
+                        .toDataLakeJsonResponse(Response.Status.NOT_FOUND.getStatusCode());
+            }
+
+            boolean recursive = Boolean.parseBoolean(request.queryParams().getOrDefault("recursive", "false"));
+            if (plan.nonEmptyDirectory() && !recursive) {
+                return new AzureErrorResponse("DirectoryNotEmpty",
+                        "The recursive query parameter value must be true to delete a non-empty directory.")
+                        .toDataLakeJsonResponse(Response.Status.CONFLICT.getStatusCode());
+            }
+
+            if (plan.exactObject() != null) {
+                Response conditionFailure = validateBlobConditions(request, Optional.of(plan.exactObject()));
+                if (conditionFailure != null) {
+                    return conditionFailure;
+                }
+                Response leaseFailure = leaseService.validateWrite(request, plan.exactKey());
+                if (leaseFailure != null) {
+                    return leaseFailure;
+                }
+            }
+
+            for (String descendantKey : plan.descendantKeys()) {
+                store.delete(descendantKey);
+                leaseService.onBlobDeleted(descendantKey);
+            }
+            if (plan.exactObject() != null) {
+                store.delete(plan.exactKey());
+                leaseService.onBlobDeleted(plan.exactKey());
+            }
+            clearDataLakeAppendChunksUnderPath(request.accountName(), filesystem, path);
+
+            return Response.status(Response.Status.ACCEPTED).build();
+        });
     }
 
     private Response deleteBlob(AzureRequest request, String containerName, String blobName) {
@@ -669,12 +2162,16 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
         boolean recursive = Boolean.parseBoolean(request.queryParams().getOrDefault("recursive", "false"));
         List<DataLakePathListResponse.PathEntry> entries =
                 dataLakePathOperations.list(request.accountName(), filesystem, directory, recursive);
-        int start = parseContinuation(request.queryParams().get("continuation"));
-        if (start < 0) {
+        DataLakeContinuation continuation = parseDataLakeContinuation(
+                request.queryParams().get("continuation"));
+        if (!continuation.valid()) {
             return new AzureErrorResponse("InvalidQueryParameterValue",
                     "Value for one of the query parameters specified in the request URI is invalid.")
-                    .toXmlResponse(Response.Status.BAD_REQUEST.getStatusCode());
+                    .toDataLakeJsonResponse(Response.Status.BAD_REQUEST.getStatusCode());
         }
+        int start = continuation.startFrom() == null
+                ? continuation.offset()
+                : findDataLakeStartIndex(entries, directory, continuation.startFrom());
         int maxResults = parseDataLakeMaxResults(request.queryParams().get("maxResults"));
         int end = Math.min(start + maxResults, entries.size());
         List<DataLakePathListResponse.PathEntry> page = start >= entries.size()
@@ -711,16 +2208,68 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
         }
     }
 
-    private static int parseContinuation(String value) {
+    /**
+     * Parse either Floci's server-generated numeric page offset or the HNS
+     * startFrom continuation token generated by Hadoop ABFS 3.3.4. Hadoop's
+     * XNS token is Base64("<crc64> 0 <entryName>"). We intentionally do not
+     * validate Hadoop's CRC: Azure treats the token as opaque and the emulator
+     * only needs the observable lexical startFrom behavior.
+     */
+    private static DataLakeContinuation parseDataLakeContinuation(String value) {
         if (value == null || value.isBlank()) {
-            return 0;
+            return new DataLakeContinuation(0, null, true);
         }
         try {
             int parsed = Integer.parseInt(value);
-            return parsed < 0 ? -1 : parsed;
-        } catch (NumberFormatException e) {
-            return -1;
+            return parsed < 0
+                    ? new DataLakeContinuation(0, null, false)
+                    : new DataLakeContinuation(parsed, null, true);
+        } catch (NumberFormatException ignored) {
+            // Hadoop HNS startFrom token is opaque Base64 rather than an integer.
         }
+        try {
+            String decoded = new String(Base64.getDecoder().decode(value), StandardCharsets.UTF_8);
+            int firstSpace = decoded.indexOf(' ');
+            int secondSpace = firstSpace < 0 ? -1 : decoded.indexOf(' ', firstSpace + 1);
+            if (firstSpace <= 0 || secondSpace <= firstSpace + 1 || secondSpace == decoded.length() - 1) {
+                return new DataLakeContinuation(0, null, false);
+            }
+            String marker = decoded.substring(firstSpace + 1, secondSpace);
+            if (!"0".equals(marker)) {
+                return new DataLakeContinuation(0, null, false);
+            }
+            String startFrom = decoded.substring(secondSpace + 1);
+            if (startFrom.isBlank() || startFrom.startsWith("/")) {
+                return new DataLakeContinuation(0, null, false);
+            }
+            return new DataLakeContinuation(0, startFrom, true);
+        } catch (IllegalArgumentException e) {
+            return new DataLakeContinuation(0, null, false);
+        }
+    }
+
+    private static int findDataLakeStartIndex(
+            List<DataLakePathListResponse.PathEntry> entries,
+            String directory,
+            String startFrom) {
+        String normalizedDirectory = normalizeDataLakePath(directory);
+        for (int index = 0; index < entries.size(); index++) {
+            String name = entries.get(index).name();
+            String relative = name;
+            if (normalizedDirectory != null && !normalizedDirectory.isBlank()) {
+                String prefix = normalizedDirectory + "/";
+                if (name.startsWith(prefix)) {
+                    relative = name.substring(prefix.length());
+                }
+            }
+            if (relative.compareTo(startFrom) >= 0) {
+                return index;
+            }
+        }
+        return entries.size();
+    }
+
+    private record DataLakeContinuation(int offset, String startFrom, boolean valid) {
     }
 
     // ── Block Blob ────────────────────────────────────────────────────────────
@@ -1036,6 +2585,19 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
             ids.add(m.group(1).trim());
         }
         return ids;
+    }
+
+    private static boolean isDataLakeRequest(AzureRequest request) {
+        String host = request.host();
+        if (host == null || host.isBlank()) {
+            return false;
+        }
+        String normalizedHost = host.trim().toLowerCase(Locale.ROOT);
+        int portSeparator = normalizedHost.indexOf(':');
+        if (portSeparator >= 0) {
+            normalizedHost = normalizedHost.substring(0, portSeparator);
+        }
+        return normalizedHost.endsWith(".dfs.core.windows.net");
     }
 
     public void clear() {

--- a/src/main/java/io/floci/az/services/blob/DataLakePathOperations.java
+++ b/src/main/java/io/floci/az/services/blob/DataLakePathOperations.java
@@ -17,11 +17,16 @@ public class DataLakePathOperations {
     private static final DateTimeFormatter RFC1123_DATE_TIME = DateTimeFormatter
             .ofPattern("EEE, dd MMM yyyy HH:mm:ss 'GMT'", Locale.US)
             .withZone(ZoneId.of("GMT"));
-    private static final String OWNER = "00000000-0000-0000-0000-000000000000";
-    private static final String GROUP = "00000000-0000-0000-0000-000000000000";
-    private static final String FILE_PERMISSIONS = "rw-r-----";
-    private static final String DIRECTORY_PERMISSIONS = "rwxr-x---";
-    private static final String RESOURCE_TYPE = "DataLakeResourceType";
+    static final String DEFAULT_OWNER = "00000000-0000-0000-0000-000000000000";
+    static final String DEFAULT_GROUP = "00000000-0000-0000-0000-000000000000";
+    static final String DEFAULT_FILE_PERMISSIONS = "rw-r-----";
+    static final String DEFAULT_DIRECTORY_PERMISSIONS = "rwxr-x---";
+    static final String RESOURCE_TYPE = "DataLakeResourceType";
+    static final String OWNER_KEY = "DataLakeOwner";
+    static final String GROUP_KEY = "DataLakeGroup";
+    static final String PERMISSIONS_KEY = "DataLakePermissions";
+    static final String ACL_KEY = "DataLakeAcl";
+    static final String PROPERTIES_KEY = "DataLakeProperties";
     private static final String BLOCK_PREFIX = "__blk__:";
     private static final String NAMESPACE_PREFIX = "__ns__:";
 
@@ -38,6 +43,22 @@ public class DataLakePathOperations {
             boolean recursive
     ) {
         String normalizedDirectory = normalizeDirectory(directory);
+
+        // Hadoop ABFS implements FileSystem.listStatus(path) through the ADLS
+        // List Paths endpoint, even when path is an exact file. ABFS expects
+        // that existing file to be represented as a singleton PathList. Handle
+        // that case before scanning directory descendants; objectPrefix()
+        // intentionally appends '/', so an exact file would otherwise produce
+        // an empty result.
+        if (normalizedDirectory != null) {
+            String exactKey = account + "/" + filesystem + "/" + normalizedDirectory;
+            var exactPath = store.get(exactKey);
+            if (exactPath.isPresent()
+                    && !"directory".equals(exactPath.get().metadata().get(RESOURCE_TYPE))) {
+                return List.of(fileEntry(normalizedDirectory, exactPath.get()));
+            }
+        }
+
         String objectPrefix = objectPrefix(account, filesystem, normalizedDirectory);
         List<DataLakePathListResponse.PathEntry> entries = new ArrayList<>();
         Set<String> emittedNames = new HashSet<>();
@@ -71,6 +92,111 @@ public class DataLakePathOperations {
         return entries;
     }
 
+
+    public DeletePlan planDelete(String account, String filesystem, String path) {
+        String normalizedPath = normalizeDirectory(path);
+        if (normalizedPath == null || normalizedPath.isEmpty()) {
+            return new DeletePlan(null, null, List.of(), false);
+        }
+
+        String exactKey = account + "/" + filesystem + "/" + normalizedPath;
+        var exact = store.get(exactKey);
+        String descendantPrefix = exactKey + "/";
+        List<String> descendants = store.keys().stream()
+                .filter(key -> key.startsWith(descendantPrefix) && !isInternalKey(key))
+                .sorted()
+                .toList();
+
+        boolean directory = exact
+                .map(object -> "directory".equals(object.metadata().get(RESOURCE_TYPE)))
+                .orElse(!descendants.isEmpty());
+
+        return new DeletePlan(exactKey, exact.orElse(null), descendants, directory);
+    }
+
+    public record DeletePlan(
+            String exactKey,
+            StoredObject exactObject,
+            List<String> descendantKeys,
+            boolean directory
+    ) {
+        public boolean exists() {
+            return exactObject != null || !descendantKeys.isEmpty();
+        }
+
+        public boolean nonEmptyDirectory() {
+            return directory && !descendantKeys.isEmpty();
+        }
+    }
+
+
+    public RenamePlan planRename(
+            String account,
+            String sourceFilesystem,
+            String sourcePath,
+            String destinationFilesystem,
+            String destinationPath
+    ) {
+        String normalizedSource = normalizeDirectory(sourcePath);
+        String normalizedDestination = normalizeDirectory(destinationPath);
+        if (normalizedSource == null || normalizedDestination == null) {
+            return new RenamePlan(null, null, null, null, null, List.of(), false);
+        }
+
+        String sourceKey = account + "/" + sourceFilesystem + "/" + normalizedSource;
+        String destinationKey = account + "/" + destinationFilesystem + "/" + normalizedDestination;
+        var exact = store.get(sourceKey);
+        String descendantPrefix = sourceKey + "/";
+        List<String> descendants = store.keys().stream()
+                .filter(key -> key.startsWith(descendantPrefix) && !isInternalKey(key))
+                .sorted()
+                .toList();
+
+        boolean directory = exact
+                .map(object -> "directory".equals(object.metadata().get(RESOURCE_TYPE)))
+                .orElse(!descendants.isEmpty());
+
+        return new RenamePlan(
+                sourceKey,
+                destinationKey,
+                exact.orElse(null),
+                normalizedSource,
+                normalizedDestination,
+                descendants,
+                directory
+        );
+    }
+
+    public record RenamePlan(
+            String sourceKey,
+            String destinationKey,
+            StoredObject exactObject,
+            String sourcePath,
+            String destinationPath,
+            List<String> descendantKeys,
+            boolean directory
+    ) {
+        public boolean exists() {
+            return exactObject != null || !descendantKeys.isEmpty();
+        }
+
+        public List<String> sourceKeys() {
+            List<String> result = new ArrayList<>();
+            if (exactObject != null) {
+                result.add(sourceKey);
+            }
+            result.addAll(descendantKeys);
+            return result;
+        }
+
+        public String destinationKeyFor(String sourceObjectKey) {
+            if (sourceObjectKey.equals(sourceKey)) {
+                return destinationKey;
+            }
+            return destinationKey + sourceObjectKey.substring(sourceKey.length());
+        }
+    }
+
     public boolean pathExists(String account, String filesystem, String path) {
         String normalizedPath = normalizeDirectory(path);
         if (normalizedPath == null || normalizedPath.isEmpty()) {
@@ -79,7 +205,7 @@ public class DataLakePathOperations {
         String exactKey = account + "/" + filesystem + "/" + normalizedPath;
         var exactPath = store.get(exactKey);
         if (exactPath.isPresent()) {
-            return "directory".equals(exactPath.get().metadata().get(RESOURCE_TYPE));
+            return true;
         }
         String descendantPrefix = exactKey + "/";
         return store.keys().stream().anyMatch(key -> key.startsWith(descendantPrefix) && !isInternalKey(key));
@@ -94,23 +220,26 @@ public class DataLakePathOperations {
                 false,
                 RFC1123_DATE_TIME.format(object.lastModified()),
                 object.data().length,
-                OWNER,
-                GROUP,
-                FILE_PERMISSIONS,
+                object.metadata().getOrDefault(OWNER_KEY, DEFAULT_OWNER),
+                object.metadata().getOrDefault(GROUP_KEY, DEFAULT_GROUP),
+                object.metadata().getOrDefault(PERMISSIONS_KEY, DEFAULT_FILE_PERMISSIONS),
                 quoteEtag(object.etag())
         );
     }
 
     private static DataLakePathListResponse.PathEntry directoryEntry(String name, StoredObject source) {
+        boolean explicitDirectory = "directory".equals(source.metadata().get(RESOURCE_TYPE));
         return new DataLakePathListResponse.PathEntry(
                 name,
                 true,
                 RFC1123_DATE_TIME.format(source.lastModified()),
                 0,
-                OWNER,
-                GROUP,
-                DIRECTORY_PERMISSIONS,
-                quoteEtag(source.etag())
+                explicitDirectory ? source.metadata().getOrDefault(OWNER_KEY, DEFAULT_OWNER) : DEFAULT_OWNER,
+                explicitDirectory ? source.metadata().getOrDefault(GROUP_KEY, DEFAULT_GROUP) : DEFAULT_GROUP,
+                explicitDirectory ? source.metadata().getOrDefault(PERMISSIONS_KEY, DEFAULT_DIRECTORY_PERMISSIONS)
+                        : DEFAULT_DIRECTORY_PERMISSIONS,
+                explicitDirectory ? quoteEtag(source.etag())
+                        : quoteEtag("implicit-" + Integer.toHexString(name.hashCode()))
         );
     }
 

--- a/src/test/java/io/floci/az/services/BlobServiceTest.java
+++ b/src/test/java/io/floci/az/services/BlobServiceTest.java
@@ -28,6 +28,7 @@ public class BlobServiceTest {
     private static final String CONTAINER = "test-container";
     private static final String BLOB = "test-blob.txt";
     private static final String BLOB_CONTENT = "Hello, Blob!";
+    private static final String DATALAKE_ID_FOR_TESTS = "00000000-0000-0000-0000-000000000000";
     private static final Pattern ISO_UTC_SECONDS = Pattern.compile("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z");
 
     @Inject
@@ -630,6 +631,524 @@ public class BlobServiceTest {
     }
 
     @Test
+    void dataLakeDeleteMissingPathReturnsPathNotFound() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().delete("/{container}/missing?recursive=true", CONTAINER)
+            .then()
+            .statusCode(404)
+            .contentType("application/json")
+            .header("x-ms-error-code", "PathNotFound")
+            .body("error.code", equalTo("PathNotFound"))
+            .body("error.message", equalTo("The specified path does not exist."));
+    }
+
+    @Test
+    void dataLakeReadMissingPathReturnsPathNotFound() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().get("/{container}/missing.txt", CONTAINER)
+            .then()
+            .statusCode(404)
+            .contentType("application/json")
+            .header("x-ms-error-code", "PathNotFound")
+            .body("error.code", equalTo("PathNotFound"))
+            .body("error.message", equalTo("The specified path does not exist."));
+    }
+
+    @Test
+    void dataLakeReadMissingFilesystemReturnsFilesystemNotFound() {
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().get("/missing-filesystem/file.txt")
+            .then()
+            .statusCode(404)
+            .contentType("application/json")
+            .header("x-ms-error-code", "FilesystemNotFound")
+            .body("error.code", equalTo("FilesystemNotFound"))
+            .body("error.message", equalTo("The specified filesystem does not exist."));
+    }
+
+    @Test
+    void blobDeleteMissingBlobStillReturnsBlobNotFound() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+
+        given()
+            .when().delete("/{account}/{container}/missing", ACCOUNT, CONTAINER)
+            .then()
+            .statusCode(404)
+            .header("x-ms-error-code", "BlobNotFound");
+    }
+
+    @Test
+    void dataLakeRecursiveDeleteRemovesDirectoryAndDescendants() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().put("/{container}/dir?resource=directory", CONTAINER)
+            .then().statusCode(201);
+        for (String path : new String[] {"dir/a.txt", "dir/sub/b.txt"}) {
+            given()
+                .header("Host", ACCOUNT + ".dfs.core.windows.net")
+                .when().put("/{container}/{path}?resource=file", CONTAINER, path)
+                .then().statusCode(201);
+        }
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().delete("/{container}/dir?recursive=true", CONTAINER)
+            .then().statusCode(202);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().get("/{container}?resource=filesystem&recursive=true", CONTAINER)
+            .then()
+            .statusCode(200)
+            .body("paths", hasSize(0));
+    }
+
+    @Test
+    void dataLakeNonRecursiveDeleteRejectsNonEmptyDirectory() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().put("/{container}/dir?resource=directory", CONTAINER)
+            .then().statusCode(201);
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().put("/{container}/dir/file.txt?resource=file", CONTAINER)
+            .then().statusCode(201);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().delete("/{container}/dir?recursive=false", CONTAINER)
+            .then()
+            .statusCode(409)
+            .contentType("application/json")
+            .header("x-ms-error-code", "DirectoryNotEmpty")
+            .body("error.code", equalTo("DirectoryNotEmpty"));
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().get("/{container}?resource=filesystem&recursive=true", CONTAINER)
+            .then()
+            .statusCode(200)
+            .body("paths.name", hasItem("dir/file.txt"));
+    }
+
+    @Test
+    void dataLakeNonRecursiveDeleteAllowsEmptyDirectory() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().put("/{container}/empty?resource=directory", CONTAINER)
+            .then().statusCode(201);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().delete("/{container}/empty?recursive=false", CONTAINER)
+            .then().statusCode(202);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().get("/{container}?resource=filesystem&recursive=true&directory=empty", CONTAINER)
+            .then()
+            .statusCode(404)
+            .header("x-ms-error-code", "PathNotFound");
+    }
+
+    @Test
+    void dataLakeRecursiveDeleteSupportsImplicitDirectory() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().put("/{container}/implicit/file.txt?resource=file", CONTAINER)
+            .then().statusCode(201);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().delete("/{container}/implicit?recursive=true", CONTAINER)
+            .then().statusCode(202);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().get("/{container}?resource=filesystem&recursive=true", CONTAINER)
+            .then()
+            .statusCode(200)
+            .body("paths", hasSize(0));
+    }
+
+    @Test
+    void dataLakeGetStatusReturnsFileAndImplicitDirectoryProperties() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().put("/{container}/implicit/file.txt?resource=file", CONTAINER)
+            .then().statusCode(201);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .queryParam("action", "getStatus")
+            .when().head("/{container}/implicit/file.txt", CONTAINER)
+            .then()
+            .statusCode(200)
+            .header("x-ms-resource-type", "file")
+            .header("Content-Length", "0")
+            .header("x-ms-owner", DATALAKE_ID_FOR_TESTS)
+            .header("x-ms-group", DATALAKE_ID_FOR_TESTS);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .queryParam("action", "getStatus")
+            .when().head("/{container}/implicit", CONTAINER)
+            .then()
+            .statusCode(200)
+            .header("x-ms-resource-type", "directory")
+            .header("Content-Length", "0")
+            .header("x-ms-permissions", "rwxr-x---");
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .queryParam("action", "getStatus")
+            .when().head("/{container}/missing", CONTAINER)
+            .then()
+            .statusCode(404)
+            .header("x-ms-error-code", "PathNotFound");
+    }
+
+    @Test
+    void dataLakeAppendAndFlushCommitsOutOfOrderChunks() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().put("/{container}/file.txt?resource=file", CONTAINER)
+            .then().statusCode(201);
+
+        // Stage the second chunk first. ABFS may have multiple async writes in flight.
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("X-Http-Method-Override", "PATCH")
+            .contentType("application/octet-stream")
+            .body("def".getBytes(StandardCharsets.UTF_8))
+            .queryParam("action", "append")
+            .queryParam("position", 3)
+            .when().put("/{container}/file.txt", CONTAINER)
+            .then().statusCode(202);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("X-Http-Method-Override", "PATCH")
+            .contentType("application/octet-stream")
+            .body("abc".getBytes(StandardCharsets.UTF_8))
+            .queryParam("action", "append")
+            .queryParam("position", 0)
+            .when().put("/{container}/file.txt", CONTAINER)
+            .then().statusCode(202);
+
+        // Appended data is uncommitted until flush, so status still reports the empty file.
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .queryParam("action", "getStatus")
+            .when().head("/{container}/file.txt", CONTAINER)
+            .then()
+            .statusCode(200)
+            .header("Content-Length", "0");
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("X-Http-Method-Override", "PATCH")
+            .queryParam("action", "flush")
+            .queryParam("position", 6)
+            .queryParam("retainUncommittedData", false)
+            .queryParam("close", true)
+            .when().put("/{container}/file.txt", CONTAINER)
+            .then().statusCode(200);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .queryParam("action", "getStatus")
+            .when().head("/{container}/file.txt", CONTAINER)
+            .then()
+            .statusCode(200)
+            .header("x-ms-resource-type", "file")
+            .header("Content-Length", "6");
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().get("/{container}/file.txt", CONTAINER)
+            .then()
+            .statusCode(200)
+            .body(equalTo("abcdef"));
+    }
+
+    @Test
+    void dataLakeFlushRejectsNonContiguousData() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().put("/{container}/file.txt?resource=file", CONTAINER)
+            .then().statusCode(201);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("X-Http-Method-Override", "PATCH")
+            .contentType("application/octet-stream")
+            .body("def".getBytes(StandardCharsets.UTF_8))
+            .queryParam("action", "append")
+            .queryParam("position", 3)
+            .when().put("/{container}/file.txt", CONTAINER)
+            .then().statusCode(202);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("X-Http-Method-Override", "PATCH")
+            .queryParam("action", "flush")
+            .queryParam("position", 6)
+            .when().put("/{container}/file.txt", CONTAINER)
+            .then()
+            .statusCode(400)
+            .contentType("application/json")
+            .header("x-ms-error-code", "InvalidFlushPosition")
+            .body("error.code", equalTo("InvalidFlushPosition"));
+    }
+
+    @Test
+    void dataLakeCreatePathRejectsNonZeroContentLength() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .contentType("application/octet-stream")
+            .body("payload".getBytes(StandardCharsets.UTF_8))
+            .queryParam("resource", "file")
+            .when().put("/{container}/file.txt", CONTAINER)
+            .then()
+            .statusCode(400)
+            .contentType("application/json")
+            .header("x-ms-error-code", "ContentLengthMustBeZero")
+            .body("error.code", equalTo("ContentLengthMustBeZero"));
+    }
+
+    @Test
+    void dataLakeRenameMovesImplicitDirectoryTreeLikeHadoopFileOutputCommitter() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+
+        String parent = "output/_temporary/0";
+        String source = parent + "/_temporary/attempt_001";
+        String destination = parent + "/task_001";
+        String child = source + "/part-00000.parquet";
+        String movedChild = destination + "/part-00000.parquet";
+
+        // Spark creates the commit parent, but the attempt directory can be implicit:
+        // only the part file itself exists below it.
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().put("/{container}/{path}?resource=directory", CONTAINER, parent)
+            .then().statusCode(201);
+
+        createAndFlushDataLakeFile(child, "parquet-bytes");
+
+        String encodedSource = java.net.URLEncoder.encode(
+                "/" + CONTAINER + "/" + source, StandardCharsets.UTF_8);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("x-ms-rename-source", encodedSource)
+            .header("If-None-Match", "*")
+            .when().put("/{container}/{path}", CONTAINER, destination)
+            .then()
+            .statusCode(201)
+            .header("Content-Length", "0");
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .queryParam("action", "getStatus")
+            .when().head("/{container}/{path}", CONTAINER, source)
+            .then()
+            .statusCode(404)
+            .header("x-ms-error-code", "PathNotFound");
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .queryParam("action", "getStatus")
+            .when().head("/{container}/{path}", CONTAINER, destination)
+            .then()
+            .statusCode(200)
+            .header("x-ms-resource-type", "directory");
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().get("/{container}/{path}", CONTAINER, movedChild)
+            .then()
+            .statusCode(200)
+            .body(equalTo("parquet-bytes"));
+    }
+
+    @Test
+    void dataLakeRenameMovesFileAndPreservesContent() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        createAndFlushDataLakeFile("source.txt", "source-data");
+
+        String encodedSource = java.net.URLEncoder.encode(
+                "/" + CONTAINER + "/source.txt", StandardCharsets.UTF_8);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("x-ms-rename-source", encodedSource)
+            .header("If-None-Match", "*")
+            .when().put("/{container}/destination.txt", CONTAINER)
+            .then().statusCode(201);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .queryParam("action", "getStatus")
+            .when().head("/{container}/source.txt", CONTAINER)
+            .then().statusCode(404);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().get("/{container}/destination.txt", CONTAINER)
+            .then()
+            .statusCode(200)
+            .body(equalTo("source-data"));
+    }
+
+    @Test
+    void dataLakeRenameHonorsHadoopIfNoneMatchDestinationCondition() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        for (String path : new String[] {"source.txt", "destination.txt"}) {
+            createAndFlushDataLakeFile(path, path);
+        }
+
+        String encodedSource = java.net.URLEncoder.encode(
+                "/" + CONTAINER + "/source.txt", StandardCharsets.UTF_8);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("x-ms-rename-source", encodedSource)
+            .header("If-None-Match", "*")
+            .when().put("/{container}/destination.txt", CONTAINER)
+            .then()
+            .statusCode(412)
+            .contentType("application/json")
+            .header("x-ms-error-code", "ConditionNotMet")
+            .body("error.code", equalTo("ConditionNotMet"));
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().get("/{container}/source.txt", CONTAINER)
+            .then().statusCode(200).body(equalTo("source.txt"));
+    }
+
+    @Test
+    void dataLakeRenameOverwritesDestinationWhenNoConditionIsSpecified() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        createAndFlushDataLakeFile("source.txt", "new-data");
+        createAndFlushDataLakeFile("destination.txt", "old-data");
+
+        String encodedSource = java.net.URLEncoder.encode(
+                "/" + CONTAINER + "/source.txt", StandardCharsets.UTF_8);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("x-ms-rename-source", encodedSource)
+            .when().put("/{container}/destination.txt", CONTAINER)
+            .then().statusCode(201);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().get("/{container}/destination.txt", CONTAINER)
+            .then().statusCode(200).body(equalTo("new-data"));
+    }
+
+    @Test
+    void dataLakeRenameRejectsNonZeroContentLength() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().put("/{container}/source.txt?resource=file", CONTAINER)
+            .then().statusCode(201);
+        String encodedSource = java.net.URLEncoder.encode(
+                "/" + CONTAINER + "/source.txt", StandardCharsets.UTF_8);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("x-ms-rename-source", encodedSource)
+            .body("unexpected-body")
+            .when().put("/{container}/destination.txt", CONTAINER)
+            .then()
+            .statusCode(400)
+            .contentType("application/json")
+            .header("x-ms-error-code", "ContentLengthMustBeZero")
+            .body("error.code", equalTo("ContentLengthMustBeZero"));
+    }
+
+    @Test
+    void dataLakeRenameMissingSourceReturnsSourcePathNotFound() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        String encodedSource = java.net.URLEncoder.encode(
+                "/" + CONTAINER + "/missing", StandardCharsets.UTF_8);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("x-ms-rename-source", encodedSource)
+            .header("If-None-Match", "*")
+            .when().put("/{container}/destination", CONTAINER)
+            .then()
+            .statusCode(404)
+            .contentType("application/json")
+            .header("x-ms-error-code", "SourcePathNotFound")
+            .body("error.code", equalTo("SourcePathNotFound"));
+    }
+
+    @Test
+    void dataLakeRenameRequiresExistingDestinationParent() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().put("/{container}/source.txt?resource=file", CONTAINER)
+            .then().statusCode(201);
+        String encodedSource = java.net.URLEncoder.encode(
+                "/" + CONTAINER + "/source.txt", StandardCharsets.UTF_8);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("x-ms-rename-source", encodedSource)
+            .header("If-None-Match", "*")
+            .when().put("/{container}/missing-parent/destination.txt", CONTAINER)
+            .then()
+            .statusCode(404)
+            .contentType("application/json")
+            .header("x-ms-error-code", "RenameDestinationParentPathNotFound")
+            .body("error.code", equalTo("RenameDestinationParentPathNotFound"));
+    }
+
+    @Test
+    void dataLakeRenameRejectsDestinationBelowSourceDirectory() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().put("/{container}/source?resource=directory", CONTAINER)
+            .then().statusCode(201);
+        String encodedSource = java.net.URLEncoder.encode(
+                "/" + CONTAINER + "/source", StandardCharsets.UTF_8);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("x-ms-rename-source", encodedSource)
+            .when().put("/{container}/source/child", CONTAINER)
+            .then()
+            .statusCode(409)
+            .contentType("application/json")
+            .header("x-ms-error-code", "InvalidRenameSourcePath")
+            .body("error.code", equalTo("InvalidRenameSourcePath"));
+    }
+
+    @Test
     void dataLakeRecursiveRootListingReturnsNestedFiles() {
         createContainerWithDataLakePaths();
 
@@ -730,21 +1249,62 @@ public class BlobServiceTest {
     }
 
     @Test
-    void dataLakeDirectoryListingRejectsFilePath() {
+    void dataLakeListPathsReturnsExactFileForHadoopListStatus() {
         given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
 
         given()
             .header("Host", ACCOUNT + ".dfs.core.windows.net")
-            .when().put("/{container}/file?resource=file", CONTAINER)
+            .when().put("/{container}/file.csv?resource=file", CONTAINER)
             .then()
             .statusCode(201);
 
         given()
             .header("Host", ACCOUNT + ".dfs.core.windows.net")
-            .when().get("/{container}?resource=filesystem&recursive=true&directory=file", CONTAINER)
+            .header("X-Http-Method-Override", "PATCH")
+            .contentType("application/octet-stream")
+            .body("abcdef".getBytes(StandardCharsets.UTF_8))
+            .queryParam("action", "append")
+            .queryParam("position", 0)
+            .when().put("/{container}/file.csv", CONTAINER)
             .then()
-            .statusCode(404)
-            .header("x-ms-error-code", "PathNotFound");
+            .statusCode(202);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("X-Http-Method-Override", "PATCH")
+            .queryParam("action", "flush")
+            .queryParam("position", 6)
+            .queryParam("retainUncommittedData", false)
+            .queryParam("close", true)
+            .when().put("/{container}/file.csv", CONTAINER)
+            .then()
+            .statusCode(200);
+
+        // Hadoop ABFS 3.3.4 implements FileSystem.listStatus(file) by sending
+        // List Paths with directory=<file> and recursive=false. The service
+        // response must represent the existing file as a singleton PathList;
+        // returning PathNotFound breaks Hadoop/Spark file discovery.
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().get("/{container}?resource=filesystem&recursive=false&directory=file.csv", CONTAINER)
+            .then()
+            .statusCode(200)
+            .body("paths", hasSize(1))
+            .body("paths[0].name", equalTo("file.csv"))
+            .body("paths[0].isDirectory", equalTo(false))
+            .body("paths[0].contentLength", equalTo(6));
+
+        // Keep recursive=true compatible as well; callers may issue the same
+        // exact-path probe with recursive listing enabled.
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().get("/{container}?resource=filesystem&recursive=true&directory=file.csv", CONTAINER)
+            .then()
+            .statusCode(200)
+            .body("paths", hasSize(1))
+            .body("paths[0].name", equalTo("file.csv"))
+            .body("paths[0].isDirectory", equalTo(false))
+            .body("paths[0].contentLength", equalTo(6));
     }
 
     @Test
@@ -792,6 +1352,423 @@ public class BlobServiceTest {
             .then()
             .statusCode(400)
             .header("x-ms-error-code", "InvalidQueryParameterValue");
+    }
+
+    @Test
+    void dataLakeFilesystemCrudAndProperties() {
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("x-ms-properties", "environment=ZGV2")
+            .queryParam("resource", "filesystem")
+            .when().put("/{container}", CONTAINER)
+            .then()
+            .statusCode(201);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .queryParam("resource", "filesystem")
+            .when().head("/{container}", CONTAINER)
+            .then()
+            .statusCode(200)
+            .header("x-ms-properties", "environment=ZGV2");
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("X-Http-Method-Override", "PATCH")
+            .header("x-ms-properties", "environment=cHJvZA==")
+            .queryParam("resource", "filesystem")
+            .when().put("/{container}", CONTAINER)
+            .then()
+            .statusCode(200);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .queryParam("resource", "filesystem")
+            .when().head("/{container}", CONTAINER)
+            .then()
+            .statusCode(200)
+            .header("x-ms-properties", "environment=cHJvZA==");
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .queryParam("resource", "filesystem")
+            .when().delete("/{container}", CONTAINER)
+            .then()
+            .statusCode(202);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .queryParam("resource", "filesystem")
+            .when().head("/{container}", CONTAINER)
+            .then()
+            .statusCode(404)
+            .header("x-ms-error-code", "FilesystemNotFound");
+    }
+
+    @Test
+    void dataLakeRootAccessControlSupportsHnsDetectionAndRootStatus() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .queryParam("action", "getAccessControl")
+            .queryParam("upn", false)
+            .when().head("/{container}", CONTAINER)
+            .then()
+            .statusCode(200)
+            .header("x-ms-owner", DATALAKE_ID_FOR_TESTS)
+            .header("x-ms-group", DATALAKE_ID_FOR_TESTS)
+            .header("x-ms-permissions", "rwxr-x---")
+            .header("x-ms-acl", not(isEmptyOrNullString()))
+            .header("ETag", not(isEmptyOrNullString()))
+            .header("Last-Modified", not(isEmptyOrNullString()));
+
+        // Plain HEAD is getPathStatus(includeProperties=true) and is also valid on root.
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().head("/{container}", CONTAINER)
+            .then()
+            .statusCode(200)
+            .header("x-ms-resource-type", "directory")
+            .header("Content-Length", "0")
+            .header("x-ms-properties", notNullValue());
+    }
+
+    @Test
+    void dataLakeConditionalCreateSupportsHadoopDefaultOverwriteProtocol() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("If-None-Match", "*")
+            .queryParam("resource", "file")
+            .when().put("/{container}/file.txt", CONTAINER)
+            .then().statusCode(201);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("If-None-Match", "*")
+            .queryParam("resource", "file")
+            .when().put("/{container}/file.txt", CONTAINER)
+            .then()
+            .statusCode(409)
+            .header("x-ms-error-code", "PathAlreadyExists")
+            .header("x-ms-existing-resource-type", "file")
+            .body("error.code", equalTo("PathAlreadyExists"));
+
+        String etag = given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .queryParam("action", "getStatus")
+            .when().head("/{container}/file.txt", CONTAINER)
+            .then().statusCode(200)
+            .extract().header("ETag");
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("If-Match", etag)
+            .queryParam("resource", "file")
+            .when().put("/{container}/file.txt", CONTAINER)
+            .then().statusCode(201);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("If-Match", "\"wrong-etag\"")
+            .queryParam("resource", "file")
+            .when().put("/{container}/file.txt", CONTAINER)
+            .then()
+            .statusCode(412)
+            .header("x-ms-error-code", "ConditionNotMet");
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .queryParam("resource", "directory")
+            .when().put("/{container}/dir", CONTAINER)
+            .then().statusCode(201);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("If-None-Match", "*")
+            .queryParam("resource", "directory")
+            .when().put("/{container}/dir", CONTAINER)
+            .then()
+            .statusCode(409)
+            .header("x-ms-existing-resource-type", "directory");
+    }
+
+    @Test
+    void dataLakePathPropertiesPreserveFileBytesAndSupportXattrs() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        given().header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .queryParam("resource", "file")
+            .when().put("/{container}/file.txt", CONTAINER).then().statusCode(201);
+        given().header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("X-Http-Method-Override", "PATCH")
+            .contentType("application/octet-stream")
+            .body("abcdef".getBytes(StandardCharsets.UTF_8))
+            .queryParam("action", "append").queryParam("position", 0)
+            .when().put("/{container}/file.txt", CONTAINER).then().statusCode(202);
+        given().header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("X-Http-Method-Override", "PATCH")
+            .queryParam("action", "flush").queryParam("position", 6)
+            .queryParam("retainUncommittedData", false).queryParam("close", true)
+            .when().put("/{container}/file.txt", CONTAINER).then().statusCode(200);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("X-Http-Method-Override", "PATCH")
+            .header("x-ms-properties", "user.test=dmFsdWU=")
+            .queryParam("action", "setProperties")
+            .when().put("/{container}/file.txt", CONTAINER)
+            .then().statusCode(200);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().head("/{container}/file.txt", CONTAINER)
+            .then()
+            .statusCode(200)
+            .header("x-ms-properties", "user.test=dmFsdWU=")
+            .header("Content-Length", "6");
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().get("/{container}/file.txt", CONTAINER)
+            .then().statusCode(200).body(equalTo("abcdef"));
+    }
+
+    @Test
+    void dataLakeAccessControlPreservesFileBytes() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        given().header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .queryParam("resource", "file")
+            .when().put("/{container}/file.txt", CONTAINER).then().statusCode(201);
+        given().header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("X-Http-Method-Override", "PATCH")
+            .contentType("application/octet-stream").body("payload".getBytes(StandardCharsets.UTF_8))
+            .queryParam("action", "append").queryParam("position", 0)
+            .when().put("/{container}/file.txt", CONTAINER).then().statusCode(202);
+        given().header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("X-Http-Method-Override", "PATCH")
+            .queryParam("action", "flush").queryParam("position", 7)
+            .queryParam("retainUncommittedData", false).queryParam("close", true)
+            .when().put("/{container}/file.txt", CONTAINER).then().statusCode(200);
+
+        String acl = "user::rw-,user:alice:r--,group::r--,mask::r--,other::---";
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("X-Http-Method-Override", "PATCH")
+            .header("x-ms-owner", "alice")
+            .header("x-ms-group", "analytics")
+            .header("x-ms-acl", acl)
+            .queryParam("action", "setAccessControl")
+            .when().put("/{container}/file.txt", CONTAINER)
+            .then().statusCode(200);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .queryParam("action", "getAccessControl")
+            .queryParam("upn", true)
+            .when().head("/{container}/file.txt", CONTAINER)
+            .then()
+            .statusCode(200)
+            .header("x-ms-owner", "alice")
+            .header("x-ms-group", "analytics")
+            .header("x-ms-acl", acl)
+            .header("x-ms-permissions", "rw-r-----+");
+
+        // Hadoop setPermission sends an octal mode using the same setAccessControl action.
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("X-Http-Method-Override", "PATCH")
+            .header("x-ms-permissions", "0750")
+            .queryParam("action", "setAccessControl")
+            .when().put("/{container}/file.txt", CONTAINER)
+            .then().statusCode(200);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .queryParam("action", "getAccessControl")
+            .when().head("/{container}/file.txt", CONTAINER)
+            .then()
+            .statusCode(200)
+            .header("x-ms-permissions", "rwxr-x---+")
+            .header("x-ms-acl", allOf(
+                    containsString("user:alice:r--"),
+                    containsString("mask::r-x")));
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().get("/{container}/file.txt", CONTAINER)
+            .then().statusCode(200).body(equalTo("payload"));
+    }
+
+    @Test
+    void dataLakeUnknownActionCannotFallThroughAndTruncateFile() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        given().header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .queryParam("resource", "file")
+            .when().put("/{container}/file.txt", CONTAINER).then().statusCode(201);
+        given().header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("X-Http-Method-Override", "PATCH")
+            .body("abc".getBytes(StandardCharsets.UTF_8))
+            .queryParam("action", "append").queryParam("position", 0)
+            .when().put("/{container}/file.txt", CONTAINER).then().statusCode(202);
+        given().header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("X-Http-Method-Override", "PATCH")
+            .queryParam("action", "flush").queryParam("position", 3)
+            .when().put("/{container}/file.txt", CONTAINER).then().statusCode(200);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("X-Http-Method-Override", "PATCH")
+            .queryParam("action", "futureHadoopAction")
+            .when().put("/{container}/file.txt", CONTAINER)
+            .then()
+            .statusCode(501)
+            .contentType("application/json")
+            .header("x-ms-error-code", "NotImplemented");
+
+        given().header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().get("/{container}/file.txt", CONTAINER)
+            .then().statusCode(200).body(equalTo("abc"));
+    }
+
+    @Test
+    void dataLakeCheckAccessUsesHnsWireContract() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        given().header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .queryParam("resource", "file")
+            .when().put("/{container}/file.txt", CONTAINER).then().statusCode(201);
+
+        given().header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .queryParam("action", "checkAccess").queryParam("fsAction", "r--")
+            .when().head("/{container}/file.txt", CONTAINER)
+            .then().statusCode(200);
+
+        given().header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .queryParam("action", "checkAccess").queryParam("fsAction", "r--")
+            .when().head("/{container}/missing", CONTAINER)
+            .then().statusCode(404).header("x-ms-error-code", "PathNotFound");
+    }
+
+    @Test
+    void dataLakePathLeaseSupportsHadoopPostApiAndWriteGuard() {
+        String leaseId = "11111111-1111-1111-1111-111111111111";
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        given().header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .queryParam("resource", "file")
+            .when().put("/{container}/file.txt", CONTAINER).then().statusCode(201);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("x-ms-lease-action", "acquire")
+            .header("x-ms-lease-duration", "-1")
+            .header("x-ms-proposed-lease-id", leaseId)
+            .when().post("/{container}/file.txt", CONTAINER)
+            .then().statusCode(201).header("x-ms-lease-id", leaseId);
+
+        given().header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("X-Http-Method-Override", "PATCH")
+            .body("abc".getBytes(StandardCharsets.UTF_8))
+            .queryParam("action", "append").queryParam("position", 0)
+            .when().put("/{container}/file.txt", CONTAINER)
+            .then().statusCode(412).header("x-ms-error-code", "LeaseIdMissing");
+
+        given().header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("X-Http-Method-Override", "PATCH")
+            .header("x-ms-lease-id", leaseId)
+            .body("abc".getBytes(StandardCharsets.UTF_8))
+            .queryParam("action", "append").queryParam("position", 0)
+            .when().put("/{container}/file.txt", CONTAINER)
+            .then().statusCode(202);
+
+        given().header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("x-ms-lease-action", "renew").header("x-ms-lease-id", leaseId)
+            .when().post("/{container}/file.txt", CONTAINER)
+            .then().statusCode(200).header("x-ms-lease-id", leaseId);
+
+        given().header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("x-ms-lease-action", "release").header("x-ms-lease-id", leaseId)
+            .when().post("/{container}/file.txt", CONTAINER)
+            .then().statusCode(200);
+
+        given().header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("x-ms-lease-action", "acquire").header("x-ms-lease-duration", "-1")
+            .header("x-ms-proposed-lease-id", leaseId)
+            .when().post("/{container}/file.txt", CONTAINER)
+            .then().statusCode(201);
+
+        given().header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("x-ms-lease-action", "break").header("x-ms-lease-break-period", "0")
+            .when().post("/{container}/file.txt", CONTAINER)
+            .then().statusCode(202).header("x-ms-lease-time", "0");
+    }
+
+    @Test
+    void dataLakeAppendBlobSupportsSequentialHadoopAppendMode() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        given().header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .queryParam("resource", "file").queryParam("blobType", "AppendBlob")
+            .when().put("/{container}/append.log", CONTAINER).then().statusCode(201);
+
+        given().header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("X-Http-Method-Override", "PATCH")
+            .body("abc".getBytes(StandardCharsets.UTF_8))
+            .queryParam("action", "append").queryParam("position", 0)
+            .when().put("/{container}/append.log", CONTAINER)
+            .then().statusCode(202);
+
+        given().header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("X-Http-Method-Override", "PATCH")
+            .body("def".getBytes(StandardCharsets.UTF_8))
+            .queryParam("action", "append").queryParam("position", 3)
+            .queryParam("flush", true).queryParam("close", true)
+            .when().put("/{container}/append.log", CONTAINER)
+            .then().statusCode(200);
+
+        given().header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("X-Http-Method-Override", "PATCH")
+            .body("again".getBytes(StandardCharsets.UTF_8))
+            .queryParam("action", "append").queryParam("position", 3)
+            .when().put("/{container}/append.log", CONTAINER)
+            .then().statusCode(400).header("x-ms-error-code", "InvalidQueryParameterValue");
+
+        given().header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .queryParam("action", "getStatus")
+            .when().head("/{container}/append.log", CONTAINER)
+            .then().statusCode(200).header("Content-Length", "6");
+
+        given().header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .when().get("/{container}/append.log", CONTAINER)
+            .then().statusCode(200).body(equalTo("abcdef"));
+    }
+
+    @Test
+    void dataLakeListPathsAcceptsHadoopXnsStartFromContinuation() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        given().header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .queryParam("resource", "directory")
+            .when().put("/{container}/folder", CONTAINER).then().statusCode(201);
+        for (String file : new String[] {"afile", "bfile", "hfile", "ifile"}) {
+            given().header("Host", ACCOUNT + ".dfs.core.windows.net")
+                .queryParam("resource", "file")
+                .when().put("/{container}/folder/{file}", CONTAINER, file)
+                .then().statusCode(201);
+        }
+
+        // Hadoop ABFS 3.3.4 generateContinuationTokenForXns() uses
+        // Base64("<crc64> 0 <startFrom>"). CRC validation is intentionally
+        // unnecessary in the emulator; the service treats the token as opaque.
+        String token = Base64.getEncoder().encodeToString("123456789 0 hfile".getBytes(StandardCharsets.UTF_8));
+
+        given().header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .queryParam("resource", "filesystem")
+            .queryParam("recursive", false)
+            .queryParam("directory", "folder")
+            .queryParam("continuation", token)
+            .when().get("/{container}", CONTAINER)
+            .then()
+            .statusCode(200)
+            .body("paths.name", contains("folder/hfile", "folder/ifile"));
     }
 
     @Test
@@ -1647,6 +2624,38 @@ public class BlobServiceTest {
                 + "&sp=r"
                 + "&srq=operation"
                 + "&sig=" + signature;
+    }
+
+    private void createAndFlushDataLakeFile(String path, String content) {
+        byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .queryParam("resource", "file")
+            .when().put("/{container}/{path}", CONTAINER, path)
+            .then().statusCode(201);
+
+        if (bytes.length > 0) {
+            given()
+                .header("Host", ACCOUNT + ".dfs.core.windows.net")
+                .header("X-Http-Method-Override", "PATCH")
+                .contentType("application/octet-stream")
+                .body(bytes)
+                .queryParam("action", "append")
+                .queryParam("position", 0)
+                .when().put("/{container}/{path}", CONTAINER, path)
+                .then().statusCode(202);
+        }
+
+        given()
+            .header("Host", ACCOUNT + ".dfs.core.windows.net")
+            .header("X-Http-Method-Override", "PATCH")
+            .queryParam("action", "flush")
+            .queryParam("position", bytes.length)
+            .queryParam("retainUncommittedData", false)
+            .queryParam("close", true)
+            .when().put("/{container}/{path}", CONTAINER, path)
+            .then().statusCode(200);
     }
 
     private static String canonicalName(String container, String blobName) {


### PR DESCRIPTION
## Summary

Closes #266.

This PR adds ADLS Gen2 DFS endpoint support required by Apache Hadoop ABFS 3.3.4 and fixes the incorrect missing-path DELETE behavior reported in #266.

Previously, a DFS DELETE for a non-existing path could fall through to Blob Storage semantics and return:

- HTTP `404`
- `BlobNotFound`
- Blob-style XML error response

Hadoop ABFS expects ADLS Gen2 DFS semantics instead:

- HTTP `404`
- `PathNotFound`
- Data Lake JSON error response

With the correct response, Hadoop `FileSystem.delete(path, true)` returns `false` for a missing path instead of raising a `FileNotFoundException`.

While validating the fix with the real Hadoop ABFS client, additional DFS operations required by `org.apache.hadoop:hadoop-azure:3.3.4` were identified and implemented.

The resulting DFS support includes:

- filesystem create/delete and get/set filesystem properties
- HNS auto-detection and root path status/access-control requests
- file and directory create
- conditional create/overwrite using ETag / `If-Match`
- Path Read with DFS `PathNotFound` / `FilesystemNotFound` semantics
- append and flush
- path properties / Hadoop XAttrs
- owner, group, permissions and ACL metadata
- `checkAccess`
- Path Lease acquire/renew/change/release/break
- AppendBlob mode used by Hadoop
- exact-file `listStatus`
- recursive/non-recursive listing and continuation handling
- file and directory rename
- recursive/non-recursive delete
- DFS JSON error normalization
- HTTP/1.1 Host and HTTP/2 authority based DFS routing
- fail-closed routing for unsupported DFS update operations

Unsupported DFS update operations no longer fall through to generic Blob PUT handling. This prevents metadata operations such as `setProperties` or `setAccessControl` from accidentally truncating file contents.

## Type of change

- [x] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

### Hadoop ABFS

Validated using the real Apache Hadoop Azure connector:

- Apache Hadoop `3.3.4`
- `org.apache.hadoop:hadoop-common:3.3.4`
- `org.apache.hadoop:hadoop-azure:3.3.4`
- `org.apache.hadoop.fs.azurebfs.AzureBlobFileSystem`

A new `HadoopAbfsCompatibilityTest` is included in the existing Java compatibility suite.

The Docker compatibility harness maps:

`devstoreaccount1.dfs.core.windows.net -> 127.0.0.1`

and enables the test with:

`FLOCI_AZ_ABFS_LOOPBACK=true`

The test runs a local TCP forwarder from port 80 to `floci-az:4577`. This preserves Hadoop's original DFS Host header and wire shape without requiring emulator-specific routing logic in production code.

Hadoop 3.3.4 defaults `fs.azure.always.use.https=true`, including for `abfs://`. The compatibility test therefore explicitly sets:

`fs.azure.always.use.https=false`

This setting is limited to the Docker compatibility harness and does not change Floci runtime routing behavior.

The Hadoop compatibility test verifies:

- Hadoop version `3.3.4`
- real `AzureBlobFileSystem` initialization
- filesystem creation during initialization
- HNS auto-detection
- root `getFileStatus("/")`
- conditional overwrite
- Path Read
- `setXAttr` / `getXAttr` without data truncation
- exact-file `listStatus`
- rename
- missing-path delete returning `false`
- recursive cleanup

### Azure Java SDK

The Java compatibility suite was also extended with a Data Lake directory rename test using the Azure Data Lake SDK.

The compatibility module uses Azure SDK BOM `1.2.28`.

No Azure CLI operation was required for this DFS data-plane change.

### Reproducing locally

Prerequisites:

- JDK 25
- Docker

Run:

    ./mvnw test
    make test-java-compat

The Hadoop ABFS compatibility test is part of `make test-java-compat` and runs through the same Docker compatibility harness used by CI.

### Test results

Repository test suite:

    Tests run: 930
    Failures: 0
    Errors: 0
    Skipped: 0

Java compatibility suite:

    Tests run: 263
    Failures: 0
    Errors: 0
    Skipped: 2
    BUILD SUCCESS

The real Hadoop ABFS 3.3.4 compatibility test is included in the Java compatibility run and passes successfully.

### Additional external Spark validation

The implementation was additionally validated against an external Spark application stack using:

- Apache Spark `3.5.2`
- Hadoop `3.3.4`
- `org.apache.hadoop.fs.azurebfs.SecureAzureBlobFileSystem`
- `abfss://` filesystem paths

End-to-end Spark workloads were successfully exercised using:

- Avro
- CSV
- CSV.GZ
- delimited files
- JSON
- OCR
- Parquet
- XML
- XLSX

The tested application flow covered:

`source -> Bronze -> Silver -> Technical Decoupling -> Gold -> Semantic`

This validation was performed against an external Spark application stack and is supplemental to the reproducible repository test suites above.

### Scope / limitations

This PR implements the ADLS Gen2 DFS wire surface exercised by Hadoop ABFS 3.3.4. It is not intended to emulate every ADLS Gen2 behavior.

Notable limitations are documented in `docs/services/blob.md`, including:

- large recursive operations complete atomically in the local backend rather than reproducing Azure server-side batching
- the full source/destination lease and time-condition matrix is not modeled
- ACLs, owner, group and permissions are metadata-compatible, but Floci does not implement a complete POSIX authorization engine
- `checkAccess` validates path existence and request shape but does not enforce emulated POSIX ACL authorization
- ADLS close/event side effects are not emulated
- lease state is process-local

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)