### PR TITLE
fix: normalize Key Vault route trailing slashes

### DIFF
--- a/compatibility-tests/sdk-test-dotnet/KeyVaultCompatibilityTests.cs
+++ b/compatibility-tests/sdk-test-dotnet/KeyVaultCompatibilityTests.cs
@@ -1,0 +1,103 @@
+using Azure.Core;
+using Azure.Core.Pipeline;
+using Azure.Extensions.AspNetCore.Configuration.Secrets;
+using Azure.Security.KeyVault.Secrets;
+using Microsoft.Extensions.Configuration;
+
+namespace FlociAz.Compatibility;
+
+public sealed class KeyVaultCompatibilityTests
+{
+    private static readonly Uri EmulatorEndpoint = new(
+        Environment.GetEnvironmentVariable("FLOCI_AZ_ENDPOINT") ?? "http://localhost:4577");
+
+    [Test]
+    [Timeout(60_000)]
+    public async Task ListsSecretsAndLoadsConfiguration(CancellationToken cancellationToken)
+    {
+        using var httpClient = new HttpClient(new EmulatorHandler());
+        var vaultUri = new UriBuilder(EmulatorEndpoint)
+        {
+            Scheme = "https",
+            Path = $"/kv{Guid.NewGuid():N}-keyvault"
+        };
+        var client = new SecretClient(vaultUri.Uri, new FakeCredential(), new SecretClientOptions
+        {
+            DisableChallengeResourceVerification = true,
+            Transport = new HttpClientTransport(httpClient)
+        });
+
+        await Assert.That(client.GetPropertiesOfSecrets(cancellationToken).Any()).IsFalse();
+        // Explicit dates isolate routing from the emulator's existing null timestamp incompatibility.
+        await client.SetSecretAsync(new KeyVaultSecret("App--Message", "hello")
+        {
+            Properties =
+            {
+                NotBefore = DateTimeOffset.UtcNow.AddMinutes(-1),
+                ExpiresOn = DateTimeOffset.UtcNow.AddHours(1)
+            }
+        }, cancellationToken);
+
+        try
+        {
+            var names = client.GetPropertiesOfSecrets(cancellationToken)
+                .Select(secret => secret.Name).ToList();
+            await Assert.That(names).IsEquivalentTo(["App--Message"]);
+
+            var asyncNames = new List<string>();
+            await foreach (var secret in client.GetPropertiesOfSecretsAsync(cancellationToken))
+            {
+                asyncNames.Add(secret.Name);
+            }
+            await Assert.That(asyncNames).IsEquivalentTo(["App--Message"]);
+
+            using var configuration = new ConfigurationManager();
+            configuration.AddAzureKeyVault(client, new AzureKeyVaultConfigurationOptions());
+            await Assert.That(configuration["App:Message"]).IsEqualTo("hello");
+        }
+        finally
+        {
+            await client.StartDeleteSecretAsync("App--Message", cancellationToken);
+            await client.PurgeDeletedSecretAsync("App--Message", cancellationToken);
+        }
+    }
+
+    private sealed class FakeCredential : TokenCredential
+    {
+        public override AccessToken GetToken(
+            TokenRequestContext requestContext, CancellationToken cancellationToken) =>
+            new("fake-token-for-local-emulator", DateTimeOffset.UtcNow.AddHours(1));
+
+        public override ValueTask<AccessToken> GetTokenAsync(
+            TokenRequestContext requestContext, CancellationToken cancellationToken) =>
+            ValueTask.FromResult(GetToken(requestContext, cancellationToken));
+    }
+
+    // Keep HTTPS in the SDK pipeline for challenge authentication; use the configured
+    // emulator scheme only at the transport boundary, as in the Python compat suite.
+    private sealed class EmulatorHandler() : DelegatingHandler(new HttpClientHandler())
+    {
+        protected override HttpResponseMessage Send(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RewriteUri(request);
+            return base.Send(request, cancellationToken);
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RewriteUri(request);
+            return base.SendAsync(request, cancellationToken);
+        }
+
+        private static void RewriteUri(HttpRequestMessage request)
+        {
+            request.RequestUri = new UriBuilder(request.RequestUri!)
+            {
+                Scheme = EmulatorEndpoint.Scheme,
+                Port = EmulatorEndpoint.Port
+            }.Uri;
+        }
+    }
+}

--- a/compatibility-tests/sdk-test-dotnet/SdkTestDotnet.csproj
+++ b/compatibility-tests/sdk-test-dotnet/SdkTestDotnet.csproj
@@ -8,8 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.4.0" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.11.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="TUnit" Version="1.63.0" />
   </ItemGroup>

