### PR TITLE
fix(cosmos): evaluate array parameter membership

### DIFF
--- a/compatibility-tests/sdk-test-dotnet/CosmosCompatibilityTests.cs
+++ b/compatibility-tests/sdk-test-dotnet/CosmosCompatibilityTests.cs
@@ -57,6 +57,22 @@ public sealed class CosmosCompatibilityTests
             await Assert.That(selected.Select(item => item.Id))
                 .IsEquivalentTo(["one", "two", "three"]);
 
+            List<QueryItem> included = await ReadAll(
+                container.GetItemQueryIterator<QueryItem>(new QueryDefinition(
+                    "SELECT * FROM c WHERE ARRAY_CONTAINS(@ids, c.id)")
+                    .WithParameter("@ids", new[] { "one", "three" })), cancellationToken);
+            await Assert.That(included.Select(item => item.Id)).IsEquivalentTo(["one", "three"]);
+            List<QueryItem> excluded = await ReadAll(
+                container.GetItemQueryIterator<QueryItem>(new QueryDefinition(
+                    "SELECT * FROM c WHERE NOT ARRAY_CONTAINS(@ids, c.id)")
+                    .WithParameter("@ids", new[] { "one", "three" })), cancellationToken);
+            await Assert.That(excluded.Select(item => item.Id)).IsEquivalentTo(["two"]);
+            List<QueryItem> empty = await ReadAll(
+                container.GetItemQueryIterator<QueryItem>(new QueryDefinition(
+                    "SELECT * FROM c WHERE ARRAY_CONTAINS(@ids, c.id)")
+                    .WithParameter("@ids", Array.Empty<string>())), cancellationToken);
+            await Assert.That(empty.Count).IsEqualTo(0);
+
             List<QueryItem> ordered = await ReadAll(
                 container.GetItemQueryIterator<QueryItem>("SELECT * FROM c ORDER BY c.rank"),
                 cancellationToken);

--- a/docs/services/cosmos.md
+++ b/docs/services/cosmos.md
@@ -15,7 +15,8 @@ Compatible with the `azure-cosmos` SDK (Java, Python, JavaScript, .NET).
   - `ORDER BY field [ASC|DESC]`, multiple fields — like Azure, an `ORDER BY` over two or more properties requires a matching composite index on the container, otherwise the query fails with `400 BadRequest` (error `SC2104`)
   - `OFFSET n LIMIT m` pagination
   - `SELECT VALUE COUNT(1)` aggregation
-  - Named parameters (`@param`)
+  - Named parameters (`@param`), including array values in `ARRAY_CONTAINS(@values, c.field)`;
+    both membership arguments may be expressions, and `NOT ARRAY_CONTAINS(...)` excludes matches
 - **System properties** — `_rid`, `_self`, `_etag`, `_ts`, `_attachments` auto-generated on every write
 - **Partition keys** — resolved from `x-ms-documentdb-partitionkey` header or extracted from document body using the container's configured path
 

--- a/src/main/java/io/floci/az/services/cosmos/CosmosQueryEngine.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosQueryEngine.java
@@ -157,8 +157,6 @@ public class CosmosQueryEngine {
                     + "(?:\\s+WHERE\\s+(.+))?\\s*\\)");
     private static final Pattern DOTNET_WRAPPED_COUNT_PATTERN = Pattern.compile(
             "(?i)^SELECT\\s+VALUE\\s+\\[\\{\\s*\"item\"\\s*:\\s*COUNT\\s*\\((?:1|\\*)\\)\\s*}]\\s+FROM\\b");
