### PR TITLE
fix(blob): validate shared-key service SAS

### DIFF
--- a/compatibility-tests/sdk-test-dotnet/BlobServiceSasCompatibilityTests.cs
+++ b/compatibility-tests/sdk-test-dotnet/BlobServiceSasCompatibilityTests.cs
@@ -3,6 +3,8 @@ using Azure.Storage;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Sas;
+using System.Net;
+using System.Net.Sockets;
 
 namespace FlociAz.Compatibility;
 
@@ -14,9 +16,16 @@ public sealed class BlobServiceSasCompatibilityTests
     public async Task ServiceSasReadsAndUploadsWithAccountKey(CancellationToken cancellationToken)
     {
         string endpoint = Environment.GetEnvironmentVariable("FLOCI_AZ_ENDPOINT") ?? "http://localhost:4577";
+        // Storage SDKs identify account-in-path endpoints by IP; Docker DNS names use host-style parsing.
+        var endpointUri = new UriBuilder(endpoint);
+        if (endpointUri.Uri.HostNameType == UriHostNameType.Dns)
+        {
+            IPAddress[] addresses = await Dns.GetHostAddressesAsync(endpointUri.Host, cancellationToken);
+            endpointUri.Host = addresses.First(address => address.AddressFamily == AddressFamily.InterNetwork).ToString();
+        }
         var credentials = new StorageSharedKeyCredential("devstoreaccount1",
             "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==");
-        var service = new BlobServiceClient(new Uri($"{endpoint}/devstoreaccount1"), credentials);
+        var service = new BlobServiceClient(new Uri($"{endpointUri.Uri.AbsoluteUri.TrimEnd('/')}/devstoreaccount1"), credentials);
         var container = service.GetBlobContainerClient($"dotnet-sas-{Guid.NewGuid():N}");
         await container.CreateAsync(PublicAccessType.None, cancellationToken: cancellationToken);
         try

--- a/compatibility-tests/sdk-test-dotnet/BlobServiceSasCompatibilityTests.cs
+++ b/compatibility-tests/sdk-test-dotnet/BlobServiceSasCompatibilityTests.cs
@@ -1,0 +1,59 @@
+using Azure;
+using Azure.Storage;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Models;
+using Azure.Storage.Sas;
+
+namespace FlociAz.Compatibility;
+
+[NotInParallel]
+public sealed class BlobServiceSasCompatibilityTests
+{
+    [Test]
+    [Timeout(60_000)]
+    public async Task ServiceSasReadsAndUploadsWithAccountKey(CancellationToken cancellationToken)
+    {
+        string endpoint = Environment.GetEnvironmentVariable("FLOCI_AZ_ENDPOINT") ?? "http://localhost:4577";
+        var credentials = new StorageSharedKeyCredential("devstoreaccount1",
+            "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==");
+        var service = new BlobServiceClient(new Uri($"{endpoint}/devstoreaccount1"), credentials);
+        var container = service.GetBlobContainerClient($"dotnet-sas-{Guid.NewGuid():N}");
+        await container.CreateAsync(PublicAccessType.None, cancellationToken: cancellationToken);
+        try
+        {
+            var blob = container.GetBlobClient("file.txt");
+            await blob.UploadAsync(BinaryData.FromString("original"), cancellationToken);
+            Uri readUri = blob.GenerateSasUri(BlobSasPermissions.Read, DateTimeOffset.UtcNow.AddHours(1));
+            var signedReader = new BlobClient(readUri);
+            var content = await signedReader.DownloadContentAsync(cancellationToken);
+            await Assert.That(content.Value.Content.ToString()).IsEqualTo("original");
+
+            var upload = container.GetBlobClient("direct.txt");
+            var sas = new BlobSasBuilder
+            {
+                BlobContainerName = container.Name, BlobName = upload.Name, Resource = "b",
+                StartsOn = DateTimeOffset.UtcNow.AddMinutes(-5),
+                ExpiresOn = DateTimeOffset.UtcNow.AddHours(1)
+            };
+            sas.SetPermissions(BlobSasPermissions.Create | BlobSasPermissions.Write);
+            await new BlobClient(upload.GenerateSasUri(sas))
+                .UploadAsync(BinaryData.FromString("uploaded"), cancellationToken);
+            var uploaded = await upload.DownloadContentAsync(cancellationToken);
+            await Assert.That(uploaded.Value.Content.ToString()).IsEqualTo("uploaded");
+
+            try
+            {
+                await signedReader.DeleteAsync(cancellationToken: cancellationToken);
+                throw new InvalidOperationException("Read-only SAS unexpectedly authorized deletion");
+            }
+            catch (RequestFailedException error)
+            {
+                await Assert.That(error.Status).IsEqualTo(403);
+            }
+        }
+        finally
+        {
+            await container.DeleteAsync(cancellationToken: cancellationToken);
+        }
+    }
+}

--- a/compatibility-tests/sdk-test-dotnet/SdkTestDotnet.csproj
+++ b/compatibility-tests/sdk-test-dotnet/SdkTestDotnet.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.4.0" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.11.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.29.2" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/docs/configuration/advanced/application-yml.md
+++ b/docs/configuration/advanced/application-yml.md
@@ -94,3 +94,17 @@ floci-az:
 | `FLOCI_AZ_SERVICES_APP_CONFIG_ENABLED` | `true` | Enable/disable App Configuration |
 | `FLOCI_AZ_SERVICES_FUNCTIONS_CODE_PATH` | `~/.floci-az/functions` | Function code directory |
 | `FLOCI_AZ_DOCKER_DOCKER_HOST` | `unix:///var/run/docker.sock` | Docker daemon socket |
+
+Blob service SAS signing keys are configured per account (independent of `auth.mode`):
+
+```yaml
+floci-az:
+  auth:
+    storage-account-keys:
+      myaccount: "<base64-account-key>"
+```
+
+`devstoreaccount1` defaults to the standard Azurite account key. For that existing entry, the
+environment override is `FLOCI_AZ_AUTH_STORAGE_ACCOUNT_KEYS_DEVSTOREACCOUNT1`.
+Use YAML to declare additional account names. User delegation SAS keeps its separate,
+process-local signing keys.

--- a/docs/services/blob.md
+++ b/docs/services/blob.md
@@ -124,7 +124,8 @@ floci-az:
   different key. Unknown accounts and invalid signatures are rejected, including in dev mode,
   as are expired tokens and operations outside the granted permissions. This is separate from
   the permissive Shared Key `Authorization` header behavior above.
-  SDK-generated user delegation SAS tokens
+  Shared-key service SAS supports directory scope (`sr=d`). Directory service SAS requires
+  `sdd` and version 2020-02-10 or later. SDK-generated user delegation SAS tokens
   for container (`sr=c`), blob (`sr=b`), and ADLS directory (`sr=d`) resources are validated.
   Account SAS, stored access policies, IP/protocol restrictions, and the full SAS feature matrix
   are not fully modeled. User delegation keys are protected by a process-local secret, so SAS

--- a/docs/services/blob.md
+++ b/docs/services/blob.md
@@ -118,7 +118,13 @@ floci-az:
   authentication/SAS authorization remains the emulator's access-control boundary.
 - **ADLS close/event semantics are storage-only** - `close=true` is accepted and committed data is
   immediately visible, but Azure Event Grid/change-notification side effects are not emulated.
-- **SAS enforcement is scoped to user delegation SAS** — SDK-generated user delegation SAS tokens
+- **SAS enforcement supports shared-key service SAS and user delegation SAS.** Service SAS
+  signatures use `floci-az.auth.storage-account-keys`, a map from account names to base64 keys.
+  The default `devstoreaccount1` entry is the standard Azurite key; override it when clients use a
+  different key. Unknown accounts and invalid signatures are rejected, including in dev mode,
+  as are expired tokens and operations outside the granted permissions. This is separate from
+  the permissive Shared Key `Authorization` header behavior above.
+  SDK-generated user delegation SAS tokens
   for container (`sr=c`), blob (`sr=b`), and ADLS directory (`sr=d`) resources are validated.
   Account SAS, stored access policies, IP/protocol restrictions, and the full SAS feature matrix
   are not fully modeled. User delegation keys are protected by a process-local secret, so SAS

--- a/src/main/java/io/floci/az/config/EmulatorConfig.java
+++ b/src/main/java/io/floci/az/config/EmulatorConfig.java
@@ -516,6 +516,9 @@ public interface EmulatorConfig {
         /** dev: accept any credentials. strict: validate HMAC-SHA256 signatures. */
         @WithDefault("dev")
         String mode();
+
+        /** Base64 account keys used to validate shared-key Blob service SAS signatures. */
+        java.util.Map<String, String> storageAccountKeys();
     }
 
     interface AppConfigServiceConfig {

--- a/src/main/java/io/floci/az/core/auth/StorageSasAuthorization.java
+++ b/src/main/java/io/floci/az/core/auth/StorageSasAuthorization.java
@@ -87,6 +87,11 @@ public class StorageSasAuthorization {
             // Stored access policies need their own lookup and revocation semantics.
             return Optional.of(authenticationFailed());
         }
+        if (!token.isUserDelegation() && "d".equals(token.resource())
+                && (token.directoryDepth() == null
+                    || LocalDate.parse(token.version()).isBefore(LocalDate.parse("2020-02-10")))) {
+            return Optional.of(authenticationFailed());
+        }
         if (!signatureMatches(request, container, path, token)) {
             return Optional.of(authenticationFailed());
         }

--- a/src/main/java/io/floci/az/core/auth/StorageSasAuthorization.java
+++ b/src/main/java/io/floci/az/core/auth/StorageSasAuthorization.java
@@ -2,6 +2,7 @@ package io.floci.az.core.auth;
 
 import io.floci.az.core.AzureErrorResponse;
 import io.floci.az.core.AzureRequest;
+import io.floci.az.config.EmulatorConfig;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.core.Response;
@@ -24,10 +25,17 @@ public class StorageSasAuthorization {
     private static final String HMAC_SHA256 = "HmacSHA256";
 
     private final UserDelegationKeyMaterial keyMaterial;
+    private final java.util.Map<String, String> storageAccountKeys;
 
     @Inject
-    public StorageSasAuthorization(UserDelegationKeyMaterial keyMaterial) {
+    public StorageSasAuthorization(UserDelegationKeyMaterial keyMaterial, EmulatorConfig config) {
         this.keyMaterial = keyMaterial;
+        this.storageAccountKeys = java.util.Map.copyOf(config.auth().storageAccountKeys());
+        for (String key : storageAccountKeys.values()) {
+            if (Base64.getDecoder().decode(key).length == 0) {
+                throw new IllegalArgumentException("Storage account SAS signing keys must not be empty");
+            }
+        }
     }
 
     public Optional<Response> authorizeRead(AzureRequest request, String container, String path, StorageSasToken token) {
@@ -72,7 +80,11 @@ public class StorageSasAuthorization {
                 || token.delegatedUserTenantId() != null || token.delegatedUserObjectId() != null) {
             return Optional.of(authenticationFailed());
         }
-        if (!delegationKeyValid(token)) {
+        if (token.isUserDelegation() && !delegationKeyValid(token)) {
+            return Optional.of(authenticationFailed());
+        }
+        if (!token.isUserDelegation() && token.identifier() != null) {
+            // Stored access policies need their own lookup and revocation semantics.
             return Optional.of(authenticationFailed());
         }
         if (!signatureMatches(request, container, path, token)) {
@@ -110,11 +122,34 @@ public class StorageSasAuthorization {
 
     private boolean signatureMatches(AzureRequest request, String container, String path, StorageSasToken token) {
         String canonicalName = canonicalName(request.accountName(), container, signedPath(token, path));
-        String expected = hmac(keyMaterial.signingKeyForAccount(request.accountName()), stringToSign(request, token, canonicalName));
+        String key = token.isUserDelegation()
+                ? keyMaterial.signingKeyForAccount(request.accountName())
+                : storageAccountKeys.get(request.accountName());
+        if (key == null) {
+            return false;
+        }
+        String signedFields = token.isUserDelegation()
+                ? stringToSign(request, token, canonicalName)
+                : serviceStringToSign(token, canonicalName);
+        String expected = hmac(key, signedFields);
         return MessageDigest.isEqual(
                 expected.getBytes(StandardCharsets.UTF_8),
                 token.signature().getBytes(StandardCharsets.UTF_8)
         );
+    }
+
+    // Service SAS has its own layout; delegation-key and agent fields are not included.
+    private static String serviceStringToSign(StorageSasToken token, String canonicalName) {
+        var fields = new java.util.ArrayList<>(Arrays.asList(
+                value(token.permissions()), value(token.startTime()), value(token.expiryTime()),
+                canonicalName, value(token.identifier()), value(token.ipRange()), value(token.protocol()),
+                value(token.version()), value(token.resource()), value(token.snapshotTime())));
+        if (!LocalDate.parse(token.version()).isBefore(LocalDate.parse("2020-12-06"))) {
+            fields.add(value(token.encryptionScope()));
+        }
+        fields.addAll(Arrays.asList(value(token.cacheControl()), value(token.contentDisposition()),
+                value(token.contentEncoding()), value(token.contentLanguage()), value(token.contentType())));
+        return String.join("\n", fields);
     }
 
     private static String signedPath(StorageSasToken token, String requestPath) {

--- a/src/main/java/io/floci/az/core/auth/StorageSasToken.java
+++ b/src/main/java/io/floci/az/core/auth/StorageSasToken.java
@@ -98,6 +98,11 @@ public record StorageSasToken(
         return permissions != null && permissions.indexOf(permission) >= 0;
     }
 
+    public boolean isUserDelegation() {
+        return signedObjectId != null || signedTenantId != null || signedKeyStart != null
+                || signedKeyExpiry != null || signedKeyService != null || signedKeyVersion != null;
+    }
+
     public boolean hasAnyPermission(char... candidates) {
         for (char candidate : candidates) {
             if (hasPermission(candidate)) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -246,3 +246,5 @@ floci-az:
     # dev: accept any credentials without signature validation
     # strict: validate HMAC-SHA256 signatures
     mode: dev
+    storage-account-keys:
+      devstoreaccount1: "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="

--- a/src/test/java/io/floci/az/services/BlobServiceSasTest.java
+++ b/src/test/java/io/floci/az/services/BlobServiceSasTest.java
@@ -58,6 +58,38 @@ class BlobServiceSasTest {
     }
 
     @Test
+    void directoryServiceSasScopesDescendantsAndListing() throws Exception {
+        for (String path : new String[] {"dir/file", "dir/sub/leaf", "sibling/file", "directory/file"}) {
+            given().header("x-ms-blob-type", "BlockBlob").body(path)
+                    .put(BASE + "/" + path).then().statusCode(201);
+        }
+        var sas = sas("rl", "d", "dir", "2020-02-10");
+        sas.put("sdd", "1");
+        for (String path : new String[] {"dir/file", "dir/sub/leaf"}) {
+            given().queryParams(sas).get(BASE + "/" + path).then().statusCode(200).body(equalTo(path));
+        }
+        given().queryParams(sas).queryParam("resource", "filesystem").queryParam("recursive", "true")
+                .queryParam("directory", "dir").get(BASE).then().statusCode(200)
+                .body("paths.name", org.hamcrest.Matchers.containsInAnyOrder("dir/file", "dir/sub/leaf"));
+        for (String path : new String[] {"sibling/file", "directory/file", "file"}) {
+            given().queryParams(sas).get(BASE + "/" + path).then().statusCode(403);
+        }
+        given().queryParams(sas).queryParam("resource", "filesystem").queryParam("recursive", "true")
+                .get(BASE).then().statusCode(403);
+    }
+
+    @Test
+    void directoryServiceSasRequiresDepthAndSupportedVersion() throws Exception {
+        var missingDepth = sas("l", "d", "dir", "2020-02-10");
+        given().queryParams(missingDepth).queryParam("resource", "filesystem")
+                .queryParam("directory", "dir").get(BASE).then().statusCode(403);
+        var oldVersion = sas("l", "d", "dir", "2018-11-09");
+        oldVersion.put("sdd", "1");
+        given().queryParams(oldVersion).queryParam("resource", "filesystem")
+                .queryParam("directory", "dir").get(BASE).then().statusCode(403);
+    }
+
+    @Test
     void incompleteDelegationTokenCannotFallBackToServiceSigning() throws Exception {
         var sas = sas("r", "b", "file", "2020-12-06");
         sas.put("sktid", "incomplete-delegation");

--- a/src/test/java/io/floci/az/services/BlobServiceSasTest.java
+++ b/src/test/java/io/floci/az/services/BlobServiceSasTest.java
@@ -1,0 +1,82 @@
+package io.floci.az.services;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+@QuarkusTest
+class BlobServiceSasTest {
+    private static final String KEY = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+    private static final String BASE = "/devstoreaccount1/service-sas";
+
+    @BeforeEach
+    void setup() {
+        given().post("/_admin/reset").then().statusCode(204);
+        given().put(BASE + "?restype=container").then().statusCode(201);
+        given().header("x-ms-blob-type", "BlockBlob").body("original")
+                .put(BASE + "/file").then().statusCode(201);
+    }
+
+    @Test
+    void serviceSasReadsAndCreatesBlobsAcrossSigningVersions() throws Exception {
+        for (String version : new String[] {"2018-11-09", "2020-02-10", "2020-12-06", "2026-04-06"}) {
+            given().queryParams(sas("r", "b", "file", version)).get(BASE + "/file")
+                    .then().statusCode(200).body(equalTo("original"));
+            given().queryParams(sas("cw", "b", version, version))
+                    .header("x-ms-blob-type", "BlockBlob").body("uploaded")
+                    .put(BASE + "/" + version).then().statusCode(201);
+        }
+    }
+
+    @Test
+    void containerSasReadsChildrenAndLists() throws Exception {
+        var sas = sas("rl", "c", null, "2020-12-06");
+        given().queryParams(sas).get(BASE + "/file").then().statusCode(200);
+        given().queryParams(sas).queryParam("restype", "container").queryParam("comp", "list")
+                .get(BASE).then().statusCode(200);
+    }
+
+    @Test
+    void rejectsWrongSignatureResourceAndPermissions() throws Exception {
+        var sas = sas("r", "b", "file", "2020-12-06");
+        given().queryParams(sas).get(BASE + "/another").then().statusCode(403);
+        given().queryParams(sas).body("overwrite").put(BASE + "/file").then()
+                .statusCode(403).header("x-ms-error-code", "AuthorizationPermissionMismatch");
+        sas.put("sig", "invalid");
+        given().queryParams(sas).get(BASE + "/file").then().statusCode(403);
+    }
+
+    @Test
+    void incompleteDelegationTokenCannotFallBackToServiceSigning() throws Exception {
+        var sas = sas("r", "b", "file", "2020-12-06");
+        sas.put("sktid", "incomplete-delegation");
+        given().queryParams(sas).get(BASE + "/file").then().statusCode(403);
+    }
+
+    private Map<String, String> sas(String permissions, String resource, String path, String version) throws Exception {
+        String expiry = Instant.now().plusSeconds(3600).toString();
+        String canonical = "/blob/devstoreaccount1/service-sas" + (path == null ? "" : "/" + path);
+        String fields = permissions + "\n\n" + expiry + "\n" + canonical + "\n\n\n\n" + version
+                + "\n" + resource + "\n";
+        if (version.compareTo("2020-12-06") >= 0) {
+            fields += "\n";
+        }
+        fields += "\n\n\n\n\n";
+        Mac mac = Mac.getInstance("HmacSHA256");
+        mac.init(new SecretKeySpec(Base64.getDecoder().decode(KEY), "HmacSHA256"));
+        var query = new LinkedHashMap<>(Map.of("sv", version, "sp", permissions, "sr", resource, "se", expiry));
+        query.put("sig", Base64.getEncoder().encodeToString(mac.doFinal(fields.getBytes(StandardCharsets.UTF_8))));
+        return query;
+    }
+}

--- a/src/test/java/io/floci/az/services/BlobServiceSasTest.java
+++ b/src/test/java/io/floci/az/services/BlobServiceSasTest.java
@@ -68,25 +68,29 @@ class BlobServiceSasTest {
         for (String path : new String[] {"dir/file", "dir/sub/leaf"}) {
             given().queryParams(sas).get(BASE + "/" + path).then().statusCode(200).body(equalTo(path));
         }
-        given().queryParams(sas).queryParam("resource", "filesystem").queryParam("recursive", "true")
-                .queryParam("directory", "dir").get(BASE).then().statusCode(200)
+        given().header("Host", "devstoreaccount1.dfs.core.windows.net")
+                .queryParams(sas).queryParam("resource", "filesystem").queryParam("recursive", "true")
+                .queryParam("directory", "dir").get("/service-sas").then().statusCode(200)
                 .body("paths.name", org.hamcrest.Matchers.containsInAnyOrder("dir/file", "dir/sub/leaf"));
         for (String path : new String[] {"sibling/file", "directory/file", "file"}) {
             given().queryParams(sas).get(BASE + "/" + path).then().statusCode(403);
         }
-        given().queryParams(sas).queryParam("resource", "filesystem").queryParam("recursive", "true")
-                .get(BASE).then().statusCode(403);
+        given().header("Host", "devstoreaccount1.dfs.core.windows.net")
+                .queryParams(sas).queryParam("resource", "filesystem").queryParam("recursive", "true")
+                .get("/service-sas").then().statusCode(403);
     }
 
     @Test
     void directoryServiceSasRequiresDepthAndSupportedVersion() throws Exception {
         var missingDepth = sas("l", "d", "dir", "2020-02-10");
-        given().queryParams(missingDepth).queryParam("resource", "filesystem")
-                .queryParam("directory", "dir").get(BASE).then().statusCode(403);
+        given().header("Host", "devstoreaccount1.dfs.core.windows.net")
+                .queryParams(missingDepth).queryParam("resource", "filesystem")
+                .queryParam("directory", "dir").get("/service-sas").then().statusCode(403);
         var oldVersion = sas("l", "d", "dir", "2018-11-09");
         oldVersion.put("sdd", "1");
-        given().queryParams(oldVersion).queryParam("resource", "filesystem")
-                .queryParam("directory", "dir").get(BASE).then().statusCode(403);
+        given().header("Host", "devstoreaccount1.dfs.core.windows.net")
+                .queryParams(oldVersion).queryParam("resource", "filesystem")
+                .queryParam("directory", "dir").get("/service-sas").then().statusCode(403);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Blob service SAS generated with `StorageSharedKeyCredential` was rejected because SAS authorization always required user delegation fields. Validate shared-key service SAS using its own versioned string-to-sign and a configured account key, while retaining the existing user delegation validation path.

Add `floci-az.auth.storage-account-keys`, defaulting `devstoreaccount1` to the standard Azurite key. Valid signatures authorize only the signed resource and granted operations. Unknown accounts, invalid signatures and incomplete delegation tokens are rejected, including in dev mode. Document configuration and the existing unsupported SAS features.

Closes #275

## Type of change

- [x] Bug fix (`fix:`)

## Azure Compatibility

Verified with Azure.Storage.Blobs 12.29.2 against the packaged JVM emulator: SDK-generated read SAS downloads an existing blob; create/write SAS uploads a new blob; read-only SAS cannot delete it. REST regression coverage includes blob and container resources and signing versions 2018-11-09, 2020-02-10, 2020-12-06 and 2026-04-06.

Directory service SAS is independently verified for descendant reads/listing, sibling and prefix rejection, and required depth/version fields. Account SAS and stored access policies remain unsupported. This change preserves the existing user delegation and permission enforcement behavior. The .NET compatibility test resolves Docker DNS endpoints to an IP address so the SDK uses account-in-path URI parsing.

## Validation

- New regression tests before implementation: 3 failed, 1 passed; all 4 pass after the fix.
- Focused Blob/SAS tests: 82 passed, including existing user delegation tests.
- `./mvnw -q -Dquarkus.http.test-port=0 package`: 892 tests passed and packaging succeeded.
- .NET build: no warnings or errors. Real SDK compatibility test: 1 passed, including a run from Docker using a DNS endpoint against the packaged JVM emulator.
- Full diff reviewed and `git diff --check` passed. Native image and other language SDK suites were not run.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
