### PR TITLE
build(deps): bump the maven-minor-patch group and pin the Artemis patch versions to the sidecar image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,11 @@ updates:
     ignore:
       - dependency-name: "com.networknt:json-schema-validator"
         versions: [">=2.0.0"]
+      # artemis-amqp-protocol and proton-j are patched at build time and copied over the same-version
+      # jars inside the apache/activemq-artemis sidecar image, so they only move together with that
+      # image tag (application.yml) — bump them by hand, see ArtemisPatchVersions.
+      - dependency-name: "org.apache.activemq:*"
+      - dependency-name: "org.apache.qpid:proton-j"
     labels:
       - "dependencies"
       - "java"

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,4 +1,4 @@
 wrapperVersion=3.3.4
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.12/apache-maven-3.9.12-bin.zip
-distributionSha256Sum=305773a68d6ddfd413df58c82b3f8050e89778e777f3a745c8e5b8cbea4018ef
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip
+distributionSha256Sum=5af3b743dd8b876b5c45da33b676251e5f1687712644abb4ee519ca56e1d89ce

--- a/docs/services/event-hub.md
+++ b/docs/services/event-hub.md
@@ -101,7 +101,7 @@ services:
 | `FLOCI_AZ_SERVICES_EVENT_HUB_AMQP_PORT` | `5672` | Host port for AMQP (Artemis) |
 | `FLOCI_AZ_SERVICES_EVENT_HUB_KAFKA_ENABLED` | `false` | Enable Kafka-compatible endpoint |
 | `FLOCI_AZ_SERVICES_EVENT_HUB_KAFKA_PORT` | `9093` | Host port for Kafka (Redpanda) |
-| `FLOCI_AZ_SERVICES_EVENT_HUB_ARTEMIS_IMAGE` | `apache/activemq-artemis:latest` | Artemis image |
+| `FLOCI_AZ_SERVICES_EVENT_HUB_ARTEMIS_IMAGE` | `apache/activemq-artemis:2.44.0` | Artemis image; must match the Artemis version floci-az was built against, because the patched AMQP jars it copies in are version-specific |
 | `FLOCI_AZ_SERVICES_EVENT_HUB_REDPANDA_IMAGE` | `redpandadata/redpanda:latest` | Redpanda image |
 
 ### application.yml

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,11 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.37.4</quarkus.platform.version>
+        <quarkus.platform.version>3.39.1</quarkus.platform.version>
+        <!-- Coupled to the Artemis sidecar image (application.yml *.artemis-image): the patched
+             artemis-amqp-protocol and proton-j jars built below replace the same-version jars inside
+             that image, so these two only move together with the image tag. Guarded by
+             ArtemisPatchVersionsTest; excluded from the dependabot group in .github/dependabot.yml. -->
         <artemis.version>2.44.0</artemis.version>
         <proton-j.version>0.34.1</proton-j.version>
         <skipITs>true</skipITs>
@@ -98,7 +102,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
-            <version>1.85</version>
+            <version>1.85.2</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
@@ -154,7 +158,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.11.0</version>
                 <executions>
                     <execution>
                         <id>unpack-servicebus-proton-j</id>
@@ -219,7 +223,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>patch-servicebus-artemis-amqp-sources</id>
@@ -354,6 +358,13 @@
                                     <fileset dir="${project.basedir}/src/artemis-plugin/resources" />
                                 </copy>
                                 <mkdir dir="${project.build.directory}/classes/artemis" />
+                                <!-- Single source of truth for the patch jar names and the sidecar lib
+                                     paths: the namespace managers read this file instead of hardcoding
+                                     the versions. -->
+                                <propertyfile file="${project.build.directory}/classes/artemis/patch-versions.properties">
+                                    <entry key="artemis.version" value="${artemis.version}" />
+                                    <entry key="proton-j.version" value="${proton-j.version}" />
+                                </propertyfile>
                                 <jar
                                     destfile="${project.build.directory}/classes/artemis/servicebus-artemis-extension.jar"
                                     basedir="${project.build.directory}/artemis-plugin-classes" />

--- a/pom.xml
+++ b/pom.xml
@@ -98,6 +98,12 @@
             <artifactId>commons-compress</artifactId>
             <version>1.28.0</version>
         </dependency>