-    private static final Pattern DOTNET_ORDER_BY_ITEM_PATTERN = Pattern.compile(
-            "\\{\\s*\"item\"\\s*:\\s*(.+)\\s*}", Pattern.CASE_INSENSITIVE);
 
     ParsedQuery parse(String sql) {
         String upper = sql.toUpperCase();
@@ -423,12 +421,10 @@ public class CosmosQueryEngine {
             return Pattern.compile(regex, pFlags).matcher(s).find();
         }
 
-        // ARRAY_CONTAINS(field, value [, partial])
-        m = Pattern.compile("(?i)ARRAY_CONTAINS\\s*\\(([^,]+),\\s*(.+?)(?:,\\s*(true|false))?\\s*\\)").matcher(pred);
+        // Both arguments are expressions: the array may itself be a parameter or literal.
+        m = Pattern.compile("(?i)ARRAY_CONTAINS\\s*\\(.*\\)").matcher(pred);
         if (m.matches()) {
-            Object arr  = resolve(doc, m.group(1).trim());
-            Object srch = parseLiteral(m.group(2).trim());
-            return arr instanceof List<?> list && list.stream().anyMatch(item -> objectEquals(item, srch));
+            return Boolean.TRUE.equals(resolveExpr(doc, pred));
         }
 
         // field IN (val1, val2, …)
@@ -662,17 +658,30 @@ public class CosmosQueryEngine {
 
     private String substituteParams(String sql, List<Map<String, Object>> params) {
         if (params == null || params.isEmpty()) return sql;
+        Map<String, String> literals = new HashMap<>();
         for (Map<String, Object> p : params) {
             String name  = (String) p.get("name");
-            Object value = p.get("value");
-            if (name == null) continue;
-            sql = sql.replace(name, toLiteral(value));
+            if (name != null) {
+                literals.put(name, toLiteral(p.get("value")));
+            }
         }
-        return sql;
+        // Match complete parameter tokens, never text within literals or replacement values.
+        Matcher tokens = Pattern.compile("'(?:(?:'')|[^'])*'|\"(?:(?:\"\")|[^\"])*\"|@[A-Za-z_][A-Za-z0-9_]*")
+                .matcher(sql);
+        return tokens.replaceAll(match -> Matcher.quoteReplacement(
+                literals.getOrDefault(match.group(), match.group())));
     }
 
     private String toLiteral(Object value) {
         if (value == null)             return "null";
+        if (value instanceof List<?> list) {
+            return list.stream().map(this::toLiteral).collect(Collectors.joining(",", "[", "]"));
+        }
+        if (value instanceof Map<?, ?> map) {
+            return map.entrySet().stream()
+                    .map(entry -> toLiteral(String.valueOf(entry.getKey())) + ":" + toLiteral(entry.getValue()))
+                    .collect(Collectors.joining(",", "{", "}"));
+        }
         // Escape embedded quotes with SQL-standard doubling ('') rather than a
         // backslash escape.  A doubled quote keeps the string scanners' state
         // balanced across the literal boundary (they exit then immediately
@@ -712,7 +721,9 @@ public class CosmosQueryEngine {
     }
 
     private String normalizeWhitespace(String s) {
-        return s.trim().replaceAll("\\s+", " ");
+        Matcher tokens = Pattern.compile("'(?:(?:'')|[^'])*'|\"(?:(?:\"\")|[^\"])*\"|\\s+").matcher(s.trim());
+        return tokens.replaceAll(match -> Matcher.quoteReplacement(
+                Character.isWhitespace(match.group().charAt(0)) ? " " : match.group()));
     }
 
     // -----------------------------------------------------------------------
@@ -831,20 +842,25 @@ public class CosmosQueryEngine {
         if ("false".equalsIgnoreCase(expr)) return Boolean.FALSE;
 
         if (expr.startsWith("[") && expr.endsWith("]")) {
-            List<Map<String, Object>> items = new ArrayList<>();
-            for (String rawItem : splitTopLevel(expr.substring(1, expr.length() - 1), ',')) {
-                Matcher orderByItem = DOTNET_ORDER_BY_ITEM_PATTERN.matcher(rawItem.trim());
-                if (!orderByItem.matches()) {
-                    items.clear();
-                    break;
+            String content = expr.substring(1, expr.length() - 1).trim();
+            if (content.isEmpty()) {
+                return List.of();
+            }
+            return splitTopLevel(content, ',').stream().map(item -> resolveExpr(doc, item)).toList();
+        }
+        if (expr.startsWith("{") && expr.endsWith("}")) {
+            Map<String, Object> object = new LinkedHashMap<>();
+            String content = expr.substring(1, expr.length() - 1).trim();
+            if (!content.isEmpty()) {
+                for (String property : splitTopLevel(content, ',')) {
+                    List<String> pair = splitTopLevel(property, ':');
+                    if (pair.size() != 2) {
+                        throw new IllegalArgumentException("Invalid object expression: " + expr);
+                    }
+                    object.put(stripQuotes(pair.get(0).trim()), resolveExpr(doc, pair.get(1)));
                 }
-                Map<String, Object> item = new LinkedHashMap<>();
-                item.put("item", resolveExpr(doc, orderByItem.group(1).trim()));
-                items.add(item);
             }
-            if (!items.isEmpty()) {
-                return items;
-            }
+            return object;
         }
 
         // Numeric literal
@@ -989,6 +1005,8 @@ public class CosmosQueryEngine {
             case "RAND"    -> Math.random();
 
             // ── Array functions ───────────────────────────────────────────
+            case "ARRAY_CONTAINS" -> a0 instanceof List<?> list
+                    && list.stream().anyMatch(item -> objectEquals(item, a1));
             case "ARRAY_LENGTH" -> a0 instanceof List<?> list ? (long) list.size() : null;
 
             case "ARRAY_SLICE" -> {

--- a/src/test/java/io/floci/az/services/cosmos/CosmosQueryEngineArrayContainsTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosQueryEngineArrayContainsTest.java
@@ -1,0 +1,57 @@
+package io.floci.az.services.cosmos;
+
+import org.junit.jupiter.api.Test;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class CosmosQueryEngineArrayContainsTest {
+    private final CosmosQueryEngine engine = new CosmosQueryEngine();
+
+    @Test
+    void parameterArrayMatchesFieldAndNegationExcludesIt() {
+        var docs = List.of(Map.<String, Object>of("id", "alice"), Map.<String, Object>of("id", "bob"));
+        var params = List.of(Map.<String, Object>of("name", "@ids", "value", List.of("alice")));
+        assertEquals(List.of("alice"), engine.execute(
+                "SELECT VALUE c.id FROM c WHERE ARRAY_CONTAINS(@ids, c.id)", params, docs).items());
+        assertEquals(List.of("bob"), engine.execute(
+                "SELECT VALUE c.id FROM c WHERE NOT ARRAY_CONTAINS(@ids, c.id)", params, docs).items());
+    }
+
+    @Test
+    void preservesArrayElementTypesAndEmptyArrays() {
+        var docs = List.of(Map.<String, Object>of("value", 1), Map.<String, Object>of("value", "1"),
+                Map.<String, Object>of("value", true));
+        assertEquals(List.of(1, true), engine.execute(
+                "SELECT VALUE c.value FROM c WHERE ARRAY_CONTAINS(@values, c.value)",
+                List.of(Map.of("name", "@values", "value", List.of(1.0, true))), docs).items());
+        assertEquals(List.of(), engine.execute(
+                "SELECT * FROM c WHERE ARRAY_CONTAINS(@values, c.value)",
+                List.of(Map.of("name", "@values", "value", List.of())), docs).items());
+        assertEquals(List.of("one"), engine.execute(
+                "SELECT VALUE c.id FROM c WHERE ARRAY_CONTAINS(@values, null)",
+                List.of(Map.of("name", "@values", "value", Arrays.asList((Object) null))),
+                List.of(Map.of("id", "one"))).items());
+    }
+
+    @Test
+    void handlesQuotedStringsWhitespaceAndParameterNamesInsideValues() {
+        var values = List.of("comma,value", "Alice's", "two  spaces", "@ids", "a\"quote", "AND OR ORDER BY");
+        var docs = values.stream().map(value -> Map.<String, Object>of("id", value)).toList();
+        assertEquals(values, engine.execute(
+                "SELECT VALUE c.id FROM c WHERE ARRAY_CONTAINS(@idsLong, c.id)",
+                List.of(Map.of("name", "@ids", "value", List.of("wrong")),
+                        Map.of("name", "@idsLong", "value", values)), docs).items());
+    }
+
+    @Test
+    void supportsDocumentArraysLiteralArraysAndFunctionArguments() {
+        var docs = List.of(Map.<String, Object>of("id", "alice", "ids", List.of("alice", "bob")));
+        for (String predicate : List.of("ARRAY_CONTAINS(c.ids, c.id)",
+                "ARRAY_CONTAINS(['bob', 'alice'], c.id)",
+                "ARRAY_CONTAINS(c.ids, 'alice')", "ARRAY_CONTAINS(['ALICE'], UPPER(c.id))")) {
+            assertEquals(docs, engine.execute("SELECT * FROM c WHERE " + predicate, List.of(), docs).items());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Cosmos queries using `ARRAY_CONTAINS(@ids, c.id)` returned no matches because array parameters lost their structure and membership arguments were treated as a field and a literal. Evaluate both arguments as expressions, preserve typed array/object values, and support negated membership through the existing predicate evaluator.

Parameter substitution now matches complete tokens outside quoted strings. Array values containing commas, apostrophes, repeated spaces or parameter-looking text retain their contents. General array/object expression evaluation also preserves the existing .NET ORDER BY wrapper support.

Closes #274

## Type of change

- [x] Bug fix (`fix:`)

## Azure Compatibility

Verified through Microsoft.Azure.Cosmos 3.62.0 in Gateway mode against the packaged JVM emulator. Added SDK assertions for included IDs, excluded IDs and empty arrays. Updated the supported-query documentation.

## Validation

- Four new regression tests failed before the fix and pass afterward.
- Focused query tests: 20 passed, including existing ORDER BY and EXISTS coverage.
- Full Java suite: 890 tests passed; Maven packaging succeeded.
- .NET Cosmos compatibility suites: 2 passed against this branch's packaged emulator, including transactional batch coverage.
- Full diff reviewed and `git diff --check` passed. Native image and other language SDK suites were not run.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
