### PR TITLE
fix(cosmos): honor query partition scope

### DIFF
--- a/compatibility-tests/sdk-test-dotnet/CosmosCompatibilityTests.cs
+++ b/compatibility-tests/sdk-test-dotnet/CosmosCompatibilityTests.cs
@@ -107,6 +107,17 @@ public sealed class CosmosCompatibilityTests
                     requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey("missing") }),
                 cancellationToken);
             await Assert.That(missingPartition.Count).IsEqualTo(0);
+            try
+            {
+                await container.CreateItemAsync(new QueryItem("wrong-partition", "b", 4),
+                    new PartitionKey("a"), cancellationToken: cancellationToken);
+                throw new InvalidOperationException("A mismatched partition header unexpectedly authorized a write");
+            }
+            catch (CosmosException error)
+            {
+                await Assert.That(error.StatusCode).IsEqualTo(System.Net.HttpStatusCode.BadRequest);
+                await Assert.That(error.SubStatusCode).IsEqualTo(1001);
+            }
         }
         finally
         {

--- a/compatibility-tests/sdk-test-dotnet/CosmosCompatibilityTests.cs
+++ b/compatibility-tests/sdk-test-dotnet/CosmosCompatibilityTests.cs
@@ -85,6 +85,28 @@ public sealed class CosmosCompatibilityTests
                         .WithParameter("@pk", "b")),
                 cancellationToken);
             await Assert.That(crossPartition.Select(item => item.Id)).IsEquivalentTo(["two"]);
