### PR TITLE
fix: omit unset Key Vault timestamps

### DIFF
--- a/compatibility-tests/sdk-test-dotnet/KeyVaultTimestampCompatibilityTests.cs
+++ b/compatibility-tests/sdk-test-dotnet/KeyVaultTimestampCompatibilityTests.cs
@@ -1,0 +1,114 @@
+using Azure.Core;
+using Azure.Core.Pipeline;
+using Azure.Security.KeyVault.Secrets;
+
+namespace FlociAz.Compatibility;
+
+public sealed class KeyVaultTimestampCompatibilityTests
+{
+    private static readonly Uri EmulatorEndpoint = new(
+        Environment.GetEnvironmentVariable("FLOCI_AZ_ENDPOINT") ?? "http://localhost:4577");
+
+    [Test]
+    [Arguments(false, false)]
+    [Arguments(true, false)]
+    [Arguments(false, true)]
+    [Arguments(true, true)]
+    [Timeout(60_000)]
+    public async Task OptionalTimestampsSurviveSecretLifecycle(
+        bool includeNotBefore, bool includeExpiresOn, CancellationToken cancellationToken)
+    {
+        using var httpClient = new HttpClient(new EmulatorHandler());
+        var vaultUri = new UriBuilder(EmulatorEndpoint)
+        {
+            Scheme = "https",
+            Path = $"/kv{Guid.NewGuid():N}-keyvault"
+        };
+        var client = new SecretClient(vaultUri.Uri, new FakeCredential(), new SecretClientOptions
+        {
+            DisableChallengeResourceVerification = true,
+            Transport = new HttpClientTransport(httpClient)
+        });
+        DateTimeOffset? notBefore = includeNotBefore ? DateTimeOffset.FromUnixTimeSeconds(1700000000) : null;
+        DateTimeOffset? expiresOn = includeExpiresOn ? DateTimeOffset.FromUnixTimeSeconds(1900000000) : null;
+        var secret = new KeyVaultSecret("timestamp-test", "hello")
+        {
+            Properties = { NotBefore = notBefore, ExpiresOn = expiresOn }
+        };
+        var created = await client.SetSecretAsync(secret, cancellationToken);
+        try
+        {
+            await CheckDates(created.Value.Properties);
+            var fetched = await client.GetSecretAsync("timestamp-test", cancellationToken: cancellationToken);
+            await CheckDates(fetched.Value.Properties);
+            var version = await client.GetSecretAsync("timestamp-test", created.Value.Properties.Version,
+                cancellationToken: cancellationToken);
+            await CheckDates(version.Value.Properties);
+            created.Value.Properties.ContentType = "text/plain";
+            var updated = await client.UpdateSecretPropertiesAsync(created.Value.Properties, cancellationToken);
+            await CheckDates(updated.Value);
+            await foreach (var properties in client.GetPropertiesOfSecretVersionsAsync("timestamp-test", cancellationToken))
+            {
+                await CheckDates(properties);
+            }
+            await client.StartDeleteSecretAsync("timestamp-test", cancellationToken);
+            var deleted = await client.GetDeletedSecretAsync("timestamp-test", cancellationToken);
+            await CheckDates(deleted.Value.Properties);
+            var recovered = await client.StartRecoverDeletedSecretAsync("timestamp-test", cancellationToken);
+            await recovered.WaitForCompletionAsync(cancellationToken);
+            await CheckDates(recovered.Value);
+        }
+        finally
+        {
+            await client.StartDeleteSecretAsync("timestamp-test", cancellationToken);
+            await client.PurgeDeletedSecretAsync("timestamp-test", cancellationToken);
+        }
+
+        async Task CheckDates(SecretProperties properties)
+        {
+            await Assert.That(properties.NotBefore).IsEqualTo(notBefore);
+            await Assert.That(properties.ExpiresOn).IsEqualTo(expiresOn);
+            await Assert.That(properties.CreatedOn).IsNotNull();
+            await Assert.That(properties.UpdatedOn).IsNotNull();
+        }
+    }
+
+    private sealed class FakeCredential : TokenCredential
+    {
+        public override AccessToken GetToken(
+            TokenRequestContext requestContext, CancellationToken cancellationToken) =>
+            new("fake-token-for-local-emulator", DateTimeOffset.UtcNow.AddHours(1));
+
+        public override ValueTask<AccessToken> GetTokenAsync(
+            TokenRequestContext requestContext, CancellationToken cancellationToken) =>
+            ValueTask.FromResult(GetToken(requestContext, cancellationToken));
+    }
+
+    // Keep HTTPS in the SDK pipeline for challenge authentication; use the configured
+    // emulator scheme only at the transport boundary, as in the Python compat suite.
+    private sealed class EmulatorHandler() : DelegatingHandler(new HttpClientHandler())
+    {
+        protected override HttpResponseMessage Send(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RewriteUri(request);
+            return base.Send(request, cancellationToken);
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RewriteUri(request);
+            return base.SendAsync(request, cancellationToken);
+        }
+
+        private static void RewriteUri(HttpRequestMessage request)
+        {
+            request.RequestUri = new UriBuilder(request.RequestUri!)
+            {
+                Scheme = EmulatorEndpoint.Scheme,
+                Port = EmulatorEndpoint.Port
+            }.Uri;
+        }
+    }
+}

