### PR TITLE
fix(email): take the capture backend from StorageFactory, and register docker-java's config classes for native

### DIFF
--- a/src/main/java/io/floci/az/config/EmulatorConfig.java
+++ b/src/main/java/io/floci/az/config/EmulatorConfig.java
@@ -87,6 +87,7 @@ public interface EmulatorConfig {
         ServiceStorageConfig sql();
         ServiceStorageConfig monitor();
         ServiceStorageConfig containerApps();
+        ServiceStorageConfig email();
     }
 
     interface ServiceStorageConfig {

--- a/src/main/java/io/floci/az/core/BannerLogger.java
+++ b/src/main/java/io/floci/az/core/BannerLogger.java
@@ -165,7 +165,7 @@ public class BannerLogger {
             sb.append(serviceStatus("monitor", true, getStorageMode("monitor")));
         }
         if (config.services().email().enabled()) {
-            sb.append(String.format("   %-9s [%s]  %s\n", "email", "enabled ", "ACS Email (captured in-memory; no delivery)"));
+            sb.append(serviceStatus("email", true, getStorageMode("email")));
         }
         LOGGER.info(sb.toString());
         LOGGER.info("=== Local Azure Emulator Ready ===");
@@ -182,6 +182,8 @@ public class BannerLogger {
             case "servicebus" -> config.storage().services().serviceBus().mode().orElse(config.storage().mode());
             case "sql"       -> config.storage().services().sql().mode().orElse(config.storage().mode());
             case "containerapps" -> config.storage().services().containerApps().mode().orElse(config.storage().mode());
+            case "monitor"   -> config.storage().services().monitor().mode().orElse(config.storage().mode());
+            case "email"     -> config.storage().services().email().mode().orElse(config.storage().mode());
             default          -> config.storage().mode();
         };
     }

--- a/src/main/java/io/floci/az/core/storage/StorageFactory.java
+++ b/src/main/java/io/floci/az/core/storage/StorageFactory.java
@@ -144,6 +144,7 @@ public class StorageFactory {
             case "servicebus" -> Optional.of(config.storage().services().serviceBus());
             case "sql"        -> Optional.of(config.storage().services().sql());
             case "monitor"    -> Optional.of(config.storage().services().monitor());
+            case "email"      -> Optional.of(config.storage().services().email());
             case "containerapps" -> Optional.of(config.storage().services().containerApps());
             default           -> Optional.empty();
         };

--- a/src/main/java/io/floci/az/services/email/EmailHandler.java
+++ b/src/main/java/io/floci/az/services/email/EmailHandler.java
@@ -9,8 +9,8 @@ import io.floci.az.core.AzureServiceHandler;
 import io.floci.az.core.ServiceRoutes;
 import io.floci.az.core.Resettable;
 import io.floci.az.core.StoredObject;
-import io.floci.az.core.storage.InMemoryStorage;
 import io.floci.az.core.storage.StorageBackend;
+import io.floci.az.core.storage.StorageFactory;
 import io.floci.az.services.email.EmailModels.CapturedEmail;
 import io.floci.az.services.email.EmailModels.EmailSendRequest;
 import io.floci.az.services.email.EmailModels.EmailSendResult;
@@ -64,8 +64,10 @@ public class EmailHandler implements AzureServiceHandler, Resettable {
     private static final String OPERATION_ID_HEADER = "Operation-Id";
     private static final String RETRY_AFTER_SECONDS = "3";
 
-    // In-memory stores — no persistence needed for email capture
-    private final StorageBackend<String, StoredObject> emailStorage = new InMemoryStorage<>();
+    // Captured messages go through StorageFactory like every other service, so the backend
+    // honours floci-az.storage.mode and joins the load/flush/reset lifecycle. The ARM-plane maps
+    // below stay in memory: they are control-plane records that /_admin/reset clears.
+    private final StorageBackend<String, StoredObject> emailStorage;
     private final Map<String, Map<String, Object>> communicationServices = new LinkedHashMap<>();
     private final Map<String, Map<String, Object>> emailServices = new LinkedHashMap<>();
     private final Map<String, Map<String, Object>> emailDomains = new LinkedHashMap<>();
@@ -73,8 +75,9 @@ public class EmailHandler implements AzureServiceHandler, Resettable {
     private final EmulatorConfig config;
 
     @Inject
-    public EmailHandler(EmulatorConfig config) {
+    public EmailHandler(EmulatorConfig config, StorageFactory storageFactory) {
         this.config = config;
+        this.emailStorage = storageFactory.create("email");
     }
 
     @Override

--- a/src/main/resources/META-INF/native-image/io.floci/az/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/io.floci/az/reflect-config.json
@@ -61,6 +61,18 @@
   "allDeclaredFields": true
  },
  {
+  "name": "com.github.dockerjava.core.DefaultDockerClientConfig",
+  "allDeclaredConstructors": true,
+  "allDeclaredMethods": true,
+  "allDeclaredFields": true
+ },
+ {
+  "name": "com.github.dockerjava.core.DockerConfigFile",
+  "allDeclaredConstructors": true,
+  "allDeclaredMethods": true,
+  "allDeclaredFields": true
+ },
+ {
   "name": "com.github.dockerjava.api.model.ExposedPort",
   "allDeclaredConstructors": true,
   "allDeclaredMethods": true,

--- a/src/main/resources/META-INF/native-image/io.floci/az/reflect-config.json
+++ b/src/main/resources/META-INF/native-image/io.floci/az/reflect-config.json
@@ -38,12 +38,6 @@
   "allDeclaredFields": true
  },
  {
-  "name": "com.github.dockerjava.core.command.AbstrSyncDockerCmd",
-  "allDeclaredConstructors": true,
-  "allDeclaredMethods": true,
-  "allDeclaredFields": true
- },
- {
   "name": "com.github.dockerjava.api.command.CreateContainerCmd",
   "allDeclaredMethods": true
  },
@@ -80,13 +74,13 @@
  },
 
  {
-  "name": "com.github.dockerjava.api.model.RootFS",
+  "name": "com.github.dockerjava.api.command.RootFS",
   "allDeclaredConstructors": true,
   "allDeclaredMethods": true,
   "allDeclaredFields": true
  },
  {
-  "name": "com.github.dockerjava.api.model.GraphDriver",
+  "name": "com.github.dockerjava.api.command.GraphDriver",
   "allDeclaredConstructors": true,
   "allDeclaredMethods": true,
   "allDeclaredFields": true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -76,6 +76,8 @@ floci-az:
         flush-interval-ms: 5000
       container-apps:
         flush-interval-ms: 5000
+      email:
+        flush-interval-ms: 5000
 
   dns:
     # When floci-az runs inside Docker, an embedded DNS server is started on port 53

--- a/src/test/java/io/floci/az/core/nativeimage/ReflectConfigTest.java
+++ b/src/test/java/io/floci/az/core/nativeimage/ReflectConfigTest.java
@@ -1,0 +1,65 @@
+package io.floci.az.core.nativeimage;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Checks that every class named in {@code reflect-config.json} actually exists.
+ *
+ * <p>GraalVM ignores an entry whose class it cannot find, so a typo or a class renamed by a
+ * dependency upgrade costs nothing at build time and silently drops the registration. The failure
+ * only appears later, in a native binary, as a reflective call returning nothing or throwing.
+ * Resolving the names here turns that into a unit-test failure.
+ *
+ * <p>Names are resolved with {@code initialize = false}: this must not run static initialisers
+ * for a few hundred third-party classes, only confirm the names resolve.
+ */
+@DisplayName("reflect-config.json — every registered class resolves")
+class ReflectConfigTest {
+
+    private static final String RESOURCE = "META-INF/native-image/io.floci/az/reflect-config.json";
+
+    @Test
+    void everyRegisteredClassExists() throws Exception {
+        List<String> names = readRegisteredNames();
+        assertFalse(names.isEmpty(), "reflect-config.json should not be empty");
+
+        List<String> unresolvable = new ArrayList<>();
+        for (String name : names) {
+            try {
+                Class.forName(name, false, getClass().getClassLoader());
+            } catch (ClassNotFoundException | NoClassDefFoundError e) {
+                unresolvable.add(name);
+            }
+        }
+
+        assertTrue(unresolvable.isEmpty(),
+            "reflect-config.json registers classes that do not exist, so GraalVM silently drops them: "
+                + unresolvable);
+    }
+
+    private List<String> readRegisteredNames() throws Exception {
+        try (InputStream in = getClass().getClassLoader().getResourceAsStream(RESOURCE)) {
+            assertNotNull(in, "missing resource: " + RESOURCE);
+            JsonNode root = new ObjectMapper().readTree(in);
+            List<String> names = new ArrayList<>();
+            for (JsonNode entry : root) {
+                JsonNode name = entry.get("name");
+                if (name != null && !name.asText().isBlank()) {
+                    names.add(name.asText());
+                }
+            }
+            return names;
+        }
+    }
+}

--- a/src/test/java/io/floci/az/core/storage/StorageLadderOverrideTest.java
+++ b/src/test/java/io/floci/az/core/storage/StorageLadderOverrideTest.java
@@ -1,0 +1,66 @@
+package io.floci.az.core.storage;
+
+import io.floci.az.config.EmulatorConfig;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Proves that a per-service storage override actually reaches the backend.
+ *
+ * <p>This is the test that fails when a service is missing its case in
+ * {@code StorageFactory.serviceConfig}. Asserting the backend type under the default
+ * configuration cannot catch that: {@code resolveMode} falls back to the global mode, so an
+ * unwired service and a correctly wired one both yield the global backend and every assertion
+ * passes either way. The override has to differ from the global mode for the wiring to be
+ * observable at all, which is why this class carries a profile and
+ * {@link StorageLadderWiringTest} does not.
+ */
+@QuarkusTest
+@TestProfile(StorageLadderOverrideTest.EmailPersistentProfile.class)
+@DisplayName("StorageFactory — a per-service mode override overrides only that service")
+class StorageLadderOverrideTest {
+
+    /**
+     * Email is pinned to {@code persistent} while the global mode stays {@code memory}.
+     * {@code persistent-path} is redirected to the build directory because the shipped default
+     * is {@code ./data}, which would write into the working tree during a test run.
+     */
+    public static class EmailPersistentProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                "floci-az.storage.mode", "memory",
+                "floci-az.storage.services.email.mode", "persistent",
+                "floci-az.storage.persistent-path", Path.of("target", "storage-ladder-test").toString());
+        }
+    }
+
+    @Inject
+    StorageFactory storageFactory;
+
+    @Inject
+    EmulatorConfig config;
+
+    @Test
+    @DisplayName("email follows its own mode, not the global one")
+    void emailOverrideTakesEffect() {
+        assertEquals("memory", config.storage().mode(), "the global mode must differ for this test to prove anything");
+        assertEquals(PersistentStorage.class, storageFactory.create("email").getClass());
+    }
+
+    @Test
+    @DisplayName("the override does not leak into other services")
+    void otherServicesKeepTheGlobalMode() {
+        assertEquals(InMemoryStorage.class, storageFactory.create("queue").getClass());
+        assertEquals(InMemoryStorage.class, storageFactory.create("blob").getClass());
+    }
+}

--- a/src/test/java/io/floci/az/core/storage/StorageLadderWiringTest.java
+++ b/src/test/java/io/floci/az/core/storage/StorageLadderWiringTest.java
@@ -1,0 +1,53 @@
+package io.floci.az.core.storage;
+
+import io.floci.az.config.EmulatorConfig;
+import io.floci.az.core.StoredObject;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+/**
+ * Guards the storage ladder for services whose backend comes from {@link StorageFactory}.
+ *
+ * <p>A service that calls {@code create(name)} without a matching case in
+ * {@code StorageFactory.serviceConfig} still gets a backend, so nothing fails visibly: it
+ * silently ignores {@code floci-az.storage.services.<name>.mode} and always follows the global
+ * mode. That is the failure this test exists to catch, because it looks identical to a working
+ * override until someone sets one.
+ */
+@QuarkusTest
+@DisplayName("StorageFactory — per-service ladder wiring")
+class StorageLadderWiringTest {
+
+    @Inject
+    StorageFactory storageFactory;
+
+    @Inject
+    EmulatorConfig config;
+
+    @Test
+    @DisplayName("email resolves its own ServiceStorageConfig, not just the global mode")
+    void emailIsWiredIntoTheLadder() {
+        assertNotNull(config.storage().services().email(),
+                "storage.services.email must exist for the per-service override to be reachable");
+
+        StorageBackend<String, StoredObject> backend = storageFactory.create("email");
+        assertNotNull(backend);
+
+        // The factory caches per service name; a second call must not create a second backend,
+        // or a flush on shutdown would write from a store nobody has been reading.
+        assertSame(backend, storageFactory.create("email"));
+    }
+
+    @Test
+    @DisplayName("the default configuration puts email on the global memory mode")
+    void emailFollowsTheGlobalModeByDefault() {
+        assertEquals("memory", config.storage().mode());
+        assertEquals(InMemoryStorage.class, storageFactory.create("email").getClass());
+    }
+}

