### PR TITLE
fix(storage): make hybrid clear() durable instead of deferring the write

### DIFF
--- a/src/main/java/io/floci/az/core/storage/HybridStorage.java
+++ b/src/main/java/io/floci/az/core/storage/HybridStorage.java
@@ -130,7 +130,11 @@ public class HybridStorage<K, V> implements StorageBackend<K, V> {
     @Override
     public void clear() {
         store.clear();
-        dirty.set(true);
+        // Write through rather than waiting for the scheduler, as persistent and wal do. A caller
+        // that clears is usually resetting between test runs and may stop the emulator straight
+        // after; a deferred write would let the next load restore the state the reset removed.
+        // persistToDisk() re-marks dirty if the write fails, so the scheduler still retries.
+        persistToDisk();
     }
 
     public void shutdown() {

--- a/src/test/java/io/floci/az/core/storage/StorageClearDurabilityTest.java
+++ b/src/test/java/io/floci/az/core/storage/StorageClearDurabilityTest.java
@@ -1,0 +1,74 @@
+package io.floci.az.core.storage;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Clearing a backend must survive a restart in every persistent mode.
+ *
+ * <p>{@code /_admin/reset} calls {@code clear()} on each service and returns; nothing flushes
+ * afterwards. If a mode defers its write, the emulator can be stopped between the reset and the
+ * next scheduler tick, and the state the reset was meant to erase comes back on the next load.
+ * For a reset endpoint whose whole purpose is test isolation, that is the difference between a
+ * clean run and one contaminated by the previous suite.
+ *
+ * <p>Each case uses a 60 s flush interval so a passing result cannot come from the background
+ * scheduler rescuing the write.
+ */
+@DisplayName("StorageBackend — clear() is durable without waiting for a flush")
+class StorageClearDurabilityTest {
+
+    private static final TypeReference<Map<String, String>> STRING_MAP = new TypeReference<>() {};
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    @DisplayName("hybrid: cleared state is on disk before clear() returns")
+    void hybridClearIsDurable() {
+        Path file = tempDir.resolve("hybrid.json");
+        HybridStorage<String, String> storage = new HybridStorage<>(file, STRING_MAP, 60_000);
+        try {
+            storage.put("captured", "value");
+            storage.flush();
+
+            storage.clear();
+
+            assertReloadsEmpty(new HybridStorage<>(file, STRING_MAP, 60_000));
+        } finally {
+            storage.shutdown();
+        }
+    }
+
+    @Test
+    @DisplayName("persistent: cleared state is on disk before clear() returns")
+    void persistentClearIsDurable() {
+        Path file = tempDir.resolve("persistent.json");
+        PersistentStorage<String, String> storage = new PersistentStorage<>(file, STRING_MAP);
+        storage.put("captured", "value");
+
+        storage.clear();
+
+        PersistentStorage<String, String> recovered = new PersistentStorage<>(file, STRING_MAP);
+        recovered.load();
+        assertTrue(recovered.keys().isEmpty(), "persistent storage restored cleared state: " + recovered.keys());
+    }
+
+    private void assertReloadsEmpty(HybridStorage<String, String> recovered) {
+        try {
+            recovered.load();
+            assertTrue(recovered.keys().isEmpty(),
+                "clear() left the pre-reset state on disk, so a restart before the next flush restores it: "
+                    + recovered.keys());
+        } finally {
+            recovered.shutdown();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`/_admin/reset` calls `clear()` on every `Resettable` and returns; nothing flushes afterwards. `PersistentStorage.clear()` writes through and `WalStorage.clear()` deletes both files synchronously, but `HybridStorage.clear()` only marked the store dirty and left the write to a scheduler tick up to `flush-interval-ms` later (5 s by default). Stop the emulator in that window and the next `load()` restores exactly the state the reset was meant to erase.

For an endpoint whose stated purpose is test isolation, that is the difference between a clean run and one contaminated by the previous suite. It affects every service configured on `hybrid`, not one: all 20+ `StorageFactory` consumers reset through the same path, and none of their `clear()` implementations flush.

Writing through matches the other two persistent modes and costs nothing on the hot path, since `clear()` is not on it. `persistToDisk()` re-marks the store dirty when the write fails, so a failed flush is still retried by the scheduler.

Found while verifying review feedback on #290, which raised the same mechanism against email. It is not specific to email, and not introduced there, so it is fixed here on its own.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

No wire-protocol change. Incorrect behaviour: with `storage.mode: hybrid`, state cleared through `/_admin/reset` could reappear after a restart that happened before the next scheduled flush.

## Checklist

- [x] `./mvnw test` passes locally (1048 tests, 0 failures)
- [x] New or updated integration test added (`StorageClearDurabilityTest`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

The new test uses a 60 s flush interval so a pass cannot come from the background scheduler rescuing the write. The hybrid case fails on `main` today with `clear() left the pre-reset state on disk, so a restart before the next flush restores it: [captured]`.
