### PR TITLE
perf(docker): move the runtime images to ubi9-micro and drop gosu

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 !native/**
 !azfloci/azfloci.py
 !docker/entrypoint.sh
+!docker/healthcheck.sh
 !pom.xml
 !src/**
 !target/*.so

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,22 +18,12 @@ ENV FLOCI_AZ_VERSION=${VERSION}
 ENV FLOCI_AZ_STORAGE_PERSISTENT_PATH=/app/data
 ENV FLOCI_AZ_SERVICES_FUNCTIONS_CODE_PATH=/app/data/functions
 
-ENV GOSU_VERSION=1.17
-ENV GOSU_AMD64_SHA256=bbc4136d03ab138b1ad66fa4fc051bafc6cc7ffae632b069a53657279a450de3
-ENV GOSU_ARM64_SHA256=c3805a85d17f4454c23d7059bcb97e1ec1af272b90126e79ed002342de08389b
+# Privilege drop happens in the entrypoint through coreutils chroot, so no gosu
+# download. The base image ships GNU coreutils at /usr/sbin/chroot, ahead of
+# busybox on PATH, so --userspec and --skip-chdir are available.
 RUN set -eux; \
     apk add --no-cache shadow ca-certificates; \
-    useradd -r -u 1001 -g root -d /app -s /sbin/nologin floci; \
-    arch="$(apk --print-arch)"; \
-    case "$arch" in \
-        x86_64) gosuArch='amd64'; gosuSha256="$GOSU_AMD64_SHA256" ;; \
-        aarch64) gosuArch='arm64'; gosuSha256="$GOSU_ARM64_SHA256" ;; \
-        *) echo >&2 "unsupported arch: $arch"; exit 1 ;; \
-    esac; \
-    wget -q -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${gosuArch}"; \
-    echo "${gosuSha256}  /usr/local/bin/gosu" | sha256sum -c -; \
-    chmod +x /usr/local/bin/gosu
-
+    useradd -r -u 1001 -g root -d /app -s /sbin/nologin floci
 WORKDIR /app
 
 RUN mkdir -p /app/data \

--- a/docker/Dockerfile.compat
+++ b/docker/Dockerfile.compat
@@ -1,5 +1,15 @@
 ARG VERSION=latest
-FROM floci/floci-az:${VERSION}
+# BASE_IMAGE is the image produced by Dockerfile.native-package. Release and nightly
+# tags use VERSION; reusable builds override BASE_IMAGE with the digest-qualified
+# native image they just published.
+#
+# That image is ubi9-micro and has no package manager, so this image cannot extend it.
+ARG BASE_IMAGE=floci/floci-az:${VERSION}
+FROM ${BASE_IMAGE} AS native
+
+# Everything that does not depend on the floci-az version. CI can build this stage
+# alone (target: tools) to warm the layer cache, pulling no floci-az image.
+FROM registry.access.redhat.com/ubi9-minimal:9.7 AS tools
 
 LABEL org.opencontainers.image.title="floci-az (compat)" \
       org.opencontainers.image.description="floci-az compatibility image with the Azure CLI and the azfloci helper pre-installed" \
@@ -15,11 +25,41 @@ LABEL org.opencontainers.image.title="floci-az (compat)" \
 RUN rpm --import https://packages.microsoft.com/keys/microsoft.asc \
     && printf '[packages-microsoft-com-prod]\nname=Microsoft Production\nbaseurl=https://packages.microsoft.com/rhel/9.0/prod/\nenabled=1\ngpgcheck=1\ngpgkey=https://packages.microsoft.com/keys/microsoft.asc\n' \
         > /etc/yum.repos.d/microsoft-prod.repo \
+    && useradd -r -u 1001 -g root -d /app -s /sbin/nologin floci \
     && microdnf install -y --nodocs azure-cli python3 \
+    # The system Python keeps what the CLI imports; the optimised .pyc variants,
+    # lib2to3 and ensurepip are build-time extras nothing loads at run time.
+    && rm -rf /usr/lib64/python3.9/lib2to3 /usr/lib64/python3.9/ensurepip \
+    && python3 -c 'import pathlib; [p.unlink() for d in ("/usr/lib64/python3.9","/usr/lib/python3.9") for p in pathlib.Path(d).rglob("*.opt-[12].pyc")]' \
     && microdnf clean all \
     && rm -f /etc/yum.repos.d/microsoft-prod.repo
 
 COPY --chmod=755 azfloci/azfloci.py /usr/local/bin/azfloci
 
-# No USER directive on purpose: the base image stays root so entrypoint.sh can
-# fix up /app/data ownership and drop to uid 1001 through gosu.
+WORKDIR /app
+# A chmod after the copy below would rewrite the binary into a second layer.
+RUN chown 1001:root /app && chmod g+rwX /app
+
+FROM tools
+
+ARG VERSION
+ENV FLOCI_AZ_VERSION=${VERSION}
+ENV FLOCI_AZ_STORAGE_PERSISTENT_PATH=/app/data
+ENV FLOCI_AZ_SERVICES_FUNCTIONS_CODE_PATH=/app/data/functions
+
+COPY --from=native --chown=1001:root /app/ /app/
+VOLUME /app/data
+
+COPY --from=native /usr/local/bin/docker-entrypoint.sh /usr/local/bin/
+# From the build context, not the native image: a published native image may predate the script.
+COPY --chmod=755 docker/healthcheck.sh /usr/local/bin/
+
+EXPOSE 4577
+
+HEALTHCHECK --interval=5s --timeout=3s --retries=10 CMD ["/usr/local/bin/healthcheck.sh"]
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["/app/application", "-Dquarkus.http.host=0.0.0.0"]
+
+# No USER directive on purpose: the image stays root so entrypoint.sh can fix up
+# /app/data ownership before dropping to uid 1001 through coreutils chroot.

--- a/docker/Dockerfile.jvm-package
+++ b/docker/Dockerfile.jvm-package
@@ -6,24 +6,12 @@ ENV FLOCI_AZ_VERSION=${VERSION}
 ENV FLOCI_AZ_STORAGE_PERSISTENT_PATH=/app/data
 ENV FLOCI_AZ_SERVICES_FUNCTIONS_CODE_PATH=/app/data/functions
 
-ENV GOSU_VERSION=1.17
-ENV GOSU_AMD64_SHA256=bbc4136d03ab138b1ad66fa4fc051bafc6cc7ffae632b069a53657279a450de3
-ENV GOSU_ARM64_SHA256=c3805a85d17f4454c23d7059bcb97e1ec1af272b90126e79ed002342de08389b
+# Privilege drop happens in the entrypoint through coreutils chroot, so no gosu
+# download. The base image ships GNU coreutils at /usr/sbin/chroot, ahead of
+# busybox on PATH, so --userspec and --skip-chdir are available.
 RUN set -eux; \
     apk add --no-cache shadow ca-certificates; \
-    useradd -r -u 1001 -g root -d /app -s /sbin/nologin floci; \
-    arch="$(apk --print-arch)"; \
-    case "$arch" in \
-        x86_64) gosuArch='amd64'; gosuSha256="$GOSU_AMD64_SHA256" ;; \
-        aarch64) gosuArch='arm64'; gosuSha256="$GOSU_ARM64_SHA256" ;; \
-        *) echo >&2 "unsupported arch: $arch"; exit 1 ;; \
-    esac; \
-    wget -q -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${gosuArch}"; \
-    echo "${gosuSha256}  /usr/local/bin/gosu" | sha256sum -c -; \
-    chmod +x /usr/local/bin/gosu; \
-    gosu --version; \
-    gosu nobody true
-
+    useradd -r -u 1001 -g root -d /app -s /sbin/nologin floci
 WORKDIR /app
 
 RUN mkdir -p /app/data \

--- a/docker/Dockerfile.native
+++ b/docker/Dockerfile.native
@@ -13,45 +13,12 @@ RUN mvn dependency:go-offline -B
 COPY src ./src
 RUN mvn clean package -Dnative -DskipTests -B
 
-# Stage 2: Build gosu + shadow-utils for the micro image
-# See: https://www.redhat.com/en/blog/build-ubi-micro-images
-FROM registry.access.redhat.com/ubi9:9.7 AS tools
+# Stage 2: Minimal runtime. Same base and user setup as Dockerfile.native-package.
+FROM registry.access.redhat.com/ubi9-micro:9.7
 
-ENV GOSU_VERSION=1.17
-ENV GOSU_AMD64_SHA256=bbc4136d03ab138b1ad66fa4fc051bafc6cc7ffae632b069a53657279a450de3
-ENV GOSU_ARM64_SHA256=c3805a85d17f4454c23d7059bcb97e1ec1af272b90126e79ed002342de08389b
-
-RUN set -eux; \
-    mkdir -p /toolsroot; \
-    dnf install -y --installroot=/toolsroot --releasever=9 \
-        --setopt=install_weak_deps=0 --nodocs \
-        shadow-utils; \
-    dnf -y --installroot=/toolsroot clean all; \
-    rm -rf /toolsroot/var/cache/* /toolsroot/var/log/dnf* /toolsroot/var/log/yum* \
-           /toolsroot/var/lib/rpm /toolsroot/var/lib/dnf; \
-    arch="$(uname -m)"; \
-    case "$arch" in \
-        x86_64) gosuArch='amd64'; gosuSha256="$GOSU_AMD64_SHA256" ;; \
-        aarch64) gosuArch='arm64'; gosuSha256="$GOSU_ARM64_SHA256" ;; \
-        *) echo >&2 "unsupported arch: $arch"; exit 1 ;; \
-    esac; \
-    mkdir -p /toolsroot/usr/local/bin; \
-    curl -fsSL -o /toolsroot/usr/local/bin/gosu \
-        "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${gosuArch}"; \
-    echo "${gosuSha256}  /toolsroot/usr/local/bin/gosu" | sha256sum -c -; \
-    chmod +x /toolsroot/usr/local/bin/gosu
-
-# Stage 3: Minimal runtime
-FROM quay.io/quarkus/quarkus-micro-image:2.0
-
-USER root
 WORKDIR /app
-
-COPY --from=tools /toolsroot/ /
-
-RUN useradd -r -u 1001 -g root -d /app -s /sbin/nologin floci
-
-RUN mkdir -p /app/data \
+RUN echo 'floci:x:1001:0:Floci:/app:/sbin/nologin' >> /etc/passwd \
+    && mkdir -p /app/data \
     && chown -R 1001:root /app \
     && chmod -R g+rwX /app
 
@@ -59,8 +26,7 @@ VOLUME /app/data
 
 EXPOSE 4577
 
-HEALTHCHECK --interval=5s --timeout=3s --retries=10 \
-    CMD bash -c 'echo -e "GET /_floci/health HTTP/1.0\r\nHost: localhost\r\n\r\n" > /dev/tcp/localhost/4577' || exit 1
+HEALTHCHECK --interval=5s --timeout=3s --retries=10 CMD ["/usr/local/bin/healthcheck.sh"]
 
 ARG VERSION=latest
 ENV FLOCI_AZ_VERSION=${VERSION}
@@ -70,6 +36,7 @@ ENV FLOCI_AZ_SERVICES_FUNCTIONS_CODE_PATH=/app/data/functions
 COPY --chmod=755 --from=build /app/target/*-runner /app/application
 
 COPY --chmod=755 docker/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY --chmod=755 docker/healthcheck.sh /usr/local/bin/healthcheck.sh
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["/app/application", "-Dquarkus.http.host=0.0.0.0"]

--- a/docker/Dockerfile.native-package
+++ b/docker/Dockerfile.native-package
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9-minimal:9.7
+FROM registry.access.redhat.com/ubi9-micro:9.7
 
 ARG VERSION=latest
 # Automatically set by Docker BuildKit to "amd64" or "arm64"
@@ -8,29 +8,11 @@ ENV FLOCI_AZ_VERSION=${VERSION}
 ENV FLOCI_AZ_STORAGE_PERSISTENT_PATH=/app/data
 ENV FLOCI_AZ_SERVICES_FUNCTIONS_CODE_PATH=/app/data/functions
 
-ENV GOSU_VERSION=1.17
-ENV GOSU_AMD64_SHA256=bbc4136d03ab138b1ad66fa4fc051bafc6cc7ffae632b069a53657279a450de3
-ENV GOSU_ARM64_SHA256=c3805a85d17f4454c23d7059bcb97e1ec1af272b90126e79ed002342de08389b
-RUN set -eux; \
-    microdnf install -y --nodocs shadow-utils; \
-    microdnf clean all; \
-    useradd -r -u 1001 -g root -d /app -s /sbin/nologin floci; \
-    arch="$(uname -m)"; \
-    case "$arch" in \
-        x86_64) gosuArch='amd64'; gosuSha256="$GOSU_AMD64_SHA256" ;; \
-        aarch64) gosuArch='arm64'; gosuSha256="$GOSU_ARM64_SHA256" ;; \
-        *) echo >&2 "unsupported arch: $arch"; exit 1 ;; \
-    esac; \
-    curl -fsSL -o /usr/local/bin/gosu \
-        "https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-${gosuArch}"; \
-    echo "${gosuSha256}  /usr/local/bin/gosu" | sha256sum -c -; \
-    chmod +x /usr/local/bin/gosu; \
-    gosu --version; \
-    gosu nobody true
-
 WORKDIR /app
 
-RUN mkdir -p /app/data \
+# ubi9-micro has no shadow-utils, so the runtime user is one /etc/passwd line.
+RUN echo 'floci:x:1001:0:Floci:/app:/sbin/nologin' >> /etc/passwd \
+    && mkdir -p /app/data \
     && chown -R 1001:root /app \
     && chmod -R g+rwX /app
 
@@ -39,6 +21,7 @@ VOLUME /app/data
 COPY --chmod=755 --chown=1001:root native/${TARGETARCH}/ /app/
 
 COPY --chmod=755 docker/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY --chmod=755 docker/healthcheck.sh /usr/local/bin/healthcheck.sh
 
 LABEL org.opencontainers.image.title="Floci AZ" \
       org.opencontainers.image.description="Local Azure emulator — open-source Azure SDK compatible emulator" \
@@ -59,8 +42,7 @@ LABEL org.opencontainers.image.title="Floci AZ" \
 
 EXPOSE 4577
 
-HEALTHCHECK --interval=5s --timeout=3s --retries=10 \
-    CMD curl -f http://localhost:4577/_floci/health || exit 1
+HEALTHCHECK --interval=5s --timeout=3s --retries=10 CMD ["/usr/local/bin/healthcheck.sh"]
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["/app/application", "-Dquarkus.http.host=0.0.0.0"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
-# Starts as root, normalizes the bind-mounted Docker socket's group
-# ownership so the unprivileged `floci` user can reach it on any host,
-# then re-executes this script as `floci` via gosu. The second invocation
-# falls through to exec the user's command.
+# Starts as root, reads the bind-mounted Docker socket's group so the
+# unprivileged `floci` user can reach it on any host, then re-executes this
+# script as `floci` via coreutils `chroot --userspec`, which also grants that
+# group as a supplementary group. The second invocation falls through to exec
+# the user's command. No gosu, no usermod: both would cost a package layer the
+# base image does not otherwise need.
 #
 # Why: on native Linux Docker, /var/run/docker.sock is owned by
 # root:docker with mode 660 and the docker GID varies by distro. On
@@ -15,15 +17,11 @@
 set -eu
 
 if [ "$(id -u)" = '0' ]; then
+    groups='0'
     if [ -S /var/run/docker.sock ]; then
         sock_gid="$(stat -c '%g' /var/run/docker.sock)"
         if [ "$sock_gid" != '0' ]; then
-            group_name="$(getent group "$sock_gid" | cut -d: -f1)" || group_name=''
-            if [ -z "$group_name" ]; then
-                groupadd -g "$sock_gid" docker-host
-                group_name='docker-host'
-            fi
-            usermod -aG "$group_name" floci
+            groups="0,$sock_gid"
         fi
     fi
 
@@ -34,7 +32,11 @@ if [ "$(id -u)" = '0' ]; then
         chown -R floci:root /app/data 2>/dev/null || true
     fi
 
-    exec gosu floci "$0" "$@"
+    # `chroot /` changes nothing but the identity: uid 1001, primary gid 0, plus the socket's
+    # group. Supplementary groups are set by number, so the group needs no /etc/group entry.
+    # --skip-chdir keeps the working directory (/app, where relative data paths resolve); GNU
+    # chroot would otherwise chdir to the new root.
+    exec chroot --userspec=1001:0 --groups="$groups" --skip-chdir / "$0" "$@"
 fi
 
 exec "$@"

--- a/docker/healthcheck.sh
+++ b/docker/healthcheck.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Container health probe. Bash only, because ubi9-micro has no curl.
+exec 3<>/dev/tcp/127.0.0.1/4577 || exit 1
+printf 'GET /_floci/health HTTP/1.0\r\nHost: localhost\r\n\r\n' >&3
+read -r _proto status _rest <&3
+[ "$status" = 200 ]

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,31 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-jackson</artifactId>
+          <!-- brotli4j resolves a JNI jar for the build host's platform (native-osx-aarch64 on a
+               Mac, native-linux-* in CI); floci-az never enables Brotli HTTP compression. Maven
+               wildcards match a whole artifactId only, hence the explicit list. -->
+          <exclusions>
+            <exclusion>
+              <groupId>com.aayushatharva.brotli4j</groupId>
+              <artifactId>native-osx-aarch64</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>com.aayushatharva.brotli4j</groupId>
+              <artifactId>native-osx-x86_64</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>com.aayushatharva.brotli4j</groupId>
+              <artifactId>native-linux-aarch64</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>com.aayushatharva.brotli4j</groupId>
+              <artifactId>native-linux-x86_64</artifactId>
+            </exclusion>
+            <exclusion>
+              <groupId>com.aayushatharva.brotli4j</groupId>
+              <artifactId>native-windows-x86_64</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>


### PR DESCRIPTION
## Summary

Completes ecosystem decision 0018 for this repo, porting floci-aws's image-size chain: [#3037](https://github.com/floci-io/floci/pull/3037), [#3085](https://github.com/floci-io/floci/pull/3085), [#3108](https://github.com/floci-io/floci/pull/3108).

**The pilot already proved it.** floci-gcp [#185](https://github.com/floci-io/floci-gcp/pull/185) merged 2026-09-07 and its nightly went **87.9 MB → 53.4 MB compressed, a 39% cut**, with all eight compat legs green. That was the gate 0018 set for this repo.

The three upstream commits are one change, not a menu: `ubi9-micro` ships no `useradd` and no `curl`, so the gosu removal and the bash health probe are what make the smaller base viable.

| File | Change |
|---|---|
| `docker/entrypoint.sh` | privilege drop moves from gosu to coreutils `chroot --userspec=1001:0 --groups=... --skip-chdir /` |
| `docker/Dockerfile.native` | drops the `ubi9:9.7` tools stage; runtime is `ubi9-micro:9.7`, user is one `/etc/passwd` line |
| `docker/Dockerfile.native-package` | same base and user setup, replacing `ubi9-minimal` plus an inline gosu install. **This is the image `release.yml` publishes** |
| `docker/Dockerfile`, `docker/Dockerfile.jvm-package` | drop their gosu downloads. This repo is the only one with the fourth Dockerfile |
| `docker/Dockerfile.compat` | `ubi9-micro` has no package manager, so this can no longer extend the native image: `ubi9-minimal` tools stage, copies `/app` out, plus the portable Python trims from #3108 |
| `docker/healthcheck.sh` | **new**. The old probe used `curl`, which `ubi9-micro` does not have |
| `pom.xml` | exclude the unused brotli4j platform JNI jars |

`--retries=10` is preserved here rather than taking floci-aws's 5. No no-op native-image args to remove: this repo writes its native args as a folded `>-` scalar and never had them.

### The divergence from floci-aws, worth a reviewer's eye

floci-aws's JVM image is Debian `noble`. This repo's is `eclipse-temurin:25-jre-alpine`, where **busybox `chroot` has no `--userspec`**:

```
chroot: can't change root directory to '--userspec=1001:0': No such file or directory
```

It works only because that image ships **GNU coreutils** at `/usr/sbin/chroot`, ahead of busybox on PATH. Verified by running it, not inferred.

### Verified on a built runtime image

- `uid=1001(floci) gid=0(root)` through the entrypoint
- a socket owned by gid 999 yields `groups=0(root),999`, so the by-number supplementary group works with no `/etc/group` entry
- `/app/data` writable
- `healthcheck.sh` exits 0 on a 200 and **1 on a 500**

The compat image keeps no `USER` directive, as before: it runs as root so `entrypoint.sh` can fix `/app/data` ownership before dropping privileges. That comment is updated, since it named gosu.

**The real numbers land when CI publishes.** This image starts at 74.9 MB rather than gcp's 87.9, so the absolute saving will differ; the compat image will move much less than the native one, as it did in gcp (6% vs 39%), because its Azure CLI and Python layers dominate.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## Azure Compatibility

No wire protocol, endpoint or emulated behavior changes. Packaging only. The compat suite against a real native build is what this PR's CI is for, and it is the check that matters: the entrypoint change alters how Functions, ACI, AKS, Redis and ACR reach the Docker socket.

## Checklist

- [x] Tests pass locally (no source changed; runtime image behavior verified as above)
- [ ] New or updated integration test added (not applicable, packaging change)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