--- a/src/test/java/io/floci/az/core/storage/StorageLadderWiringTest.java
+++ b/src/test/java/io/floci/az/core/storage/StorageLadderWiringTest.java
@@ -12,13 +12,13 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 /**
- * Guards the storage ladder for services whose backend comes from {@link StorageFactory}.
+ * Covers email's default-configuration behaviour: the accessor exists, the factory hands back a
+ * backend, and repeat calls reuse it.
  *
- * <p>A service that calls {@code create(name)} without a matching case in
- * {@code StorageFactory.serviceConfig} still gets a backend, so nothing fails visibly: it
- * silently ignores {@code floci-az.storage.services.<name>.mode} and always follows the global
- * mode. That is the failure this test exists to catch, because it looks identical to a working
- * override until someone sets one.
+ * <p>These assertions deliberately do <em>not</em> prove the per-service override is wired up.
+ * Under the shipped configuration the global mode and the email mode are the same, so an unwired
+ * service is indistinguishable from a wired one here. {@link StorageLadderOverrideTest} is the
+ * test that pins that, by setting an email mode that differs from the global one.
  */
 @QuarkusTest
 @DisplayName("StorageFactory — per-service ladder wiring")


### PR DESCRIPTION
## Summary

Two independent defects, both in the "works until it doesn't" family.

**Email capture bypassed the storage ladder.** `EmailHandler` built its own `new InMemoryStorage<>()` instead of asking `StorageFactory` for one, so captured email was the single service that ignored `floci-az.storage.mode` and stayed outside the load/flush/reset lifecycle. Wiring it through the factory means completing the ladder rather than half of it: `storage.services.email` now exists in `EmulatorConfig` and `application.yml`, `StorageFactory` maps the name, and the banner reports the resolved mode instead of claiming email is always in memory. The ARM-plane maps stay in memory on purpose, since they are control-plane records that `/_admin/reset` clears.

`StorageLadderWiringTest` guards the wiring, because the failure mode is invisible: a service missing its case in `StorageFactory.serviceConfig` still gets a backend and silently follows the global mode, which looks identical to a working override until somebody sets one.

**The native image could not start any sidecar on a host with `~/.docker/config.json`.** docker-java reads that file reflectively through `DefaultDockerClientConfig` and `DockerConfigFile`, neither of which was registered in `reflect-config.json`.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

No wire-protocol change. Incorrect behaviour: `storage.services.email.mode` and the global `storage.mode` had no effect on captured email, and in the native image every sidecar-backed service failed to start when a Docker config file was present.

## Checklist

- [x] `./mvnw test` passes locally (1048 tests, 0 failures)
- [x] New or updated integration test added (`StorageLadderWiringTest`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