--- a/compatibility-tests/sdk-test-dotnet/SdkTestDotnet.csproj
+++ b/compatibility-tests/sdk-test-dotnet/SdkTestDotnet.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.11.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.62.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="TUnit" Version="1.63.0" />

--- a/docs/services/key-vault.md
+++ b/docs/services/key-vault.md
@@ -9,6 +9,7 @@ Compatible with `azure-keyvault-secrets` SDKs (Python, Java, JavaScript, .NET).
 - **Soft-delete lifecycle** — delete moves a secret to the deleted namespace; recover or purge it
 - **Properties update** — update `content_type`, `tags`, `enabled`, `nbf`, `exp` without changing the value
 - **Attributes** — `enabled`, `not_before`, `expires_on`; disabled secrets return 403 on get
+- **Optional timestamps** — unset `nbf` and `exp` attributes are omitted from responses; supplied values remain numeric Unix timestamps
 - **List operations** — list active secrets, deleted secrets, or versions of a specific secret
 - **Backup** — backup a secret (base64-encoded blob)
 - **32-char hex version IDs** — matches Azure's version ID format

--- a/src/main/java/io/floci/az/services/keyvault/KeyVaultHandler.java
+++ b/src/main/java/io/floci/az/services/keyvault/KeyVaultHandler.java
@@ -491,9 +491,13 @@ public class KeyVaultHandler implements AzureServiceHandler, Resettable {
         Map<String, Object> attrs = new LinkedHashMap<>();
         attrs.put("enabled", Boolean.parseBoolean(meta.getOrDefault("enabled", "true")));
         String nbf = meta.get("nbf");
-        attrs.put("nbf", (nbf != null && !nbf.isEmpty() && !"null".equals(nbf)) ? parseLong(nbf, 0L) : null);
+        if (nbf != null && !nbf.isEmpty() && !"null".equals(nbf)) {
+            attrs.put("nbf", parseLong(nbf, 0L));
+        }
         String exp = meta.get("exp");
-        attrs.put("exp", (exp != null && !exp.isEmpty() && !"null".equals(exp)) ? parseLong(exp, 0L) : null);
+        if (exp != null && !exp.isEmpty() && !"null".equals(exp)) {
+            attrs.put("exp", parseLong(exp, 0L));
+        }
         attrs.put("created", parseLong(meta.get("created"), 0L));
         attrs.put("updated", parseLong(meta.get("updated"), 0L));
         attrs.put("recoveryLevel", RECOVERY_LEVEL);

--- a/src/test/java/io/floci/az/services/keyvault/KeyVaultTimestampTest.java
+++ b/src/test/java/io/floci/az/services/keyvault/KeyVaultTimestampTest.java
@@ -1,0 +1,108 @@
+package io.floci.az.services.keyvault;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.ValidatableResponse;
+import io.restassured.specification.RequestSpecification;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+
+@QuarkusTest
+class KeyVaultTimestampTest {
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void unsetDatesAreOmittedThroughoutSecretLifecycle(boolean explicitNulls) {
+        String vault = vault();
+        Map<String, Object> body = new HashMap<>(Map.of("value", "secret-value"));
+        if (explicitNulls) {
+            Map<String, Object> attributes = new HashMap<>();
+            attributes.put("nbf", null);
+            attributes.put("exp", null);
+            body.put("attributes", attributes);
+        }
+
+        var created = request().body(body).put(vault + "secrets/example");
+        try {
+            assertUnsetDates(created.then(), "attributes");
+            String id = created.jsonPath().getString("id");
+            String version = id.substring(id.lastIndexOf('/') + 1);
+
+            assertUnsetDates(request().get(vault + "secrets/example").then(), "attributes");
+            assertUnsetDates(request().get(vault + "secrets/example/" + version).then(), "attributes");
+            assertUnsetDates(request().get(vault + "secrets").then(), "value[0].attributes");
+            assertUnsetDates(request().get(vault + "secrets/example/versions").then(), "value[0].attributes");
+            assertUnsetDates(request().body(Map.of("contentType", "text/plain"))
+                    .patch(vault + "secrets/example/" + version).then(), "attributes");
+            assertUnsetDates(request().delete(vault + "secrets/example").then(), "attributes");
+            assertUnsetDates(request().get(vault + "deletedsecrets/example").then(), "attributes");
+            assertUnsetDates(request().get(vault + "deletedsecrets").then(), "value[0].attributes");
+            assertUnsetDates(request().post(vault + "deletedsecrets/example/recover").then(), "attributes");
+        } finally {
+            purge(vault);
+        }
+    }
+
+    @ParameterizedTest
+    @CsvSource({"nbf, 0", "exp, 0", "nbf, 1700000000", "exp, 1900000000"})
+    void setDatesStayNumericAndClearedDatesAreOmitted(String attribute, int timestamp) {
+        String vault = vault();
+        String otherAttribute = "nbf".equals(attribute) ? "exp" : "nbf";
+        var created = request().body(Map.of("value", "secret-value",
+                        "attributes", Map.of(attribute, timestamp)))
+                .put(vault + "secrets/example");
+        try {
+            created.then().statusCode(200)
+                    .body("attributes." + attribute, equalTo(timestamp))
+                    .body("attributes", not(hasKey(otherAttribute)));
+            String id = created.jsonPath().getString("id");
+            String version = id.substring(id.lastIndexOf('/') + 1);
+            String versionPath = vault + "secrets/example/" + version;
+
+            request().body(Map.of("contentType", "text/plain"))
+                    .patch(versionPath).then().statusCode(200)
+                    .body("attributes." + attribute, equalTo(timestamp));
+            request().get(vault + "secrets").then().statusCode(200)
+                    .body("value[0].attributes." + attribute, equalTo(timestamp));
+
+            Map<String, Object> cleared = new HashMap<>();
+            cleared.put(attribute, null);
+            assertUnsetDates(request().body(Map.of("attributes", cleared))
+                    .patch(versionPath).then(), "attributes");
+            assertUnsetDates(request().get(versionPath).then(), "attributes");
+            assertUnsetDates(request().get(vault + "secrets/example").then(), "attributes");
+        } finally {
+            purge(vault);
+        }
+    }
+
+    private static void assertUnsetDates(ValidatableResponse response, String path) {
+        response.statusCode(200)
+                .body(path, not(hasKey("nbf")))
+                .body(path, not(hasKey("exp")))
+                .body(path + ".enabled", equalTo(true))
+                .body(path + ".created", instanceOf(Number.class))
+                .body(path + ".updated", instanceOf(Number.class));
+    }
+
+    private static RequestSpecification request() {
+        return given().header("Authorization", "Bearer test-token")
+                .contentType("application/json").queryParam("api-version", "7.4");
+    }
+
+    private static String vault() {
+        return "/kv" + UUID.randomUUID().toString().replace("-", "") + "-keyvault/";
+    }
+
+    private static void purge(String vault) {
+        request().delete(vault + "secrets/example").then().statusCode(anyOf(is(200), is(404)));
+        request().delete(vault + "deletedsecrets/example").then().statusCode(204);
+    }
+}


### PR DESCRIPTION
## Summary

Key Vault emitted `"nbf": null` and `"exp": null` for unset validity dates. Azure.Security.KeyVault.Secrets 4.11.0 reads present timestamp properties as integers, so ordinary `SetSecretAsync` calls failed with `InvalidOperationException` when either date was absent.

Omit unset validity dates from the shared attribute serializer. Preserve numeric values, including Unix epoch zero, and continue recognizing empty or `"null"` metadata produced by existing storage and update paths. This fixes secret bundles, list items, deleted secrets, and recovered secrets without changing persistence or request handling.

This is the independent timestamp follow-up discovered while fixing #238 in #279. Neither PR includes the other's implementation changes; the two branches merge cleanly.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

The [Azure Key Vault 7.4 attribute schema](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/keyvault/data-plane/Legacy/stable/7.4/common.json) defines optional `nbf` and `exp` properties as integer Unix timestamps. The [.NET SDK attribute reader](https://github.com/Azure/azure-sdk-for-net/blob/Azure.Security.KeyVault.Secrets_4.11.0/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretAttributes.cs) calls `GetInt64()` when either property is present.

Added automated .NET lifecycle coverage for neither date, either date individually, and both dates. HTTP regression tests verify actual key omission across CRUD, lists, updates, deletion, and recovery, plus preservation of numeric zero and handling of explicitly cleared dates.

## Validation

- Before the fix: all 6 new HTTP cases failed; 3 of 4 .NET timestamp combinations reproduced the null-to-number exception.
- After the fix: 27 focused Java tests passed (`KeyVaultTimestampTest`, `AzureRoutingFilterTest`, `DisabledServiceRoutingTest`).
- .NET Key Vault timestamp suite: 4 passed.
- Existing Java / Python / JavaScript Key Vault suites: 17 / 24 / 14 passed.
- `./mvnw package -DskipTests` passed after stopping the local test emulator to release Windows JAR locks.
- `git diff --check` passed.

## Checklist

- [ ] `./mvnw test` passes locally (focused tests and relevant SDK suites run; full suite not run)
- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits
