### PR TITLE
fix(eventhub): accept the latest position unquoted, as .NET writes it

### DIFF
--- a/src/artemis-amqp-patch/java/org/apache/activemq/artemis/protocol/amqp/proton/EventHubFilterSupport.java
+++ b/src/artemis-amqp-patch/java/org/apache/activemq/artemis/protocol/amqp/proton/EventHubFilterSupport.java
@@ -16,9 +16,16 @@ public final class EventHubFilterSupport {
 
    private static final String ANNOTATION_PREFIX = "amqp.annotation.";
 
-   /** {@code amqp.annotation.x-opt-offset > '@latest'} — the start position with no numeric form. */
+   /**
+    * {@code amqp.annotation.x-opt-offset > '@latest'} — the start position with no numeric form.
+    *
+    * <p>The quotes are optional because the SDKs disagree about them: the Java and Rust clients
+    * quote the operand, the .NET one does not. Accepting either costs nothing, and requiring them
+    * refused a .NET consumer's attach outright — {@code @latest} is no more a valid selector token
+    * unquoted than quoted, so what reached the parser had nothing where the operand should be.
+    */
    private static final Pattern LATEST =
-      Pattern.compile("amqp\\.annotation\\.x-opt-offset\\s*>=?\\s*'@latest'");
+      Pattern.compile("amqp\\.annotation\\.x-opt-offset\\s*>=?\\s*(?:'@latest'|@latest)");
 
    /** A quoted operand on one of the rewritten properties, e.g. {@code floci_offset > '-1'}. */
    private static final Pattern QUOTED_OPERAND = Pattern.compile(

--- a/src/test/java/org/apache/activemq/artemis/protocol/amqp/proton/EventHubFilterSupportTest.java
+++ b/src/test/java/org/apache/activemq/artemis/protocol/amqp/proton/EventHubFilterSupportTest.java
@@ -1,0 +1,98 @@
+package org.apache.activemq.artemis.protocol.amqp.proton;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Every Event Hubs start position arrives as a selector, and the SDKs do not write them the same
+ * way — so these cover each spelling one of them emits, rather than letting the shape a single
+ * client happens to send stand in for all of them.
+ */
+class EventHubFilterSupportTest {
+
+    private static URLClassLoader loader;
+    private static Method rewriteSelector;
+
+    @BeforeAll
+    static void loadFromPatchJar() throws Exception {
+        Path patchJar = Path.of("target", "classes", "artemis",
+                "artemis-amqp-protocol-2.44.0-floci-az-artemis-amqp-patch.jar");
+        loader = new URLClassLoader(new URL[]{patchJar.toUri().toURL()},
+                EventHubFilterSupportTest.class.getClassLoader());
+        rewriteSelector = Class.forName(
+                        "org.apache.activemq.artemis.protocol.amqp.proton.EventHubFilterSupport",
+                        true, loader)
+                .getMethod("rewriteSelector", String.class);
+    }
+
+    @AfterAll
+    static void close() throws Exception {
+        loader.close();
+    }
+
+    private static String rewrite(String selector) throws Exception {
+        return (String) rewriteSelector.invoke(null, selector);
+    }
+
+    /**
+     * The Java and Rust SDKs quote the operand; the .NET one does not, building it straight into
+     * the expression. Both mean the same position, and requiring the quotes refused a .NET
+     * consumer's attach: {@code @latest} is not a valid selector token either way, so what reached
+     * the parser had nothing where the operand should be.
+     */
+    @Test
+    @DisplayName("the latest position is honoured whether or not the SDK quotes it")
+    void latestIsRecognisedQuotedAndUnquoted() throws Exception {
+        for (String selector : new String[]{
+                "amqp.annotation.x-opt-offset > '@latest'",
+                "amqp.annotation.x-opt-offset > @latest",
+                "amqp.annotation.x-opt-offset >= '@latest'",
+                "amqp.annotation.x-opt-offset >=@latest"}) {
+            String rewritten = rewrite(selector);
+            // Inclusive: the clock has only millisecond resolution, and rewriteSelector's javadoc
+            // explains why that boundary is the safer way round.
+            assertTrue(rewritten.matches("floci_enqueued_time >= \\d+"),
+                    "not rewritten to a clock comparison: " + selector + " -> " + rewritten);
+        }
+    }
+
+    /**
+     * A numeric operand needs no special casing either way: the name mapping does not care about
+     * quoting, and unquoting only has to happen when the SDK supplied quotes, because Artemis
+     * compares a numeric property against a string constant only under a thread-local flag.
+     */
+    @Test
+    @DisplayName("numeric positions are rewritten whichever way the SDK writes them")
+    void numericPositionsAreRewritten() throws Exception {
+        assertEquals("floci_offset > -1", rewrite("amqp.annotation.x-opt-offset > '-1'"));
+        assertEquals("floci_offset > -1", rewrite("amqp.annotation.x-opt-offset > -1"));
+        assertEquals("floci_sequence_number >= 12345",
+                rewrite("amqp.annotation.x-opt-sequence-number >= '12345'"));
+        assertEquals("floci_sequence_number >= 12345",
+                rewrite("amqp.annotation.x-opt-sequence-number >= 12345"));
+        assertEquals("floci_enqueued_time > 1756400000000",
+                rewrite("amqp.annotation.x-opt-enqueued-time > '1756400000000'"));
+        assertEquals("floci_enqueued_time > 1756400000000",
+                rewrite("amqp.annotation.x-opt-enqueued-time > 1756400000000"));
+    }
+
+    /** Anything that is not an Event Hubs start position is somebody else's selector. */
+    @Test
+    @DisplayName("an unrelated selector passes through untouched")
+    void leavesOtherSelectorsAlone() throws Exception {
+        assertEquals("testId = 'abc123'", rewrite("testId = 'abc123'"));
+        assertEquals("floci_partition = '0'", rewrite("floci_partition = '0'"));
+        assertNull(rewrite(null));
+    }
+}


### PR DESCRIPTION
The follow-up you asked for on #242, now that it has landed — based on `main`, so nothing is stacked this time.

## The bug

The SDKs disagree about quoting the filter operand. Java and Rust send `amqp.annotation.x-opt-offset > '@latest'`; .NET builds it into the expression bare ([`AmqpFilter.cs#L62`](https://github.com/Azure/azure-sdk-for-net/blob/e345636942bb5b24c090a6df28e6b4bf65f8f8e4/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpFilter.cs#L62), your pointer). Only the quoted form was recognised, so a .NET consumer opening at the latest position got:

```
amqp.annotation.x-opt-offset > @latest   ->   floci_offset > @latest
```

`@latest` is not a valid selector token, so this is refused at parse time — the attach fails outright rather than merely matching nothing.

## Scope, which is narrower than it first looks

I probed `EventHubFilterSupport` directly rather than reasoning about the regex:

```
amqp.annotation.x-opt-offset > '@latest'             ->  floci_enqueued_time >= 1788352451343
amqp.annotation.x-opt-offset > @latest               ->  floci_offset > @latest        <-- the bug
amqp.annotation.x-opt-offset > -1                    ->  floci_offset > -1
amqp.annotation.x-opt-sequence-number >= 12345       ->  floci_sequence_number >= 12345
amqp.annotation.x-opt-enqueued-time > 1756400000000  ->  floci_enqueued_time > 1756400000000
```

Only `@latest` breaks. The numeric positions were never affected: the name mapping does not care about quoting, and the unquoting step only has to fire when the SDK supplied quotes — so .NET's offset, sequence-number and enqueued-time positions already worked.

## The change

One pattern accepts both spellings:

```java
- "amqp\\.annotation\\.x-opt-offset\\s*>=?\\s*'@latest'"
+ "amqp\\.annotation\\.x-opt-offset\\s*>=?\\s*(?:'@latest'|@latest)"
```

An explicit alternation rather than `'?@latest'?`, which would also accept a mismatched quote — no SDK sends that, and quietly accepting malformed input is not a feature.

## Testing

`EventHubFilterSupport` had no test of its own, which is exactly how one client's spelling came to stand in for all of them. It has one now, covering each form an SDK emits — quoted and unquoted, across all three annotations, plus selectors it must leave alone.

I checked the test actually bites: reverting the pattern fails it on precisely the .NET form and nothing else.

```
1007 tests, 0 failures
```

(`AksDockerTest` and `PostgresDockerTest` are excluded — they fail the same way on a clean `main` on this machine, which runs k3d and a dozen containers.)