+        <!-- GraalVM substitution annotations (see core/docker/graal); provided, never packaged. -->
+        <dependency>
+            <groupId>org.graalvm.sdk</groupId>
+            <artifactId>nativeimage</artifactId>
+            <scope>provided</scope>
+        </dependency>
         <!-- BouncyCastle for self-signed TLS cert generation (Artemis AMQP TLS) -->
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/src/main/java/io/floci/az/core/docker/graal/HttpClient5CommonsCompressSubstitutions.java
+++ b/src/main/java/io/floci/az/core/docker/graal/HttpClient5CommonsCompressSubstitutions.java
@@ -1,0 +1,55 @@
+package io.floci.az.core.docker.graal;
+
+import com.oracle.svm.core.annotate.Substitute;
+import com.oracle.svm.core.annotate.TargetClass;
+import org.apache.hc.client5.http.entity.compress.ContentCoding;
+import org.apache.hc.core5.io.IOFunction;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+/**
+ * Keeps Apache HttpClient 5.6+ from wiring commons-compress into its content-coding registry in the
+ * native image.
+ *
+ * <p>docker-java talks to the daemon through httpclient5, and since 5.6 the client registers every
+ * commons-compress codec (xz, zstd, brotli, lzma, ...) as soon as commons-compress is on the classpath.
+ * floci-az has commons-compress for tar streams only, so those codec classes become reachable for
+ * GraalVM's analysis, which links them at build time and fails on their optional native libraries
+ * ({@code org.tukaani.xz}, {@code com.github.luben.zstd}, ...). The Docker daemon never compresses
+ * responses with any of them, so the substitutions below report commons-compress as absent and the
+ * registry falls back to the JDK gzip/deflate codecs, exactly as on a classpath without commons-compress.
+ */
+final class HttpClient5CommonsCompressSubstitutions {
+
+    private HttpClient5CommonsCompressSubstitutions() {
+    }
+
+    @TargetClass(className = "org.apache.hc.client5.http.entity.compress.CommonsCompressRuntime")
+    static final class Target_CommonsCompressRuntime {
+
+        @Substitute
+        static boolean available() {
+            return false;
+        }
+    }
+
+    @TargetClass(className = "org.apache.hc.client5.http.entity.compress.CommonsCompressCodecFactory")
+    static final class Target_CommonsCompressCodecFactory {
+
+        @Substitute
+        static IOFunction<InputStream, InputStream> decoder(String name) {
+            return null;
+        }
+
+        @Substitute
+        static IOFunction<OutputStream, OutputStream> encoder(String name) {
+            return null;
+        }
+
+        @Substitute
+        static boolean runtimeAvailable(ContentCoding coding) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/io/floci/az/services/eventhub/EventHubNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/eventhub/EventHubNamespaceManager.java
@@ -1,5 +1,6 @@
 package io.floci.az.services.eventhub;
 
+import io.floci.az.services.servicebus.ArtemisPatchVersions;
 import io.floci.az.config.EmulatorConfig;
 import io.floci.az.core.docker.ContainerStorageHelper;
 import io.floci.az.core.docker.ContainerBuilder;
@@ -53,12 +54,10 @@ public class EventHubNamespaceManager {
 
     // Artemis library patches, shared with the Service Bus broker — see where they are
     // copied in below for why each is needed.
-    static final String PROTON_PATCH_RESOURCE = "/artemis/proton-j-0.34.1-floci-az-proton-patch.jar";
-    static final String ARTEMIS_AMQP_PATCH_RESOURCE =
-            "/artemis/artemis-amqp-protocol-2.44.0-floci-az-artemis-amqp-patch.jar";
-    private static final String PROTON_J_PATH = "/opt/activemq-artemis/lib/proton-j-0.34.1.jar";
-    private static final String ARTEMIS_AMQP_PATH =
-            "/opt/activemq-artemis/lib/artemis-amqp-protocol-2.44.0.jar";
+    static final String PROTON_PATCH_RESOURCE = ArtemisPatchVersions.PROTON_PATCH_RESOURCE;
+    static final String ARTEMIS_AMQP_PATCH_RESOURCE = ArtemisPatchVersions.ARTEMIS_AMQP_PATCH_RESOURCE;
+    private static final String PROTON_J_PATH = ArtemisPatchVersions.PROTON_J_CONTAINER_PATH;
+    private static final String ARTEMIS_AMQP_PATH = ArtemisPatchVersions.ARTEMIS_AMQP_CONTAINER_PATH;
     static final String ARTEMIS_EXTENSION_RESOURCE = "/artemis/servicebus-artemis-extension.jar";
     private static final String ARTEMIS_EXTENSION_PATH =
             "/var/lib/artemis-instance/lib/floci-az-artemis-extension.jar";

--- a/src/main/java/io/floci/az/services/servicebus/ArtemisPatchVersions.java
+++ b/src/main/java/io/floci/az/services/servicebus/ArtemisPatchVersions.java
@@ -1,0 +1,69 @@
+package io.floci.az.services.servicebus;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+/**
+ * The Artemis and proton-j versions the build patched, read from the {@code artemis/patch-versions.properties}
+ * file the Maven build writes next to the patch jars. The patched jars replace the same-version jars inside the
+ * Artemis sidecar image, so the resource names below, the paths inside the container and the image tag in
+ * {@code application.yml} must all agree; keeping the versions in one place (the pom) makes a bump a two-line
+ * change and lets {@code ArtemisPatchVersionsTest} catch a library bump that forgot the image.
+ */
+public final class ArtemisPatchVersions {
+
+    private static final String VERSIONS_RESOURCE = "/artemis/patch-versions.properties";
+    private static final Properties VERSIONS = load();
+
+    public static final String ARTEMIS_VERSION = require("artemis.version");
+    public static final String PROTON_J_VERSION = require("proton-j.version");
+
+    /** Embedded resource holding the patched proton-j jar. */
+    public static final String PROTON_PATCH_RESOURCE =
+            "/artemis/proton-j-" + PROTON_J_VERSION + "-floci-az-proton-patch.jar";
+    /** Embedded resource holding the patched artemis-amqp-protocol jar. */
+    public static final String ARTEMIS_AMQP_PATCH_RESOURCE =
+            "/artemis/artemis-amqp-protocol-" + ARTEMIS_VERSION + "-floci-az-artemis-amqp-patch.jar";
+    /** Where the stock proton-j jar lives inside the {@code apache/activemq-artemis} image. */
+    public static final String PROTON_J_CONTAINER_PATH =
+            "/opt/activemq-artemis/lib/proton-j-" + PROTON_J_VERSION + ".jar";
+    /** Where the stock artemis-amqp-protocol jar lives inside the {@code apache/activemq-artemis} image. */
+    public static final String ARTEMIS_AMQP_CONTAINER_PATH =
+            "/opt/activemq-artemis/lib/artemis-amqp-protocol-" + ARTEMIS_VERSION + ".jar";
+
+    private ArtemisPatchVersions() {
+    }
+
+    /** True when {@code imageRef} (e.g. {@code apache/activemq-artemis:2.44.0}) is tagged with the patched Artemis version. */
+    public static boolean matchesImage(String imageRef) {
+        int colon = imageRef.lastIndexOf(':');
+        if (colon < 0 || imageRef.lastIndexOf('/') > colon) {
+            return false;
+        }
+        String tag = imageRef.substring(colon + 1);
+        return tag.equals(ARTEMIS_VERSION) || tag.startsWith(ARTEMIS_VERSION + "-");
+    }
+
+    private static Properties load() {
+        Properties properties = new Properties();
+        try (InputStream stream = ArtemisPatchVersions.class.getResourceAsStream(VERSIONS_RESOURCE)) {
+            if (stream == null) {
+                throw new IllegalStateException("Embedded Artemis resource not found: " + VERSIONS_RESOURCE
+                        + " (written by the package-servicebus-artemis-patches step in pom.xml)");
+            }
+            properties.load(stream);
+        } catch (IOException e) {
+            throw new IllegalStateException("Could not read " + VERSIONS_RESOURCE, e);
+        }
+        return properties;
+    }
+
+    private static String require(String key) {
+        String value = VERSIONS.getProperty(key);
+        if (value == null || value.isBlank()) {
+            throw new IllegalStateException(VERSIONS_RESOURCE + " is missing " + key);
+        }
+        return value.trim();
+    }
+}

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -47,14 +47,12 @@ public class ServiceBusNamespaceManager {
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     static final String ARTEMIS_EXTENSION_RESOURCE = "/artemis/servicebus-artemis-extension.jar";
-    static final String PROTON_PATCH_RESOURCE = "/artemis/proton-j-0.34.1-floci-az-proton-patch.jar";
-    static final String ARTEMIS_AMQP_PATCH_RESOURCE =
-            "/artemis/artemis-amqp-protocol-2.44.0-floci-az-artemis-amqp-patch.jar";
+    static final String PROTON_PATCH_RESOURCE = ArtemisPatchVersions.PROTON_PATCH_RESOURCE;
+    static final String ARTEMIS_AMQP_PATCH_RESOURCE = ArtemisPatchVersions.ARTEMIS_AMQP_PATCH_RESOURCE;
     private static final String ARTEMIS_EXTENSION_PATH =
             "/var/lib/artemis-instance/lib/floci-az-servicebus-extension.jar";
-    private static final String PROTON_J_PATH = "/opt/activemq-artemis/lib/proton-j-0.34.1.jar";
-    private static final String ARTEMIS_AMQP_PATH =
-            "/opt/activemq-artemis/lib/artemis-amqp-protocol-2.44.0.jar";
+    private static final String PROTON_J_PATH = ArtemisPatchVersions.PROTON_J_CONTAINER_PATH;
+    private static final String ARTEMIS_AMQP_PATH = ArtemisPatchVersions.ARTEMIS_AMQP_CONTAINER_PATH;
     private static final String MANAGEMENT_XML = """
             <?xml version="1.0" encoding="UTF-8"?>
             <management-context xmlns="http://activemq.apache.org/schema">

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -149,7 +149,7 @@ floci-az:
       amqp-tls-port: 5671
       kafka-enabled: false
       kafka-port: 9093
-      artemis-image: "apache/activemq-artemis:latest"
+      artemis-image: "apache/activemq-artemis:2.44.0"   # must match artemis.version in pom.xml (patched jars are version-specific)
       redpanda-image: "redpandadata/redpanda:latest"
       consumer-groups: "$Default,my-consumer-group"
     sql:

--- a/src/test/java/io/floci/az/services/servicebus/ArtemisPatchVersionsTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ArtemisPatchVersionsTest.java
@@ -1,0 +1,48 @@
+package io.floci.az.services.servicebus;
+
+import io.floci.az.config.EmulatorConfig;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The patched Artemis jars replace the same-version jars inside the sidecar image, so the library version in
+ * pom.xml and the image tags in application.yml must agree. A dependabot bump of artemis-amqp-protocol or
+ * proton-j without the matching image (or the other way round) fails here with a message that says which.
+ */
+@QuarkusTest
+@DisplayName("Artemis patch versions — pom.xml, embedded jars and sidecar image tags agree")
+class ArtemisPatchVersionsTest {
+
+    @Inject
+    EmulatorConfig config;
+
+    @Test
+    void serviceBusImageIsTaggedWithThePatchedArtemisVersion() {
+        String image = config.services().serviceBus().artemisImage();
+        assertTrue(ArtemisPatchVersions.matchesImage(image), mismatch("service-bus", image));
+    }
+
+    @Test
+    void eventHubImageIsTaggedWithThePatchedArtemisVersion() {
+        String image = config.services().eventHub().artemisImage();
+        assertTrue(ArtemisPatchVersions.matchesImage(image), mismatch("event-hub", image));
+    }
+
+    @Test
+    void embeddedPatchJarsExistForTheDeclaredVersions() {
+        assertTrue(ArtemisPatchVersions.class.getResource(ArtemisPatchVersions.PROTON_PATCH_RESOURCE) != null,
+                "missing " + ArtemisPatchVersions.PROTON_PATCH_RESOURCE);
+        assertTrue(ArtemisPatchVersions.class.getResource(ArtemisPatchVersions.ARTEMIS_AMQP_PATCH_RESOURCE) != null,
+                "missing " + ArtemisPatchVersions.ARTEMIS_AMQP_PATCH_RESOURCE);
+    }
+
+    private static String mismatch(String service, String image) {
+        return "floci-az.services." + service + ".artemis-image is '" + image + "' but pom.xml patches Artemis "
+                + ArtemisPatchVersions.ARTEMIS_VERSION + " (proton-j " + ArtemisPatchVersions.PROTON_J_VERSION
+                + "); the patched jars are copied over the same-version jars in that image, so bump both together";
+    }
+}


### PR DESCRIPTION
## Summary

Takes the dependabot `maven-minor-patch` group from #257 minus the two libraries that cannot move: Quarkus 3.39.1, BouncyCastle 1.85.2, maven-dependency-plugin 3.11.0, maven-antrun-plugin 3.2.0 and the Maven wrapper. `artemis-amqp-protocol` stays at 2.44.0 and `proton-j` at 0.34.1 because the build patches those two jars and copies them over the same-version jars inside the `apache/activemq-artemis` sidecar image, whose newest published tag is 2.44.0.

That coupling is what broke #257: the pom names the patch jars from `artemis.version` / `proton-j.version` while both namespace managers hardcoded `0.34.1` and `2.44.0` in the resource names and in the `/opt/activemq-artemis/lib/` paths. The versions now flow from the pom into `artemis/patch-versions.properties`, read by a new `ArtemisPatchVersions`. The Event Hubs image default moves from `latest` to `2.44.0` (a newer upstream push would have received a 2.44.0 patch jar), dependabot ignores `org.apache.activemq:*` and `org.apache.qpid:proton-j`, and a guard test fails with a message naming the mismatch if either image tag or the library version moves alone.

Supersedes #257.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## Azure Compatibility

No emulated wire surface changes. The Service Bus and Event Hubs brokers keep running Artemis 2.44.0 with the same patched jars; only where the version is declared moved. Not verified locally: the Docker compat suites under Quarkus 3.39.1 (CI runs them).

## Checklist

- [x] `./mvnw test` passes locally (1013 run, 0 failures, 0 errors, 0 skipped)
- [x] New or updated integration test added (`ArtemisPatchVersionsTest`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