--- a/docs/services/key-vault.md
+++ b/docs/services/key-vault.md
@@ -10,6 +10,7 @@ Compatible with `azure-keyvault-secrets` SDKs (Python, Java, JavaScript, .NET).
 - **Properties update** — update `content_type`, `tags`, `enabled`, `nbf`, `exp` without changing the value
 - **Attributes** — `enabled`, `not_before`, `expires_on`; disabled secrets return 403 on get
 - **List operations** — list active secrets, deleted secrets, or versions of a specific secret
+- **Optional trailing slash** — fixed routes (`/secrets`, `/deletedsecrets`, `/certificates/contacts`) accept a trailing slash, including .NET `AddAzureKeyVault` configuration loading
 - **Backup** — backup a secret (base64-encoded blob)
 - **32-char hex version IDs** — matches Azure's version ID format
 

--- a/src/main/java/io/floci/az/services/keyvault/KeyVaultHandler.java
+++ b/src/main/java/io/floci/az/services/keyvault/KeyVaultHandler.java
@@ -69,6 +69,8 @@ public class KeyVaultHandler implements AzureServiceHandler, Resettable {
     @Override
     public Response handle(AzureRequest req) {
         String path = req.resourcePath();
+        // Normalize fixed-route comparisons only; preserve the original path for resource parsing.
+        String routePath = path.endsWith("/") ? path.substring(0, path.length() - 1) : path;
         String method = req.method().toUpperCase();
         String account = req.accountName();
 
@@ -87,20 +89,20 @@ public class KeyVaultHandler implements AzureServiceHandler, Resettable {
         }
 
         // Root probe — azurerm provider polls this to confirm the vault is reachable.
-        if (path.isEmpty() || path.equals("/")) {
+        if (routePath.isEmpty()) {
             return Response.ok(java.util.Map.of(
                 "type", "Microsoft.KeyVault/vaults",
                 "id",   "https://" + account + ".vault.azure.net/"
             )).build();
         }
 
-        if ("secrets".equals(path)) {
+        if ("secrets".equals(routePath)) {
             return "GET".equals(method) ? listSecrets(account) : methodNotAllowed();
         }
         if (path.startsWith("secrets/")) {
             return handleSecrets(req, method, account, path.substring("secrets/".length()));
         }
-        if ("deletedsecrets".equals(path)) {
+        if ("deletedsecrets".equals(routePath)) {
             return "GET".equals(method) ? listDeletedSecrets(account) : methodNotAllowed();
         }
         if (path.startsWith("deletedsecrets/")) {
@@ -109,7 +111,7 @@ public class KeyVaultHandler implements AzureServiceHandler, Resettable {
 
         // Certificate contacts — azurerm provider reads this after key vault creation.
         // Return an empty contacts list so the provider sees no contacts configured.
-        if ("certificates/contacts".equals(path)) {
+        if ("certificates/contacts".equals(routePath)) {
             if ("GET".equals(method)) {
                 return Response.ok(java.util.Map.of(
                     "id", "https://" + account + ".vault.azure.net/certificates/contacts",

--- a/src/test/java/io/floci/az/services/keyvault/KeyVaultServiceTest.java
+++ b/src/test/java/io/floci/az/services/keyvault/KeyVaultServiceTest.java
@@ -1,0 +1,114 @@
+package io.floci.az.services.keyvault;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.nullValue;
+
+@QuarkusTest
+class KeyVaultServiceTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {"secrets", "secrets/"})
+    void listSecretsWithOptionalTrailingSlash(String path) {
+        String vault = "/kv" + UUID.randomUUID().toString().replace("-", "") + "-keyvault/";
+
+        given().header("Authorization", "Bearer test-token")
+                .queryParam("api-version", "7.4")
+                .when().get(vault + path)
+                .then().statusCode(200)
+                .body("value", hasSize(0))
+                .body("nextLink", nullValue());
+
+        given().header("Authorization", "Bearer test-token")
+                .contentType("application/json")
+                .body(Map.of("value", "secret-value", "contentType", "text/plain"))
+                .when().put(vault + "secrets/example?api-version=7.4")
+                .then().statusCode(200);
+
+        try {
+            String expected = given().header("Authorization", "Bearer test-token")
+                    .when().get(vault + "secrets?api-version=7.4")
+                    .then().statusCode(200).extract().asString();
+
+            given().header("Authorization", "Bearer test-token")
+                    .queryParam("api-version", "7.4")
+                    .when().get(vault + path)
+                    .then().statusCode(200)
+                    .body(equalTo(expected))
+                    .body("value", hasSize(1))
+                    .body("value[0].id", containsString("/secrets/example"))
+                    .body("value[0].contentType", equalTo("text/plain"))
+                    .body("value[0].value", nullValue());
+        } finally {
+            given().header("Authorization", "Bearer test-token")
+                    .when().delete(vault + "secrets/example").then().statusCode(200);
+            given().header("Authorization", "Bearer test-token")
+                    .when().delete(vault + "deletedsecrets/example").then().statusCode(204);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"deletedsecrets", "deletedsecrets/"})
+    void listDeletedSecretsWithOptionalTrailingSlash(String path) {
+        String vault = "/kv" + UUID.randomUUID().toString().replace("-", "") + "-keyvault/";
+        given().header("Authorization", "Bearer test-token")
+                .contentType("application/json").body(Map.of("value", "secret-value"))
+                .when().put(vault + "secrets/example").then().statusCode(200);
+        given().header("Authorization", "Bearer test-token")
+                .when().delete(vault + "secrets/example").then().statusCode(200);
+        try {
+            given().header("Authorization", "Bearer test-token")
+                    .when().get(vault + path + "?api-version=7.4")
+                    .then().statusCode(200)
+                    .body("value", hasSize(1))
+                    .body("value[0].id", containsString("/secrets/example"));
+        } finally {
+            given().header("Authorization", "Bearer test-token")
+                    .when().delete(vault + "deletedsecrets/example").then().statusCode(204);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"", "deletedsecrets", "certificates/contacts"})
+    void fixedRoutesAcceptOptionalTrailingSlash(String path) {
+        String url = "/kv" + UUID.randomUUID().toString().replace("-", "") + "-keyvault"
+                + (path.isEmpty() ? "" : "/" + path);
+        String expected = given().header("Authorization", "Bearer test-token")
+                .when().get(url + "?api-version=7.4")
+                .then().statusCode(200).extract().asString();
+
+        given().header("Authorization", "Bearer test-token")
+                .when().get(url + "/?api-version=7.4")
+                .then().statusCode(200).body(equalTo(expected));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"secrets", "secrets/", "deletedsecrets", "deletedsecrets/",
+            "certificates/contacts", "certificates/contacts/"})
+    void fixedRoutesRequireAuthentication(String path) {
+        given().when().get("/devstoreaccount1-keyvault/" + path + "?api-version=7.4")
+                .then().statusCode(401)
+                .header("WWW-Authenticate", containsString("Bearer"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"POST", "PUT", "PATCH", "DELETE"})
+    void fixedRoutesRejectNonGetMethods(String method) {
+        for (String path : new String[]{"secrets", "secrets/", "deletedsecrets", "deletedsecrets/",
+                "certificates/contacts", "certificates/contacts/"}) {
+            given().header("Authorization", "Bearer test-token")
+                    .contentType("application/json").body(Map.of("value", "invalid"))
+                    .when().request(method, "/devstoreaccount1-keyvault/" + path + "?api-version=7.4")
+                    .then().statusCode(405);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Key Vault treated `GET /secrets/` as a lookup for an empty secret name, returning `SecretNotFound` and breaking .NET `AddAzureKeyVault` configuration loading.

Normalize one optional trailing slash for every fixed-route equality check in `KeyVaultHandler`, covering secrets, deleted secrets, certificate contacts, and the root probe. Preserve the original path for named-resource parsing and leave other services' paths untouched.

Closes #238.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

Azure.Security.KeyVault.Secrets 4.11.0 uses `/secrets/` and `/deletedsecrets/` collection paths. Added .NET coverage for empty and populated listing, synchronous and asynchronous enumeration, and `AddAzureKeyVault` configuration loading. HTTP regressions cover optional slashes, populated deleted-secret listings, authentication challenges, and method restrictions.

The .NET fixture sets explicit validity dates to isolate this routing regression from an existing, separate failure when the emulator emits null timestamp attributes. Timestamp serialization is addressed separately in #280.

## Validation

All relevant checks passed against the rebuilt emulator:

- `./mvnw package -Dtest=KeyVaultServiceTest,AzureRoutingFilterTest,DisabledServiceRoutingTest`: 38 tests.
- .NET Key Vault compatibility test: 1 test.
- Java Key Vault compatibility suite: 17 tests.
- Python Key Vault compatibility suite: 24 tests.
- JavaScript Key Vault compatibility suite: 14 tests.
- `git diff --check`.

Before the fix, the new HTTP regressions reproduced the 404 listing failure and incorrect acceptance of collection writes.

## Checklist

- [ ] `./mvnw test` passes locally (focused tests and relevant SDK suites run; full suite not run)
- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits

