### PR TITLE
fix(config): ship the MySQL and MariaDB config blocks, complete the banner, and align the defaults with application.yml

### DIFF
--- a/src/main/java/io/floci/az/config/EmulatorConfig.java
+++ b/src/main/java/io/floci/az/config/EmulatorConfig.java
@@ -258,7 +258,7 @@ public interface EmulatorConfig {
          * When {@code true}, no registry container is started; registries transition immediately to
          * "Succeeded" with a cosmetic {@code {name}.azurecr.io} loginServer. Useful for tests without Docker.
          */
-        @WithDefault("true")
+        @WithDefault("false")
         boolean mocked();
 
         /** Docker image backing each registry (standard Docker Registry V2). */
@@ -325,7 +325,7 @@ public interface EmulatorConfig {
          * When {@code true}, no Redis container is started; caches transition immediately to
          * "Succeeded" with {@code hostName=localhost}. Useful for tests without Docker.
          */
-        @WithDefault("true")
+        @WithDefault("false")
         boolean mocked();
 
         /** Docker image backing the cache. Valkey is a drop-in, RESP-compatible Redis fork. */
@@ -353,7 +353,7 @@ public interface EmulatorConfig {
          * When {@code true}, no k3s sidecar is started; clusters transition immediately to
          * "Succeeded" with a synthetic kubeconfig. Useful for tests without Docker.
          */
-        @WithDefault("true")
+        @WithDefault("false")
         boolean mocked();
 
         /** Docker image for the k3s container. */
@@ -399,7 +399,7 @@ public interface EmulatorConfig {
          * When {@code true}, no Artemis sidecar is started; service responds to management
          * calls but AMQP data-plane is unavailable. Useful for tests without Docker.
          */
-        @WithDefault("false")
+        @WithDefault("true")
         boolean mocked();
 
         /**
@@ -468,7 +468,7 @@ public interface EmulatorConfig {
         @WithDefault("9093")
         int kafkaPort();
 
-        @WithDefault("apache/activemq-artemis:latest")
+        @WithDefault("apache/activemq-artemis:2.44.0")
         String artemisImage();
 
         @WithDefault("redpandadata/redpanda:latest")

--- a/src/main/java/io/floci/az/core/BannerLogger.java
+++ b/src/main/java/io/floci/az/core/BannerLogger.java
@@ -84,6 +84,21 @@ public class BannerLogger {
             sb.append(String.format("   %-9s [%s]  data-plane: %-8s storage: %s\n",
                 "sql", "enabled ", provider, getStorageMode("sql")));
         }
+        if (config.services().postgres().enabled()) {
+            sb.append(serviceStatusDocker("postgres", true, config.services().postgres().mocked()
+                    ? "mocked  (no docker)"
+                    : "image:" + config.services().postgres().image()));
+        }
+        if (config.services().mysql().enabled()) {
+            sb.append(serviceStatusDocker("mysql", true, config.services().mysql().mocked()
+                    ? "mocked  (no docker)"
+                    : "image:" + config.services().mysql().image()));
+        }
+        if (config.services().mariaDb().enabled()) {
+            sb.append(serviceStatusDocker("mariadb", true, config.services().mariaDb().mocked()
+                    ? "mocked  (no docker)"
+                    : "image:" + config.services().mariaDb().image()));
+        }
         if (config.services().eventHub().enabled()) {
             String amqpInfo = "amqp:" + config.services().eventHub().amqpPort()
                     + "  ns:" + config.services().eventHub().defaultNamespace();
@@ -158,6 +173,10 @@ public class BannerLogger {
         sb.append(String.format("   %-9s [%s]  %s\n", "managedid",
                 config.services().managedIdentity().enabled() ? "enabled " : "disabled",
                 "Microsoft.ManagedIdentity (user-assigned identities + IMDS token endpoint)"));
+        if (config.services().apim().enabled()) {
+            sb.append(String.format("   %-9s [%s]  %s\n", "apim", "enabled ",
+                    "Microsoft.ApiManagement (services, apis, products, subscriptions) + /{account}-apim/ gateway"));
+        }
         if (config.services().eventGrid().enabled()) {
             sb.append(serviceStatus("eventgrid", true, getStorageMode("eventgrid")));
         }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -171,6 +171,18 @@ floci-az:
       image: "postgres:17-alpine"
       startup-timeout-seconds: 60
       default-port: 0        # 0 = OS picks a free port per server (recommended)
+    mysql:                  # Azure Database for MySQL (Flexible Server). No EULA (mysql image is GPL-licensed).
+      enabled: true
+      mocked: false         # false = back servers with a real mysql container. true = no Docker; servers are pure ARM state (no live endpoint)
+      image: "mysql:8.0"
+      startup-timeout-seconds: 60
+      default-port: 0        # 0 = OS picks a free port per server (recommended)
+    maria-db:               # Azure Database for MariaDB (single server). No EULA (mariadb image is GPL-licensed).
+      enabled: true
+      mocked: false         # false = back servers with a real mariadb container. true = no Docker; servers are pure ARM state (no live endpoint)
+      image: "mariadb:10.11"
+      startup-timeout-seconds: 60
+      default-port: 0        # 0 = OS picks a free port per server (recommended)
     service-bus:
       enabled: true
       # Keep the broker opt-in because each namespace owns an Artemis sidecar.


### PR DESCRIPTION
## Summary

Three gaps with the same shape: the code supports something the shipped configuration or the startup banner does not admit to.

- `application.yml` had no `mysql` or `maria-db` block, so both services were configurable only by knowing the property names. Both blocks are added next to `postgres`, with the same keys and commentary.
- The banner never listed postgres, mysql, mariadb or apim, so startup output did not say whether they were enabled, or whether the database services were mocked or Docker-backed.
- Four `@WithDefault` values disagreed with `application.yml`: acr, redis and aks defaulted to `mocked = true` while the shipped file sets `false`; service-bus defaulted to `false` while the file sets `true`; and the event-hub Artemis image defaulted to `latest` while the file pins `2.44.0`.

The default alignment is **not** a behaviour change for the shipped emulator, because `application.yml` sets every one of those keys explicitly. It matters when a key is absent: a test profile or a user-supplied configuration that overrides the file would otherwise get the opposite of the documented default, and the unpinned Artemis image would not match the patched jars that #282 tied to the pom.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

No wire-protocol change. The incorrect behaviour was configuration-side: two emulated services had no entry in the shipped config file, four defaults contradicted it, and the banner under-reported which services were running.

## Checklist

- [x] `./mvnw test` passes locally (1046 tests, 0 failures)
- [ ] New or updated integration test added <!-- config and banner wiring; the existing suite covers the config mapping and the routing table -->
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