+
+            var partitionOptions = new QueryRequestOptions
+            {
+                PartitionKey = new PartitionKey("a"),
+                MaxItemCount = 1
+            };
+            List<QueryItem> scoped = await ReadAll(
+                container.GetItemQueryIterator<QueryItem>(
+                    "SELECT * FROM c ORDER BY c.rank", requestOptions: partitionOptions),
+                cancellationToken);
+            await Assert.That(scoped.Select(item => item.Id)).IsEquivalentTo(["one", "three"]);
+            await Assert.That(scoped[0].Id).IsEqualTo("three");
+            List<int> scopedCounts = await ReadAll(
+                container.GetItemQueryIterator<int>(
+                    "SELECT VALUE COUNT(1) FROM c", requestOptions: partitionOptions),
+                cancellationToken);
+            await Assert.That(scopedCounts).IsEquivalentTo([2]);
+            List<QueryItem> missingPartition = await ReadAll(
+                container.GetItemQueryIterator<QueryItem>("SELECT * FROM c",
+                    requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey("missing") }),
+                cancellationToken);
+            await Assert.That(missingPartition.Count).IsEqualTo(0);
         }
         finally
         {

--- a/docs/services/cosmos.md
+++ b/docs/services/cosmos.md
@@ -23,6 +23,8 @@ Queries with `x-ms-documentdb-partitionkey` (including .NET `QueryRequestOptions
 are scoped to the configured logical partition before SQL filtering, aggregation, ordering and
 pagination. Key values retain their JSON types; `[null]` and `[{}]` select null and undefined
 keys respectively. Omitting the header permits cross-partition queries. Malformed scopes return 400.
+Writes reject partition headers that disagree with the document body, and patches cannot change
+partition-key values. Transactional batches enforce the same rules before committing staged writes.
 
 ### .NET query planner configuration
 

--- a/docs/services/cosmos.md
+++ b/docs/services/cosmos.md
@@ -19,6 +19,11 @@ Compatible with the `azure-cosmos` SDK (Java, Python, JavaScript, .NET).
 - **System properties** — `_rid`, `_self`, `_etag`, `_ts`, `_attachments` auto-generated on every write
 - **Partition keys** — resolved from `x-ms-documentdb-partitionkey` header or extracted from document body using the container's configured path
 
+Queries with `x-ms-documentdb-partitionkey` (including .NET `QueryRequestOptions.PartitionKey`)
+are scoped to the configured logical partition before SQL filtering, aggregation, ordering and
+pagination. Key values retain their JSON types; `[null]` and `[{}]` select null and undefined
+keys respectively. Omitting the header permits cross-partition queries. Malformed scopes return 400.
+
 ### .NET query planner configuration
 
 The account response advertises query-engine capabilities. Floci-AZ emits 20 keys, while the

--- a/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
@@ -610,6 +610,10 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         boolean upsert = "True".equalsIgnoreCase(req.headers().getHeaderString("x-ms-documentdb-is-upsert"));
 
         Map<String, Object> collMeta = parseData(collFound.get());
+        Response partitionFailure = partitionKeyFailure(req, collMeta, body);
+        if (partitionFailure != null) {
+            return partitionFailure;
+        }
         String pk     = resolvePartitionKey(body, collMeta, req);
         String pkEnc  = encodeKey(pk);
         String docKey = docKey(req.accountName(), dbId, collId, pkEnc, id);
@@ -650,6 +654,10 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         body.put("id", docId);
 
         Map<String, Object> collMeta = parseData(collFound.get());
+        Response partitionFailure = partitionKeyFailure(req, collMeta, body);
+        if (partitionFailure != null) {
+            return partitionFailure;
+        }
         String pk     = resolvePartitionKey(body, collMeta, req);
         String pkEnc  = encodeKey(pk);
         String docKey = docKey(req.accountName(), dbId, collId, pkEnc, docId);
@@ -694,6 +702,12 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
 
         Map<String, Object> doc = parseData(obj);
 
+        Map<String, Object> collMeta = parseData(store.get(collKey(req.accountName(), dbId, collId)).orElseThrow());
+        Response partitionFailure = partitionKeyFailure(req, collMeta, doc);
+        if (partitionFailure != null) {
+            return partitionFailure;
+        }
+
         // The Cosmos DB PATCH body can arrive in two forms:
         //   1. {"operations": [...]}  — Java / Python SDKs
         //   2. [{op, path, value}, …] — Node SDK (sends the array directly)
@@ -703,6 +717,9 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
             return errorResponse(412, "PreconditionFailed", "The patch filter predicate was not satisfied.");
         }
         applyPatchOperations(doc, patch.operations());
+        if (!CosmosQueryPartition.samePartition(parseData(obj), doc, collMeta)) {
+            return errorResponse(400, "BadRequest", "The partition key cannot be changed by a patch.");
+        }
 
         Instant now  = Instant.now();
         String  etag = newEtag();
@@ -853,6 +870,7 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
 
         String pkEnc = encodeKey(extractPartitionKeyValue(req));
         Object defaultTtl = containerDefaultTtl(collFound);
+        Map<String, Object> collMeta = parseData(collFound.get());
 
         List<Map<String, Object>> operations;
         boolean hybridRow;
@@ -882,7 +900,10 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
             String ifMatch = op.get("ifMatch") instanceof String value ? value : null;
             String ifNoneMatch = op.get("ifNoneMatch") instanceof String value ? value : null;
 
-            Map<String, Object> result = switch (opType) {
+            StoredObject beforeWrite = staged.get(docKey(req.accountName(), dbId, collId, pkEnc, docId));
+            boolean partitionMismatch = body != null && Set.of("Create", "Upsert", "Replace").contains(opType)
+                    && partitionKeyFailure(req, collMeta, body) != null;
+            Map<String, Object> result = partitionMismatch ? batchResultError(400) : switch (opType) {
                 case "Create"  -> batchCreate(staged, req.accountName(), dbId, collId, pkEnc, body, false,
                         defaultTtl, ifMatch, ifNoneMatch);
                 case "Upsert"  -> batchCreate(staged, req.accountName(), dbId, collId, pkEnc, body, true,
@@ -896,6 +917,16 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
                         defaultTtl, ifMatch, ifNoneMatch);
                 default        -> batchResultError(400);
             };
+            // Patches must preserve the partition even when the request omits its partition header.
+            if (((Number) result.get("statusCode")).intValue() < 400
+                    && "Patch".equals(opType)) {
+                Map<String, Object> written = (Map<String, Object>) result.get("resourceBody");
+                if (partitionKeyFailure(req, collMeta, written) != null
+                        || (beforeWrite != null && !CosmosQueryPartition.samePartition(
+                                parseData(beforeWrite), written, collMeta))) {
+                    result = batchResultError(400);
+                }
+            }
             results.add(result);
 
             if (((Number) result.get("statusCode")).intValue() >= 400) {
@@ -1289,6 +1320,21 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
     // -----------------------------------------------------------------------
     // Partition key helpers
     // -----------------------------------------------------------------------
+
+    private Response partitionKeyFailure(AzureRequest req, Map<String, Object> container,
+            Map<String, Object> document) {
+        try {
+            if (!CosmosQueryPartition.parse(
+                    req.headers().getHeaderString("x-ms-documentdb-partitionkey"), container).test(document)) {
+                return Response.fromResponse(errorResponse(400, "BadRequest",
+                        "PartitionKey extracted from document doesn't match the one specified in the header"))
+                        .header("x-ms-substatus", "1001").build();
+            }
+        } catch (IllegalArgumentException e) {
+            return errorResponse(400, "BadRequest", e.getMessage());
+        }
+        return null;
+    }
 
     private String extractPartitionKeyValue(AzureRequest req) {
         String header = req.headers().getHeaderString("x-ms-documentdb-partitionkey");

--- a/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
@@ -1147,7 +1147,15 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         List<Map<String, Object>> allDocs =
                 liveDocuments(req.accountName(), dbId, collId, containerDefaultTtl(collFound));
 
-        CosmosQueryEngine.QueryResult result = queryEngine.execute(parsed, allDocs);
+        final List<Map<String, Object>> scopedDocs;
+        try {
+            scopedDocs = allDocs.stream().filter(CosmosQueryPartition.parse(
+                    req.headers().getHeaderString("x-ms-documentdb-partitionkey"),
+                    parseData(collFound.get()))).toList();
+        } catch (IllegalArgumentException e) {
+            return errorResponse(400, "BadRequest", e.getMessage());
+        }
+        CosmosQueryEngine.QueryResult result = queryEngine.execute(parsed, scopedDocs);
 
         // ---- Pagination ----
         int maxItemCount = parseMaxItemCount(req.headers().getHeaderString("x-ms-max-item-count"));

--- a/src/main/java/io/floci/az/services/cosmos/CosmosQueryPartition.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosQueryPartition.java
@@ -15,6 +15,25 @@ final class CosmosQueryPartition {
 
     private CosmosQueryPartition() {}
 
+    static boolean samePartition(Map<String, Object> before, Map<String, Object> after,
+            Map<String, Object> container) {
+        JsonNode original = MAPPER.valueToTree(before);
+        JsonNode updated = MAPPER.valueToTree(after);
+        JsonNode paths = MAPPER.valueToTree(container).path("partitionKey").path("paths");
+        for (JsonNode path : paths) {
+            JsonNode left = original.at(path.asText());
+            JsonNode right = updated.at(path.asText());
+            if (left.isNumber() && right.isNumber()) {
+                if (left.decimalValue().compareTo(right.decimalValue()) != 0) {
+                    return false;
+                }
+            } else if (!left.equals(right)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     static Predicate<Map<String, Object>> parse(String header, Map<String, Object> container) {
         if (header == null) {
             return document -> true;

--- a/src/main/java/io/floci/az/services/cosmos/CosmosQueryPartition.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosQueryPartition.java
@@ -1,0 +1,59 @@
+package io.floci.az.services.cosmos;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+
+/** Logical partition scope applied before SQL evaluation, including aggregates and paging. */
+final class CosmosQueryPartition {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private CosmosQueryPartition() {}
+
+    static Predicate<Map<String, Object>> parse(String header, Map<String, Object> container) {
+        if (header == null) {
+            return document -> true;
+        }
+        final JsonNode values;
+        try {
+            values = MAPPER.reader().with(DeserializationFeature.FAIL_ON_TRAILING_TOKENS).readTree(header);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Invalid x-ms-documentdb-partitionkey JSON", e);
+        }
+        JsonNode paths = MAPPER.valueToTree(container).path("partitionKey").path("paths");
+        if (values == null || !values.isArray() || values.isEmpty() || values.size() != paths.size()) {
+            throw new IllegalArgumentException("Partition key must contain one value for each configured path");
+        }
+        for (JsonNode value : values) {
+            if (!(value.isValueNode() || (value.isObject() && value.isEmpty()))) {
+                throw new IllegalArgumentException("Invalid partition key value");
+            }
+        }
+        List<String> pointers = MAPPER.convertValue(paths,
+                MAPPER.getTypeFactory().constructCollectionType(List.class, String.class));
+        return document -> {
+            JsonNode item = MAPPER.valueToTree(document);
+            for (int i = 0; i < pointers.size(); i++) {
+                JsonNode actual = item.at(pointers.get(i));
+                JsonNode expected = values.get(i);
+                boolean matches;
+                if (expected.isObject()) {
+                    matches = actual.isMissingNode();
+                } else if (actual.isNumber() && expected.isNumber()) {
+                    matches = actual.decimalValue().compareTo(expected.decimalValue()) == 0;
+                } else {
+                    matches = actual.equals(expected);
+                }
+                if (!matches) {
+                    return false;
+                }
+            }
+            return true;
+        };
+    }
+}

--- a/src/test/java/io/floci/az/services/cosmos/CosmosQueryPartitionTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosQueryPartitionTest.java
@@ -1,0 +1,101 @@
+package io.floci.az.services.cosmos;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@QuarkusTest
+class CosmosQueryPartitionTest {
+    private static final String DB = "/partitionacct-cosmos/dbs/queryscope";
+    private static final String DOCS = DB + "/colls/items/docs";
+
+    @BeforeEach
+    void setup() {
+        given().post("/_admin/reset").then().statusCode(204);
+        given().contentType("application/json").body(Map.of("id", "queryscope"))
+                .post("/partitionacct-cosmos/dbs").then().statusCode(201);
+        given().contentType("application/json").body("""
+                {"id":"items","partitionKey":{"paths":["/tenant/key"],"kind":"Hash"}}
+                """).post(DB + "/colls").then().statusCode(201);
+        insert("a1", "\"alice\"", 2);
+        insert("b1", "\"bob\"", 0);
+        insert("a2", "\"alice\"", 1);
+    }
+
+    @Test
+    void scopesRowsBeforeAggregationAndPagination() {
+        query("SELECT * FROM c", "[\"alice\"]", null).then()
+                .body("Documents.id", containsInAnyOrder("a1", "a2"));
+        query("SELECT VALUE COUNT(1) FROM c", "[\"alice\"]", null).then()
+                .body("Documents", contains(2));
+        String sql = "SELECT * FROM c ORDER BY c.rank";
+        Response first = query(sql, "[\"alice\"]", null);
+        first.then().body("Documents.id", contains("a2"));
+        query(sql, "[\"alice\"]", first.header("x-ms-continuation")).then()
+                .body("Documents.id", contains("a1"))
+                .header("x-ms-continuation", nullValue());
+        query("SELECT TOP 1 * FROM c ORDER BY c.rank", "[\"alice\"]", null)
+                .then().body("Documents.id", contains("a2"));
+    }
+
+    @Test
+    void missingPartitionIsEmptyAndUnscopedQueriesStillCrossPartitions() {
+        query("SELECT * FROM c", "[\"nobody\"]", null).then().body("_count", is(0));
+        query("SELECT * FROM c", null, null).then()
+                .body("Documents.id", containsInAnyOrder("a1", "a2", "b1"));
+    }
+
+    @Test
+    void preservesPartitionValueTypes() {
+        insert("number", "1", 3);
+        insert("string", "\"1\"", 4);
+        insert("null", "null", 5);
+        insert("boolean", "true", 6);
+        given().contentType("application/json").body("{\"id\":\"missing\"}")
+                .post(DOCS).then().statusCode(201);
+        query("SELECT * FROM c", "[1.0]", null).then().body("Documents.id", contains("number"));
+        query("SELECT * FROM c", "[\"1\"]", null).then().body("Documents.id", contains("string"));
+        query("SELECT * FROM c", "[null]", null).then().body("Documents.id", contains("null"));
+        query("SELECT * FROM c", "[true]", null).then().body("Documents.id", contains("boolean"));
+        query("SELECT * FROM c", "[{}]", null).then().body("Documents.id", contains("missing"));
+    }
+
+    @Test
+    void malformedScopeDoesNotBecomeCrossPartitionQuery() {
+        for (String scope : new String[] {"oops", "{}", "[]", "[[]]", "[{\"x\":1}]", "[1,2]"}) {
+            given().contentType("application/query+json")
+                    .header("x-ms-documentdb-isquery", "true")
+                    .header("x-ms-documentdb-partitionkey", scope)
+                    .body(Map.of("query", "SELECT * FROM c"))
+                    .post(DOCS).then().statusCode(400);
+        }
+    }
+
+    private void insert(String id, String key, int rank) {
+        given().contentType("application/json")
+                .header("x-ms-documentdb-partitionkey", "[" + key + "]")
+                .body("{\"id\":\"%s\",\"tenant\":{\"key\":%s},\"rank\":%d}".formatted(id, key, rank))
+                .post(DOCS).then().statusCode(201);
+    }
+
+    private Response query(String sql, String scope, String continuation) {
+        var request = given().contentType("application/query+json")
+                .header("x-ms-documentdb-isquery", "true").body(Map.of("query", sql));
+        if (scope != null) {
+            request.header("x-ms-documentdb-partitionkey", scope);
+        }
+        if (sql.equals("SELECT * FROM c ORDER BY c.rank")) {
+            request.header("x-ms-max-item-count", "1");
+        }
+        if (continuation != null) {
+            request.header("x-ms-continuation", continuation);
+        }
+        return request.post(DOCS).then().statusCode(200).extract().response();
+    }
+}

--- a/src/test/java/io/floci/az/services/cosmos/CosmosQueryPartitionTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosQueryPartitionTest.java
@@ -67,6 +67,36 @@ class CosmosQueryPartitionTest {
     }
 
     @Test
+    void rejectsWritesWhoseHeaderDisagreesWithDocumentPartition() {
+        String body = "{\"id\":\"a1\",\"tenant\":{\"key\":\"bob\"}}";
+        given().contentType("application/json").header("x-ms-documentdb-partitionkey", "[\"alice\"]")
+                .body(body).post(DOCS).then().statusCode(400);
+        given().contentType("application/json").header("x-ms-documentdb-partitionkey", "[\"alice\"]")
+                .header("x-ms-documentdb-is-upsert", "true").body(body).post(DOCS).then().statusCode(400);
+        given().contentType("application/json").header("x-ms-documentdb-partitionkey", "[\"alice\"]")
+                .body(body).put(DOCS + "/a1").then().statusCode(400);
+        query("SELECT * FROM c", "[\"alice\"]", null).then()
+                .body("Documents.id", containsInAnyOrder("a1", "a2"));
+        query("SELECT * FROM c", "[\"bob\"]", null).then().body("Documents.id", contains("b1"));
+    }
+
+    @Test
+    void rejectsPartitionChangesThroughPatchAndTransactionalBatch() {
+        String patch = "{\"operations\":[{\"op\":\"set\",\"path\":\"/tenant/key\",\"value\":\"bob\"}]}";
+        given().contentType("application/json").header("x-ms-documentdb-partitionkey", "[\"alice\"]")
+                .body(patch).patch(DOCS + "/a1").then().statusCode(400);
+        for (String operation : new String[] {"Create", "Upsert", "Replace", "Patch"}) {
+            String body = operation.equals("Patch") ? patch : "{\"id\":\"a1\",\"tenant\":{\"key\":\"bob\"}}";
+            given().contentType("application/json").header("x-ms-documentdb-partitionkey", "[\"alice\"]")
+                    .header("x-ms-cosmos-is-batch-request", "true")
+                    .body("[{\"operationType\":\"%s\",\"id\":\"a1\",\"resourceBody\":%s}]".formatted(operation, body))
+                    .post(DOCS).then().body("[0].statusCode", is(400));
+        }
+        query("SELECT * FROM c", "[\"alice\"]", null).then()
+                .body("Documents.id", containsInAnyOrder("a1", "a2"));
+    }
+
+    @Test
     void malformedScopeDoesNotBecomeCrossPartitionQuery() {
         for (String scope : new String[] {"oops", "{}", "[]", "[[]]", "[{\"x\":1}]", "[1,2]"}) {
             given().contentType("application/query+json")


### PR DESCRIPTION
## Summary

Cosmos queries ignored `x-ms-documentdb-partitionkey`, allowing a scoped query to return and count documents from other logical partitions. Apply the request scope before SQL evaluation so filtering, aggregation, ordering, TOP and continuation pages all use only the requested partition.

Resolve configured nested partition paths and preserve JSON key types, including the distinction between null and undefined. Malformed scopes return 400 instead of becoming cross-partition queries. Requests without a partition header retain cross-partition behavior. Create, upsert and replace reject mismatched partition headers with 400 / substatus 1001; patches cannot mutate partition values. Transactional batches enforce the same rules before committing.

Closes #273

## Type of change

- [x] Bug fix (`fix:`)

## Azure Compatibility

Verified with Microsoft.Azure.Cosmos 3.62.0 in Gateway mode against this branch's packaged JVM emulator. Added SDK checks for `QueryRequestOptions.PartitionKey`, ordered continuation pages, scoped counts and an empty nonexistent partition. Added HTTP tests for typed nested keys and malformed headers; updated the query documentation.

## Validation

- All four new HTTP regression tests failed before the fix and pass afterward.
- .NET Cosmos compatibility suites: 2 passed, including transactional batch coverage.
- Maven packaging succeeded.
- Final full run with `./mvnw -q -Dquarkus.http.test-port=0 package`: 892 tests passed, zero failures or errors. Two additional failing-first tests cover partition consistency across normal writes, patches and transactional batches; the .NET SDK suite verifies the mismatch response.
- Initial full Java suite: 890 tests, one failure in the untouched `SqlProvisioningServiceTest.boundsRetainedTerminalOperations:145`. Its focused rerun and a full run on unchanged upstream both passed. SQL retention sorts completion timestamps from a ConcurrentHashMap; tied timestamps can disagree with this test's assumption that the first submitted operation is evicted. No SQL code or tests were changed or suppressed.
- Full diff reviewed and `git diff --check` passed. Native image and other language SDK suites were not run.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
