### PR TITLE
feat(policy): add Azure Policy control plane (definitions, set definitions, assignments, exemptions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <!-- 
 AI Context: This is Floci-Az, a lightweight Local Azure Emulator. 
 Identity: It is the Azure equivalent of Floci (AWS). It is NOT LocalStack.
-Protocols: Implements Azure Storage (Blob, Queue, Table), Azure Functions, App Configuration, Key Vault, Event Hubs, Service Bus (Microsoft.ServiceBus), Cosmos DB, Azure SQL Database, Azure Database for PostgreSQL (Microsoft.DBforPostgreSQL), Azure Kubernetes Service (AKS), API Management (Microsoft.ApiManagement), Virtual Network (Microsoft.Network), Virtual Machines (Microsoft.Compute), Azure Cache for Redis (Microsoft.Cache), Azure Container Registry (Microsoft.ContainerRegistry), Azure Container Instances (Microsoft.ContainerInstance), Event Grid (Microsoft.EventGrid), Azure Monitor / Log Analytics (Microsoft.OperationalInsights / Microsoft.Insights), Communication Services Email (Microsoft.Communication), Managed Identity (Microsoft.ManagedIdentity + IMDS token endpoint), Microsoft Entra ID (OpenID Connect / OAuth2 token issuance, including interactive auth-code+PKCE sign-in), and a narrow Microsoft Graph slice (service principal discovery, group membership).
+Protocols: Implements Azure Storage (Blob, Queue, Table), Azure Functions, App Configuration, Key Vault, Event Hubs, Service Bus (Microsoft.ServiceBus), Cosmos DB, Azure SQL Database, Azure Database for PostgreSQL (Microsoft.DBforPostgreSQL), Azure Kubernetes Service (AKS), API Management (Microsoft.ApiManagement), Virtual Network (Microsoft.Network), Virtual Machines (Microsoft.Compute), Azure Cache for Redis (Microsoft.Cache), Azure Container Registry (Microsoft.ContainerRegistry), Azure Container Instances (Microsoft.ContainerInstance), Event Grid (Microsoft.EventGrid), Azure Monitor / Log Analytics (Microsoft.OperationalInsights / Microsoft.Insights), Communication Services Email (Microsoft.Communication), Managed Identity (Microsoft.ManagedIdentity + IMDS token endpoint), Azure Policy (Microsoft.Authorization policy definitions, set definitions, assignments and exemptions), Microsoft Entra ID (OpenID Connect / OAuth2 token issuance, including interactive auth-code+PKCE sign-in), and a narrow Microsoft Graph slice (service principal discovery, group membership).
 Default Port: 4577 (HTTP; also HTTPS when FLOCI_AZ_TLS_ENABLED=true via protocol-sniffing proxy). AMQP port: 5672 (Event Hubs). Kafka port: 9093 (Event Hubs, opt-in). k3s API: 6443-7443 (AKS). Redis: 6379-6399 (Azure Cache for Redis).
 Tech Stack: Java, Quarkus, Docker-in-Docker for Functions. Artemis sidecar for Event Hubs AMQP. Redpanda sidecar for Kafka. k3s sidecar for AKS. Redis sidecar for Azure Cache for Redis.
 TLS: Optional. Set FLOCI_AZ_TLS_ENABLED=true. Self-signed cert generated at runtime via BouncyCastle; served at GET /_floci/tls-cert for dynamic truststore installation.
@@ -176,6 +176,7 @@ Floci AZ gives you more services than the official local tools, consolidated on 
 | Azure Monitor / Logs | ✅                        | ❌                                           | ❌                                                                           |
 | Communication Email | ✅                         | ❌                                           | ❌                                                                           |
 | Managed Identity    | ✅                         | ❌                                           | ❌                                                                           |
+| Azure Policy        | ✅                         | ❌                                           | ❌                                                                           |
 | Microsoft Entra ID  | ✅                         | ❌                                           | ❌                                                                           |
 | Microsoft Graph     | ✅                         | ❌                                           | ❌                                                                           |
 | Native binary       | ✅                         | ❌                                           | ✅                                                                           |
@@ -276,7 +277,7 @@ flowchart LR
         Router["HTTP Router\nJAX-RS / Vert.x\nprotocol-sniffing TLS proxy"]
 
         subgraph Stateless ["Stateless Services"]
-            A["App Configuration · Key Vault\nAPI Management · Event Grid\nVirtual Network · Virtual Machines\nContainer Instances · Monitor / Log Analytics\nCommunication Email\nManaged Identity · Microsoft Entra ID · Microsoft Graph · ARM management plane"]
+            A["App Configuration · Key Vault\nAPI Management · Event Grid\nVirtual Network · Virtual Machines\nContainer Instances · Monitor / Log Analytics\nCommunication Email\nManaged Identity · Azure Policy · Microsoft Entra ID · Microsoft Graph · ARM management plane"]
         end
 
         subgraph Stateful ["Stateful Services"]
@@ -326,6 +327,7 @@ flowchart LR
 | **Azure Monitor / Log Analytics** | ARM path (`Microsoft.OperationalInsights` / `Microsoft.Insights`) + `/dataCollectionRules/{id}/streams/{stream}` + `/v1/workspaces/{id}/query` | Workspaces, Data Collection Endpoints/Rules; Logs Ingestion API; Log Analytics query with a KQL subset (`where`/`project`/`take`/`limit` + timespan); HTTP-only (no sidecar) |
 | **Communication Services Email** | `/emails:send` + `/emails/operations/{id}` + `/emailMessages` + ARM path (`Microsoft.Communication`) | ACS Email send + status polling; in-memory inspection mailbox (Mailpit-style `GET /emailMessages`); communication/email services + domains via ARM; captures messages locally, no real delivery; HTTP-only (no sidecar)  |
 | **Managed Identity**    | ARM path (`Microsoft.ManagedIdentity`) + `/metadata/identity/oauth2/token` | User-assigned identities (server-generated `principalId`/`clientId`), federated identity credentials, system-assigned `identities/default`; IMDS token endpoint for `ManagedIdentityCredential` (point the SDK at the emulator with `AZURE_POD_IDENTITY_AUTHORITY_HOST`); v1.0 JWTs signed with the Entra key, verifiable via JWKS; HTTP-only (no sidecar) |
+| **Azure Policy**        | ARM path (`Microsoft.Authorization/policy*`) | Policy definitions, set definitions (initiatives), assignments and exemptions at management-group, subscription, resource-group and resource scope; `$filter` scope forms (`atScope()`, `atExactScope()`, `atScopeAndBelow()`); server-side `scope`, `instanceId`, `definitionVersion`, audit metadata and assignment identities; referential integrity on delete. Control plane only: rules are stored, never evaluated, and no built-ins are seeded; HTTP-only (no sidecar) |
 
 <details>
 <summary><strong>API Management details</strong></summary>

--- a/compatibility-tests/compat-azcli/test/policy.bats
+++ b/compatibility-tests/compat-azcli/test/policy.bats
@@ -1,0 +1,79 @@
+#!/usr/bin/env bats
+# Azure Policy control plane: definitions, assignments and exemptions through `az policy`.
+
+setup_file() {
+    load 'test_helper/common-setup'
+
+    az group create -n "$RG_NAME" -l "$LOCATION" -o none
+}
+
+setup() {
+    load 'test_helper/common-setup'
+
+    export POLICY_NAME="floci-test-policy"
+    export ASSIGNMENT_NAME="floci-test-assignment"
+    export EXEMPTION_NAME="floci-test-exemption"
+    export POLICY_RULE='{"if":{"field":"location","notIn":["eastus"]},"then":{"effect":"deny"}}'
+}
+
+@test "az policy definition: create is Custom and shows the rule" {
+    run az_json policy definition create --name "$POLICY_NAME" --display-name "Floci test policy" \
+        --mode All --rules "$POLICY_RULE"
+    assert_success
+    assert_equal "$(echo "$output" | jq -r '.policyType')" "Custom"
+    assert_equal "$(echo "$output" | jq -r '.mode')" "All"
+
+    run az_json policy definition show --name "$POLICY_NAME"
+    assert_success
+    assert_equal "$(echo "$output" | jq -r '.name')" "$POLICY_NAME"
+    assert_equal "$(echo "$output" | jq -r '.policyRule.then.effect')" "deny"
+}
+
+@test "az policy definition: listed in the subscription" {
+    run az_json policy definition list --query "[?name=='$POLICY_NAME'] | length(@)"
+    assert_success
+    assert_output "1"
+}
+
+@test "az policy assignment: create at resource group scope" {
+    run az_json policy assignment create --name "$ASSIGNMENT_NAME" --policy "$POLICY_NAME" \
+        -g "$RG_NAME" --display-name "Floci test assignment"
+    assert_success
+    assert_equal "$(echo "$output" | jq -r '.enforcementMode')" "Default"
+    assert_output --partial "/resourceGroups/$RG_NAME"
+
+    run az_json policy assignment list -g "$RG_NAME" --query "[?name=='$ASSIGNMENT_NAME'] | length(@)"
+    assert_success
+    assert_output "1"
+}
+
+@test "az policy exemption: create for the assignment and delete" {
+    run az_json policy assignment show --name "$ASSIGNMENT_NAME" -g "$RG_NAME" --query id -o tsv
+    assert_success
+    local assignment_id="$output"
+
+    run az_json policy exemption create --name "$EXEMPTION_NAME" -g "$RG_NAME" \
+        --policy-assignment "$assignment_id" --exemption-category Waiver \
+        --display-name "Floci test exemption"
+    assert_success
+    assert_equal "$(echo "$output" | jq -r '.exemptionCategory')" "Waiver"
+
+    run az policy exemption delete --name "$EXEMPTION_NAME" -g "$RG_NAME"
+    assert_success
+}
+
+@test "az policy definition: cannot be deleted while assigned, then deleted after the assignment" {
+    run az policy definition delete --name "$POLICY_NAME"
+    assert_failure
+    assert_output --partial "InvalidDeletePolicyDefinitionRequest"
+
+    run az policy assignment delete --name "$ASSIGNMENT_NAME" -g "$RG_NAME"
+    assert_success
+
+    run az policy definition delete --name "$POLICY_NAME"
+    assert_success
+
+    run az policy definition show --name "$POLICY_NAME"
+    assert_failure
+    assert_output --partial "PolicyDefinitionNotFound"
+}

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/PolicyCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/PolicyCompatibilityTest.java
@@ -1,0 +1,245 @@
+package io.floci.az.compat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Compatibility test for the Azure Policy control plane (Microsoft.Authorization policy definitions,
+ * set definitions, assignments and exemptions) exposed by floci-az.
+ *
+ * <p>Mirrors {@link ManagedIdentityCompatibilityTest}: the ARM management plane is driven with a raw
+ * {@link HttpClient} against the real REST wire protocol (policy spec 2025-03-01, exemptions
+ * 2022-07-01-preview), which is what every Azure SDK and the Azure CLI emit.
+ */
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@DisplayName("Azure Policy Compatibility")
+class PolicyCompatibilityTest {
+
+    private static final String BASE =
+            System.getenv().getOrDefault("FLOCI_AZ_ENDPOINT", "http://localhost:4577");
+    private static final String SUBSCRIPTION = "00000000-0000-0000-0000-000000000001";
+    private static final String SUFFIX = UUID.randomUUID().toString().substring(0, 8);
+    private static final String RG = "policy-rg-" + SUFFIX;
+    private static final String DEFINITION = "policy-def-" + SUFFIX;
+    private static final String SET_DEFINITION = "policy-set-" + SUFFIX;
+    private static final String ASSIGNMENT = "policy-assign-" + SUFFIX;
+    private static final String EXEMPTION = "policy-exempt-" + SUFFIX;
+
+    private static final String POLICY_API = "2025-03-01";
+    private static final String EXEMPTION_API = "2022-07-01-preview";
+    private static final String RG_API = "2021-04-01";
+
+    private static final HttpClient http = HttpClient.newHttpClient();
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    @BeforeAll
+    static void setup() {
+        EmulatorConfig.assumeEmulatorRunning();
+    }
+
+    @Test
+    @Order(1)
+    void createDefinition_isCustomWithServerStamps() throws Exception {
+        assertOk(put(resourceGroupUrl(), "{\"location\":\"eastus\"}"), "create resource group");
+
+        HttpResponse<String> resp = put(definitionUrl(), """
+                {"properties":{"displayName":"Compat allowed locations","mode":"All",
+                 "policyRule":{"if":{"field":"location","notIn":["eastus"]},"then":{"effect":"deny"}}}}""");
+        assertEquals(201, resp.statusCode(), "create definition: " + resp.body());
+
+        JsonNode json = mapper.readTree(resp.body());
+        assertEquals(DEFINITION, json.get("name").asText());
+        assertEquals("Microsoft.Authorization/policyDefinitions", json.get("type").asText());
+        assertEquals(definitionId(), json.get("id").asText());
+        JsonNode props = json.get("properties");
+        assertEquals("Custom", props.get("policyType").asText());
+        assertEquals("All", props.get("mode").asText());
+        assertEquals("deny", props.get("policyRule").get("then").get("effect").asText());
+        assertNotNull(props.get("metadata").get("createdOn"), "metadata.createdOn is stamped server-side");
+    }
+
+    @Test
+    @Order(2)
+    void createSetDefinition_generatesReferenceIds() throws Exception {
+        HttpResponse<String> resp = put(setDefinitionUrl(), """
+                {"properties":{"displayName":"Compat initiative",
+                 "policyDefinitions":[{"policyDefinitionId":"%s"}]}}""".formatted(definitionId()));
+        assertEquals(201, resp.statusCode(), "create set definition: " + resp.body());
+
+        JsonNode reference = mapper.readTree(resp.body()).get("properties").get("policyDefinitions").get(0);
+        assertEquals(definitionId(), reference.get("policyDefinitionId").asText());
+        assertFalse(reference.get("policyDefinitionReferenceId").asText().isBlank());
+    }
+
+    @Test
+    @Order(3)
+    void createAssignment_populatesScopeAndIdentity() throws Exception {
+        HttpResponse<String> resp = put(assignmentUrl(), """
+                {"location":"eastus","identity":{"type":"SystemAssigned"},
+                 "properties":{"displayName":"Compat assignment","policyDefinitionId":"%s"}}""".formatted(definitionId()));
+        assertEquals(201, resp.statusCode(), "create assignment: " + resp.body());
+
+        JsonNode json = mapper.readTree(resp.body());
+        assertEquals("Microsoft.Authorization/policyAssignments", json.get("type").asText());
+        assertEquals("/subscriptions/" + SUBSCRIPTION + "/resourceGroups/" + RG,
+                json.get("properties").get("scope").asText());
+        assertEquals("Default", json.get("properties").get("enforcementMode").asText());
+        assertEquals("SystemAssigned", json.get("identity").get("type").asText());
+        assertGuid(json.get("identity").get("principalId").asText(), "identity.principalId");
+        assertGuid(json.get("properties").get("instanceId").asText(), "properties.instanceId");
+    }
+
+    @Test
+    @Order(4)
+    void listAssignments_forResourceGroupAndSubscription() throws Exception {
+        HttpResponse<String> rg = get(assignmentsUrl(resourceGroupScope()) + "&$filter=atExactScope()");
+        assertOk(rg, "list resource group assignments");
+        assertTrue(contains(rg.body(), ASSIGNMENT), "resource-group listing names the assignment");
+
+        HttpResponse<String> sub = get(assignmentsUrl("/subscriptions/" + SUBSCRIPTION));
+        assertOk(sub, "list subscription assignments");
+        assertTrue(contains(sub.body(), ASSIGNMENT), "subscription listing includes descendants by default");
+    }
+
+    @Test
+    @Order(5)
+    void createExemption_forTheAssignment() throws Exception {
+        HttpResponse<String> resp = put(exemptionUrl(), """
+                {"properties":{"policyAssignmentId":"%s","exemptionCategory":"Waiver",
+                 "displayName":"Compat exemption"}}""".formatted(assignmentId()));
+        assertEquals(201, resp.statusCode(), "create exemption: " + resp.body());
+
+        JsonNode props = mapper.readTree(resp.body()).get("properties");
+        assertEquals(assignmentId(), props.get("policyAssignmentId").asText());
+        assertEquals("Waiver", props.get("exemptionCategory").asText());
+        assertEquals("Default", props.get("assignmentScopeValidation").asText());
+    }
+
+    @Test
+    @Order(6)
+    void deleteDefinitionInUse_isRejected() throws Exception {
+        HttpResponse<String> resp = delete(definitionUrl());
+        assertEquals(400, resp.statusCode(), "delete referenced definition: " + resp.body());
+        assertEquals("InvalidDeletePolicyDefinitionRequest",
+                mapper.readTree(resp.body()).get("error").get("code").asText());
+    }
+
+    @Test
+    @Order(7)
+    void deleteEverything_inDependencyOrder() throws Exception {
+        HttpResponse<String> assignment = delete(assignmentUrl());
+        assertOk(assignment, "delete assignment");
+        assertEquals(ASSIGNMENT, mapper.readTree(assignment.body()).get("name").asText(),
+                "assignment delete returns the deleted resource");
+
+        // The exemption went with its assignment.
+        assertEquals(404, get(exemptionUrl()).statusCode(), "exemption cascades with its assignment");
+
+        assertOk(delete(setDefinitionUrl()), "delete set definition");
+        assertOk(delete(definitionUrl()), "delete definition");
+
+        HttpResponse<String> gone = get(definitionUrl());
+        assertEquals(404, gone.statusCode());
+        assertEquals("PolicyDefinitionNotFound", mapper.readTree(gone.body()).get("error").get("code").asText());
+
+        assertOk(delete(resourceGroupUrl()), "delete resource group");
+    }
+
+    // ── URLs ────────────────────────────────────────────────────────────────────
+
+    private static String resourceGroupScope() {
+        return "/subscriptions/" + SUBSCRIPTION + "/resourceGroups/" + RG;
+    }
+
+    private static String resourceGroupUrl() {
+        return BASE + resourceGroupScope() + "?api-version=" + RG_API;
+    }
+
+    private static String definitionId() {
+        return "/subscriptions/" + SUBSCRIPTION + "/providers/Microsoft.Authorization/policyDefinitions/" + DEFINITION;
+    }
+
+    private static String definitionUrl() {
+        return BASE + definitionId() + "?api-version=" + POLICY_API;
+    }
+
+    private static String setDefinitionUrl() {
+        return BASE + "/subscriptions/" + SUBSCRIPTION
+                + "/providers/Microsoft.Authorization/policySetDefinitions/" + SET_DEFINITION
+                + "?api-version=" + POLICY_API;
+    }
+
+    private static String assignmentId() {
+        return resourceGroupScope() + "/providers/Microsoft.Authorization/policyAssignments/" + ASSIGNMENT;
+    }
+
+    private static String assignmentUrl() {
+        return BASE + assignmentId() + "?api-version=" + POLICY_API;
+    }
+
+    private static String assignmentsUrl(String scope) {
+        return BASE + scope + "/providers/Microsoft.Authorization/policyAssignments?api-version=" + POLICY_API;
+    }
+
+    private static String exemptionUrl() {
+        return BASE + resourceGroupScope() + "/providers/Microsoft.Authorization/policyExemptions/" + EXEMPTION
+                + "?api-version=" + EXEMPTION_API;
+    }
+
+    // ── HTTP helpers ────────────────────────────────────────────────────────────
+
+    private static HttpResponse<String> put(String url, String body) throws Exception {
+        return send(HttpRequest.newBuilder(URI.create(url))
+                .header("Content-Type", "application/json")
+                .PUT(HttpRequest.BodyPublishers.ofString(body)));
+    }
+
+    private static HttpResponse<String> get(String url) throws Exception {
+        return send(HttpRequest.newBuilder(URI.create(url)).GET());
+    }
+
+    private static HttpResponse<String> delete(String url) throws Exception {
+        return send(HttpRequest.newBuilder(URI.create(url)).DELETE());
+    }
+
+    private static HttpResponse<String> send(HttpRequest.Builder request) throws Exception {
+        return http.send(request.timeout(Duration.ofSeconds(30)).build(), HttpResponse.BodyHandlers.ofString());
+    }
+
+    private static void assertOk(HttpResponse<String> resp, String action) {
+        assertTrue(resp.statusCode() >= 200 && resp.statusCode() < 300,
+                action + " failed with " + resp.statusCode() + ": " + resp.body());
+    }
+
+    private static void assertGuid(String value, String field) {
+        assertTrue(value.matches("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"),
+                field + " must be a GUID, got " + value);
+    }
+
+    private static boolean contains(String listBody, String name) throws Exception {
+        for (JsonNode item : mapper.readTree(listBody).get("value")) {
+            if (name.equals(item.get("name").asText())) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/docs/services/index.md
+++ b/docs/services/index.md
@@ -29,6 +29,7 @@ Floci-AZ provides emulation for several core Azure services.
 | **Azure Monitor / Log Analytics** | ARM path (`Microsoft.OperationalInsights` / `Microsoft.Insights`) + `/dataCollectionRules/...` + `/v1/workspaces/...` | ✅ Workspaces, Data Collection Endpoints/Rules; Logs Ingestion API; Log Analytics query with a KQL subset (`where`/`project`/`take`/`limit`, timespan) |
 | **Communication Services Email** | `/emails:send` + `/emailMessages` + ARM path (`Microsoft.Communication`) | ✅ ACS Email send + status polling; in-memory inspection mailbox (Mailpit-style); ARM communication/email services + domains. No real delivery |
 | **Managed Identity** | ARM path (`Microsoft.ManagedIdentity`) + `/metadata/identity/oauth2/token` | ✅ User-assigned identities + federated identity credentials, system-assigned `identities/default`, IMDS token endpoint (`ManagedIdentityCredential` via `AZURE_POD_IDENTITY_AUTHORITY_HOST`); tokens signed with the Entra key |
+| **Azure Policy** | ARM path (`Microsoft.Authorization/policy*`) | ✅ Policy definitions, set definitions, assignments and exemptions at management-group, subscription, resource-group and resource scope; control plane only (no rule evaluation, no compliance data, no built-in definitions) |
 
 ## Unified Endpoint
 

--- a/docs/services/policy.md
+++ b/docs/services/policy.md
@@ -1,0 +1,205 @@
+# Azure Policy
+
+Compatible with the `Microsoft.Authorization` policy management plane used by the Azure CLI
+(`az policy ...`), the `azurerm` Terraform provider (`azurerm_policy_definition`,
+`azurerm_policy_set_definition`, `azurerm_*_policy_assignment`, `azurerm_*_policy_exemption`) and the
+Azure SDKs (`azure-resourcemanager-resources`, `armpolicy`, `azure-mgmt-resource`). Covers **policy
+definitions**, **policy set definitions** (initiatives), **policy assignments** and **policy
+exemptions** at every scope the real service accepts.
+
+> **HTTP-only, no Docker.** All policy state is in-memory and ephemeral, like the rest of the ARM
+> control plane.
+
+> **Control plane only.** Definitions are stored and validated structurally, but policy rules are
+> never evaluated against resource requests: nothing is denied, audited or remediated, and there is no
+> compliance state (`Microsoft.PolicyInsights` is not implemented). Use this to exercise the code that
+> authors and deploys policies, not the code that reacts to their effects.
+
+---
+
+## Features
+
+- **Policy definitions** at subscription and management-group scope: CreateOrUpdate, Get, Delete, List
+  (`$filter=policyType eq 'Custom'` and `atExactScope()` are honoured). `policyType` is always
+  `Custom`, `mode` defaults to `Indexed`, `version` defaults to `1.0.0`, and `metadata` gains the
+  `createdBy` / `createdOn` / `updatedBy` / `updatedOn` stamps Azure adds
+- **Policy set definitions** at subscription and management-group scope: CreateOrUpdate, Get, Delete,
+  List. Each reference gets a server-generated `policyDefinitionReferenceId` when none is supplied and
+  a `definitionVersion` of `1.*.*`
+- **Policy assignments** at management-group, subscription, resource-group and resource scope:
+  Create, Get, Update (PATCH of `identity`, `location`, `resourceSelectors`, `overrides`), Delete
+  (returns the deleted assignment), List for subscription / resource group / resource / management
+  group with `atScope()`, `atExactScope()`, `atScopeAndBelow()` and `policyDefinitionId eq '...'`.
+  `scope`, `enforcementMode`, `definitionVersion` and `instanceId` are populated server-side;
+  a `SystemAssigned` identity receives a stable `principalId`, and `UserAssigned` identities resolve
+  their `principalId` / `clientId` from [Managed Identity](managed-identity.md) when the identity exists
+- **Policy exemptions** at the same scopes: CreateOrUpdate, Get, Update (PATCH of
+  `resourceSelectors`, `assignmentScopeValidation`), Delete (returns the deleted exemption), List with
+  `atScope()`, `atExactScope()`, `excludeExpired()` and `policyAssignmentId eq '...'`. Exemptions are
+  deleted together with their assignment
+- **Referential integrity**: assignments and set definitions must reference definitions that exist
+  (`PolicyDefinitionNotFound` / `PolicySetDefinitionNotFound`), exemptions must reference an existing
+  assignment (`PolicyAssignmentNotFound`), and a definition or set definition that is still referenced
+  cannot be deleted (`InvalidDeletePolicyDefinitionRequest` / `InvalidDeletePolicySetDefinitionRequest`)
+- **Azure error shapes**: `PolicyDefinitionNotFound`, `PolicySetDefinitionNotFound`,
+  `PolicyAssignmentNotFound`, `PolicyExemptionNotFound`, `InvalidPolicyRule`,
+  `InvalidCreatePolicySetDefinitionRequest`, `InvalidPolicyDefinitionReference`, `MissingSubscription`
+  for tenant-level writes, and ARM's `InvalidRequestContent` for malformed JSON
+
+---
+
+## Endpoints
+
+`{scope}` is empty (tenant root), `providers/Microsoft.Management/managementGroups/{mg}`,
+`subscriptions/{sub}`, `subscriptions/{sub}/resourceGroups/{rg}` or a full resource id.
+
+```
+# Definitions and set definitions: subscription or management-group scope
+PUT    /{scope}/providers/Microsoft.Authorization/policyDefinitions/{name}
+GET    /{scope}/providers/Microsoft.Authorization/policyDefinitions/{name}
+DELETE /{scope}/providers/Microsoft.Authorization/policyDefinitions/{name}
+GET    /{scope}/providers/Microsoft.Authorization/policyDefinitions[?$filter=...]
+PUT    /{scope}/providers/Microsoft.Authorization/policySetDefinitions/{name}
+GET    /{scope}/providers/Microsoft.Authorization/policySetDefinitions/{name}
+DELETE /{scope}/providers/Microsoft.Authorization/policySetDefinitions/{name}
+GET    /{scope}/providers/Microsoft.Authorization/policySetDefinitions[?$filter=...]
+
+# Built-in listings at the tenant root (always empty, see deviations)
+GET    /providers/Microsoft.Authorization/policyDefinitions
+GET    /providers/Microsoft.Authorization/policySetDefinitions
+
+# Assignments and exemptions: management group, subscription, resource group or resource scope
+PUT    /{scope}/providers/Microsoft.Authorization/policyAssignments/{name}
+PATCH  /{scope}/providers/Microsoft.Authorization/policyAssignments/{name}
+GET    /{scope}/providers/Microsoft.Authorization/policyAssignments/{name}
+DELETE /{scope}/providers/Microsoft.Authorization/policyAssignments/{name}
+GET    /{scope}/providers/Microsoft.Authorization/policyAssignments[?$filter=...]
+PUT    /{scope}/providers/Microsoft.Authorization/policyExemptions/{name}
+PATCH  /{scope}/providers/Microsoft.Authorization/policyExemptions/{name}
+GET    /{scope}/providers/Microsoft.Authorization/policyExemptions/{name}
+DELETE /{scope}/providers/Microsoft.Authorization/policyExemptions/{name}
+GET    /{scope}/providers/Microsoft.Authorization/policyExemptions[?$filter=...]
+```
+
+Any `api-version` is accepted. Shapes follow the policy spec `2025-03-01` and the exemptions spec
+`2022-07-01-preview`.
+
+---
+
+## Quickstart
+
+### 1. Create a definition and assign it to a resource group
+
+```bash
+BASE=http://localhost:4577
+SUB=00000000-0000-0000-0000-000000000001
+
+curl -s -X PUT "$BASE/subscriptions/$SUB/providers/Microsoft.Authorization/policyDefinitions/allowed-locations?api-version=2025-03-01" \
+  -H "Content-Type: application/json" \
+  -d '{"properties":{"displayName":"Allowed locations","mode":"All",
+       "policyRule":{"if":{"field":"location","notIn":["eastus"]},"then":{"effect":"deny"}}}}'
+
+curl -s -X PUT "$BASE/subscriptions/$SUB/resourceGroups/my-rg/providers/Microsoft.Authorization/policyAssignments/enforce-locations?api-version=2025-03-01" \
+  -H "Content-Type: application/json" \
+  -d "{\"location\":\"eastus\",\"identity\":{\"type\":\"SystemAssigned\"},
+       \"properties\":{\"policyDefinitionId\":\"/subscriptions/$SUB/providers/Microsoft.Authorization/policyDefinitions/allowed-locations\"}}"
+```
+
+```json
+{
+  "identity": {"principalId": "4f0c…", "tenantId": "00000000-0000-0000-0000-000000000002", "type": "SystemAssigned"},
+  "properties": {
+    "policyDefinitionId": "/subscriptions/…/providers/Microsoft.Authorization/policyDefinitions/allowed-locations",
+    "definitionVersion": "1.*.*",
+    "scope": "/subscriptions/…/resourceGroups/my-rg",
+    "metadata": {"createdBy": "…", "createdOn": "2026-09-04T10:00:00Z"},
+    "enforcementMode": "Default",
+    "instanceId": "…"
+  },
+  "id": "/subscriptions/…/resourceGroups/my-rg/providers/Microsoft.Authorization/policyAssignments/enforce-locations",
+  "type": "Microsoft.Authorization/policyAssignments",
+  "name": "enforce-locations",
+  "location": "eastus"
+}
+```
+
+### 2. Azure CLI
+
+With the CLI pointed at the emulator (see the `compat-azcli` suite for the custom-cloud setup):
+
+```bash
+az policy definition create --name allowed-locations --mode All \
+  --rules '{"if":{"field":"location","notIn":["eastus"]},"then":{"effect":"deny"}}'
+az policy assignment create --name enforce-locations --policy allowed-locations -g my-rg
+az policy exemption create --name legacy -g my-rg --exemption-category Waiver \
+  --policy-assignment "$(az policy assignment show -n enforce-locations -g my-rg --query id -o tsv)"
+az policy assignment list -g my-rg
+```
+
+### 3. Terraform
+
+```hcl
+resource "azurerm_policy_definition" "allowed_locations" {
+  name         = "allowed-locations"
+  policy_type  = "Custom"
+  mode         = "All"
+  display_name = "Allowed locations"
+  policy_rule  = jsonencode({
+    if   = { field = "location", notIn = ["eastus"] }
+    then = { effect = "deny" }
+  })
+}
+
+resource "azurerm_resource_group_policy_assignment" "enforce" {
+  name                 = "enforce-locations"
+  resource_group_id    = azurerm_resource_group.example.id
+  policy_definition_id = azurerm_policy_definition.allowed_locations.id
+}
+```
+
+---
+
+## Configuration
+
+```yaml
+floci-az:
+  services:
+    policy:
+      enabled: true
+```
+
+| Property | Env var | Default | Description |
+|---|---|---|---|
+| `enabled` | `FLOCI_AZ_SERVICES_POLICY_ENABLED` | `true` | Enables the `Microsoft.Authorization` policy resources. When disabled, their paths fall through to the generic ARM handler and answer `404` |
+
+---
+
+## Intentional deviations
+
+- **No enforcement and no compliance data.** Policy rules are stored, not evaluated. Resource
+  requests are never denied with `RequestDisallowedByPolicy`, `audit` / `modify` /
+  `deployIfNotExists` effects do nothing, and `Microsoft.PolicyInsights` (policy states, remediations,
+  compliance summaries) is not implemented.
+- **No built-in definitions.** Azure ships thousands of built-in definitions and initiatives; none are
+  seeded. Tenant-rooted listings return an empty collection, tenant-rooted reads return
+  `PolicyDefinitionNotFound` / `PolicySetDefinitionNotFound`, and built-in ids
+  (`/providers/Microsoft.Authorization/policyDefinitions/{guid}`) are accepted in assignments and set
+  definitions without validation.
+- **Management groups are scopes, not resources.** `Microsoft.Management/managementGroups/{mg}` is
+  accepted as a scope for definitions, set definitions, assignments and exemptions, but management
+  groups themselves are not modelled: any id is accepted, there is no hierarchy, and a
+  management-group assignment does not appear in subscription-scoped listings.
+- **Policy rules are validated structurally only.** A rule must be an object with an `if` condition
+  and a `then` block that names an `effect`; aliases, functions, parameter references and effect
+  details are not checked. Assignment parameters are not validated against the definition's
+  parameter schema.
+- **Exemption scope is not validated** against the assignment's scope (`assignmentScopeValidation` is
+  stored and echoed only).
+- **Definition versions are not implemented.** `versions` sub-resources answer `404`; `version` and
+  `definitionVersion` are stored and echoed as plain strings.
+- **`systemData` and `metadata` audit fields** name a fixed emulator identity rather than the caller,
+  and `metadata.updatedBy` / `updatedOn` appear only after the first update instead of being present
+  as `null` from creation.
+- **Listings are unpaginated** (`nextLink` is never returned) and `$top` is ignored.
+- **Policy state is in-memory only**, regardless of `storage.mode`, like the rest of the ARM control
+  plane.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,5 +94,6 @@ nav:
     - Azure Monitor / Log Analytics: services/monitor.md
     - Communication Services Email: services/email.md
     - Managed Identity: services/managed-identity.md
+    - Azure Policy: services/policy.md
   - Contributing: contributing.md
   - Changelog: changelog.md

--- a/src/main/java/io/floci/az/config/EmulatorConfig.java
+++ b/src/main/java/io/floci/az/config/EmulatorConfig.java
@@ -138,6 +138,7 @@ public interface EmulatorConfig {
         NetworkConfig          network();
         EventGridConfig        eventGrid();
         ManagedIdentityConfig  managedIdentity();
+        PolicyConfig           policy();
 
 
         /** Shared Docker network for sidecar containers (Artemis, Redpanda, etc.). */
@@ -198,6 +199,15 @@ public interface EmulatorConfig {
          */
         @WithDefault("subscriptions/00000000-0000-0000-0000-000000000001")
         String systemAssignedScope();
+    }
+
+    /**
+     * Azure Policy control plane under Microsoft.Authorization: policy definitions, set definitions,
+     * assignments and exemptions. Control plane only; rules are stored, never evaluated.
+     */
+    interface PolicyConfig {
+        @WithDefault("true")
+        boolean enabled();
     }
 
     /** Microsoft Entra ID (Azure AD) emulation — local OpenID Connect provider. */

--- a/src/main/java/io/floci/az/core/AzureRoutingFilter.java
+++ b/src/main/java/io/floci/az/core/AzureRoutingFilter.java
@@ -457,18 +457,26 @@ public class AzureRoutingFilter {
     }
 
     /**
-     * ARM management-plane provider routing: {@code subscriptions/{sub}/.../providers/Microsoft.X/...}.
-     * Iterated in {@link #providerRoutes} order (guarded first): Managed Identity is guarded so its provider
-     * segment must be the last {@code /providers/} in the path — identity-scoped children (role
-     * assignments, locks, ...) have a later segment and fall through to {@link #routeArmGeneric}. All of
-     * these must precede the generic ARM stage, which would otherwise swallow every path.
+     * ARM management-plane provider routing: {@code subscriptions/{sub}/.../providers/Microsoft.X/...}
+     * and the tenant-rooted {@code providers/Microsoft.X/...} forms (built-in policy definitions,
+     * management-group scopes). Iterated in {@link #providerRoutes} order (guarded first): Managed
+     * Identity is guarded so its provider segment must be the last {@code /providers/} in the path;
+     * identity-scoped children (role assignments, locks, ...) have a later segment and fall through to
+     * {@link #routeArmGeneric}. Azure Policy is guarded so it claims only the policy resource types of
+     * Microsoft.Authorization. All of these must precede the generic ARM stage, which would otherwise
+     * swallow every path.
      */
     private Outcome routeArmProviders(RoutingContext ctx) {
-        if (!ctx.path().startsWith("subscriptions/")) {
+        String path = ctx.path();
+        boolean tenantRooted = path.startsWith("providers/");
+        if (!path.startsWith("subscriptions/") && !tenantRooted) {
             return Fallthrough.TO_NEXT_STAGE;
         }
+        // A tenant-rooted path has no segment before "providers/", so the "/providers/<ns>/" marker is
+        // matched against the slash-prefixed path; guards see the same form.
+        String markerPath = tenantRooted ? "/" + path : path;
         for (ResolvedProvider route : providerRoutes) {
-            if (!ctx.path().contains(route.marker()) || !route.guard().test(ctx.path())) {
+            if (!markerPath.contains(route.marker()) || !route.guard().test(markerPath)) {
                 continue;
             }
             // A disabled provider service declines, letting a later provider (or generic ARM) claim it.

--- a/src/main/java/io/floci/az/core/BannerLogger.java
+++ b/src/main/java/io/floci/az/core/BannerLogger.java
@@ -151,6 +151,9 @@ public class BannerLogger {
         sb.append(String.format("   %-9s [%s]  %s\n", "managedid",
                 config.services().managedIdentity().enabled() ? "enabled " : "disabled",
                 "Microsoft.ManagedIdentity (user-assigned identities + IMDS token endpoint)"));
+        sb.append(String.format("   %-9s [%s]  %s\n", "policy",
+                config.services().policy().enabled() ? "enabled " : "disabled",
+                "Microsoft.Authorization policy (definitions, set definitions, assignments, exemptions)"));
         if (config.services().eventGrid().enabled()) {
             sb.append(serviceStatus("eventgrid", true, getStorageMode("eventgrid")));
         }

--- a/src/main/java/io/floci/az/services/policy/PolicyHandler.java
+++ b/src/main/java/io/floci/az/services/policy/PolicyHandler.java
@@ -1,0 +1,824 @@
+package io.floci.az.services.policy;
+
+import io.floci.az.config.EmulatorConfig;
+import io.floci.az.core.AzureRequest;
+import io.floci.az.core.AzureServiceHandler;
+import io.floci.az.core.Resettable;
+import io.floci.az.core.ServiceRoutes;
+import io.floci.az.core.arm.ArmErrors;
+import io.floci.az.core.arm.ArmJson;
+import io.floci.az.services.entra.TokenIssuer;
+import io.floci.az.services.managedidentity.ManagedIdentityStore;
+import io.floci.az.services.policy.PolicyPath.ScopeKind;
+import io.floci.az.services.policy.PolicyPath.Type;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.Response;
+import org.jboss.logging.Logger;
+
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Azure Policy control plane under {@code Microsoft.Authorization}: policy definitions, policy set
+ * definitions (initiatives), policy assignments and policy exemptions, at every ARM scope the real
+ * service accepts. Shapes follow the policy spec {@code 2025-03-01} (exemptions:
+ * {@code 2022-07-01-preview}); any {@code api-version} is accepted.
+ *
+ * <p>This is the control plane only. Definitions are stored and validated structurally, but no
+ * policy rule is ever evaluated against resource requests, so nothing is denied, audited or
+ * remediated, and there is no compliance state. Built-in definitions are not seeded: the tenant-rooted
+ * built-in listings answer an empty collection and built-in ids are accepted in references without
+ * validation.</p>
+ */
+@ApplicationScoped
+public class PolicyHandler implements AzureServiceHandler, Resettable {
+
+    private static final Logger LOG = Logger.getLogger(PolicyHandler.class);
+
+    static final String SERVICE_TYPE = "policy";
+    private static final String SCOPE_KEY = "_scope";
+    /** Object id reported as the author in {@code metadata} and {@code systemData}, stable across restarts. */
+    private static final String AUTHOR = TokenIssuer.deterministicGuid("policy-author");
+    private static final Set<String> EXEMPTION_CATEGORIES = Set.of("Waiver", "Mitigated");
+    private static final Set<ScopeKind> DEFINITION_SCOPES = EnumSet.of(ScopeKind.MANAGEMENT_GROUP, ScopeKind.SUBSCRIPTION);
+    private static final Set<ScopeKind> ASSIGNMENT_SCOPES = EnumSet.of(ScopeKind.MANAGEMENT_GROUP,
+            ScopeKind.SUBSCRIPTION, ScopeKind.RESOURCE_GROUP, ScopeKind.RESOURCE);
+    private static final Pattern FILTER_EQUALS = Pattern.compile("(\\w+)\\s+eq\\s+'([^']*)'", Pattern.CASE_INSENSITIVE);
+
+    private final EmulatorConfig config;
+    private final PolicyStore store;
+    private final ManagedIdentityStore identities;
+
+    @Inject
+    public PolicyHandler(EmulatorConfig config, PolicyStore store, ManagedIdentityStore identities) {
+        this.config = config;
+        this.store = store;
+        this.identities = identities;
+    }
+
+    @Override
+    public String getServiceType() {
+        return SERVICE_TYPE;
+    }
+
+    @Override
+    public boolean enabled(String serviceType) {
+        return config.services().policy().enabled();
+    }
+
+    /**
+     * Guarded: Microsoft.Authorization also owns role assignments, locks and deny assignments, which
+     * this handler does not serve. Only paths whose last {@code Microsoft.Authorization} segment names a
+     * policy resource type are claimed; everything else keeps falling through to the generic ARM handler.
+     */
+    @Override
+    public ServiceRoutes routes() {
+        return ServiceRoutes.builder()
+                .provider("Microsoft.Authorization", PolicyPath::isPolicyPath)
+                .build();
+    }
+
+    @Override
+    public boolean canHandle(AzureRequest request) {
+        return SERVICE_TYPE.equals(request.serviceType());
+    }
+
+    @Override
+    public Response handle(AzureRequest req) {
+        String method = req.method().toUpperCase(Locale.ROOT);
+        String path = PolicyPath.stripQuery(req.resourcePath());
+        PolicyPath parsed = PolicyPath.parse(path);
+        if (parsed == null || parsed.type() == null) {
+            return ArmErrors.error(404, "ResourceNotFound", "Unsupported Microsoft.Authorization path: " + path);
+        }
+        if (!parsed.remainder().isEmpty()) {
+            return ArmErrors.error(404, "ResourceNotFound",
+                    "Sub-resources of " + parsed.type().armType() + " are not supported: " + path);
+        }
+        ListFilter filter = ListFilter.parse(req.queryParams() == null ? null : req.queryParams().get("$filter"));
+        try {
+            return switch (parsed.type()) {
+                case DEFINITION -> handleDefinition(req, parsed, method, filter);
+                case SET_DEFINITION -> handleSetDefinition(req, parsed, method, filter);
+                case ASSIGNMENT -> handleAssignment(req, parsed, method, filter);
+                case EXEMPTION -> handleExemption(req, parsed, method, filter);
+            };
+        } catch (ArmJson.InvalidBodyException e) {
+            return ArmErrors.error(400, "InvalidRequestContent",
+                    "The request content was invalid and could not be deserialized.");
+        }
+    }
+
+    @Override
+    public void clear() {
+        store.clear();
+    }
+
+    // ── Policy definitions ──────────────────────────────────────────────────────
+
+    private Response handleDefinition(AzureRequest req, PolicyPath path, String method, ListFilter filter) {
+        ScopeKind kind = path.scopeKind();
+        if (kind == ScopeKind.TENANT) {
+            return handleBuiltIn(path, method, "PolicyDefinitionNotFound",
+                    "The policy definition '" + path.name() + "' could not be found.");
+        }
+        if (!DEFINITION_SCOPES.contains(kind)) {
+            return unsupportedScope(path);
+        }
+        if (path.name() == null) {
+            if (!"GET".equals(method)) {
+                return methodNotAllowed(method);
+            }
+            return listResponse(store.listDefinitions(), path, filter, true);
+        }
+        String id = path.resourceId();
+        return switch (method) {
+            case "PUT" -> putDefinition(req, path, id);
+            case "GET" -> {
+                Map<String, Object> existing = store.getDefinition(id);
+                yield existing == null
+                        ? ArmErrors.error(404, "PolicyDefinitionNotFound",
+                                "The policy definition '" + path.name() + "' could not be found.")
+                        : Response.ok(strip(existing)).build();
+            }
+            case "DELETE" -> deleteDefinition(path, id);
+            default -> methodNotAllowed(method);
+        };
+    }
+
+    private Response putDefinition(AzureRequest req, PolicyPath path, String id) {
+        Map<String, Object> body = ArmJson.parseBodyStrict(req);
+        Map<String, Object> props = ArmJson.cast(body.get("properties"));
+        Object rule = props.get("policyRule");
+        if (rule == null) {
+            return ArmErrors.error(400, "InvalidCreatePolicyDefinitionRequest",
+                    "The policy definition '" + path.name() + "' create request is invalid. "
+                            + "The 'policyRule' property is required.");
+        }
+        if (!(rule instanceof Map<?, ?> ruleMap)
+                || !(ruleMap.get("if") instanceof Map<?, ?>)
+                || !(ruleMap.get("then") instanceof Map<?, ?> then)
+                || !(then.get("effect") instanceof String)) {
+            return ArmErrors.error(400, "InvalidPolicyRule",
+                    "Failed to parse policy rule: the rule must be an object with an 'if' condition "
+                            + "and a 'then' block that names an 'effect'.");
+        }
+        Map<String, Object> existing = store.getDefinition(id);
+
+        Map<String, Object> properties = new LinkedHashMap<>();
+        putIfString(properties, "displayName", props);
+        properties.put("policyType", "Custom");
+        properties.put("mode", ArmJson.string(props, "mode", "Indexed"));
+        putIfString(properties, "description", props);
+        properties.put("metadata", auditedMetadata(props.get("metadata"), existing));
+        properties.put("version", ArmJson.string(props, "version", "1.0.0"));
+        putIfMap(properties, "parameters", props);
+        properties.put("policyRule", rule);
+
+        Map<String, Object> resource = envelope(path, id, properties, existing);
+        store.putDefinition(id, resource);
+        // Per the policy spec, CreateOrUpdate on a definition answers 201 for both create and update.
+        return Response.status(201).entity(strip(resource)).build();
+    }
+
+    private Response deleteDefinition(PolicyPath path, String id) {
+        if (store.getDefinition(id) == null) {
+            return Response.status(204).build();
+        }
+        Optional<String> set = store.findSetDefinitionReferencing(id);
+        if (set.isPresent()) {
+            return ArmErrors.error(400, "InvalidDeletePolicyDefinitionRequest",
+                    "The policy definition '" + path.name() + "' cannot be deleted. It is referenced by the "
+                            + "policy set definition '" + set.get() + "'. Please remove this policy definition "
+                            + "from all policy set definitions that reference it.");
+        }
+        Optional<String> assignment = store.findAssignmentReferencing(id);
+        if (assignment.isPresent()) {
+            return ArmErrors.error(400, "InvalidDeletePolicyDefinitionRequest",
+                    "The policy definition '" + path.name() + "' cannot be deleted. It is referenced by the "
+                            + "policy assignment '" + assignment.get() + "'. Please remove this policy assignment "
+                            + "before deleting the policy definition.");
+        }
+        store.removeDefinition(id);
+        return Response.ok().build();
+    }
+
+    // ── Policy set definitions ──────────────────────────────────────────────────
+
+    private Response handleSetDefinition(AzureRequest req, PolicyPath path, String method, ListFilter filter) {
+        ScopeKind kind = path.scopeKind();
+        if (kind == ScopeKind.TENANT) {
+            return handleBuiltIn(path, method, "PolicySetDefinitionNotFound",
+                    "The policy set definition '" + path.name() + "' could not be found.");
+        }
+        if (!DEFINITION_SCOPES.contains(kind)) {
+            return unsupportedScope(path);
+        }
+        if (path.name() == null) {
+            if (!"GET".equals(method)) {
+                return methodNotAllowed(method);
+            }
+            return listResponse(store.listSetDefinitions(), path, filter, true);
+        }
+        String id = path.resourceId();
+        return switch (method) {
+            case "PUT" -> putSetDefinition(req, path, id);
+            case "GET" -> {
+                Map<String, Object> existing = store.getSetDefinition(id);
+                yield existing == null
+                        ? ArmErrors.error(404, "PolicySetDefinitionNotFound",
+                                "The policy set definition '" + path.name() + "' could not be found.")
+                        : Response.ok(strip(existing)).build();
+            }
+            case "DELETE" -> deleteSetDefinition(path, id);
+            default -> methodNotAllowed(method);
+        };
+    }
+
+    private Response putSetDefinition(AzureRequest req, PolicyPath path, String id) {
+        Map<String, Object> body = ArmJson.parseBodyStrict(req);
+        Map<String, Object> props = ArmJson.cast(body.get("properties"));
+        if (!(props.get("policyDefinitions") instanceof List<?> references) || references.isEmpty()) {
+            return ArmErrors.error(400, "InvalidCreatePolicySetDefinitionRequest",
+                    "The policy set definition '" + path.name() + "' create request is invalid. "
+                            + "At least one policy definition must be referenced.");
+        }
+        List<Map<String, Object>> normalized = new ArrayList<>();
+        for (Object element : references) {
+            if (!(element instanceof Map<?, ?> raw)
+                    || !(raw.get("policyDefinitionId") instanceof String definitionId)
+                    || definitionId.isBlank()) {
+                return ArmErrors.error(400, "InvalidPolicyDefinitionReference",
+                        "The policy set definition '" + path.name() + "' references a policy definition "
+                                + "without a 'policyDefinitionId'.");
+            }
+            Response missing = requireDefinition(definitionId);
+            if (missing != null) {
+                return missing;
+            }
+            Map<String, Object> reference = new LinkedHashMap<>();
+            reference.put("policyDefinitionReferenceId",
+                    raw.get("policyDefinitionReferenceId") instanceof String refId && !refId.isBlank()
+                            ? refId : generatedReferenceId());
+            reference.put("policyDefinitionId", definitionId);
+            reference.put("definitionVersion",
+                    raw.get("definitionVersion") instanceof String version ? version : "1.*.*");
+            if (raw.get("parameters") instanceof Map<?, ?> parameters) {
+                reference.put("parameters", parameters);
+            }
+            if (raw.get("groupNames") instanceof List<?> groupNames) {
+                reference.put("groupNames", groupNames);
+            }
+            normalized.add(reference);
+        }
+        Map<String, Object> existing = store.getSetDefinition(id);
+
+        Map<String, Object> properties = new LinkedHashMap<>();
+        putIfString(properties, "displayName", props);
+        properties.put("policyType", "Custom");
+        putIfString(properties, "description", props);
+        properties.put("metadata", auditedMetadata(props.get("metadata"), existing));
+        properties.put("version", ArmJson.string(props, "version", "1.0.0"));
+        putIfMap(properties, "parameters", props);
+        properties.put("policyDefinitions", normalized);
+        putIfList(properties, "policyDefinitionGroups", props);
+
+        Map<String, Object> resource = envelope(path, id, properties, existing);
+        store.putSetDefinition(id, resource);
+        return Response.status(existing == null ? 201 : 200).entity(strip(resource)).build();
+    }
+
+    private Response deleteSetDefinition(PolicyPath path, String id) {
+        if (store.getSetDefinition(id) == null) {
+            return Response.status(204).build();
+        }
+        Optional<String> assignment = store.findAssignmentReferencing(id);
+        if (assignment.isPresent()) {
+            return ArmErrors.error(400, "InvalidDeletePolicySetDefinitionRequest",
+                    "The policy set definition '" + path.name() + "' cannot be deleted. It is referenced by "
+                            + "the policy assignment '" + assignment.get() + "'. Please remove this policy "
+                            + "assignment before deleting the policy set definition.");
+        }
+        store.removeSetDefinition(id);
+        return Response.ok().build();
+    }
+
+    // ── Policy assignments ──────────────────────────────────────────────────────
+
+    private Response handleAssignment(AzureRequest req, PolicyPath path, String method, ListFilter filter) {
+        Response scopeError = requireAssignmentScope(path);
+        if (scopeError != null) {
+            return scopeError;
+        }
+        if (path.name() == null) {
+            if (!"GET".equals(method)) {
+                return methodNotAllowed(method);
+            }
+            return listResponse(store.listAssignments(), path, filter, false);
+        }
+        String id = path.resourceId();
+        return switch (method) {
+            case "PUT" -> putAssignment(req, path, id);
+            case "PATCH" -> patchAssignment(req, path, id);
+            case "GET" -> {
+                Map<String, Object> existing = store.getAssignment(id);
+                yield existing == null ? assignmentNotFound(path.name()) : Response.ok(strip(existing)).build();
+            }
+            case "DELETE" -> {
+                Map<String, Object> existing = store.getAssignment(id);
+                if (existing == null) {
+                    yield Response.status(204).build();
+                }
+                // Exemptions are bound to their assignment and go with it, as on Azure.
+                store.removeExemptionsForAssignment(id);
+                store.removeAssignment(id);
+                yield Response.ok(strip(existing)).build();
+            }
+            default -> methodNotAllowed(method);
+        };
+    }
+
+    private Response putAssignment(AzureRequest req, PolicyPath path, String id) {
+        Map<String, Object> body = ArmJson.parseBodyStrict(req);
+        Map<String, Object> props = ArmJson.cast(body.get("properties"));
+        String definitionId = ArmJson.string(props, "policyDefinitionId", null);
+        if (definitionId == null || definitionId.isBlank()) {
+            return ArmErrors.error(400, "InvalidCreatePolicyAssignmentRequest",
+                    "The policy assignment '" + path.name() + "' create request is invalid. "
+                            + "A 'policyDefinitionId' must be provided.");
+        }
+        Response missing = definitionId.toLowerCase(Locale.ROOT).contains("/policysetdefinitions/")
+                ? requireSetDefinition(definitionId)
+                : requireDefinition(definitionId);
+        if (missing != null) {
+            return missing;
+        }
+        Map<String, Object> existing = store.getAssignment(id);
+
+        Map<String, Object> resource = new LinkedHashMap<>();
+        Map<String, Object> identity = buildIdentity(body.get("identity"), existing);
+        if (identity != null) {
+            resource.put("identity", identity);
+        }
+        Map<String, Object> properties = new LinkedHashMap<>();
+        putIfString(properties, "displayName", props);
+        properties.put("policyDefinitionId", definitionId);
+        properties.put("definitionVersion", ArmJson.string(props, "definitionVersion", "1.*.*"));
+        properties.put("scope", "/" + path.scope());
+        putIfList(properties, "notScopes", props);
+        putIfMap(properties, "parameters", props);
+        putIfString(properties, "description", props);
+        properties.put("metadata", auditedMetadata(props.get("metadata"), existing));
+        properties.put("enforcementMode", ArmJson.string(props, "enforcementMode", "Default"));
+        putIfList(properties, "nonComplianceMessages", props);
+        putIfList(properties, "resourceSelectors", props);
+        putIfList(properties, "overrides", props);
+        properties.put("instanceId", existing == null
+                ? UUID.randomUUID().toString()
+                : propertiesOf(existing).get("instanceId"));
+
+        resource.put("properties", properties);
+        resource.put("id", id);
+        resource.put("type", path.type().armType());
+        resource.put("name", path.name());
+        if (body.get("location") instanceof String location) {
+            resource.put("location", location);
+        }
+        resource.put("systemData", systemData(existing));
+        resource.put(SCOPE_KEY, path.scopeKey());
+        store.putAssignment(id, resource);
+        // Per the policy spec, Create on an assignment answers 201 for both create and update.
+        return Response.status(201).entity(strip(resource)).build();
+    }
+
+    /** PATCH updates only the identity, location, resource selectors and overrides (PolicyAssignmentUpdate). */
+    private Response patchAssignment(AzureRequest req, PolicyPath path, String id) {
+        Map<String, Object> existing = store.getAssignment(id);
+        if (existing == null) {
+            return assignmentNotFound(path.name());
+        }
+        Map<String, Object> body = ArmJson.parseBodyStrict(req);
+        Map<String, Object> patch = ArmJson.cast(body.get("properties"));
+
+        Map<String, Object> updated = new LinkedHashMap<>();
+        Object identity = body.containsKey("identity") ? buildIdentity(body.get("identity"), existing) : existing.get("identity");
+        if (identity != null) {
+            updated.put("identity", identity);
+        }
+        Map<String, Object> properties = new LinkedHashMap<>(propertiesOf(existing));
+        if (patch.get("resourceSelectors") instanceof List<?> selectors) {
+            properties.put("resourceSelectors", selectors);
+        }
+        if (patch.get("overrides") instanceof List<?> overrides) {
+            properties.put("overrides", overrides);
+        }
+        updated.put("properties", properties);
+        updated.put("id", existing.get("id"));
+        updated.put("type", existing.get("type"));
+        updated.put("name", existing.get("name"));
+        Object location = body.get("location") instanceof String given ? given : existing.get("location");
+        if (location != null) {
+            updated.put("location", location);
+        }
+        updated.put("systemData", systemData(existing));
+        updated.put(SCOPE_KEY, existing.get(SCOPE_KEY));
+        store.putAssignment(id, updated);
+        return Response.ok(strip(updated)).build();
+    }
+
+    /**
+     * Managed identity for an assignment. System-assigned identities get a server-generated principal
+     * that stays stable across updates; user-assigned identities resolve their principal and client ids
+     * from the Managed Identity store when the identity exists there, and get deterministic ids otherwise.
+     */
+    private Map<String, Object> buildIdentity(Object given, Map<String, Object> existing) {
+        if (!(given instanceof Map<?, ?> requested)) {
+            return null;
+        }
+        String type = requested.get("type") instanceof String value ? value : "None";
+        Map<String, Object> identity = new LinkedHashMap<>();
+        if ("SystemAssigned".equalsIgnoreCase(type)) {
+            Map<?, ?> previous = existing != null && existing.get("identity") instanceof Map<?, ?> map ? map : Map.of();
+            String principalId = "SystemAssigned".equalsIgnoreCase(String.valueOf(previous.get("type")))
+                    && previous.get("principalId") instanceof String kept
+                    ? kept : UUID.randomUUID().toString();
+            identity.put("principalId", principalId);
+            identity.put("tenantId", config.services().entra().defaultTenantId());
+            identity.put("type", "SystemAssigned");
+            return identity;
+        }
+        if ("UserAssigned".equalsIgnoreCase(type)) {
+            identity.put("type", "UserAssigned");
+            Map<String, Object> userAssigned = new LinkedHashMap<>();
+            if (requested.get("userAssignedIdentities") instanceof Map<?, ?> ids) {
+                for (Object key : ids.keySet()) {
+                    String resourceId = String.valueOf(key);
+                    userAssigned.put(resourceId, identities.findByResourceId(resourceId)
+                            .map(PolicyHandler::identityIds)
+                            .orElseGet(() -> Map.<String, Object>of(
+                                    "principalId", TokenIssuer.deterministicGuid("policy-uai-principal:" + resourceId.toLowerCase(Locale.ROOT)),
+                                    "clientId", TokenIssuer.deterministicGuid("policy-uai-client:" + resourceId.toLowerCase(Locale.ROOT)))));
+                }
+            }
+            identity.put("userAssignedIdentities", userAssigned);
+            return identity;
+        }
+        identity.put("type", "None");
+        return identity;
+    }
+
+    private static Map<String, Object> identityIds(Map<String, Object> identity) {
+        Map<String, Object> props = ArmJson.cast(identity.get("properties"));
+        Map<String, Object> ids = new LinkedHashMap<>();
+        ids.put("principalId", props.get("principalId"));
+        ids.put("clientId", props.get("clientId"));
+        return ids;
+    }
+
+    private static Response assignmentNotFound(String name) {
+        return ArmErrors.error(404, "PolicyAssignmentNotFound", "The policy assignment '" + name + "' is not found.");
+    }
+
+    // ── Policy exemptions ───────────────────────────────────────────────────────
+
+    private Response handleExemption(AzureRequest req, PolicyPath path, String method, ListFilter filter) {
+        Response scopeError = requireAssignmentScope(path);
+        if (scopeError != null) {
+            return scopeError;
+        }
+        if (path.name() == null) {
+            if (!"GET".equals(method)) {
+                return methodNotAllowed(method);
+            }
+            return listResponse(store.listExemptions(), path, filter, false);
+        }
+        String id = path.resourceId();
+        return switch (method) {
+            case "PUT" -> putExemption(req, path, id);
+            case "PATCH" -> patchExemption(req, path, id);
+            case "GET" -> {
+                Map<String, Object> existing = store.getExemption(id);
+                yield existing == null ? exemptionNotFound(path.name()) : Response.ok(strip(existing)).build();
+            }
+            case "DELETE" -> {
+                Map<String, Object> removed = store.removeExemption(id);
+                yield removed == null ? Response.status(204).build() : Response.ok(strip(removed)).build();
+            }
+            default -> methodNotAllowed(method);
+        };
+    }
+
+    private Response putExemption(AzureRequest req, PolicyPath path, String id) {
+        Map<String, Object> body = ArmJson.parseBodyStrict(req);
+        Map<String, Object> props = ArmJson.cast(body.get("properties"));
+        String assignmentId = ArmJson.string(props, "policyAssignmentId", null);
+        if (assignmentId == null || assignmentId.isBlank()) {
+            return ArmErrors.error(400, "InvalidCreatePolicyExemptionRequest",
+                    "The policy exemption '" + path.name() + "' create request is invalid. "
+                            + "A 'policyAssignmentId' must be provided.");
+        }
+        String category = ArmJson.string(props, "exemptionCategory", null);
+        if (category == null || !EXEMPTION_CATEGORIES.contains(category)) {
+            return ArmErrors.error(400, "InvalidCreatePolicyExemptionRequest",
+                    "The policy exemption '" + path.name() + "' create request is invalid. "
+                            + "The 'exemptionCategory' must be 'Waiver' or 'Mitigated'.");
+        }
+        if (store.getAssignment(assignmentId) == null) {
+            return assignmentNotFound(leaf(assignmentId));
+        }
+        Map<String, Object> existing = store.getExemption(id);
+
+        Map<String, Object> properties = new LinkedHashMap<>();
+        properties.put("policyAssignmentId", assignmentId);
+        putIfList(properties, "policyDefinitionReferenceIds", props);
+        properties.put("exemptionCategory", category);
+        putIfString(properties, "expiresOn", props);
+        putIfString(properties, "displayName", props);
+        putIfString(properties, "description", props);
+        properties.put("assignmentScopeValidation", ArmJson.string(props, "assignmentScopeValidation", "Default"));
+        putIfMap(properties, "metadata", props);
+        putIfList(properties, "resourceSelectors", props);
+
+        Map<String, Object> resource = envelope(path, id, properties, existing);
+        store.putExemption(id, resource);
+        return Response.status(existing == null ? 201 : 200).entity(strip(resource)).build();
+    }
+
+    /** PATCH updates only the resource selectors and the scope validation mode (PolicyExemptionUpdate). */
+    private Response patchExemption(AzureRequest req, PolicyPath path, String id) {
+        Map<String, Object> existing = store.getExemption(id);
+        if (existing == null) {
+            return exemptionNotFound(path.name());
+        }
+        Map<String, Object> patch = ArmJson.cast(ArmJson.parseBodyStrict(req).get("properties"));
+        Map<String, Object> properties = new LinkedHashMap<>(propertiesOf(existing));
+        if (patch.get("resourceSelectors") instanceof List<?> selectors) {
+            properties.put("resourceSelectors", selectors);
+        }
+        if (patch.get("assignmentScopeValidation") instanceof String validation) {
+            properties.put("assignmentScopeValidation", validation);
+        }
+        Map<String, Object> updated = envelope(path, id, properties, existing);
+        store.putExemption(id, updated);
+        return Response.ok(strip(updated)).build();
+    }
+
+    private static Response exemptionNotFound(String name) {
+        return ArmErrors.error(404, "PolicyExemptionNotFound", "The policy exemption '" + name + "' could not be found.");
+    }
+
+    // ── Shared: scopes, references, listing ─────────────────────────────────────
+
+    /**
+     * Tenant-rooted definition paths are where Azure serves built-in definitions. None are seeded, so
+     * collections are empty and names are not found; writes get the ARM gateway's tenant-level rejection.
+     */
+    private Response handleBuiltIn(PolicyPath path, String method, String notFoundCode, String notFoundMessage) {
+        if ("GET".equals(method)) {
+            return path.name() == null
+                    ? Response.ok(Map.of("value", List.of())).build()
+                    : ArmErrors.error(404, notFoundCode, notFoundMessage);
+        }
+        return missingSubscription();
+    }
+
+    private Response requireAssignmentScope(PolicyPath path) {
+        ScopeKind kind = path.scopeKind();
+        if (kind == ScopeKind.TENANT) {
+            return missingSubscription();
+        }
+        return ASSIGNMENT_SCOPES.contains(kind) ? null : unsupportedScope(path);
+    }
+
+    /**
+     * Definitions in a subscription or management group must exist; tenant-rooted ids are built-in
+     * references and are accepted as-is because built-ins are not seeded.
+     */
+    private Response requireDefinition(String definitionId) {
+        if (isScopedId(definitionId) && store.getDefinition(definitionId) == null) {
+            return ArmErrors.error(404, "PolicyDefinitionNotFound",
+                    "The policy definition '" + leaf(definitionId) + "' could not be found.");
+        }
+        return null;
+    }
+
+    private Response requireSetDefinition(String setDefinitionId) {
+        if (isScopedId(setDefinitionId) && store.getSetDefinition(setDefinitionId) == null) {
+            return ArmErrors.error(404, "PolicySetDefinitionNotFound",
+                    "The policy set definition '" + leaf(setDefinitionId) + "' could not be found.");
+        }
+        return null;
+    }
+
+    private static boolean isScopedId(String id) {
+        String lower = id.toLowerCase(Locale.ROOT);
+        return lower.contains("/subscriptions/") || lower.contains("/managementgroups/");
+    }
+
+    /**
+     * Lists resources for a scope. Definitions and set definitions live at exactly the requested
+     * scope. Assignments and exemptions are extension resources whose default listing also includes
+     * the ancestors and descendants of the scope, narrowed by {@code atScope()}, {@code atExactScope()}
+     * or {@code atScopeAndBelow()}, plus the {@code eq} filters the spec allows.
+     */
+    private Response listResponse(List<Map<String, Object>> candidates, PolicyPath path, ListFilter filter,
+                                  boolean exactScopeOnly) {
+        String requested = path.scopeKey();
+        List<Map<String, Object>> value = new ArrayList<>();
+        for (Map<String, Object> resource : candidates) {
+            String candidate = String.valueOf(resource.get(SCOPE_KEY));
+            boolean scopeMatch = exactScopeOnly ? candidate.equals(requested) : filter.matchesScope(candidate, requested);
+            if (scopeMatch && filter.matchesProperties(propertiesOf(resource))) {
+                value.add(strip(resource));
+            }
+        }
+        return Response.ok(Map.of("value", value)).build();
+    }
+
+    /** The {@code $filter} grammar of the policy list operations, parsed leniently. */
+    record ListFilter(boolean atExactScope, boolean atScope, boolean atScopeAndBelow, boolean excludeExpired,
+                      Map<String, String> equalities) {
+
+        static ListFilter parse(String raw) {
+            if (raw == null || raw.isBlank()) {
+                return new ListFilter(false, false, false, false, Map.of());
+            }
+            String lower = raw.toLowerCase(Locale.ROOT).replace(" ", "");
+            Map<String, String> equalities = new LinkedHashMap<>();
+            Matcher matcher = FILTER_EQUALS.matcher(raw);
+            while (matcher.find()) {
+                equalities.put(matcher.group(1).toLowerCase(Locale.ROOT), matcher.group(2));
+            }
+            return new ListFilter(lower.contains("atexactscope()"), lower.contains("atscope()"),
+                    lower.contains("atscopeandbelow()"), lower.contains("excludeexpired()"), equalities);
+        }
+
+        boolean matchesScope(String candidate, String requested) {
+            boolean equal = candidate.equals(requested);
+            boolean ancestor = requested.startsWith(candidate + "/");
+            boolean descendant = candidate.startsWith(requested + "/");
+            if (atExactScope) {
+                return equal;
+            }
+            if (atScope) {
+                return equal || ancestor;
+            }
+            if (atScopeAndBelow) {
+                return equal || descendant;
+            }
+            return equal || ancestor || descendant;
+        }
+
+        boolean matchesProperties(Map<String, Object> properties) {
+            for (Map.Entry<String, String> equality : equalities.entrySet()) {
+                String wanted = equality.getValue();
+                switch (equality.getKey()) {
+                    case "policytype" -> {
+                        if (!"Custom".equalsIgnoreCase(wanted)) {
+                            return false;
+                        }
+                    }
+                    case "policydefinitionid" -> {
+                        if (!wanted.equalsIgnoreCase(String.valueOf(properties.get("policyDefinitionId")))) {
+                            return false;
+                        }
+                    }
+                    case "policyassignmentid" -> {
+                        if (!wanted.equalsIgnoreCase(String.valueOf(properties.get("policyAssignmentId")))) {
+                            return false;
+                        }
+                    }
+                    default -> {
+                        // Unknown filter keys are ignored rather than rejected, matching the lenient
+                        // treatment ARM-plane handlers give unrecognised query options.
+                    }
+                }
+            }
+            if (excludeExpired && properties.get("expiresOn") instanceof String expiresOn) {
+                try {
+                    if (Instant.parse(expiresOn).isBefore(Instant.now())) {
+                        return false;
+                    }
+                } catch (DateTimeParseException e) {
+                    LOG.debugf("Ignoring unparseable expiresOn %s while filtering exemptions", expiresOn);
+                }
+            }
+            return true;
+        }
+    }
+
+    // ── Shared: resource assembly ───────────────────────────────────────────────
+
+    /** Wraps {@code properties} in the ARM envelope: properties, id, type, name, systemData. */
+    private Map<String, Object> envelope(PolicyPath path, String id, Map<String, Object> properties,
+                                         Map<String, Object> existing) {
+        Map<String, Object> resource = new LinkedHashMap<>();
+        resource.put("properties", properties);
+        resource.put("id", id);
+        resource.put("type", path.type().armType());
+        resource.put("name", path.name());
+        resource.put("systemData", systemData(existing));
+        resource.put(SCOPE_KEY, path.scopeKey());
+        return resource;
+    }
+
+    /**
+     * The caller-supplied {@code metadata} plus the audit keys Azure stamps on definitions, set
+     * definitions and assignments. Server values always win over any audit keys echoed back by the client.
+     */
+    private static Map<String, Object> auditedMetadata(Object given, Map<String, Object> existing) {
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        if (given instanceof Map<?, ?> map) {
+            map.forEach((key, value) -> metadata.put(String.valueOf(key), value));
+        }
+        String now = Instant.now().toString();
+        Map<String, Object> previous = existing == null ? null : ArmJson.cast(propertiesOf(existing).get("metadata"));
+        if (previous == null || previous.isEmpty()) {
+            metadata.put("createdBy", AUTHOR);
+            metadata.put("createdOn", now);
+        } else {
+            metadata.put("createdBy", previous.get("createdBy"));
+            metadata.put("createdOn", previous.get("createdOn"));
+            metadata.put("updatedBy", AUTHOR);
+            metadata.put("updatedOn", now);
+        }
+        return metadata;
+    }
+
+    private static Map<String, Object> systemData(Map<String, Object> existing) {
+        String now = Instant.now().toString();
+        Map<String, Object> previous = existing == null ? Map.of() : ArmJson.cast(existing.get("systemData"));
+        Map<String, Object> systemData = new LinkedHashMap<>();
+        systemData.put("createdBy", previous.getOrDefault("createdBy", AUTHOR));
+        systemData.put("createdByType", "Application");
+        systemData.put("createdAt", previous.getOrDefault("createdAt", now));
+        systemData.put("lastModifiedBy", AUTHOR);
+        systemData.put("lastModifiedByType", "Application");
+        systemData.put("lastModifiedAt", now);
+        return systemData;
+    }
+
+    /** Azure hands out numeric reference ids for policy definition references that were created without one. */
+    private static String generatedReferenceId() {
+        return Long.toUnsignedString(ThreadLocalRandom.current().nextLong());
+    }
+
+    private static Map<String, Object> strip(Map<String, Object> resource) {
+        Map<String, Object> copy = new LinkedHashMap<>(resource);
+        copy.remove(SCOPE_KEY);
+        return copy;
+    }
+
+    private static Map<String, Object> propertiesOf(Map<String, Object> resource) {
+        return ArmJson.cast(resource.get("properties"));
+    }
+
+    private static String leaf(String resourceId) {
+        return resourceId.substring(resourceId.lastIndexOf('/') + 1);
+    }
+
+    private static void putIfString(Map<String, Object> target, String key, Map<String, Object> source) {
+        if (source.get(key) instanceof String value) {
+            target.put(key, value);
+        }
+    }
+
+    private static void putIfMap(Map<String, Object> target, String key, Map<String, Object> source) {
+        if (source.get(key) instanceof Map<?, ?> value) {
+            target.put(key, value);
+        }
+    }
+
+    private static void putIfList(Map<String, Object> target, String key, Map<String, Object> source) {
+        if (source.get(key) instanceof List<?> value) {
+            target.put(key, value);
+        }
+    }
+
+    private static Response unsupportedScope(PolicyPath path) {
+        return ArmErrors.error(404, "ResourceNotFound",
+                path.type().armType() + " is not available at scope '/" + path.scope() + "'.");
+    }
+
+    private static Response missingSubscription() {
+        return ArmErrors.error(400, "MissingSubscription",
+                "The request did not have a subscription or a valid tenant level resource provider.");
+    }
+
+    private static Response methodNotAllowed(String method) {
+        return ArmErrors.error(405, "MethodNotAllowed", "Method not allowed: " + method);
+    }
+}

--- a/src/main/java/io/floci/az/services/policy/PolicyPath.java
+++ b/src/main/java/io/floci/az/services/policy/PolicyPath.java
@@ -1,0 +1,128 @@
+package io.floci.az.services.policy;
+
+import java.util.Locale;
+import java.util.regex.Pattern;
+
+/**
+ * A parsed Microsoft.Authorization policy path:
+ * {@code {scope}/providers/Microsoft.Authorization/{type}[/{name}[/{remainder}]]}.
+ *
+ * <p>Policy resources are ARM extension resources, so the scope is whatever precedes the
+ * <em>last</em> {@code /providers/Microsoft.Authorization/} segment: empty for tenant-rooted built-in
+ * reads, a management group, a subscription, a resource group, or any resource id. The scope keeps
+ * the caller's casing so it can be echoed back in resource ids; comparisons happen on
+ * {@link #scopeKey()}.</p>
+ *
+ * @param scope     the scope path without leading or trailing slash ({@code ""} at the tenant root)
+ * @param type      the policy resource type, or {@code null} when the segment is not a policy type
+ * @param name      the resource name, or {@code null} for a collection request
+ * @param remainder anything after the name ({@code versions/...}); empty for plain resource paths
+ */
+record PolicyPath(String scope, Type type, String name, String remainder) {
+
+    private static final String MARKER = "/providers/microsoft.authorization/";
+    private static final Pattern SUBSCRIPTION = Pattern.compile("subscriptions/[^/]+");
+    private static final Pattern RESOURCE_GROUP = Pattern.compile("subscriptions/[^/]+/resourcegroups/[^/]+");
+    private static final Pattern RESOURCE = Pattern.compile("subscriptions/[^/]+/resourcegroups/[^/]+/providers/.+");
+    private static final Pattern MANAGEMENT_GROUP = Pattern.compile("providers/microsoft.management/managementgroups/[^/]+");
+
+    enum Type {
+        DEFINITION("policyDefinitions"),
+        SET_DEFINITION("policySetDefinitions"),
+        ASSIGNMENT("policyAssignments"),
+        EXEMPTION("policyExemptions");
+
+        final String segment;
+
+        Type(String segment) {
+            this.segment = segment;
+        }
+
+        /** The ARM resource type, e.g. {@code Microsoft.Authorization/policyDefinitions}. */
+        String armType() {
+            return "Microsoft.Authorization/" + segment;
+        }
+
+        static Type fromSegment(String segment) {
+            for (Type type : values()) {
+                if (type.segment.equalsIgnoreCase(segment)) {
+                    return type;
+                }
+            }
+            return null;
+        }
+    }
+
+    enum ScopeKind { TENANT, MANAGEMENT_GROUP, SUBSCRIPTION, RESOURCE_GROUP, RESOURCE, UNKNOWN }
+
+    /**
+     * Parses a query-less request path (with or without a leading slash). Returns {@code null} when
+     * the path carries no {@code /providers/Microsoft.Authorization/} segment at all.
+     */
+    static PolicyPath parse(String path) {
+        String normalized = path.startsWith("/") ? path : "/" + path;
+        int marker = normalized.toLowerCase(Locale.ROOT).lastIndexOf(MARKER);
+        if (marker < 0) {
+            return null;
+        }
+        String scope = stripSlashes(normalized.substring(0, marker));
+        String[] rest = stripSlashes(normalized.substring(marker + MARKER.length())).split("/", 3);
+        Type type = rest.length > 0 && !rest[0].isEmpty() ? Type.fromSegment(rest[0]) : null;
+        String name = rest.length > 1 && !rest[1].isEmpty() ? rest[1] : null;
+        String remainder = rest.length > 2 ? rest[2] : "";
+        return new PolicyPath(scope, type, name, remainder);
+    }
+
+    /** True when the last Microsoft.Authorization segment of {@code path} names a policy resource type. */
+    static boolean isPolicyPath(String path) {
+        PolicyPath parsed = parse(stripQuery(path));
+        return parsed != null && parsed.type() != null;
+    }
+
+    static String stripQuery(String path) {
+        int q = path.indexOf('?');
+        return q >= 0 ? path.substring(0, q) : path;
+    }
+
+    /** Lower-cased scope for comparisons and store keys. */
+    String scopeKey() {
+        return scope.toLowerCase(Locale.ROOT);
+    }
+
+    ScopeKind scopeKind() {
+        String key = scopeKey();
+        if (key.isEmpty()) {
+            return ScopeKind.TENANT;
+        }
+        if (MANAGEMENT_GROUP.matcher(key).matches()) {
+            return ScopeKind.MANAGEMENT_GROUP;
+        }
+        if (SUBSCRIPTION.matcher(key).matches()) {
+            return ScopeKind.SUBSCRIPTION;
+        }
+        if (RESOURCE_GROUP.matcher(key).matches()) {
+            return ScopeKind.RESOURCE_GROUP;
+        }
+        if (RESOURCE.matcher(key).matches()) {
+            return ScopeKind.RESOURCE;
+        }
+        return ScopeKind.UNKNOWN;
+    }
+
+    /** The ARM resource id of this path's resource, e.g. {@code /subscriptions/s/providers/Microsoft.Authorization/policyDefinitions/d}. */
+    String resourceId() {
+        return "/" + scope + "/providers/Microsoft.Authorization/" + type.segment + "/" + name;
+    }
+
+    private static String stripSlashes(String value) {
+        int start = 0;
+        int end = value.length();
+        while (start < end && value.charAt(start) == '/') {
+            start++;
+        }
+        while (end > start && value.charAt(end - 1) == '/') {
+            end--;
+        }
+        return value.substring(start, end);
+    }
+}

--- a/src/main/java/io/floci/az/services/policy/PolicyStore.java
+++ b/src/main/java/io/floci/az/services/policy/PolicyStore.java
@@ -1,0 +1,151 @@
+package io.floci.az.services.policy;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * In-memory ARM resource state for the Microsoft.Authorization policy resources: definitions, set
+ * definitions, assignments and exemptions. Like the other ARM control-plane stores (Managed Identity,
+ * Network) this does not use a StorageBackend: ARM state is ephemeral by convention.
+ *
+ * <p>Every map is keyed by the lower-cased ARM resource id, so lookups are scope- and
+ * name-insensitive the way ARM itself is. All access goes through methods: the handler holds a
+ * normal-scoped client proxy, and direct field reads on a proxy would hit the proxy's own (empty)
+ * maps instead of this contextual instance.</p>
+ */
+@ApplicationScoped
+public class PolicyStore {
+
+    private final Map<String, Map<String, Object>> definitions = new ConcurrentHashMap<>();
+    private final Map<String, Map<String, Object>> setDefinitions = new ConcurrentHashMap<>();
+    private final Map<String, Map<String, Object>> assignments = new ConcurrentHashMap<>();
+    private final Map<String, Map<String, Object>> exemptions = new ConcurrentHashMap<>();
+
+    static String key(String resourceId) {
+        return resourceId.toLowerCase(Locale.ROOT);
+    }
+
+    // ── Definitions ─────────────────────────────────────────────────────────────
+
+    public Map<String, Object> getDefinition(String id) {
+        return definitions.get(key(id));
+    }
+
+    public void putDefinition(String id, Map<String, Object> resource) {
+        definitions.put(key(id), resource);
+    }
+
+    public Map<String, Object> removeDefinition(String id) {
+        return definitions.remove(key(id));
+    }
+
+    public List<Map<String, Object>> listDefinitions() {
+        return new ArrayList<>(definitions.values());
+    }
+
+    // ── Set definitions ─────────────────────────────────────────────────────────
+
+    public Map<String, Object> getSetDefinition(String id) {
+        return setDefinitions.get(key(id));
+    }
+
+    public void putSetDefinition(String id, Map<String, Object> resource) {
+        setDefinitions.put(key(id), resource);
+    }
+
+    public Map<String, Object> removeSetDefinition(String id) {
+        return setDefinitions.remove(key(id));
+    }
+
+    public List<Map<String, Object>> listSetDefinitions() {
+        return new ArrayList<>(setDefinitions.values());
+    }
+
+    /** Id of the first set definition whose {@code policyDefinitions} reference {@code definitionId}. */
+    public Optional<String> findSetDefinitionReferencing(String definitionId) {
+        String wanted = key(definitionId);
+        for (Map<String, Object> set : setDefinitions.values()) {
+            if (properties(set).get("policyDefinitions") instanceof List<?> references) {
+                for (Object reference : references) {
+                    if (reference instanceof Map<?, ?> ref
+                            && ref.get("policyDefinitionId") instanceof String id
+                            && wanted.equals(key(id))) {
+                        return Optional.of(String.valueOf(set.get("id")));
+                    }
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    // ── Assignments ─────────────────────────────────────────────────────────────
+
+    public Map<String, Object> getAssignment(String id) {
+        return assignments.get(key(id));
+    }
+
+    public void putAssignment(String id, Map<String, Object> resource) {
+        assignments.put(key(id), resource);
+    }
+
+    public Map<String, Object> removeAssignment(String id) {
+        return assignments.remove(key(id));
+    }
+
+    public List<Map<String, Object>> listAssignments() {
+        return new ArrayList<>(assignments.values());
+    }
+
+    /** Id of the first assignment whose {@code policyDefinitionId} is {@code definitionId} (definition or set). */
+    public Optional<String> findAssignmentReferencing(String definitionId) {
+        String wanted = key(definitionId);
+        for (Map<String, Object> assignment : assignments.values()) {
+            if (properties(assignment).get("policyDefinitionId") instanceof String id && wanted.equals(key(id))) {
+                return Optional.of(String.valueOf(assignment.get("id")));
+            }
+        }
+        return Optional.empty();
+    }
+
+    // ── Exemptions ──────────────────────────────────────────────────────────────
+
+    public Map<String, Object> getExemption(String id) {
+        return exemptions.get(key(id));
+    }
+
+    public void putExemption(String id, Map<String, Object> resource) {
+        exemptions.put(key(id), resource);
+    }
+
+    public Map<String, Object> removeExemption(String id) {
+        return exemptions.remove(key(id));
+    }
+
+    public List<Map<String, Object>> listExemptions() {
+        return new ArrayList<>(exemptions.values());
+    }
+
+    /** Removes every exemption bound to {@code assignmentId}; Azure deletes them with the assignment. */
+    public void removeExemptionsForAssignment(String assignmentId) {
+        String wanted = key(assignmentId);
+        exemptions.values().removeIf(exemption ->
+                properties(exemption).get("policyAssignmentId") instanceof String id && wanted.equals(key(id)));
+    }
+
+    public void clear() {
+        definitions.clear();
+        setDefinitions.clear();
+        assignments.clear();
+        exemptions.clear();
+    }
+
+    private static Map<?, ?> properties(Map<String, Object> resource) {
+        return resource.get("properties") instanceof Map<?, ?> props ? props : Map.of();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -240,6 +240,8 @@ floci-az:
       # ARM scope that seeds the system-assigned IMDS identity; set it to your resource's
       # scope so IMDS tokens match GET {scope}/.../identities/default reads.
       system-assigned-scope: subscriptions/00000000-0000-0000-0000-000000000001
+    policy:
+      enabled: true       # Microsoft.Authorization policy definitions, set definitions, assignments and exemptions (control plane only, no rule evaluation)
 
   auth:
     # dev: accept any credentials without signature validation

--- a/src/test/java/io/floci/az/core/AzureRoutingFilterTest.java
+++ b/src/test/java/io/floci/az/core/AzureRoutingFilterTest.java
@@ -226,4 +226,28 @@ class AzureRoutingFilterTest {
                         + "11111111-1111-1111-1111-111111111111?api-version=2022-04-01")
                 .then().statusCode(404);
     }
+
+    @Test
+    void policyProviderRoutesToPolicyAtEveryScope() {
+        // Tenant-rooted built-in listing: no segment precedes "providers/", yet the guarded policy
+        // route must still claim it (empty, since no built-ins are seeded).
+        given().when().get("/providers/Microsoft.Authorization/policyDefinitions?api-version=2025-03-01")
+                .then().statusCode(200)
+                .body(containsString("\"value\":[]"));
+        // Subscription-rooted: a missing definition is the policy 404, not the generic ARM 404.
+        given().when().get("/subscriptions/s/providers/Microsoft.Authorization/policyDefinitions/none"
+                        + "?api-version=2025-03-01")
+                .then().statusCode(404)
+                .body(containsString("PolicyDefinitionNotFound"));
+    }
+
+    @Test
+    void policyGuardLeavesOtherAuthorizationResourcesToArm() {
+        // Role assignments share the Microsoft.Authorization namespace but are not policy resources:
+        // the policy guard must not capture them.
+        given().when().get("/subscriptions/s/providers/Microsoft.Authorization/roleAssignments/"
+                        + "11111111-1111-1111-1111-111111111111?api-version=2022-04-01")
+                .then().statusCode(404)
+                .body(org.hamcrest.Matchers.not(containsString("Policy")));
+    }
 }

--- a/src/test/java/io/floci/az/core/RoutingTableAssemblyTest.java
+++ b/src/test/java/io/floci/az/core/RoutingTableAssemblyTest.java
@@ -70,10 +70,12 @@ class RoutingTableAssemblyTest {
     /**
      * A4's PROVIDER_ROUTES minus {@code Microsoft.EventGrid}: A6 moved Event Grid's control plane out
      * of the filter's provider lane into the ArmHandler lane (it implements {@code ArmProviderService}),
-     * so it is no longer a filter provider route. Every other entry is unchanged from A4.
+     * so it is no longer a filter provider route. {@code Microsoft.Authorization} was added later for
+     * the guarded Azure Policy route. Every other entry is unchanged from A4.
      */
     private static final Set<Map.Entry<String, String>> GOLDEN_PROVIDER_ROUTES = Set.of(
         Map.entry("/providers/Microsoft.ManagedIdentity/", "managedidentity"),
+        Map.entry("/providers/Microsoft.Authorization/", "policy"),
         Map.entry("/providers/Microsoft.ContainerService/", "aks"),
         Map.entry("/providers/Microsoft.ContainerRegistry/", "acr"),
         Map.entry("/providers/Microsoft.ContainerInstance/", "aci"),
@@ -129,15 +131,17 @@ class RoutingTableAssemblyTest {
     }
 
     /**
-     * Managed Identity's guarded route must be tried before the broader providers: a path may carry both
-     * a Compute/ContainerService segment and a trailing ManagedIdentity segment. Handler discovery order
-     * is arbitrary, so the filter's guarded-first sort is what guarantees this.
+     * The guarded routes (Managed Identity, Azure Policy) must be tried before the broader providers: a
+     * path may carry both a Compute/ContainerService segment and a trailing ManagedIdentity or
+     * Authorization segment. Handler discovery order is arbitrary, so the filter's guarded-first sort is
+     * what guarantees this.
      */
     @Test
-    void guardedManagedIdentityProviderIsTriedFirst() {
+    void guardedProvidersAreTriedBeforeUnguardedOnes() {
         List<Map.Entry<String, String>> providers = filter.providerRoutesInMatchOrder();
-        assertEquals("managedidentity", providers.get(0).getValue(),
-            "the guarded Managed Identity route must sort first, got " + providers);
+        assertEquals(Set.of("managedidentity", "policy"),
+            Set.of(providers.get(0).getValue(), providers.get(1).getValue()),
+            "the guarded Managed Identity and Azure Policy routes must sort first, got " + providers);
     }
 
     /**

--- a/src/test/java/io/floci/az/services/policy/PolicyDisabledTest.java
+++ b/src/test/java/io/floci/az/services/policy/PolicyDisabledTest.java
@@ -1,0 +1,65 @@
+package io.floci.az.services.policy;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Verifies that {@code floci-az.services.policy.enabled=false} removes the Microsoft.Authorization
+ * policy resources while the rest of the ARM management plane keeps working.
+ */
+@QuarkusTest
+@TestProfile(PolicyDisabledTest.DisabledProfile.class)
+@DisplayName("Azure Policy disabled: provider route gated off, ARM otherwise intact")
+@SuppressWarnings("unused")
+class PolicyDisabledTest {
+
+    public static class DisabledProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of("floci-az.services.policy.enabled", "false");
+        }
+    }
+
+    private static final String SUB = "test-sub-policyoff";
+    private static final String RG = "test-rg-policyoff";
+    private static final String API = "?api-version=2025-03-01";
+    private static final String DEFINITION = "/subscriptions/" + SUB
+            + "/providers/Microsoft.Authorization/policyDefinitions/d1";
+    private static final String ASSIGNMENT = "/subscriptions/" + SUB + "/resourceGroups/" + RG
+            + "/providers/Microsoft.Authorization/policyAssignments/a1";
+
+    @Test
+    @DisplayName("PUT policy definition returns 404 when the policy service is disabled")
+    void definitionCreateGatedOff() {
+        given().contentType("application/json")
+                .body("{\"properties\":{\"policyRule\":{\"if\":{\"field\":\"type\"},\"then\":{\"effect\":\"audit\"}}}}")
+                .when().put(DEFINITION + API)
+                .then().statusCode(404);
+    }
+
+    @Test
+    @DisplayName("PUT resource-group policy assignment returns 404 when the policy service is disabled")
+    void assignmentCreateGatedOff() {
+        given().contentType("application/json")
+                .body("{\"properties\":{\"policyDefinitionId\":\"" + DEFINITION + "\"}}")
+                .when().put(ASSIGNMENT + API)
+                .then().statusCode(404);
+    }
+
+    @Test
+    @DisplayName("resource groups still work when the policy service is disabled")
+    void resourceGroupStillWorks() {
+        given().contentType("application/json").body("{\"location\":\"eastus\"}")
+                .when().put("/subscriptions/" + SUB + "/resourceGroups/" + RG + "?api-version=2021-04-01")
+                .then().statusCode(anyOf(equalTo(200), equalTo(201)));
+    }
+}

--- a/src/test/java/io/floci/az/services/policy/PolicyTest.java
+++ b/src/test/java/io/floci/az/services/policy/PolicyTest.java
@@ -1,0 +1,563 @@
+package io.floci.az.services.policy;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.ValidatableResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+@DisplayName("PolicyHandler - Microsoft.Authorization policy definitions, set definitions, assignments and exemptions")
+class PolicyTest {
+
+    private static final String SUB = "test-sub-policy";
+    private static final String RG = "test-rg-policy";
+    private static final String API = "?api-version=2025-03-01";
+    private static final String AUTH = "/providers/Microsoft.Authorization";
+    private static final String SUB_SCOPE = "/subscriptions/" + SUB;
+    private static final String RG_SCOPE = SUB_SCOPE + "/resourceGroups/" + RG;
+    private static final String RESOURCE_SCOPE = RG_SCOPE + "/providers/Microsoft.Storage/storageAccounts/sa1";
+    private static final String MG_SCOPE = "/providers/Microsoft.Management/managementGroups/test-mg";
+    private static final String DEFINITIONS = SUB_SCOPE + AUTH + "/policyDefinitions";
+    private static final String SET_DEFINITIONS = SUB_SCOPE + AUTH + "/policySetDefinitions";
+    private static final String BUILT_IN_DEFINITION =
+            "/providers/Microsoft.Authorization/policyDefinitions/0a914e76-4921-4c19-b460-a2d36003525a";
+    private static final String UUID_PATTERN =
+            "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}";
+
+    private static final String RULE = """
+            {"if": {"field": "location", "notIn": ["eastus"]}, "then": {"effect": "deny"}}""";
+    private static final String DEFINITION_BODY = """
+            {"properties": {"displayName": "Allowed locations", "mode": "All", "description": "Only eastus",
+                            "metadata": {"category": "General"},
+                            "parameters": {"tagName": {"type": "String"}},
+                            "policyRule": %s}}""".formatted(RULE);
+
+    @BeforeEach
+    void reset() {
+        given().when().post("/_admin/reset").then().statusCode(204);
+    }
+
+    // ── Policy definitions ──────────────────────────────────────────────────────
+
+    @Test
+    void definitionLifecycle() {
+        String createdOn = putJson(DEFINITIONS + "/allowed-locations", DEFINITION_BODY)
+                .statusCode(201)
+                .body("name", equalTo("allowed-locations"))
+                .body("type", equalTo("Microsoft.Authorization/policyDefinitions"))
+                .body("id", equalTo(DEFINITIONS + "/allowed-locations"))
+                .body("properties.policyType", equalTo("Custom"))
+                .body("properties.mode", equalTo("All"))
+                .body("properties.displayName", equalTo("Allowed locations"))
+                .body("properties.metadata.category", equalTo("General"))
+                .body("properties.metadata.createdBy", matchesPattern(UUID_PATTERN))
+                .body("properties.metadata.updatedOn", nullValue())
+                .body("properties.version", equalTo("1.0.0"))
+                .body("properties.parameters.tagName.type", equalTo("String"))
+                .body("properties.policyRule.then.effect", equalTo("deny"))
+                .body("systemData.createdAt", notNullValue())
+                .extract().path("properties.metadata.createdOn");
+
+        // Definitions answer 201 on update too, keep their creation stamp and gain an update stamp.
+        putJson(DEFINITIONS + "/allowed-locations", DEFINITION_BODY)
+                .statusCode(201)
+                .body("properties.metadata.createdOn", equalTo(createdOn))
+                .body("properties.metadata.updatedOn", notNullValue());
+
+        given().when().get(DEFINITIONS + "/allowed-locations" + API)
+                .then().statusCode(200)
+                .body("name", equalTo("allowed-locations"))
+                .body("properties.policyRule.if.field", equalTo("location"));
+
+        given().when().get(DEFINITIONS + API)
+                .then().statusCode(200)
+                .body("value", hasSize(1))
+                .body("value[0].name", equalTo("allowed-locations"));
+
+        given().when().delete(DEFINITIONS + "/allowed-locations" + API)
+                .then().statusCode(200);
+
+        given().when().get(DEFINITIONS + "/allowed-locations" + API)
+                .then().statusCode(404)
+                .body("error.code", equalTo("PolicyDefinitionNotFound"))
+                .body("error.message", equalTo("The policy definition 'allowed-locations' could not be found."));
+
+        given().when().delete(DEFINITIONS + "/allowed-locations" + API)
+                .then().statusCode(204);
+    }
+
+    @Test
+    void definitionRequiresAWellFormedPolicyRule() {
+        putJson(DEFINITIONS + "/no-rule", "{\"properties\": {\"displayName\": \"x\"}}")
+                .statusCode(400)
+                .body("error.code", equalTo("InvalidCreatePolicyDefinitionRequest"));
+
+        putJson(DEFINITIONS + "/no-then", "{\"properties\": {\"policyRule\": {\"if\": {\"field\": \"type\"}}}}")
+                .statusCode(400)
+                .body("error.code", equalTo("InvalidPolicyRule"));
+
+        given().when().get(DEFINITIONS + API)
+                .then().statusCode(200)
+                .body("value", hasSize(0));
+    }
+
+    @Test
+    void malformedJsonBodyIsRejected() {
+        given().contentType("application/json").body("{not json")
+                .when().put(DEFINITIONS + "/broken" + API)
+                .then().statusCode(400)
+                .body("error.code", equalTo("InvalidRequestContent"));
+    }
+
+    @Test
+    void definitionListFiltersByPolicyType() {
+        putJson(DEFINITIONS + "/custom", DEFINITION_BODY).statusCode(201);
+
+        given().queryParam("api-version", "2025-03-01").queryParam("$filter", "policyType eq 'Custom'")
+                .when().get(DEFINITIONS)
+                .then().statusCode(200)
+                .body("value", hasSize(1));
+
+        // No built-in definitions are seeded.
+        given().queryParam("api-version", "2025-03-01").queryParam("$filter", "policyType eq 'BuiltIn'")
+                .when().get(DEFINITIONS)
+                .then().statusCode(200)
+                .body("value", hasSize(0));
+    }
+
+    @Test
+    void definitionsCannotLiveInResourceGroupsOrHaveSubResources() {
+        putJson(RG_SCOPE + AUTH + "/policyDefinitions/rg-scoped", DEFINITION_BODY)
+                .statusCode(404)
+                .body("error.code", equalTo("ResourceNotFound"));
+
+        given().when().get(DEFINITIONS + "/x/versions" + API)
+                .then().statusCode(404)
+                .body("error.code", equalTo("ResourceNotFound"));
+    }
+
+    // ── Policy set definitions ──────────────────────────────────────────────────
+
+    @Test
+    void setDefinitionLifecycle() {
+        putJson(DEFINITIONS + "/member", DEFINITION_BODY).statusCode(201);
+        String definitionId = DEFINITIONS + "/member";
+
+        String setBody = """
+                {"properties": {"displayName": "Initiative",
+                                "policyDefinitions": [{"policyDefinitionId": "%s",
+                                                       "parameters": {"tagName": {"value": "env"}}}]}}"""
+                .formatted(definitionId);
+
+        putJson(SET_DEFINITIONS + "/initiative", setBody)
+                .statusCode(201)
+                .body("type", equalTo("Microsoft.Authorization/policySetDefinitions"))
+                .body("properties.policyType", equalTo("Custom"))
+                .body("properties.policyDefinitions", hasSize(1))
+                .body("properties.policyDefinitions[0].policyDefinitionId", equalTo(definitionId))
+                .body("properties.policyDefinitions[0].policyDefinitionReferenceId", notNullValue())
+                .body("properties.policyDefinitions[0].definitionVersion", equalTo("1.*.*"))
+                .body("properties.policyDefinitions[0].parameters.tagName.value", equalTo("env"));
+
+        // Updates answer 200 (the set-definition spec allows both 200 and 201).
+        putJson(SET_DEFINITIONS + "/initiative", setBody).statusCode(200);
+
+        // The member definition is now pinned by the initiative.
+        given().when().delete(DEFINITIONS + "/member" + API)
+                .then().statusCode(400)
+                .body("error.code", equalTo("InvalidDeletePolicyDefinitionRequest"))
+                .body("error.message", containsString("policy set definition"));
+
+        given().when().get(SET_DEFINITIONS + API)
+                .then().statusCode(200)
+                .body("value", hasSize(1));
+
+        given().when().delete(SET_DEFINITIONS + "/initiative" + API)
+                .then().statusCode(200);
+        given().when().get(SET_DEFINITIONS + "/initiative" + API)
+                .then().statusCode(404)
+                .body("error.code", equalTo("PolicySetDefinitionNotFound"));
+
+        given().when().delete(DEFINITIONS + "/member" + API)
+                .then().statusCode(200);
+    }
+
+    @Test
+    void setDefinitionValidatesItsReferences() {
+        putJson(SET_DEFINITIONS + "/empty", "{\"properties\": {\"policyDefinitions\": []}}")
+                .statusCode(400)
+                .body("error.code", equalTo("InvalidCreatePolicySetDefinitionRequest"));
+
+        putJson(SET_DEFINITIONS + "/no-id", "{\"properties\": {\"policyDefinitions\": [{\"parameters\": {}}]}}")
+                .statusCode(400)
+                .body("error.code", equalTo("InvalidPolicyDefinitionReference"));
+
+        // A subscription-scoped definition must exist.
+        putJson(SET_DEFINITIONS + "/dangling", """
+                {"properties": {"policyDefinitions": [{"policyDefinitionId": "%s/missing"}]}}""".formatted(DEFINITIONS))
+                .statusCode(404)
+                .body("error.code", equalTo("PolicyDefinitionNotFound"));
+
+        // Built-in ids are accepted without lookup: built-ins are not seeded.
+        putJson(SET_DEFINITIONS + "/built-in", """
+                {"properties": {"policyDefinitions": [{"policyDefinitionId": "%s"}]}}""".formatted(BUILT_IN_DEFINITION))
+                .statusCode(201);
+    }
+
+    // ── Policy assignments ──────────────────────────────────────────────────────
+
+    @Test
+    void assignmentLifecycleAtResourceGroupScope() {
+        putJson(DEFINITIONS + "/assigned", DEFINITION_BODY).statusCode(201);
+        String assignments = RG_SCOPE + AUTH + "/policyAssignments";
+        String body = """
+                {"location": "eastus",
+                 "identity": {"type": "SystemAssigned"},
+                 "properties": {"displayName": "Enforce locations",
+                                "policyDefinitionId": "%s/assigned",
+                                "parameters": {"tagName": {"value": "env"}},
+                                "nonComplianceMessages": [{"message": "Only eastus is allowed"}]}}"""
+                .formatted(DEFINITIONS);
+
+        Map<String, Object> first = putJson(assignments + "/enforce", body)
+                .statusCode(201)
+                .body("type", equalTo("Microsoft.Authorization/policyAssignments"))
+                .body("id", equalTo(assignments + "/enforce"))
+                .body("location", equalTo("eastus"))
+                .body("identity.type", equalTo("SystemAssigned"))
+                .body("identity.principalId", matchesPattern(UUID_PATTERN))
+                .body("identity.tenantId", matchesPattern(UUID_PATTERN))
+                .body("properties.scope", equalTo(RG_SCOPE))
+                .body("properties.policyDefinitionId", equalTo(DEFINITIONS + "/assigned"))
+                .body("properties.definitionVersion", equalTo("1.*.*"))
+                .body("properties.enforcementMode", equalTo("Default"))
+                .body("properties.parameters.tagName.value", equalTo("env"))
+                .body("properties.nonComplianceMessages[0].message", equalTo("Only eastus is allowed"))
+                .body("properties.metadata.createdBy", matchesPattern(UUID_PATTERN))
+                .body("properties.instanceId", matchesPattern(UUID_PATTERN))
+                .extract().path("");
+
+        // Re-PUT keeps the server-generated principal and instance ids.
+        putJson(assignments + "/enforce", body)
+                .statusCode(201)
+                .body("identity.principalId", equalTo(identityPrincipal(first)))
+                .body("properties.instanceId", equalTo(instanceId(first)));
+
+        given().contentType("application/json")
+                .body("{\"properties\": {\"resourceSelectors\": [{\"name\": \"prod\", \"selectors\": []}]}}")
+                .when().patch(assignments + "/enforce" + API)
+                .then().statusCode(200)
+                .body("properties.resourceSelectors", hasSize(1))
+                .body("properties.displayName", equalTo("Enforce locations"));
+
+        given().when().get(assignments + "/enforce" + API)
+                .then().statusCode(200)
+                .body("properties.scope", equalTo(RG_SCOPE));
+
+        // Delete returns the deleted assignment, as on Azure.
+        given().when().delete(assignments + "/enforce" + API)
+                .then().statusCode(200)
+                .body("name", equalTo("enforce"));
+
+        given().when().get(assignments + "/enforce" + API)
+                .then().statusCode(404)
+                .body("error.code", equalTo("PolicyAssignmentNotFound"))
+                .body("error.message", equalTo("The policy assignment 'enforce' is not found."));
+
+        given().when().delete(assignments + "/enforce" + API)
+                .then().statusCode(204);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static String identityPrincipal(Map<String, Object> resource) {
+        return String.valueOf(((Map<String, Object>) resource.get("identity")).get("principalId"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static String instanceId(Map<String, Object> resource) {
+        return String.valueOf(((Map<String, Object>) resource.get("properties")).get("instanceId"));
+    }
+
+    @Test
+    void assignmentValidatesItsDefinitionReference() {
+        String assignments = SUB_SCOPE + AUTH + "/policyAssignments";
+
+        putJson(assignments + "/no-definition", "{\"properties\": {\"displayName\": \"x\"}}")
+                .statusCode(400)
+                .body("error.code", equalTo("InvalidCreatePolicyAssignmentRequest"));
+
+        putJson(assignments + "/dangling", """
+                {"properties": {"policyDefinitionId": "%s/missing"}}""".formatted(DEFINITIONS))
+                .statusCode(404)
+                .body("error.code", equalTo("PolicyDefinitionNotFound"));
+
+        putJson(assignments + "/dangling-set", """
+                {"properties": {"policyDefinitionId": "%s/missing"}}""".formatted(SET_DEFINITIONS))
+                .statusCode(404)
+                .body("error.code", equalTo("PolicySetDefinitionNotFound"));
+
+        putJson(assignments + "/built-in", """
+                {"properties": {"policyDefinitionId": "%s"}}""".formatted(BUILT_IN_DEFINITION))
+                .statusCode(201)
+                .body("properties.scope", equalTo(SUB_SCOPE));
+    }
+
+    @Test
+    void assignmentListingHonoursScopeFilters() {
+        putJson(DEFINITIONS + "/listed", DEFINITION_BODY).statusCode(201);
+        String reference = "{\"properties\": {\"policyDefinitionId\": \"" + DEFINITIONS + "/listed\"}}";
+        putJson(SUB_SCOPE + AUTH + "/policyAssignments/at-sub", reference).statusCode(201);
+        putJson(RG_SCOPE + AUTH + "/policyAssignments/at-rg", reference).statusCode(201);
+        putJson(RESOURCE_SCOPE + AUTH + "/policyAssignments/at-resource", reference)
+                .statusCode(201)
+                .body("properties.scope", equalTo(RESOURCE_SCOPE));
+
+        String rgAssignments = RG_SCOPE + AUTH + "/policyAssignments";
+        // Default: assignments applying to the group from above, at the group, and on resources within it.
+        listAt(rgAssignments, null).body("value", hasSize(3));
+        listAt(rgAssignments, "atExactScope()").body("value", hasSize(1)).body("value[0].name", equalTo("at-rg"));
+        listAt(rgAssignments, "atScope()").body("value", hasSize(2));
+        listAt(rgAssignments, "atScopeAndBelow()").body("value", hasSize(2));
+
+        String subAssignments = SUB_SCOPE + AUTH + "/policyAssignments";
+        listAt(subAssignments, null).body("value", hasSize(3));
+        listAt(subAssignments, "atExactScope()").body("value", hasSize(1)).body("value[0].name", equalTo("at-sub"));
+        listAt(subAssignments, "policyDefinitionId eq '" + DEFINITIONS + "/listed'").body("value", hasSize(3));
+        listAt(subAssignments, "policyDefinitionId eq '" + DEFINITIONS + "/other'").body("value", hasSize(0));
+
+        // The resource listing form of the spec.
+        listAt(RESOURCE_SCOPE + AUTH + "/policyAssignments", "atExactScope()")
+                .body("value", hasSize(1))
+                .body("value[0].name", equalTo("at-resource"));
+    }
+
+    private static ValidatableResponse listAt(String collection, String filter) {
+        var request = given().queryParam("api-version", "2025-03-01");
+        if (filter != null) {
+            request = request.queryParam("$filter", filter);
+        }
+        return request.when().get(collection).then().statusCode(200);
+    }
+
+    @Test
+    void definitionInUseByAnAssignmentCannotBeDeleted() {
+        putJson(DEFINITIONS + "/pinned", DEFINITION_BODY).statusCode(201);
+        putJson(SUB_SCOPE + AUTH + "/policyAssignments/pin",
+                "{\"properties\": {\"policyDefinitionId\": \"" + DEFINITIONS + "/pinned\"}}").statusCode(201);
+
+        given().when().delete(DEFINITIONS + "/pinned" + API)
+                .then().statusCode(400)
+                .body("error.code", equalTo("InvalidDeletePolicyDefinitionRequest"))
+                .body("error.message", containsString("policy assignment"));
+
+        given().when().delete(SUB_SCOPE + AUTH + "/policyAssignments/pin" + API).then().statusCode(200);
+        given().when().delete(DEFINITIONS + "/pinned" + API).then().statusCode(200);
+    }
+
+    @Test
+    void assignmentUserAssignedIdentityResolvesManagedIdentities() {
+        String identityId = RG_SCOPE + "/providers/Microsoft.ManagedIdentity/userAssignedIdentities/policy-mi";
+        String clientId = given().contentType("application/json").body("{\"location\": \"eastus\"}")
+                .when().put(identityId + "?api-version=2024-11-30")
+                .then().statusCode(201)
+                .extract().path("properties.clientId");
+        putJson(DEFINITIONS + "/with-uai", DEFINITION_BODY).statusCode(201);
+
+        Map<String, Map<String, String>> userAssigned = putJson(RG_SCOPE + AUTH + "/policyAssignments/uai", """
+                {"location": "eastus",
+                 "identity": {"type": "UserAssigned", "userAssignedIdentities": {"%s": {}}},
+                 "properties": {"policyDefinitionId": "%s/with-uai"}}""".formatted(identityId, DEFINITIONS))
+                .statusCode(201)
+                .body("identity.type", equalTo("UserAssigned"))
+                .extract().path("identity.userAssignedIdentities");
+
+        assertEquals(clientId, userAssigned.get(identityId).get("clientId"));
+    }
+
+    @Test
+    void resourceGroupSegmentIsCaseInsensitive() {
+        putJson(DEFINITIONS + "/cased", DEFINITION_BODY).statusCode(201);
+        String lowerCased = SUB_SCOPE + "/resourcegroups/" + RG + AUTH + "/policyAssignments/cased";
+        putJson(lowerCased, "{\"properties\": {\"policyDefinitionId\": \"" + DEFINITIONS + "/cased\"}}")
+                .statusCode(201)
+                .body("properties.scope", equalTo(SUB_SCOPE + "/resourcegroups/" + RG));
+
+        given().when().get(RG_SCOPE + AUTH + "/policyAssignments/cased" + API)
+                .then().statusCode(200)
+                .body("name", equalTo("cased"));
+    }
+
+    // ── Policy exemptions ───────────────────────────────────────────────────────
+
+    @Test
+    void exemptionLifecycle() {
+        putJson(DEFINITIONS + "/exempted", DEFINITION_BODY).statusCode(201);
+        String assignmentId = RG_SCOPE + AUTH + "/policyAssignments/to-exempt";
+        putJson(assignmentId, "{\"properties\": {\"policyDefinitionId\": \"" + DEFINITIONS + "/exempted\"}}")
+                .statusCode(201);
+        String exemptions = RESOURCE_SCOPE + AUTH + "/policyExemptions";
+        String body = """
+                {"properties": {"policyAssignmentId": "%s", "exemptionCategory": "Waiver",
+                                "displayName": "Legacy account", "expiresOn": "2999-01-01T00:00:00Z",
+                                "metadata": {"ticket": "OPS-1"}}}""".formatted(assignmentId);
+
+        putJson(exemptions + "/legacy", body)
+                .statusCode(201)
+                .body("type", equalTo("Microsoft.Authorization/policyExemptions"))
+                .body("id", equalTo(exemptions + "/legacy"))
+                .body("properties.policyAssignmentId", equalTo(assignmentId))
+                .body("properties.exemptionCategory", equalTo("Waiver"))
+                .body("properties.assignmentScopeValidation", equalTo("Default"))
+                .body("properties.metadata.ticket", equalTo("OPS-1"))
+                .body("systemData.createdAt", notNullValue());
+
+        putJson(exemptions + "/legacy", body).statusCode(200);
+
+        given().contentType("application/json")
+                .body("{\"properties\": {\"assignmentScopeValidation\": \"DoNotValidate\"}}")
+                .when().patch(exemptions + "/legacy" + API)
+                .then().statusCode(200)
+                .body("properties.assignmentScopeValidation", equalTo("DoNotValidate"))
+                .body("properties.exemptionCategory", equalTo("Waiver"));
+
+        // An expired exemption is dropped by excludeExpired() but listed by default.
+        putJson(exemptions + "/expired", body.replace("2999-01-01T00:00:00Z", "2000-01-01T00:00:00Z"))
+                .statusCode(201);
+        listAt(RG_SCOPE + AUTH + "/policyExemptions", null).body("value", hasSize(2));
+        listAt(RG_SCOPE + AUTH + "/policyExemptions", "excludeExpired()").body("value", hasSize(1));
+        listAt(RG_SCOPE + AUTH + "/policyExemptions", "policyAssignmentId eq '" + assignmentId + "'")
+                .body("value", hasSize(2));
+
+        // Delete returns the deleted exemption, as on Azure.
+        given().when().delete(exemptions + "/expired" + API)
+                .then().statusCode(200)
+                .body("name", equalTo("expired"));
+        given().when().delete(exemptions + "/expired" + API)
+                .then().statusCode(204);
+
+        // Exemptions are bound to their assignment and disappear with it.
+        given().when().delete(assignmentId + API).then().statusCode(200);
+        given().when().get(exemptions + "/legacy" + API)
+                .then().statusCode(404)
+                .body("error.code", equalTo("PolicyExemptionNotFound"))
+                .body("error.message", equalTo("The policy exemption 'legacy' could not be found."));
+    }
+
+    @Test
+    void exemptionValidatesCategoryAndAssignment() {
+        String exemptions = RG_SCOPE + AUTH + "/policyExemptions";
+
+        putJson(exemptions + "/no-assignment", "{\"properties\": {\"exemptionCategory\": \"Waiver\"}}")
+                .statusCode(400)
+                .body("error.code", equalTo("InvalidCreatePolicyExemptionRequest"));
+
+        putJson(exemptions + "/bad-category", """
+                {"properties": {"policyAssignmentId": "%s/policyAssignments/a", "exemptionCategory": "Forever"}}"""
+                .formatted(RG_SCOPE + AUTH))
+                .statusCode(400)
+                .body("error.code", equalTo("InvalidCreatePolicyExemptionRequest"));
+
+        putJson(exemptions + "/dangling", """
+                {"properties": {"policyAssignmentId": "%s/policyAssignments/missing", "exemptionCategory": "Waiver"}}"""
+                .formatted(RG_SCOPE + AUTH))
+                .statusCode(404)
+                .body("error.code", equalTo("PolicyAssignmentNotFound"));
+    }
+
+    // ── Management group and tenant scopes ──────────────────────────────────────
+
+    @Test
+    void managementGroupScopedDefinitionsAndAssignments() {
+        String mgDefinitions = MG_SCOPE + AUTH + "/policyDefinitions";
+        putJson(mgDefinitions + "/mg-def", DEFINITION_BODY)
+                .statusCode(201)
+                .body("id", equalTo(mgDefinitions + "/mg-def"));
+
+        given().when().get(mgDefinitions + API)
+                .then().statusCode(200)
+                .body("value", hasSize(1));
+        // Management-group definitions are not listed at the subscription.
+        given().when().get(DEFINITIONS + API)
+                .then().statusCode(200)
+                .body("value", hasSize(0));
+
+        putJson(MG_SCOPE + AUTH + "/policyAssignments/mg-assign",
+                "{\"properties\": {\"policyDefinitionId\": \"" + mgDefinitions + "/mg-def\"}}")
+                .statusCode(201)
+                .body("properties.scope", equalTo(MG_SCOPE));
+
+        // A subscription may assign a definition that lives in a management group.
+        putJson(SUB_SCOPE + AUTH + "/policyAssignments/from-mg",
+                "{\"properties\": {\"policyDefinitionId\": \"" + mgDefinitions + "/mg-def\"}}")
+                .statusCode(201);
+
+        listAt(MG_SCOPE + AUTH + "/policyAssignments", "atExactScope()")
+                .body("value", hasSize(1))
+                .body("value[0].name", equalTo("mg-assign"));
+    }
+
+    @Test
+    void tenantRootServesEmptyBuiltInsAndRejectsWrites() {
+        given().when().get("/providers/Microsoft.Authorization/policyDefinitions" + API)
+                .then().statusCode(200)
+                .body("value", hasSize(0));
+        given().when().get("/providers/Microsoft.Authorization/policySetDefinitions" + API)
+                .then().statusCode(200)
+                .body("value", hasSize(0));
+
+        given().when().get(BUILT_IN_DEFINITION + API)
+                .then().statusCode(404)
+                .body("error.code", equalTo("PolicyDefinitionNotFound"));
+        given().when().get("/providers/Microsoft.Authorization/policySetDefinitions/missing" + API)
+                .then().statusCode(404)
+                .body("error.code", equalTo("PolicySetDefinitionNotFound"));
+
+        putJson(BUILT_IN_DEFINITION, DEFINITION_BODY)
+                .statusCode(400)
+                .body("error.code", equalTo("MissingSubscription"));
+        putJson("/providers/Microsoft.Authorization/policyAssignments/tenant-wide",
+                "{\"properties\": {\"policyDefinitionId\": \"" + BUILT_IN_DEFINITION + "\"}}")
+                .statusCode(400)
+                .body("error.code", equalTo("MissingSubscription"));
+    }
+
+    // ── Routing boundaries ──────────────────────────────────────────────────────
+
+    @Test
+    void otherMicrosoftAuthorizationResourcesAreNotClaimed() {
+        // Role assignments stay with the generic ARM handler, which does not implement them.
+        given().contentType("application/json").body("{\"properties\": {}}")
+                .when().put(SUB_SCOPE + AUTH + "/roleAssignments/11111111-1111-1111-1111-111111111111"
+                        + "?api-version=2022-04-01")
+                .then().statusCode(404);
+
+        // A policy assignment scoped to another Microsoft.Authorization resource is still ours.
+        putJson(DEFINITIONS + "/nested", DEFINITION_BODY).statusCode(201);
+        putJson(RG_SCOPE + AUTH + "/roleAssignments/22222222-2222-2222-2222-222222222222"
+                        + AUTH + "/policyAssignments/on-role",
+                "{\"properties\": {\"policyDefinitionId\": \"" + DEFINITIONS + "/nested\"}}")
+                .statusCode(201)
+                .body("properties.scope", startsWith(RG_SCOPE + AUTH + "/roleAssignments/"));
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────────
+
+    private static ValidatableResponse putJson(String path, String body) {
+        return given().contentType("application/json").body(body)
+                .when().put(path + API)
+                .then();
+    }
+}


### PR DESCRIPTION
## Summary

Adds the Azure Policy control plane under `Microsoft.Authorization`: policy definitions, policy set definitions (initiatives), policy assignments and policy exemptions, at every ARM scope the real service accepts (management group, subscription, resource group, resource; tenant-rooted built-in reads answer empty). This lets `az policy ...`, the `azurerm` policy resources and the policy SDKs (`armpolicy`, `azure-mgmt-resource`, `azure-resourcemanager-resources`) author and deploy policies against floci-az instead of a real subscription.

Scope is deliberately the control plane only: rules are stored and validated structurally, never evaluated. Nothing is denied, audited or remediated, there is no compliance state (`Microsoft.PolicyInsights` is not implemented) and no built-in definitions are seeded. The docs page lists every deviation.

What is in the change:

- `services/policy/`: `PolicyHandler` (filter-lane `AzureServiceHandler`, guarded provider route on `Microsoft.Authorization` so role assignments, locks and deny assignments keep falling through to the generic ARM handler), `PolicyStore` (in-memory, keyed by lower-cased resource id like the other ARM control-plane stores) and `PolicyPath` (scope / type / name parsing for extension resources).
- Definitions and set definitions: CreateOrUpdate, Get, Delete, List with `$filter=policyType eq '...'`. Server-side `policyType=Custom`, `mode` default `Indexed`, `version` default `1.0.0`, `metadata.createdBy/createdOn/updatedBy/updatedOn` stamps, generated `policyDefinitionReferenceId` and `definitionVersion=1.*.*` on references.
- Assignments: Create, Get, Update (PATCH of identity, location, resourceSelectors, overrides), Delete (returns the deleted assignment), List for subscription / resource group / resource / management group with `atScope()`, `atExactScope()`, `atScopeAndBelow()` and `policyDefinitionId eq '...'`. `scope`, `enforcementMode`, `definitionVersion`, `instanceId` populated server-side; `SystemAssigned` identities get a stable principal, `UserAssigned` identities resolve `principalId`/`clientId` from the Managed Identity store when the identity exists.
- Exemptions: CreateOrUpdate, Get, Update (PATCH), Delete (returns the body), List with `atScope()`, `atExactScope()`, `excludeExpired()`, `policyAssignmentId eq '...'`; deleted together with their assignment.
- Referential integrity: scoped definition / set definition references must exist (`PolicyDefinitionNotFound`, `PolicySetDefinitionNotFound`), exemptions need an existing assignment (`PolicyAssignmentNotFound`), and referenced definitions / set definitions cannot be deleted (`InvalidDeletePolicyDefinitionRequest`, `InvalidDeletePolicySetDefinitionRequest`). Built-in ids (`/providers/Microsoft.Authorization/policyDefinitions/{guid}`) are accepted without lookup.
- Routing: `routeArmProviders` now also considers tenant-rooted `providers/Microsoft.X/...` paths (matching the `/providers/<ns>/` marker against the slash-prefixed path), which is how built-in listings and management-group scopes arrive. Subscription-rooted behaviour is unchanged; `RoutingTableAssemblyTest` gains the new golden entry and the guarded-first invariant now covers both guarded routes.
- Config `floci-az.services.policy.enabled` (`FLOCI_AZ_SERVICES_POLICY_ENABLED`, default `true`), banner line, `docs/services/policy.md`, nav, service matrix and README rows.
- Tests: `PolicyTest` (definitions, set definitions, assignments, exemptions, scope filters, management-group and tenant scopes, referential integrity, routing boundaries), `PolicyDisabledTest`, two new cases in `AzureRoutingFilterTest`; a Java compat test (`PolicyCompatibilityTest`, raw REST like the Managed Identity one) and an `az policy` BATS file for the az CLI suite.

Out of scope, left for follow-ups: rule evaluation / deny effects, PolicyInsights compliance and remediation, built-in definition catalogue, the `versions` sub-resource API, pagination of listings.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

- Request/response shapes follow `azure-rest-api-specs` policy `stable/2025-03-01/openapi.json` and exemptions `preview/2022-07-01-preview/policyExemptions.json`; any `api-version` is accepted.
- Response conventions were cross-checked against the Azure CLI's recorded live traffic in `Azure/azure-cli` (`test_resource_policy_default.yaml`, `test_resource_policyset_default.yaml`, `test_resource_policyexemption_default.yaml`, api-version 2025-11-01): `201` on definition and assignment PUT, `200` on set definition / exemption update, `metadata.createdBy/createdOn` stamps, generated numeric `policyDefinitionReferenceId`, `definitionVersion` `1.*.*`, assignment `instanceId`, DELETE of assignments and exemptions returning the resource body, and the exact `PolicyDefinitionNotFound` / `PolicySetDefinitionNotFound` messages.
- `InvalidDeletePolicyDefinitionRequest` (definition referenced by a set definition) reproduces the live message reported in hashicorp/terraform-provider-azurerm#15615.
- Not verified against a live tenant: the `InvalidCreatePolicyDefinitionRequest` / `InvalidCreatePolicyAssignmentRequest` / `InvalidCreatePolicyExemptionRequest` codes returned for missing required properties (modelled on the recorded `InvalidCreatePolicySetDefinitionRequest`), and the assignment-referenced variant of `InvalidDeletePolicyDefinitionRequest`. Happy to adjust if a maintainer has live samples.
- Verification SDKs: the Java compat test drives the REST wire protocol directly (java.net.http, as `ManagedIdentityCompatibilityTest` does); the BATS file uses `az` from `mcr.microsoft.com/azure-cli:latest`.

## Checklist

- [x] `./mvnw test` passes locally
- [x] New or updated integration test added
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
