### PR TITLE
fix(config): honour default-port for SQL, PostgreSQL, MySQL and MariaDB

### DIFF
--- a/docs/services/postgresql.md
+++ b/docs/services/postgresql.md
@@ -258,9 +258,15 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock   # required for PostgreSQL containers
 ```
 
-> **Sidecar ports:** PostgreSQL containers bind a random host port directly via the Docker
-> daemon. These ports are **not** published on the `floci-az` service — use
-> `FLOCI_AZ_SERVICES_POSTGRES_DEFAULT_PORT` (`0` = random) only if you need a fixed port.
+> **Sidecar ports:** PostgreSQL containers bind a host port directly via the Docker daemon;
+> these ports are **not** published on the `floci-az` service. With
+> `FLOCI_AZ_SERVICES_POSTGRES_DEFAULT_PORT=0` (the default) the OS assigns one per server.
+> Set it to a specific port and the **first** server to start binds exactly that port; any
+> further server, or a start when the port is already in use, falls back to an OS-assigned
+> port with a warning in the log. Read the real port from `properties.localPort` or
+> `/connect` rather than assuming. When floci-az itself runs in a container, the fixed port is
+> bound on the Docker host, while clients on the shared network still reach the sidecar by
+> container name on 5432.
 
 ---
 

--- a/docs/services/postgresql.md
+++ b/docs/services/postgresql.md
@@ -262,8 +262,9 @@ services:
 > these ports are **not** published on the `floci-az` service. With
 > `FLOCI_AZ_SERVICES_POSTGRES_DEFAULT_PORT=0` (the default) the OS assigns one per server.
 > Set it to a specific port and the **first** server to start binds exactly that port; any
-> further server, or a start when the port is already in use, falls back to an OS-assigned
-> port with a warning in the log. Read the real port from `properties.localPort` or
+> further server, or a start when the port is already taken, falls back to an OS-assigned port
+> with a warning in the log. Availability is judged when the server starts, so a port that
+> something else grabs in the same instant fails the create like any other bind conflict. Read the real port from `properties.localPort` or
 > `/connect` rather than assuming. When floci-az itself runs in a container, the fixed port is
 > bound on the Docker host, while clients on the shared network still reach the sidecar by
 > container name on 5432.

--- a/docs/services/sql.md
+++ b/docs/services/sql.md
@@ -365,8 +365,9 @@ services:
 > these ports are **not** published on the `floci-az` service. With
 > `FLOCI_AZ_SERVICES_SQL_DEFAULT_PORT=0` (the default) the OS assigns one per server. Set it to
 > a specific port and the **first** server to start binds exactly that port; any further server,
-> or a start when the port is already in use, falls back to an OS-assigned port with a warning
-> in the log. Read the real port from the server's connection details rather than assuming.
+> or a start when the port is already taken, falls back to an OS-assigned port with a warning in
+> the log. Availability is judged when the server starts, so a port that something else grabs in
+> the same instant fails the create like any other bind conflict. Read the real port from the server's connection details rather than assuming.
 
 ---
 

--- a/docs/services/sql.md
+++ b/docs/services/sql.md
@@ -361,9 +361,12 @@ services:
       # Do NOT add those ports here — floci-az manages them via Docker socket.
 ```
 
-> **Sidecar ports:** SQL Server containers bind a random host port directly via the Docker daemon.
-> These ports are **not** published on the `floci-az` service — add them to the `floci-az` service
-> only if you need a fixed port (use `FLOCI_AZ_SERVICES_SQL_DEFAULT_PORT`; `0` = random).
+> **Sidecar ports:** SQL Server containers bind a host port directly via the Docker daemon;
+> these ports are **not** published on the `floci-az` service. With
+> `FLOCI_AZ_SERVICES_SQL_DEFAULT_PORT=0` (the default) the OS assigns one per server. Set it to
+> a specific port and the **first** server to start binds exactly that port; any further server,
+> or a start when the port is already in use, falls back to an OS-assigned port with a warning
+> in the log. Read the real port from the server's connection details rather than assuming.
 
 ---
 

--- a/src/main/java/io/floci/az/core/docker/ContainerLifecycleManager.java
+++ b/src/main/java/io/floci/az/core/docker/ContainerLifecycleManager.java
@@ -103,6 +103,17 @@ public class ContainerLifecycleManager {
      * @param spec the container specification
      * @return the container ID
      */
+    /**
+     * Ensures an image is present locally, pulling it once if not.
+     *
+     * <p>{@link #create} does this anyway; callers use it directly when they need the pull to
+     * happen at a specific point, for example before reserving a host port so a slow pull does
+     * not hold the reservation.
+     */
+    public void ensureImageAvailable(String image) {
+        imageCacheService.ensureImageExists(image);
+    }
+
     public String create(ContainerSpec spec) {
         LOG.debugv("Creating container: image={0}, name={1}", spec.image(), spec.name());
 

--- a/src/main/java/io/floci/az/core/docker/PortAllocator.java
+++ b/src/main/java/io/floci/az/core/docker/PortAllocator.java
@@ -52,6 +52,10 @@ public class PortAllocator {
      * already the repo-wide "let the OS pick" sentinel, so the result can be handed straight to
      * {@code withPortBinding}.
      *
+     * <p>Availability is judged when the claim is made. A port that another process takes between
+     * that check and the container's bind is not caught here: Docker fails the bind and the create
+     * fails like any other port conflict, the same window {@link #allocate(int, int)} already has.
+     *
      * @param port the configured host port; {@code 0} or negative means no preference
      * @return {@code port} if it was claimed (release it with {@link #release(int)}), else {@code 0}
      */

--- a/src/main/java/io/floci/az/core/docker/PortAllocator.java
+++ b/src/main/java/io/floci/az/core/docker/PortAllocator.java
@@ -43,6 +43,31 @@ public class PortAllocator {
     }
 
     /**
+     * Claims one specific host port when it is configured and actually available.
+     *
+     * <p>Used by the per-server database sidecars, where a configured port expresses a preference
+     * that only the first server can be given: the second server asking for the same port, or a
+     * port an unrelated process already holds, falls back to an OS-assigned one. Returning
+     * {@code 0} rather than throwing is what makes that fallback expressible, and {@code 0} is
+     * already the repo-wide "let the OS pick" sentinel, so the result can be handed straight to
+     * {@code withPortBinding}.
+     *
+     * @param port the configured host port; {@code 0} or negative means no preference
+     * @return {@code port} if it was claimed (release it with {@link #release(int)}), else {@code 0}
+     */
+    public synchronized int claimOrZero(int port) {
+        if (port <= 0) {
+            return 0;
+        }
+        if (reserved.contains(port) || !isPortFree(port)) {
+            return 0;
+        }
+        reserved.add(port);
+        LOG.debugv("Claimed configured host port {0}", String.valueOf(port));
+        return port;
+    }
+
+    /**
      * Marks a port as reserved without probing whether it is free. Used on restart to
      * re-reserve host ports already held by surviving containers so the allocator does
      * not hand them out again.

--- a/src/main/java/io/floci/az/services/mariadb/MariaDbServerManager.java
+++ b/src/main/java/io/floci/az/services/mariadb/MariaDbServerManager.java
@@ -52,6 +52,15 @@ public class MariaDbServerManager {
 
         LOG.infof("Starting MariaDB container: server=%s image=%s", entry.serverName(), image);
 
+        // Pull before claiming, not after: create() pulls the image, and a cold pull of a large
+
+        // image would otherwise hold the port claimed but unbound for minutes, widening the
+
+        // window for something else to take it. The call is idempotent and free once cached.
+
+        containerManager.ensureImageAvailable(image);
+
+
         int configuredPort = mariaConfig.defaultPort();
         int requestedHostPort = portAllocator.claimOrZero(configuredPort);
         if (configuredPort > 0 && requestedHostPort == 0) {
@@ -70,65 +79,66 @@ public class MariaDbServerManager {
             .withLogRotation()
             .build();
 
-        String containerId;
+        // Everything from here to the hand-off is inside the claim's ownership window: if it ends
+        // in a throw, nothing has taken responsibility for the port yet, so the finally gives it
+        // back. Guarding each individual step instead is what let this leak twice already.
+        boolean claimTransferred = false;
         try {
-            containerId = containerManager.create(spec);
-        } catch (RuntimeException e) {
-            releaseClaimedPort(requestedHostPort);
-            throw e;
-        }
-        try {
-            containerManager.copyFileToContainer(containerId, grantAdminSql(entry.administratorLogin()),
-                "/docker-entrypoint-initdb.d/10-grant-admin.sql");
-            var info = containerManager.startCreated(containerId, spec);
-
-            int hostPort = Optional.ofNullable(info.getEndpoint(MARIADB_CONTAINER_PORT))
-                .map(ContainerLifecycleManager.EndpointInfo::port)
-                .orElseThrow(() -> new RuntimeException(
-                    "Could not resolve host port for MariaDB container " + containerName));
-
-            String reachableHost;
-            int reachablePort;
-            if (containerDetector.isRunningInContainer()) {
-                reachableHost = containerName;
-                reachablePort = MARIADB_CONTAINER_PORT;
-            } else {
-                reachableHost = "localhost";
-                reachablePort = hostPort;
-            }
-
-            managedContainers.put(containerId, containerName);
-
-            // Record the port we claimed, not the one Docker reported: only a claimed port is
-
-            // reserved in the allocator, and only that one may be released later.
-
-            if (requestedHostPort > 0) {
-
-                claimedPorts.put(containerId, requestedHostPort);
-
-            }
-            LOG.infof("MariaDB container started: server=%s containerId=%s endpoint=%s:%d",
-                entry.serverName(), containerId, reachableHost, reachablePort);
-
-            waitForReady(reachableHost, reachablePort, mariaConfig.startupTimeoutSeconds());
-            LOG.infof("MariaDB server ready: server=%s endpoint=%s:%d",
-                entry.serverName(), reachableHost, reachablePort);
-
-            return entry.withContainer(containerId, reachablePort, reachableHost);
-        } catch (RuntimeException e) {
-            // The caller rolls back state that never learned this containerId, so a failed
-            // start must dispose of its own container or it leaks as a running orphan.
-            managedContainers.remove(containerId);
-            claimedPorts.remove(containerId);
-            releaseClaimedPort(requestedHostPort);
+            String containerId = containerManager.create(spec);
             try {
-                containerManager.stopAndRemove(containerId, null);
-            } catch (Exception cleanup) {
-                LOG.warnf(cleanup, "Failed to clean up MariaDB container %s after start failure",
-                    containerName);
+                containerManager.copyFileToContainer(containerId, grantAdminSql(entry.administratorLogin()),
+                    "/docker-entrypoint-initdb.d/10-grant-admin.sql");
+                var info = containerManager.startCreated(containerId, spec);
+
+                int hostPort = Optional.ofNullable(info.getEndpoint(MARIADB_CONTAINER_PORT))
+                    .map(ContainerLifecycleManager.EndpointInfo::port)
+                    .orElseThrow(() -> new RuntimeException(
+                        "Could not resolve host port for MariaDB container " + containerName));
+
+                String reachableHost;
+                int reachablePort;
+                if (containerDetector.isRunningInContainer()) {
+                    reachableHost = containerName;
+                    reachablePort = MARIADB_CONTAINER_PORT;
+                } else {
+                    reachableHost = "localhost";
+                    reachablePort = hostPort;
+                }
+
+                managedContainers.put(containerId, containerName);
+
+                // Record the port we claimed, not the one Docker reported: only a claimed port is
+                // reserved in the allocator, and only that one may be released later.
+                if (requestedHostPort > 0) {
+                    claimedPorts.put(containerId, requestedHostPort);
+                    claimTransferred = true;
+                }
+                LOG.infof("MariaDB container started: server=%s containerId=%s endpoint=%s:%d",
+                    entry.serverName(), containerId, reachableHost, reachablePort);
+
+                waitForReady(reachableHost, reachablePort, mariaConfig.startupTimeoutSeconds());
+                LOG.infof("MariaDB server ready: server=%s endpoint=%s:%d",
+                    entry.serverName(), reachableHost, reachablePort);
+
+                return entry.withContainer(containerId, reachablePort, reachableHost);
+            } catch (RuntimeException e) {
+                // The caller rolls back state that never learned this containerId, so a failed
+                // start must dispose of its own container or it leaks as a running orphan.
+                managedContainers.remove(containerId);
+                claimedPorts.remove(containerId);
+                claimTransferred = false;
+                try {
+                    containerManager.stopAndRemove(containerId, null);
+                } catch (Exception cleanup) {
+                    LOG.warnf(cleanup, "Failed to clean up MariaDB container %s after start failure",
+                        containerName);
+                }
+                throw e;
             }
-            throw e;
+        } finally {
+            if (!claimTransferred) {
+                releaseClaimedPort(requestedHostPort);
+            }
         }
     }
 
@@ -156,12 +166,15 @@ public class MariaDbServerManager {
         if (entry.containerId() == null) return;
         LOG.infof("Stopping MariaDB container: server=%s containerId=%s",
             entry.serverName(), entry.containerId());
-        containerManager.stopAndRemove(entry.containerId(), null);
+        // Give the port and the bookkeeping back first: stopAndRemove can throw on a daemon
+        // hiccup, every caller swallows that, and the delete path has already dropped the
+        // server from state, so nothing would ever retry the release.
         managedContainers.remove(entry.containerId());
         Integer claimed = claimedPorts.remove(entry.containerId());
         if (claimed != null) {
             releaseClaimedPort(claimed);
         }
+        containerManager.stopAndRemove(entry.containerId(), null);
     }
 
     /**

--- a/src/main/java/io/floci/az/services/mariadb/MariaDbServerManager.java
+++ b/src/main/java/io/floci/az/services/mariadb/MariaDbServerManager.java
@@ -53,17 +53,11 @@ public class MariaDbServerManager {
         LOG.infof("Starting MariaDB container: server=%s image=%s", entry.serverName(), image);
 
         int configuredPort = mariaConfig.defaultPort();
-
         int requestedHostPort = portAllocator.claimOrZero(configuredPort);
-
         if (configuredPort > 0 && requestedHostPort == 0) {
-
-            LOG.warnf("Configured MariaDB default-port %d is unavailable (already claimed or in use) "
-
-                + "- falling back to an OS-assigned host port for server=%s", configuredPort, entry.serverName());
-
+            LOG.warnf("Configured MariaDB default-port %d is already claimed or in use - falling back "
+                + "to an OS-assigned host port for server=%s", configuredPort, entry.serverName());
         }
-
 
         ContainerSpec spec = containerBuilder.newContainer(image)
             .withName(containerName)
@@ -76,7 +70,13 @@ public class MariaDbServerManager {
             .withLogRotation()
             .build();
 
-        String containerId = containerManager.create(spec);
+        String containerId;
+        try {
+            containerId = containerManager.create(spec);
+        } catch (RuntimeException e) {
+            releaseClaimedPort(requestedHostPort);
+            throw e;
+        }
         try {
             containerManager.copyFileToContainer(containerId, grantAdminSql(entry.administratorLogin()),
                 "/docker-entrypoint-initdb.d/10-grant-admin.sql");
@@ -120,7 +120,8 @@ public class MariaDbServerManager {
             // The caller rolls back state that never learned this containerId, so a failed
             // start must dispose of its own container or it leaks as a running orphan.
             managedContainers.remove(containerId);
-            releaseClaimedPort(containerId);
+            claimedPorts.remove(containerId);
+            releaseClaimedPort(requestedHostPort);
             try {
                 containerManager.stopAndRemove(containerId, null);
             } catch (Exception cleanup) {
@@ -131,20 +132,25 @@ public class MariaDbServerManager {
         }
     }
 
-    /** Gives a claimed fixed port back, so deleting and recreating a server keeps it. */
+    /**
 
-    private void releaseClaimedPort(String containerId) {
+     * Gives a claimed fixed port back so a later create can have it again. Takes the port
 
-        Integer claimed = claimedPorts.remove(containerId);
+     * rather than the containerId on purpose: a start that fails before the container is
 
-        if (claimed != null) {
+     * registered has nothing in the map, and looking it up there would leak the claim.
 
-            portAllocator.release(claimed);
+     */
+
+    private void releaseClaimedPort(int claimedPort) {
+
+        if (claimedPort > 0) {
+
+            portAllocator.release(claimedPort);
 
         }
 
     }
-
 
     public void stopServer(MariaDbState.ServerEntry entry) {
         if (entry.containerId() == null) return;
@@ -152,7 +158,10 @@ public class MariaDbServerManager {
             entry.serverName(), entry.containerId());
         containerManager.stopAndRemove(entry.containerId(), null);
         managedContainers.remove(entry.containerId());
-        releaseClaimedPort(entry.containerId());
+        Integer claimed = claimedPorts.remove(entry.containerId());
+        if (claimed != null) {
+            releaseClaimedPort(claimed);
+        }
     }
 
     /**

--- a/src/main/java/io/floci/az/services/mariadb/MariaDbServerManager.java
+++ b/src/main/java/io/floci/az/services/mariadb/MariaDbServerManager.java
@@ -6,6 +6,7 @@ import io.floci.az.core.docker.ContainerBuilder;
 import io.floci.az.core.docker.ContainerDetector;
 import io.floci.az.core.docker.ContainerLifecycleManager;
 import io.floci.az.core.docker.ContainerSpec;
+import io.floci.az.core.docker.PortAllocator;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -33,8 +34,14 @@ public class MariaDbServerManager {
     @Inject ContainerLifecycleManager containerManager;
     @Inject ContainerBuilder containerBuilder;
     @Inject ContainerDetector containerDetector;
+    @Inject PortAllocator portAllocator;
 
     private final ConcurrentHashMap<String, String> managedContainers = new ConcurrentHashMap<>();
+
+
+    /** containerId -> the fixed host port claimed for it, so the claim is released with the container. */
+
+    private final ConcurrentHashMap<String, Integer> claimedPorts = new ConcurrentHashMap<>();
 
     public MariaDbState.ServerEntry startServer(MariaDbState.ServerEntry entry) {
         EmulatorConfig.MariaDbServiceConfig mariaConfig = config.services().mariaDb();
@@ -45,9 +52,22 @@ public class MariaDbServerManager {
 
         LOG.infof("Starting MariaDB container: server=%s image=%s", entry.serverName(), image);
 
+        int configuredPort = mariaConfig.defaultPort();
+
+        int requestedHostPort = portAllocator.claimOrZero(configuredPort);
+
+        if (configuredPort > 0 && requestedHostPort == 0) {
+
+            LOG.warnf("Configured MariaDB default-port %d is unavailable (already claimed or in use) "
+
+                + "- falling back to an OS-assigned host port for server=%s", configuredPort, entry.serverName());
+
+        }
+
+
         ContainerSpec spec = containerBuilder.newContainer(image)
             .withName(containerName)
-            .withDynamicPort(MARIADB_CONTAINER_PORT)
+            .withPortBinding(MARIADB_CONTAINER_PORT, requestedHostPort)   // 0 = OS picks (default-port unset or unavailable)
             .withDockerNetwork(config.services().dockerNetwork())
             .withEnv("MARIADB_ROOT_PASSWORD", entry.administratorLoginPassword())
             .withEnv("MARIADB_USER", entry.administratorLogin())
@@ -78,6 +98,16 @@ public class MariaDbServerManager {
             }
 
             managedContainers.put(containerId, containerName);
+
+            // Record the port we claimed, not the one Docker reported: only a claimed port is
+
+            // reserved in the allocator, and only that one may be released later.
+
+            if (requestedHostPort > 0) {
+
+                claimedPorts.put(containerId, requestedHostPort);
+
+            }
             LOG.infof("MariaDB container started: server=%s containerId=%s endpoint=%s:%d",
                 entry.serverName(), containerId, reachableHost, reachablePort);
 
@@ -90,6 +120,7 @@ public class MariaDbServerManager {
             // The caller rolls back state that never learned this containerId, so a failed
             // start must dispose of its own container or it leaks as a running orphan.
             managedContainers.remove(containerId);
+            releaseClaimedPort(containerId);
             try {
                 containerManager.stopAndRemove(containerId, null);
             } catch (Exception cleanup) {
@@ -100,12 +131,28 @@ public class MariaDbServerManager {
         }
     }
 
+    /** Gives a claimed fixed port back, so deleting and recreating a server keeps it. */
+
+    private void releaseClaimedPort(String containerId) {
+
+        Integer claimed = claimedPorts.remove(containerId);
+
+        if (claimed != null) {
+
+            portAllocator.release(claimed);
+
+        }
+
+    }
+
+
     public void stopServer(MariaDbState.ServerEntry entry) {
         if (entry.containerId() == null) return;
         LOG.infof("Stopping MariaDB container: server=%s containerId=%s",
             entry.serverName(), entry.containerId());
         containerManager.stopAndRemove(entry.containerId(), null);
         managedContainers.remove(entry.containerId());
+        releaseClaimedPort(entry.containerId());
     }
 
     /**
@@ -192,5 +239,7 @@ public class MariaDbServerManager {
             }
         }
         managedContainers.clear();
+        claimedPorts.values().forEach(portAllocator::release);
+        claimedPorts.clear();
     }
 }

--- a/src/main/java/io/floci/az/services/mysql/MySqlServerManager.java
+++ b/src/main/java/io/floci/az/services/mysql/MySqlServerManager.java
@@ -52,6 +52,15 @@ public class MySqlServerManager {
 
         LOG.infof("Starting MySQL container: server=%s image=%s", entry.serverName(), image);
 
+        // Pull before claiming, not after: create() pulls the image, and a cold pull of a large
+
+        // image would otherwise hold the port claimed but unbound for minutes, widening the
+
+        // window for something else to take it. The call is idempotent and free once cached.
+
+        containerManager.ensureImageAvailable(image);
+
+
         int configuredPort = mysqlConfig.defaultPort();
         int requestedHostPort = portAllocator.claimOrZero(configuredPort);
         if (configuredPort > 0 && requestedHostPort == 0) {
@@ -70,65 +79,66 @@ public class MySqlServerManager {
             .withLogRotation()
             .build();
 
-        String containerId;
+        // Everything from here to the hand-off is inside the claim's ownership window: if it ends
+        // in a throw, nothing has taken responsibility for the port yet, so the finally gives it
+        // back. Guarding each individual step instead is what let this leak twice already.
+        boolean claimTransferred = false;
         try {
-            containerId = containerManager.create(spec);
-        } catch (RuntimeException e) {
-            releaseClaimedPort(requestedHostPort);
-            throw e;
-        }
-        try {
-            containerManager.copyFileToContainer(containerId, grantAdminSql(entry.administratorLogin()),
-                "/docker-entrypoint-initdb.d/10-grant-admin.sql");
-            var info = containerManager.startCreated(containerId, spec);
-
-            int hostPort = Optional.ofNullable(info.getEndpoint(MYSQL_CONTAINER_PORT))
-                .map(ContainerLifecycleManager.EndpointInfo::port)
-                .orElseThrow(() -> new RuntimeException(
-                    "Could not resolve host port for MySQL container " + containerName));
-
-            String reachableHost;
-            int reachablePort;
-            if (containerDetector.isRunningInContainer()) {
-                reachableHost = containerName;
-                reachablePort = MYSQL_CONTAINER_PORT;
-            } else {
-                reachableHost = "localhost";
-                reachablePort = hostPort;
-            }
-
-            managedContainers.put(containerId, containerName);
-
-            // Record the port we claimed, not the one Docker reported: only a claimed port is
-
-            // reserved in the allocator, and only that one may be released later.
-
-            if (requestedHostPort > 0) {
-
-                claimedPorts.put(containerId, requestedHostPort);
-
-            }
-            LOG.infof("MySQL container started: server=%s containerId=%s endpoint=%s:%d",
-                entry.serverName(), containerId, reachableHost, reachablePort);
-
-            waitForReady(reachableHost, reachablePort, mysqlConfig.startupTimeoutSeconds());
-            LOG.infof("MySQL server ready: server=%s endpoint=%s:%d",
-                entry.serverName(), reachableHost, reachablePort);
-
-            return entry.withContainer(containerId, reachablePort, reachableHost);
-        } catch (RuntimeException e) {
-            // The caller rolls back state that never learned this containerId, so a failed
-            // start must dispose of its own container or it leaks as a running orphan.
-            managedContainers.remove(containerId);
-            claimedPorts.remove(containerId);
-            releaseClaimedPort(requestedHostPort);
+            String containerId = containerManager.create(spec);
             try {
-                containerManager.stopAndRemove(containerId, null);
-            } catch (Exception cleanup) {
-                LOG.warnf(cleanup, "Failed to clean up MySQL container %s after start failure",
-                    containerName);
+                containerManager.copyFileToContainer(containerId, grantAdminSql(entry.administratorLogin()),
+                    "/docker-entrypoint-initdb.d/10-grant-admin.sql");
+                var info = containerManager.startCreated(containerId, spec);
+
+                int hostPort = Optional.ofNullable(info.getEndpoint(MYSQL_CONTAINER_PORT))
+                    .map(ContainerLifecycleManager.EndpointInfo::port)
+                    .orElseThrow(() -> new RuntimeException(
+                        "Could not resolve host port for MySQL container " + containerName));
+
+                String reachableHost;
+                int reachablePort;
+                if (containerDetector.isRunningInContainer()) {
+                    reachableHost = containerName;
+                    reachablePort = MYSQL_CONTAINER_PORT;
+                } else {
+                    reachableHost = "localhost";
+                    reachablePort = hostPort;
+                }
+
+                managedContainers.put(containerId, containerName);
+
+                // Record the port we claimed, not the one Docker reported: only a claimed port is
+                // reserved in the allocator, and only that one may be released later.
+                if (requestedHostPort > 0) {
+                    claimedPorts.put(containerId, requestedHostPort);
+                    claimTransferred = true;
+                }
+                LOG.infof("MySQL container started: server=%s containerId=%s endpoint=%s:%d",
+                    entry.serverName(), containerId, reachableHost, reachablePort);
+
+                waitForReady(reachableHost, reachablePort, mysqlConfig.startupTimeoutSeconds());
+                LOG.infof("MySQL server ready: server=%s endpoint=%s:%d",
+                    entry.serverName(), reachableHost, reachablePort);
+
+                return entry.withContainer(containerId, reachablePort, reachableHost);
+            } catch (RuntimeException e) {
+                // The caller rolls back state that never learned this containerId, so a failed
+                // start must dispose of its own container or it leaks as a running orphan.
+                managedContainers.remove(containerId);
+                claimedPorts.remove(containerId);
+                claimTransferred = false;
+                try {
+                    containerManager.stopAndRemove(containerId, null);
+                } catch (Exception cleanup) {
+                    LOG.warnf(cleanup, "Failed to clean up MySQL container %s after start failure",
+                        containerName);
+                }
+                throw e;
             }
-            throw e;
+        } finally {
+            if (!claimTransferred) {
+                releaseClaimedPort(requestedHostPort);
+            }
         }
     }
 
@@ -156,12 +166,15 @@ public class MySqlServerManager {
         if (entry.containerId() == null) return;
         LOG.infof("Stopping MySQL container: server=%s containerId=%s",
             entry.serverName(), entry.containerId());
-        containerManager.stopAndRemove(entry.containerId(), null);
+        // Give the port and the bookkeeping back first: stopAndRemove can throw on a daemon
+        // hiccup, every caller swallows that, and the delete path has already dropped the
+        // server from state, so nothing would ever retry the release.
         managedContainers.remove(entry.containerId());
         Integer claimed = claimedPorts.remove(entry.containerId());
         if (claimed != null) {
             releaseClaimedPort(claimed);
         }
+        containerManager.stopAndRemove(entry.containerId(), null);
     }
 
     /**

--- a/src/main/java/io/floci/az/services/mysql/MySqlServerManager.java
+++ b/src/main/java/io/floci/az/services/mysql/MySqlServerManager.java
@@ -6,6 +6,7 @@ import io.floci.az.core.docker.ContainerBuilder;
 import io.floci.az.core.docker.ContainerDetector;
 import io.floci.az.core.docker.ContainerLifecycleManager;
 import io.floci.az.core.docker.ContainerSpec;
+import io.floci.az.core.docker.PortAllocator;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -33,8 +34,14 @@ public class MySqlServerManager {
     @Inject ContainerLifecycleManager containerManager;
     @Inject ContainerBuilder containerBuilder;
     @Inject ContainerDetector containerDetector;
+    @Inject PortAllocator portAllocator;
 
     private final ConcurrentHashMap<String, String> managedContainers = new ConcurrentHashMap<>();
+
+
+    /** containerId -> the fixed host port claimed for it, so the claim is released with the container. */
+
+    private final ConcurrentHashMap<String, Integer> claimedPorts = new ConcurrentHashMap<>();
 
     public MySqlState.ServerEntry startServer(MySqlState.ServerEntry entry) {
         EmulatorConfig.MySqlServiceConfig mysqlConfig = config.services().mysql();
@@ -45,9 +52,22 @@ public class MySqlServerManager {
 
         LOG.infof("Starting MySQL container: server=%s image=%s", entry.serverName(), image);
 
+        int configuredPort = mysqlConfig.defaultPort();
+
+        int requestedHostPort = portAllocator.claimOrZero(configuredPort);
+
+        if (configuredPort > 0 && requestedHostPort == 0) {
+
+            LOG.warnf("Configured MySQL default-port %d is unavailable (already claimed or in use) "
+
+                + "- falling back to an OS-assigned host port for server=%s", configuredPort, entry.serverName());
+
+        }
+
+
         ContainerSpec spec = containerBuilder.newContainer(image)
             .withName(containerName)
-            .withDynamicPort(MYSQL_CONTAINER_PORT)
+            .withPortBinding(MYSQL_CONTAINER_PORT, requestedHostPort)   // 0 = OS picks (default-port unset or unavailable)
             .withDockerNetwork(config.services().dockerNetwork())
             .withEnv("MYSQL_ROOT_PASSWORD", entry.administratorLoginPassword())
             .withEnv("MYSQL_USER", entry.administratorLogin())
@@ -78,6 +98,16 @@ public class MySqlServerManager {
             }
 
             managedContainers.put(containerId, containerName);
+
+            // Record the port we claimed, not the one Docker reported: only a claimed port is
+
+            // reserved in the allocator, and only that one may be released later.
+
+            if (requestedHostPort > 0) {
+
+                claimedPorts.put(containerId, requestedHostPort);
+
+            }
             LOG.infof("MySQL container started: server=%s containerId=%s endpoint=%s:%d",
                 entry.serverName(), containerId, reachableHost, reachablePort);
 
@@ -90,6 +120,7 @@ public class MySqlServerManager {
             // The caller rolls back state that never learned this containerId, so a failed
             // start must dispose of its own container or it leaks as a running orphan.
             managedContainers.remove(containerId);
+            releaseClaimedPort(containerId);
             try {
                 containerManager.stopAndRemove(containerId, null);
             } catch (Exception cleanup) {
@@ -100,12 +131,28 @@ public class MySqlServerManager {
         }
     }
 
+    /** Gives a claimed fixed port back, so deleting and recreating a server keeps it. */
+
+    private void releaseClaimedPort(String containerId) {
+
+        Integer claimed = claimedPorts.remove(containerId);
+
+        if (claimed != null) {
+
+            portAllocator.release(claimed);
+
+        }
+
+    }
+
+
     public void stopServer(MySqlState.ServerEntry entry) {
         if (entry.containerId() == null) return;
         LOG.infof("Stopping MySQL container: server=%s containerId=%s",
             entry.serverName(), entry.containerId());
         containerManager.stopAndRemove(entry.containerId(), null);
         managedContainers.remove(entry.containerId());
+        releaseClaimedPort(entry.containerId());
     }
 
     /**
@@ -192,5 +239,7 @@ public class MySqlServerManager {
             }
         }
         managedContainers.clear();
+        claimedPorts.values().forEach(portAllocator::release);
+        claimedPorts.clear();
     }
 }

--- a/src/main/java/io/floci/az/services/mysql/MySqlServerManager.java
+++ b/src/main/java/io/floci/az/services/mysql/MySqlServerManager.java
@@ -53,17 +53,11 @@ public class MySqlServerManager {
         LOG.infof("Starting MySQL container: server=%s image=%s", entry.serverName(), image);
 
         int configuredPort = mysqlConfig.defaultPort();
-
         int requestedHostPort = portAllocator.claimOrZero(configuredPort);
-
         if (configuredPort > 0 && requestedHostPort == 0) {
-
-            LOG.warnf("Configured MySQL default-port %d is unavailable (already claimed or in use) "
-
-                + "- falling back to an OS-assigned host port for server=%s", configuredPort, entry.serverName());
-
+            LOG.warnf("Configured MySQL default-port %d is already claimed or in use - falling back "
+                + "to an OS-assigned host port for server=%s", configuredPort, entry.serverName());
         }
-
 
         ContainerSpec spec = containerBuilder.newContainer(image)
             .withName(containerName)
@@ -76,7 +70,13 @@ public class MySqlServerManager {
             .withLogRotation()
             .build();
 
-        String containerId = containerManager.create(spec);
+        String containerId;
+        try {
+            containerId = containerManager.create(spec);
+        } catch (RuntimeException e) {
+            releaseClaimedPort(requestedHostPort);
+            throw e;
+        }
         try {
             containerManager.copyFileToContainer(containerId, grantAdminSql(entry.administratorLogin()),
                 "/docker-entrypoint-initdb.d/10-grant-admin.sql");
@@ -120,7 +120,8 @@ public class MySqlServerManager {
             // The caller rolls back state that never learned this containerId, so a failed
             // start must dispose of its own container or it leaks as a running orphan.
             managedContainers.remove(containerId);
-            releaseClaimedPort(containerId);
+            claimedPorts.remove(containerId);
+            releaseClaimedPort(requestedHostPort);
             try {
                 containerManager.stopAndRemove(containerId, null);
             } catch (Exception cleanup) {
@@ -131,20 +132,25 @@ public class MySqlServerManager {
         }
     }
 
-    /** Gives a claimed fixed port back, so deleting and recreating a server keeps it. */
+    /**
 
-    private void releaseClaimedPort(String containerId) {
+     * Gives a claimed fixed port back so a later create can have it again. Takes the port
 
-        Integer claimed = claimedPorts.remove(containerId);
+     * rather than the containerId on purpose: a start that fails before the container is
 
-        if (claimed != null) {
+     * registered has nothing in the map, and looking it up there would leak the claim.
 
-            portAllocator.release(claimed);
+     */
+
+    private void releaseClaimedPort(int claimedPort) {
+
+        if (claimedPort > 0) {
+
+            portAllocator.release(claimedPort);
 
         }
 
     }
-
 
     public void stopServer(MySqlState.ServerEntry entry) {
         if (entry.containerId() == null) return;
@@ -152,7 +158,10 @@ public class MySqlServerManager {
             entry.serverName(), entry.containerId());
         containerManager.stopAndRemove(entry.containerId(), null);
         managedContainers.remove(entry.containerId());
-        releaseClaimedPort(entry.containerId());
+        Integer claimed = claimedPorts.remove(entry.containerId());
+        if (claimed != null) {
+            releaseClaimedPort(claimed);
+        }
     }
 
     /**

--- a/src/main/java/io/floci/az/services/postgres/PostgresServerManager.java
+++ b/src/main/java/io/floci/az/services/postgres/PostgresServerManager.java
@@ -70,17 +70,11 @@ public class PostgresServerManager {
         LOG.infof("Starting PostgreSQL container: server=%s image=%s", entry.serverName(), image);
 
         int configuredPort = pgConfig.defaultPort();
-
         int requestedHostPort = portAllocator.claimOrZero(configuredPort);
-
         if (configuredPort > 0 && requestedHostPort == 0) {
-
-            LOG.warnf("Configured PostgreSQL default-port %d is unavailable (already claimed or in use) "
-
-                + "- falling back to an OS-assigned host port for server=%s", configuredPort, entry.serverName());
-
+            LOG.warnf("Configured PostgreSQL default-port %d is already claimed or in use - falling back "
+                + "to an OS-assigned host port for server=%s", configuredPort, entry.serverName());
         }
-
 
         ContainerSpec spec = containerBuilder.newContainer(image)
             .withName(containerName)
@@ -98,9 +92,7 @@ public class PostgresServerManager {
         } catch (RuntimeException e) {
             // No container exists to clean up here, but the port claim must not outlive the
             // attempt or the next create for this server cannot have its configured port.
-            if (requestedHostPort > 0) {
-                portAllocator.release(requestedHostPort);
-            }
+            releaseClaimedPort(requestedHostPort);
             throw e;
         }
         String containerId = info.containerId();
@@ -147,11 +139,14 @@ public class PostgresServerManager {
     /**
      * Stops and removes the container associated with the given server entry.
      */
-    /** Gives a claimed fixed port back, so deleting and recreating a server keeps it. */
-    private void releaseClaimedPort(String containerId) {
-        Integer claimed = claimedPorts.remove(containerId);
-        if (claimed != null) {
-            portAllocator.release(claimed);
+    /**
+     * Gives a claimed fixed port back so a later create can have it again. Takes the port
+     * rather than the containerId on purpose: a start that fails before the container is
+     * registered has nothing in the map, and looking it up there would leak the claim.
+     */
+    private void releaseClaimedPort(int claimedPort) {
+        if (claimedPort > 0) {
+            portAllocator.release(claimedPort);
         }
     }
 
@@ -161,7 +156,10 @@ public class PostgresServerManager {
             entry.serverName(), entry.containerId());
         containerManager.stopAndRemove(entry.containerId(), null);
         managedContainers.remove(entry.containerId());
-        releaseClaimedPort(entry.containerId());
+        Integer claimed = claimedPorts.remove(entry.containerId());
+        if (claimed != null) {
+            releaseClaimedPort(claimed);
+        }
     }
 
     // ── Private helpers ───────────────────────────────────────────────────────

--- a/src/main/java/io/floci/az/services/postgres/PostgresServerManager.java
+++ b/src/main/java/io/floci/az/services/postgres/PostgresServerManager.java
@@ -6,6 +6,7 @@ import io.floci.az.core.docker.ContainerBuilder;
 import io.floci.az.core.docker.ContainerDetector;
 import io.floci.az.core.docker.ContainerLifecycleManager;
 import io.floci.az.core.docker.ContainerSpec;
+import io.floci.az.core.docker.PortAllocator;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -43,9 +44,13 @@ public class PostgresServerManager {
     @Inject ContainerLifecycleManager containerManager;
     @Inject ContainerBuilder containerBuilder;
     @Inject ContainerDetector containerDetector;
+    @Inject PortAllocator portAllocator;
 
     /** containerId → container name, for cleanup on shutdown. */
     private final ConcurrentHashMap<String, String> managedContainers = new ConcurrentHashMap<>();
+
+    /** containerId -> the fixed host port claimed for it, so the claim is released with the container. */
+    private final ConcurrentHashMap<String, Integer> claimedPorts = new ConcurrentHashMap<>();
 
     // ── Public API ────────────────────────────────────────────────────────────
 
@@ -64,9 +69,22 @@ public class PostgresServerManager {
 
         LOG.infof("Starting PostgreSQL container: server=%s image=%s", entry.serverName(), image);
 
+        int configuredPort = pgConfig.defaultPort();
+
+        int requestedHostPort = portAllocator.claimOrZero(configuredPort);
+
+        if (configuredPort > 0 && requestedHostPort == 0) {
+
+            LOG.warnf("Configured PostgreSQL default-port %d is unavailable (already claimed or in use) "
+
+                + "- falling back to an OS-assigned host port for server=%s", configuredPort, entry.serverName());
+
+        }
+
+
         ContainerSpec spec = containerBuilder.newContainer(image)
             .withName(containerName)
-            .withDynamicPort(PG_CONTAINER_PORT)   // OS picks host port (used for host networking)
+            .withPortBinding(PG_CONTAINER_PORT, requestedHostPort)   // 0 = OS picks (default-port unset or unavailable)
             .withDockerNetwork(config.services().dockerNetwork())  // join the shared network when running in Docker
             .withEnv("POSTGRES_USER", entry.administratorLogin())
             .withEnv("POSTGRES_PASSWORD", entry.administratorLoginPassword())
@@ -74,7 +92,17 @@ public class PostgresServerManager {
             .withLogRotation()
             .build();
 
-        var info = containerManager.createAndStart(spec);
+        ContainerLifecycleManager.ContainerInfo info;
+        try {
+            info = containerManager.createAndStart(spec);
+        } catch (RuntimeException e) {
+            // No container exists to clean up here, but the port claim must not outlive the
+            // attempt or the next create for this server cannot have its configured port.
+            if (requestedHostPort > 0) {
+                portAllocator.release(requestedHostPort);
+            }
+            throw e;
+        }
         String containerId = info.containerId();
 
         int hostPort = Optional.ofNullable(info.getEndpoint(PG_CONTAINER_PORT))
@@ -96,6 +124,16 @@ public class PostgresServerManager {
         }
 
         managedContainers.put(containerId, containerName);
+
+        // Record the port we claimed, not the one Docker reported: only a claimed port is
+
+        // reserved in the allocator, and only that one may be released later.
+
+        if (requestedHostPort > 0) {
+
+            claimedPorts.put(containerId, requestedHostPort);
+
+        }
         LOG.infof("PostgreSQL container started: server=%s containerId=%s endpoint=%s:%d",
             entry.serverName(), containerId, reachableHost, reachablePort);
 
@@ -109,12 +147,21 @@ public class PostgresServerManager {
     /**
      * Stops and removes the container associated with the given server entry.
      */
+    /** Gives a claimed fixed port back, so deleting and recreating a server keeps it. */
+    private void releaseClaimedPort(String containerId) {
+        Integer claimed = claimedPorts.remove(containerId);
+        if (claimed != null) {
+            portAllocator.release(claimed);
+        }
+    }
+
     public void stopServer(PostgresState.ServerEntry entry) {
         if (entry.containerId() == null) return;
         LOG.infof("Stopping PostgreSQL container: server=%s containerId=%s",
             entry.serverName(), entry.containerId());
         containerManager.stopAndRemove(entry.containerId(), null);
         managedContainers.remove(entry.containerId());
+        releaseClaimedPort(entry.containerId());
     }
 
     // ── Private helpers ───────────────────────────────────────────────────────
@@ -172,5 +219,7 @@ public class PostgresServerManager {
             }
         }
         managedContainers.clear();
+        claimedPorts.values().forEach(portAllocator::release);
+        claimedPorts.clear();
     }
 }

--- a/src/main/java/io/floci/az/services/postgres/PostgresServerManager.java
+++ b/src/main/java/io/floci/az/services/postgres/PostgresServerManager.java
@@ -69,6 +69,15 @@ public class PostgresServerManager {
 
         LOG.infof("Starting PostgreSQL container: server=%s image=%s", entry.serverName(), image);
 
+        // Pull before claiming, not after: create() pulls the image, and a cold pull of a large
+
+        // image would otherwise hold the port claimed but unbound for minutes, widening the
+
+        // window for something else to take it. The call is idempotent and free once cached.
+
+        containerManager.ensureImageAvailable(image);
+
+
         int configuredPort = pgConfig.defaultPort();
         int requestedHostPort = portAllocator.claimOrZero(configuredPort);
         if (configuredPort > 0 && requestedHostPort == 0) {
@@ -86,54 +95,62 @@ public class PostgresServerManager {
             .withLogRotation()
             .build();
 
-        ContainerLifecycleManager.ContainerInfo info;
+        // Everything from here to the hand-off is inside the claim's ownership window: if it ends
+        // in a throw, nothing has taken responsibility for the port yet, so the finally gives it
+        // back. Guarding each individual step instead is what let this leak twice already.
+        boolean claimTransferred = false;
         try {
-            info = containerManager.createAndStart(spec);
-        } catch (RuntimeException e) {
-            // No container exists to clean up here, but the port claim must not outlive the
-            // attempt or the next create for this server cannot have its configured port.
-            releaseClaimedPort(requestedHostPort);
-            throw e;
+            ContainerLifecycleManager.ContainerInfo info = containerManager.createAndStart(spec);
+            String containerId = info.containerId();
+
+            int hostPort = Optional.ofNullable(info.getEndpoint(PG_CONTAINER_PORT))
+                .map(ContainerLifecycleManager.EndpointInfo::port)
+                .orElseThrow(() -> new RuntimeException(
+                    "Could not resolve host port for PostgreSQL container " + containerName));
+
+            // Pick the address an application can actually reach (mirrors RedisCacheManager):
+            // when floci-az runs inside a container, clients on the shared Docker network reach the
+            // sidecar by its container name on the container port; otherwise via localhost:hostPort.
+            String reachableHost;
+            int reachablePort;
+            if (containerDetector.isRunningInContainer()) {
+                reachableHost = containerName;
+                reachablePort = PG_CONTAINER_PORT;
+            } else {
+                reachableHost = "localhost";
+                reachablePort = hostPort;
+            }
+
+            managedContainers.put(containerId, containerName);
+
+            // Record the port we claimed, not the one Docker reported: only a claimed port is
+            // reserved in the allocator, and only that one may be released later.
+            if (requestedHostPort > 0) {
+                claimedPorts.put(containerId, requestedHostPort);
+                claimTransferred = true;
+            }
+            LOG.infof("PostgreSQL container started: server=%s containerId=%s endpoint=%s:%d",
+                entry.serverName(), containerId, reachableHost, reachablePort);
+
+            try {
+                waitForReady(reachableHost, reachablePort, pgConfig.startupTimeoutSeconds());
+            } catch (RuntimeException startupFailure) {
+                // The container itself is left for the pre-existing cleanup gap to deal with;
+                // the port claim is this method's to give back.
+                managedContainers.remove(containerId);
+                claimedPorts.remove(containerId);
+                claimTransferred = false;
+                throw startupFailure;
+            }
+            LOG.infof("PostgreSQL server ready: server=%s endpoint=%s:%d",
+                entry.serverName(), reachableHost, reachablePort);
+
+            return entry.withContainer(containerId, reachablePort, reachableHost);
+        } finally {
+            if (!claimTransferred) {
+                releaseClaimedPort(requestedHostPort);
+            }
         }
-        String containerId = info.containerId();
-
-        int hostPort = Optional.ofNullable(info.getEndpoint(PG_CONTAINER_PORT))
-            .map(ContainerLifecycleManager.EndpointInfo::port)
-            .orElseThrow(() -> new RuntimeException(
-                "Could not resolve host port for PostgreSQL container " + containerName));
-
-        // Pick the address an application can actually reach (mirrors RedisCacheManager):
-        // when floci-az runs inside a container, clients on the shared Docker network reach the
-        // sidecar by its container name on the container port; otherwise via localhost:hostPort.
-        String reachableHost;
-        int reachablePort;
-        if (containerDetector.isRunningInContainer()) {
-            reachableHost = containerName;
-            reachablePort = PG_CONTAINER_PORT;
-        } else {
-            reachableHost = "localhost";
-            reachablePort = hostPort;
-        }
-
-        managedContainers.put(containerId, containerName);
-
-        // Record the port we claimed, not the one Docker reported: only a claimed port is
-
-        // reserved in the allocator, and only that one may be released later.
-
-        if (requestedHostPort > 0) {
-
-            claimedPorts.put(containerId, requestedHostPort);
-
-        }
-        LOG.infof("PostgreSQL container started: server=%s containerId=%s endpoint=%s:%d",
-            entry.serverName(), containerId, reachableHost, reachablePort);
-
-        waitForReady(reachableHost, reachablePort, pgConfig.startupTimeoutSeconds());
-        LOG.infof("PostgreSQL server ready: server=%s endpoint=%s:%d",
-            entry.serverName(), reachableHost, reachablePort);
-
-        return entry.withContainer(containerId, reachablePort, reachableHost);
     }
 
     /**
@@ -154,12 +171,15 @@ public class PostgresServerManager {
         if (entry.containerId() == null) return;
         LOG.infof("Stopping PostgreSQL container: server=%s containerId=%s",
             entry.serverName(), entry.containerId());
-        containerManager.stopAndRemove(entry.containerId(), null);
+        // Give the port and the bookkeeping back first: stopAndRemove can throw on a daemon
+        // hiccup, every caller swallows that, and the delete path has already dropped the
+        // server from state, so nothing would ever retry the release.
         managedContainers.remove(entry.containerId());
         Integer claimed = claimedPorts.remove(entry.containerId());
         if (claimed != null) {
             releaseClaimedPort(claimed);
         }
+        containerManager.stopAndRemove(entry.containerId(), null);
     }
 
     // ── Private helpers ───────────────────────────────────────────────────────

--- a/src/main/java/io/floci/az/services/sql/SqlServerManager.java
+++ b/src/main/java/io/floci/az/services/sql/SqlServerManager.java
@@ -84,17 +84,11 @@ public class SqlServerManager {
         LOG.infof("Starting SQL Server container: server=%s image=%s", entry.serverName(), image);
 
         int configuredPort = sqlConfig.defaultPort();
-
         int requestedHostPort = portAllocator.claimOrZero(configuredPort);
-
         if (configuredPort > 0 && requestedHostPort == 0) {
-
-            LOG.warnf("Configured SQL Server default-port %d is unavailable (already claimed or in use) "
-
-                + "- falling back to an OS-assigned host port for server=%s", configuredPort, entry.serverName());
-
+            LOG.warnf("Configured SQL Server default-port %d is already claimed or in use - falling back "
+                + "to an OS-assigned host port for server=%s", configuredPort, entry.serverName());
         }
-
 
         ContainerSpec spec = containerBuilder.newContainer(image)
             .withName(containerName)
@@ -144,7 +138,8 @@ public class SqlServerManager {
             waitForReady(reachableHost, reachablePort, sqlConfig.startupTimeoutSeconds());
         } catch (RuntimeException startupFailure) {
             managedContainers.remove(containerId);
-            releaseClaimedPort(containerId);
+            claimedPorts.remove(containerId);
+            releaseClaimedPort(requestedHostPort);
             try {
                 containerManager.stopAndRemove(containerId, null);
             } catch (RuntimeException cleanupFailure) {
@@ -162,11 +157,14 @@ public class SqlServerManager {
     /**
      * Stops and removes the container associated with the given server entry.
      */
-    /** Gives a claimed fixed port back, so deleting and recreating a server keeps it. */
-    private void releaseClaimedPort(String containerId) {
-        Integer claimed = claimedPorts.remove(containerId);
-        if (claimed != null) {
-            portAllocator.release(claimed);
+    /**
+     * Gives a claimed fixed port back so a later create can have it again. Takes the port
+     * rather than the containerId on purpose: a start that fails before the container is
+     * registered has nothing in the map, and looking it up there would leak the claim.
+     */
+    private void releaseClaimedPort(int claimedPort) {
+        if (claimedPort > 0) {
+            portAllocator.release(claimedPort);
         }
     }
 
@@ -176,7 +174,10 @@ public class SqlServerManager {
             entry.serverName(), entry.containerId());
         containerManager.stopAndRemove(entry.containerId(), null);
         managedContainers.remove(entry.containerId());
-        releaseClaimedPort(entry.containerId());
+        Integer claimed = claimedPorts.remove(entry.containerId());
+        if (claimed != null) {
+            releaseClaimedPort(claimed);
+        }
     }
 
     // ── Private helpers ───────────────────────────────────────────────────────

--- a/src/main/java/io/floci/az/services/sql/SqlServerManager.java
+++ b/src/main/java/io/floci/az/services/sql/SqlServerManager.java
@@ -83,6 +83,15 @@ public class SqlServerManager {
 
         LOG.infof("Starting SQL Server container: server=%s image=%s", entry.serverName(), image);
 
+        // Pull before claiming, not after: create() pulls the image, and a cold pull of a large
+
+        // image would otherwise hold the port claimed but unbound for minutes, widening the
+
+        // window for something else to take it. The call is idempotent and free once cached.
+
+        containerManager.ensureImageAvailable(image);
+
+
         int configuredPort = sqlConfig.defaultPort();
         int requestedHostPort = portAllocator.claimOrZero(configuredPort);
         if (configuredPort > 0 && requestedHostPort == 0) {
@@ -99,59 +108,66 @@ public class SqlServerManager {
             .withLogRotation()
             .build();
 
-        var info = containerManager.createAndStart(spec);
-        String containerId = info.containerId();
-
-        int hostPort = Optional.ofNullable(info.getEndpoint(SQL_CONTAINER_PORT))
-            .map(ContainerLifecycleManager.EndpointInfo::port)
-            .orElseThrow(() -> new RuntimeException(
-                "Could not resolve host port for SQL Server container " + containerName));
-
-        // Pick the address an application can actually reach (mirrors RedisCacheManager):
-        // when floci-az runs inside a container, clients on the shared Docker network reach the
-        // sidecar by its container name on the container port; otherwise via localhost:hostPort.
-        String reachableHost;
-        int reachablePort;
-        if (containerDetector.isRunningInContainer()) {
-            reachableHost = containerName;
-            reachablePort = SQL_CONTAINER_PORT;
-        } else {
-            reachableHost = "localhost";
-            reachablePort = hostPort;
-        }
-
-        managedContainers.put(containerId, containerName);
-
-        // Record the port we claimed, not the one Docker reported: only a claimed port is
-
-        // reserved in the allocator, and only that one may be released later.
-
-        if (requestedHostPort > 0) {
-
-            claimedPorts.put(containerId, requestedHostPort);
-
-        }
-        LOG.infof("SQL Server container started: server=%s containerId=%s endpoint=%s:%d",
-            entry.serverName(), containerId, reachableHost, reachablePort);
-
+        // Everything from here to the hand-off is inside the claim's ownership window: if it ends
+        // in a throw, nothing has taken responsibility for the port yet, so the finally gives it
+        // back. Guarding each individual step instead is what let this leak twice already.
+        boolean claimTransferred = false;
         try {
-            waitForReady(reachableHost, reachablePort, sqlConfig.startupTimeoutSeconds());
-        } catch (RuntimeException startupFailure) {
-            managedContainers.remove(containerId);
-            claimedPorts.remove(containerId);
-            releaseClaimedPort(requestedHostPort);
-            try {
-                containerManager.stopAndRemove(containerId, null);
-            } catch (RuntimeException cleanupFailure) {
-                startupFailure.addSuppressed(cleanupFailure);
-                LOG.warnf(cleanupFailure,
-                    "Failed to remove unready SQL Server container '%s'", containerName);
-            }
-            throw startupFailure;
-        }
-        LOG.infof("SQL Server ready: server=%s endpoint=%s:%d", entry.serverName(), reachableHost, reachablePort);
+            var info = containerManager.createAndStart(spec);
+            String containerId = info.containerId();
 
-        return entry.withContainer(containerId, reachablePort, reachableHost);
+            int hostPort = Optional.ofNullable(info.getEndpoint(SQL_CONTAINER_PORT))
+                .map(ContainerLifecycleManager.EndpointInfo::port)
+                .orElseThrow(() -> new RuntimeException(
+                    "Could not resolve host port for SQL Server container " + containerName));
+
+            // Pick the address an application can actually reach (mirrors RedisCacheManager):
+            // when floci-az runs inside a container, clients on the shared Docker network reach the
+            // sidecar by its container name on the container port; otherwise via localhost:hostPort.
+            String reachableHost;
+            int reachablePort;
+            if (containerDetector.isRunningInContainer()) {
+                reachableHost = containerName;
+                reachablePort = SQL_CONTAINER_PORT;
+            } else {
+                reachableHost = "localhost";
+                reachablePort = hostPort;
+            }
+
+            managedContainers.put(containerId, containerName);
+
+            // Record the port we claimed, not the one Docker reported: only a claimed port is
+            // reserved in the allocator, and only that one may be released later.
+            if (requestedHostPort > 0) {
+                claimedPorts.put(containerId, requestedHostPort);
+                claimTransferred = true;
+            }
+            LOG.infof("SQL Server container started: server=%s containerId=%s endpoint=%s:%d",
+                entry.serverName(), containerId, reachableHost, reachablePort);
+
+            try {
+                waitForReady(reachableHost, reachablePort, sqlConfig.startupTimeoutSeconds());
+            } catch (RuntimeException startupFailure) {
+                managedContainers.remove(containerId);
+                claimedPorts.remove(containerId);
+                claimTransferred = false;
+                try {
+                    containerManager.stopAndRemove(containerId, null);
+                } catch (RuntimeException cleanupFailure) {
+                    startupFailure.addSuppressed(cleanupFailure);
+                    LOG.warnf(cleanupFailure,
+                        "Failed to remove unready SQL Server container '%s'", containerName);
+                }
+                throw startupFailure;
+            }
+            LOG.infof("SQL Server ready: server=%s endpoint=%s:%d", entry.serverName(), reachableHost, reachablePort);
+
+            return entry.withContainer(containerId, reachablePort, reachableHost);
+        } finally {
+            if (!claimTransferred) {
+                releaseClaimedPort(requestedHostPort);
+            }
+        }
     }
 
     /**
@@ -172,12 +188,15 @@ public class SqlServerManager {
         if (entry.containerId() == null) return;
         LOG.infof("Stopping SQL Server container: server=%s containerId=%s",
             entry.serverName(), entry.containerId());
-        containerManager.stopAndRemove(entry.containerId(), null);
+        // Give the port and the bookkeeping back first: stopAndRemove can throw on a daemon
+        // hiccup, every caller swallows that, and the delete path has already dropped the
+        // server from state, so nothing would ever retry the release.
         managedContainers.remove(entry.containerId());
         Integer claimed = claimedPorts.remove(entry.containerId());
         if (claimed != null) {
             releaseClaimedPort(claimed);
         }
+        containerManager.stopAndRemove(entry.containerId(), null);
     }
 
     // ── Private helpers ───────────────────────────────────────────────────────

--- a/src/main/java/io/floci/az/services/sql/SqlServerManager.java
+++ b/src/main/java/io/floci/az/services/sql/SqlServerManager.java
@@ -6,6 +6,7 @@ import io.floci.az.core.docker.ContainerBuilder;
 import io.floci.az.core.docker.ContainerDetector;
 import io.floci.az.core.docker.ContainerLifecycleManager;
 import io.floci.az.core.docker.ContainerSpec;
+import io.floci.az.core.docker.PortAllocator;
 import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
@@ -40,19 +41,25 @@ public class SqlServerManager {
     private final ContainerLifecycleManager containerManager;
     private final ContainerBuilder containerBuilder;
     private final ContainerDetector containerDetector;
+    private final PortAllocator portAllocator;
 
     /** containerId → container name, for cleanup on shutdown. */
     private final ConcurrentHashMap<String, String> managedContainers = new ConcurrentHashMap<>();
+
+    /** containerId -> the fixed host port claimed for it, so the claim is released with the container. */
+    private final ConcurrentHashMap<String, Integer> claimedPorts = new ConcurrentHashMap<>();
 
     @Inject
     public SqlServerManager(EmulatorConfig config,
                             ContainerLifecycleManager containerManager,
                             ContainerBuilder containerBuilder,
-                            ContainerDetector containerDetector) {
+                            ContainerDetector containerDetector,
+                            PortAllocator portAllocator) {
         this.config = config;
         this.containerManager = containerManager;
         this.containerBuilder = containerBuilder;
         this.containerDetector = containerDetector;
+        this.portAllocator = portAllocator;
     }
 
     // ── Public API ────────────────────────────────────────────────────────────
@@ -76,9 +83,22 @@ public class SqlServerManager {
 
         LOG.infof("Starting SQL Server container: server=%s image=%s", entry.serverName(), image);
 
+        int configuredPort = sqlConfig.defaultPort();
+
+        int requestedHostPort = portAllocator.claimOrZero(configuredPort);
+
+        if (configuredPort > 0 && requestedHostPort == 0) {
+
+            LOG.warnf("Configured SQL Server default-port %d is unavailable (already claimed or in use) "
+
+                + "- falling back to an OS-assigned host port for server=%s", configuredPort, entry.serverName());
+
+        }
+
+
         ContainerSpec spec = containerBuilder.newContainer(image)
             .withName(containerName)
-            .withDynamicPort(SQL_CONTAINER_PORT)   // OS picks host port (used for host networking)
+            .withPortBinding(SQL_CONTAINER_PORT, requestedHostPort)   // 0 = OS picks (default-port unset or unavailable)
             .withDockerNetwork(config.services().dockerNetwork())  // join the shared network when running in Docker
             .withEnv("ACCEPT_EULA", "Y")
             .withEnv("MSSQL_SA_PASSWORD", password)
@@ -107,6 +127,16 @@ public class SqlServerManager {
         }
 
         managedContainers.put(containerId, containerName);
+
+        // Record the port we claimed, not the one Docker reported: only a claimed port is
+
+        // reserved in the allocator, and only that one may be released later.
+
+        if (requestedHostPort > 0) {
+
+            claimedPorts.put(containerId, requestedHostPort);
+
+        }
         LOG.infof("SQL Server container started: server=%s containerId=%s endpoint=%s:%d",
             entry.serverName(), containerId, reachableHost, reachablePort);
 
@@ -114,6 +144,7 @@ public class SqlServerManager {
             waitForReady(reachableHost, reachablePort, sqlConfig.startupTimeoutSeconds());
         } catch (RuntimeException startupFailure) {
             managedContainers.remove(containerId);
+            releaseClaimedPort(containerId);
             try {
                 containerManager.stopAndRemove(containerId, null);
             } catch (RuntimeException cleanupFailure) {
@@ -131,12 +162,21 @@ public class SqlServerManager {
     /**
      * Stops and removes the container associated with the given server entry.
      */
+    /** Gives a claimed fixed port back, so deleting and recreating a server keeps it. */
+    private void releaseClaimedPort(String containerId) {
+        Integer claimed = claimedPorts.remove(containerId);
+        if (claimed != null) {
+            portAllocator.release(claimed);
+        }
+    }
+
     public void stopServer(SqlState.SqlServerEntry entry) {
         if (entry.containerId() == null) return;
         LOG.infof("Stopping SQL Server container: server=%s containerId=%s",
             entry.serverName(), entry.containerId());
         containerManager.stopAndRemove(entry.containerId(), null);
         managedContainers.remove(entry.containerId());
+        releaseClaimedPort(entry.containerId());
     }
 
     // ── Private helpers ───────────────────────────────────────────────────────
@@ -221,6 +261,8 @@ public class SqlServerManager {
             }
         }
         managedContainers.clear();
+        claimedPorts.values().forEach(portAllocator::release);
+        claimedPorts.clear();
     }
 
     /** Thrown when the SQL Server EULA has not been explicitly accepted. */

--- a/src/test/java/io/floci/az/core/docker/PortAllocatorTest.java
+++ b/src/test/java/io/floci/az/core/docker/PortAllocatorTest.java
@@ -56,6 +56,22 @@ class PortAllocatorTest {
     }
 
     @Test
+    @DisplayName("a claim released after a failed start is immediately reclaimable")
+    void claimReleasedOnFailureIsReusable() {
+        PortAllocator allocator = new PortAllocator();
+        int port = allocator.allocateAny();
+        allocator.release(port);
+
+        // What a manager does when the container fails to start: it claimed the port, never got
+        // as far as recording the container, and must still hand the port back.
+        assertEquals(port, allocator.claimOrZero(port));
+        allocator.release(port);
+
+        assertEquals(port, allocator.claimOrZero(port),
+            "a start that fails before the container is registered must not strand the claim");
+    }
+
+    @Test
     @DisplayName("a claim does not get handed out again by range allocation")
     void claimIsVisibleToRangeAllocation() {
         PortAllocator allocator = new PortAllocator();

--- a/src/test/java/io/floci/az/core/docker/PortAllocatorTest.java
+++ b/src/test/java/io/floci/az/core/docker/PortAllocatorTest.java
@@ -1,0 +1,70 @@
+package io.floci.az.core.docker;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@DisplayName("PortAllocator — claiming a specific configured port")
+class PortAllocatorTest {
+
+    @Test
+    @DisplayName("no preference: 0 and negative ports claim nothing")
+    void noPreferenceClaimsNothing() {
+        PortAllocator allocator = new PortAllocator();
+        assertEquals(0, allocator.claimOrZero(0));
+        assertEquals(0, allocator.claimOrZero(-1));
+    }
+
+    @Test
+    @DisplayName("a free port is claimed, and only once")
+    void secondClaimOfTheSamePortFallsBack() {
+        PortAllocator allocator = new PortAllocator();
+        int port = allocator.allocateAny();
+        allocator.release(port);
+
+        assertEquals(port, allocator.claimOrZero(port), "the first server should get its configured port");
+        assertEquals(0, allocator.claimOrZero(port), "a second server must fall back rather than collide");
+    }
+
+    @Test
+    @DisplayName("releasing lets the same port be claimed again")
+    void releaseAllowsReclaim() {
+        PortAllocator allocator = new PortAllocator();
+        int port = allocator.allocateAny();
+        allocator.release(port);
+
+        assertEquals(port, allocator.claimOrZero(port));
+        allocator.release(port);
+        assertEquals(port, allocator.claimOrZero(port),
+            "deleting and recreating a server must be able to reclaim its configured port");
+    }
+
+    @Test
+    @DisplayName("a port held by another process is not claimed")
+    void portHeldElsewhereFallsBack() throws IOException {
+        PortAllocator allocator = new PortAllocator();
+        try (ServerSocket occupied = new ServerSocket(0)) {
+            assertEquals(0, allocator.claimOrZero(occupied.getLocalPort()),
+                "claiming a port an unrelated process holds would fail at container start");
+        }
+    }
+
+    @Test
+    @DisplayName("a claim does not get handed out again by range allocation")
+    void claimIsVisibleToRangeAllocation() {
+        PortAllocator allocator = new PortAllocator();
+        int base = allocator.allocateAny();
+        allocator.release(base);
+
+        assertEquals(base, allocator.claimOrZero(base));
+        int fromRange = allocator.allocate(base, base + 20);
+        assertNotEquals(base, fromRange, "range allocation must not reissue a claimed port");
+        assertTrue(fromRange > base && fromRange <= base + 20);
+    }
+}

--- a/src/test/java/io/floci/az/services/PortClaimReleaseTest.java
+++ b/src/test/java/io/floci/az/services/PortClaimReleaseTest.java
@@ -1,0 +1,167 @@
+package io.floci.az.services;
+
+import io.floci.az.core.docker.ContainerLifecycleManager;
+import io.floci.az.core.docker.ContainerSpec;
+import io.floci.az.core.docker.PortAllocator;
+import io.floci.az.services.postgres.PostgresServerManager;
+import io.floci.az.services.postgres.PostgresState;
+import io.floci.az.services.sql.SqlServerManager;
+import io.floci.az.services.sql.SqlState;
+import io.quarkus.test.InjectMock;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * A failed start must hand the configured host port back to the allocator.
+ *
+ * <p>This is the failure mode that makes {@code default-port} break silently rather than loudly.
+ * The port is claimed before the container is built, so a start that throws anywhere before
+ * ownership moves to {@code claimedPorts} leaves it reserved for the life of the process. Nothing
+ * surfaces: the next create simply gets {@code claimOrZero() == 0} and falls back to an
+ * OS-assigned port, so the configured port quietly stops being honoured.
+ *
+ * <p>The managers are driven directly with a mocked {@link ContainerLifecycleManager}, so the real
+ * release path is what has to make this pass. PostgreSQL and SQL Server are covered because they
+ * are the two that leaked; MySQL and MariaDB share the same structure.
+ */
+@QuarkusTest
+@TestProfile(PortClaimReleaseTest.FixedPortProfile.class)
+@DisplayName("Server managers — a failed start releases the claimed host port")
+class PortClaimReleaseTest {
+
+    private static final int PG_PORT = 15433;
+    private static final int SQL_PORT = 14434;
+
+    public static class FixedPortProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                "floci-az.services.postgres.mocked", "false",
+                "floci-az.services.postgres.default-port", String.valueOf(PG_PORT),
+                "floci-az.services.postgres.startup-timeout-seconds", "1",
+                "floci-az.services.sql.mocked", "false",
+                "floci-az.services.sql.accept-eula", "Y",
+                "floci-az.services.sql.default-port", String.valueOf(SQL_PORT));
+        }
+    }
+
+    @InjectMock
+    ContainerLifecycleManager containerManager;
+
+    @Inject
+    PortAllocator portAllocator;
+
+    @Inject
+    PostgresServerManager postgresManager;
+
+    @Inject
+    SqlServerManager sqlManager;
+
+    @Test
+    @DisplayName("PostgreSQL releases the claim when the container fails to start")
+    void postgresReleasesClaimOnStartFailure() {
+        when(containerManager.createAndStart(any(ContainerSpec.class)))
+            .thenThrow(new RuntimeException("simulated: driver failed programming external connectivity"));
+
+        assertThrows(RuntimeException.class, () -> postgresManager.startServer(postgresEntry()));
+
+        assertClaimWasMade(PG_PORT, 5432);
+        assertEquals(PG_PORT, portAllocator.claimOrZero(PG_PORT),
+            "the configured port must be claimable again, or default-port silently stops working");
+        portAllocator.release(PG_PORT);
+    }
+
+    @Test
+    @DisplayName("SQL Server releases the claim when the container fails to start")
+    void sqlReleasesClaimOnStartFailure() {
+        when(containerManager.createAndStart(any(ContainerSpec.class)))
+            .thenThrow(new RuntimeException("simulated: port is already allocated"));
+
+        assertThrows(RuntimeException.class, () -> sqlManager.startServer(sqlEntry()));
+
+        assertClaimWasMade(SQL_PORT, 1433);
+        assertEquals(SQL_PORT, portAllocator.claimOrZero(SQL_PORT),
+            "the configured port must be claimable again, or default-port silently stops working");
+        portAllocator.release(SQL_PORT);
+    }
+
+    @Test
+    @DisplayName("PostgreSQL releases the claim when the port readback finds no endpoint")
+    void postgresReleasesClaimWhenEndpointMissing() {
+        // The container starts, but Docker reports no binding for the container port: the manager
+        // throws on the readback, which is after createAndStart and before the claim is recorded.
+        when(containerManager.createAndStart(any(ContainerSpec.class)))
+            .thenReturn(new ContainerLifecycleManager.ContainerInfo("pg-container", Map.of()));
+
+        assertThrows(RuntimeException.class, () -> postgresManager.startServer(postgresEntry()));
+
+        assertClaimWasMade(PG_PORT, 5432);
+        assertEquals(PG_PORT, portAllocator.claimOrZero(PG_PORT),
+            "a failed port readback must not strand the claim");
+        portAllocator.release(PG_PORT);
+    }
+
+    @Test
+    @DisplayName("stopServer releases the claim even when the container teardown throws")
+    void stopServerReleasesClaimWhenTeardownFails() {
+        var endpoint = new ContainerLifecycleManager.EndpointInfo("localhost", PG_PORT);
+        when(containerManager.createAndStart(any(ContainerSpec.class)))
+            .thenReturn(new ContainerLifecycleManager.ContainerInfo("pg-running", Map.of(5432, endpoint)));
+
+        PostgresState.ServerEntry started = postgresManager.startServer(postgresEntry());
+        assertEquals(0, portAllocator.claimOrZero(PG_PORT), "the running server should still hold its port");
+
+        // A daemon hiccup on teardown. Every caller of stopServer swallows this, and the delete
+        // path has already dropped the server from state, so nothing would ever retry the release.
+        doThrow(new RuntimeException("simulated: docker daemon unavailable"))
+            .when(containerManager).stopAndRemove(any(), any());
+
+        assertThrows(RuntimeException.class, () -> postgresManager.stopServer(started));
+
+        assertEquals(PG_PORT, portAllocator.claimOrZero(PG_PORT),
+            "a failed teardown must not strand the claim: the port is unreachable for every later create");
+        portAllocator.release(PG_PORT);
+    }
+
+    /**
+     * Without this the assertions below pass for the wrong reason: if the manager threw before it
+     * ever claimed the port, nothing was reserved and reclaiming it trivially succeeds. Checking the
+     * spec Docker was asked to create proves the claim was made and applied.
+     */
+    private void assertClaimWasMade(int expectedHostPort, int containerPort) {
+        ArgumentCaptor<ContainerSpec> spec = ArgumentCaptor.forClass(ContainerSpec.class);
+        verify(containerManager).createAndStart(spec.capture());
+        assertEquals(expectedHostPort, spec.getValue().portBindings().get(containerPort),
+            "the manager must have claimed and bound the configured port for this test to mean anything");
+    }
+
+    private PostgresState.ServerEntry postgresEntry() {
+        return new PostgresState.ServerEntry(
+            "leak-test-pg", "sub", "rg", "eastus", "16",
+            "pgadmin", "Str0ng!Passw0rd", "Standard_B1ms", "Burstable", 32,
+            null, 0, null, Map.of(), Map.of(), Map.of(), Map.of(), Instant.now());
+    }
+
+    private SqlState.SqlServerEntry sqlEntry() {
+        return new SqlState.SqlServerEntry(
+            "leak-test-sql", "sub", "rg", "eastus", "sa", "FlociAz_Strong123!",
+            null, 0, "localhost", "Creating", null, null,
+            Map.of(), new ConcurrentHashMap<>(), new ConcurrentHashMap<>(), Instant.now());
+    }
+}

--- a/src/test/java/io/floci/az/services/PortClaimReleaseTest.java
+++ b/src/test/java/io/floci/az/services/PortClaimReleaseTest.java
@@ -16,6 +16,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.ServerSocket;
 import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -45,19 +48,47 @@ import static org.mockito.Mockito.when;
 @DisplayName("Server managers — a failed start releases the claimed host port")
 class PortClaimReleaseTest {
 
-    private static final int PG_PORT = 15433;
-    private static final int SQL_PORT = 14434;
+    // Ephemeral, not hardcoded: a port another process already owns would make claimOrZero return
+    // 0, and these tests would fail for reasons that have nothing to do with claim cleanup.
+    //
+    // The value goes through a system property because Quarkus loads the profile and the test in
+    // different classloaders: a plain static field is initialised twice and the config the emulator
+    // booted with would not be the constant the assertions check.
+    private static final String PG_PORT_PROPERTY = "flociaz.test.portclaim.pg";
+    private static final String SQL_PORT_PROPERTY = "flociaz.test.portclaim.sql";
+
+    private static int reserveTestPort(String property) {
+        String existing = System.getProperty(property);
+        if (existing != null) {
+            return Integer.parseInt(existing);
+        }
+        try (ServerSocket socket = new ServerSocket(0)) {
+            int port = socket.getLocalPort();
+            System.setProperty(property, String.valueOf(port));
+            return port;
+        } catch (IOException e) {
+            throw new UncheckedIOException("Could not find a free port for the test profile", e);
+        }
+    }
+
+    private static int pgPort() {
+        return reserveTestPort(PG_PORT_PROPERTY);
+    }
+
+    private static int sqlPort() {
+        return reserveTestPort(SQL_PORT_PROPERTY);
+    }
 
     public static class FixedPortProfile implements QuarkusTestProfile {
         @Override
         public Map<String, String> getConfigOverrides() {
             return Map.of(
                 "floci-az.services.postgres.mocked", "false",
-                "floci-az.services.postgres.default-port", String.valueOf(PG_PORT),
+                "floci-az.services.postgres.default-port", String.valueOf(pgPort()),
                 "floci-az.services.postgres.startup-timeout-seconds", "1",
                 "floci-az.services.sql.mocked", "false",
                 "floci-az.services.sql.accept-eula", "Y",
-                "floci-az.services.sql.default-port", String.valueOf(SQL_PORT));
+                "floci-az.services.sql.default-port", String.valueOf(sqlPort()));
         }
     }
 
@@ -81,10 +112,10 @@ class PortClaimReleaseTest {
 
         assertThrows(RuntimeException.class, () -> postgresManager.startServer(postgresEntry()));
 
-        assertClaimWasMade(PG_PORT, 5432);
-        assertEquals(PG_PORT, portAllocator.claimOrZero(PG_PORT),
+        assertClaimWasMade(pgPort(), 5432);
+        assertEquals(pgPort(), portAllocator.claimOrZero(pgPort()),
             "the configured port must be claimable again, or default-port silently stops working");
-        portAllocator.release(PG_PORT);
+        portAllocator.release(pgPort());
     }
 
     @Test
@@ -95,10 +126,10 @@ class PortClaimReleaseTest {
 
         assertThrows(RuntimeException.class, () -> sqlManager.startServer(sqlEntry()));
 
-        assertClaimWasMade(SQL_PORT, 1433);
-        assertEquals(SQL_PORT, portAllocator.claimOrZero(SQL_PORT),
+        assertClaimWasMade(sqlPort(), 1433);
+        assertEquals(sqlPort(), portAllocator.claimOrZero(sqlPort()),
             "the configured port must be claimable again, or default-port silently stops working");
-        portAllocator.release(SQL_PORT);
+        portAllocator.release(sqlPort());
     }
 
     @Test
@@ -111,21 +142,21 @@ class PortClaimReleaseTest {
 
         assertThrows(RuntimeException.class, () -> postgresManager.startServer(postgresEntry()));
 
-        assertClaimWasMade(PG_PORT, 5432);
-        assertEquals(PG_PORT, portAllocator.claimOrZero(PG_PORT),
+        assertClaimWasMade(pgPort(), 5432);
+        assertEquals(pgPort(), portAllocator.claimOrZero(pgPort()),
             "a failed port readback must not strand the claim");
-        portAllocator.release(PG_PORT);
+        portAllocator.release(pgPort());
     }
 
     @Test
     @DisplayName("stopServer releases the claim even when the container teardown throws")
     void stopServerReleasesClaimWhenTeardownFails() {
-        var endpoint = new ContainerLifecycleManager.EndpointInfo("localhost", PG_PORT);
+        var endpoint = new ContainerLifecycleManager.EndpointInfo("localhost", pgPort());
         when(containerManager.createAndStart(any(ContainerSpec.class)))
             .thenReturn(new ContainerLifecycleManager.ContainerInfo("pg-running", Map.of(5432, endpoint)));
 
         PostgresState.ServerEntry started = postgresManager.startServer(postgresEntry());
-        assertEquals(0, portAllocator.claimOrZero(PG_PORT), "the running server should still hold its port");
+        assertEquals(0, portAllocator.claimOrZero(pgPort()), "the running server should still hold its port");
 
         // A daemon hiccup on teardown. Every caller of stopServer swallows this, and the delete
         // path has already dropped the server from state, so nothing would ever retry the release.
@@ -134,9 +165,9 @@ class PortClaimReleaseTest {
 
         assertThrows(RuntimeException.class, () -> postgresManager.stopServer(started));
 
-        assertEquals(PG_PORT, portAllocator.claimOrZero(PG_PORT),
+        assertEquals(pgPort(), portAllocator.claimOrZero(pgPort()),
             "a failed teardown must not strand the claim: the port is unreachable for every later create");
-        portAllocator.release(PG_PORT);
+        portAllocator.release(pgPort());
     }
 
     /**

--- a/src/test/java/io/floci/az/services/mysql/MySqlDefaultPortMockedTest.java
+++ b/src/test/java/io/floci/az/services/mysql/MySqlDefaultPortMockedTest.java
@@ -7,25 +7,37 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.ServerSocket;
 import java.util.Map;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**
  * Setting {@code default-port} must not make mocked mode start claiming host ports.
  *
  * <p>Mocked mode exists so that {@code plan}/CI runs need no Docker; a configured port there
- * describes a container that is never created, so nothing should be reserved and nothing should
- * be bound. This runs everywhere, with or without a Docker daemon.
+ * describes a container that is never created, so nothing should be reserved and nothing bound.
+ *
+ * <p>The port is chosen at class-init time from an ephemeral bind rather than hardcoded, because
+ * a fixed number would make this test fail on any machine already using it.
  */
 @QuarkusTest
 @TestProfile(MySqlDefaultPortMockedTest.FixedPortMockedProfile.class)
 @DisplayName("MySqlHandler — default-port is inert in mocked mode")
 class MySqlDefaultPortMockedTest {
 
-    private static final int CONFIGURED_PORT = 15306;
+    private static final int CONFIGURED_PORT = findFreePort();
+
+    private static int findFreePort() {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        } catch (IOException e) {
+            throw new UncheckedIOException("Could not find a free port for the test profile", e);
+        }
+    }
 
     public static class FixedPortMockedProfile implements QuarkusTestProfile {
         @Override
@@ -41,7 +53,7 @@ class MySqlDefaultPortMockedTest {
 
     @Test
     @DisplayName("a mocked server is created without claiming the configured port")
-    void mockedServerDoesNotClaimTheConfiguredPort() throws IOException {
+    void mockedServerDoesNotClaimTheConfiguredPort() {
         given()
             .contentType("application/json")
             .body("""
@@ -60,8 +72,10 @@ class MySqlDefaultPortMockedTest {
             .body("properties.state", equalTo("Ready"));
 
         // Nothing was started, so the port must still be bindable by anyone else.
-        try (ServerSocket probe = new ServerSocket(CONFIGURED_PORT)) {
-            assert probe.isBound();
-        }
+        assertDoesNotThrow(() -> {
+            try (ServerSocket probe = new ServerSocket(CONFIGURED_PORT)) {
+                probe.getLocalPort();
+            }
+        }, "mocked mode must not bind or reserve the configured port");
     }
 }

--- a/src/test/java/io/floci/az/services/mysql/MySqlDefaultPortMockedTest.java
+++ b/src/test/java/io/floci/az/services/mysql/MySqlDefaultPortMockedTest.java
@@ -1,0 +1,67 @@
+package io.floci.az.services.mysql;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+/**
+ * Setting {@code default-port} must not make mocked mode start claiming host ports.
+ *
+ * <p>Mocked mode exists so that {@code plan}/CI runs need no Docker; a configured port there
+ * describes a container that is never created, so nothing should be reserved and nothing should
+ * be bound. This runs everywhere, with or without a Docker daemon.
+ */
+@QuarkusTest
+@TestProfile(MySqlDefaultPortMockedTest.FixedPortMockedProfile.class)
+@DisplayName("MySqlHandler — default-port is inert in mocked mode")
+class MySqlDefaultPortMockedTest {
+
+    private static final int CONFIGURED_PORT = 15306;
+
+    public static class FixedPortMockedProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                "floci-az.services.mysql.mocked", "true",
+                "floci-az.services.mysql.default-port", String.valueOf(CONFIGURED_PORT));
+        }
+    }
+
+    private static final String BASE = "/subscriptions/test-sub-mysql-port/resourceGroups/test-rg-mysql-port"
+                                     + "/providers/Microsoft.DBforMySQL";
+
+    @Test
+    @DisplayName("a mocked server is created without claiming the configured port")
+    void mockedServerDoesNotClaimTheConfiguredPort() throws IOException {
+        given()
+            .contentType("application/json")
+            .body("""
+                {
+                  "location": "eastus",
+                  "properties": {
+                    "administratorLogin": "mysqladmin",
+                    "administratorLoginPassword": "Str0ng!Passw0rd",
+                    "version": "8.0"
+                  }
+                }""")
+            .when()
+            .put(BASE + "/flexibleServers/port-test-server?api-version=2023-06-30")
+            .then()
+            .statusCode(201)
+            .body("properties.state", equalTo("Ready"));
+
+        // Nothing was started, so the port must still be bindable by anyone else.
+        try (ServerSocket probe = new ServerSocket(CONFIGURED_PORT)) {
+            assert probe.isBound();
+        }
+    }
+}

--- a/src/test/java/io/floci/az/services/mysql/MySqlDefaultPortMockedTest.java
+++ b/src/test/java/io/floci/az/services/mysql/MySqlDefaultPortMockedTest.java
@@ -29,11 +29,20 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 @DisplayName("MySqlHandler — default-port is inert in mocked mode")
 class MySqlDefaultPortMockedTest {
 
-    private static final int CONFIGURED_PORT = findFreePort();
+    // Shared through a system property, not a static field: Quarkus loads the profile and the test
+    // in different classloaders, so a plain static is initialised twice and the assertion below
+    // would probe a port the emulator was never configured with.
+    private static final String PORT_PROPERTY = "flociaz.test.mysqlport.mocked";
 
-    private static int findFreePort() {
+    private static int configuredPort() {
+        String existing = System.getProperty(PORT_PROPERTY);
+        if (existing != null) {
+            return Integer.parseInt(existing);
+        }
         try (ServerSocket socket = new ServerSocket(0)) {
-            return socket.getLocalPort();
+            int port = socket.getLocalPort();
+            System.setProperty(PORT_PROPERTY, String.valueOf(port));
+            return port;
         } catch (IOException e) {
             throw new UncheckedIOException("Could not find a free port for the test profile", e);
         }
@@ -44,7 +53,7 @@ class MySqlDefaultPortMockedTest {
         public Map<String, String> getConfigOverrides() {
             return Map.of(
                 "floci-az.services.mysql.mocked", "true",
-                "floci-az.services.mysql.default-port", String.valueOf(CONFIGURED_PORT));
+                "floci-az.services.mysql.default-port", String.valueOf(configuredPort()));
         }
     }
 
@@ -73,7 +82,7 @@ class MySqlDefaultPortMockedTest {
 
         // Nothing was started, so the port must still be bindable by anyone else.
         assertDoesNotThrow(() -> {
-            try (ServerSocket probe = new ServerSocket(CONFIGURED_PORT)) {
+            try (ServerSocket probe = new ServerSocket(configuredPort())) {
                 probe.getLocalPort();
             }
         }, "mocked mode must not bind or reserve the configured port");


### PR DESCRIPTION
## Summary

`defaultPort()` is declared on four database service configs — `sql`, `postgres`, `mysql`, `maria-db` — and was read by none of them. Every manager called `withDynamicPort(...)`, so the OS assigned the host port no matter what the key said, while `docs/services/postgresql.md` and `docs/services/sql.md` told users to set it when they needed a fixed port. A configuration key that looks supported and silently does nothing is worse than no key at all.

The managers now claim the configured port through `PortAllocator` and bind it, falling back to an OS-assigned port when it is unavailable. `claimOrZero` returns `0` rather than throwing precisely so the fallback is expressible, and `0` is already the repo's "let the OS pick" sentinel, so `withPortBinding(PORT, 0)` is byte-identical to the old `withDynamicPort(PORT)`. **With the shipped default of `0`, current behaviour is unchanged.**

**Falling back rather than failing is deliberate.** These containers start from an ARM create request, one per logical server, so a single configured port can only ever serve the first server. Failing the second create would turn a working `terraform apply` into a 500 over what the key's own javadoc calls a preference: *"0 lets the OS pick a free port (recommended when running multiple servers)"*. The fallback is logged with the service and server name, and the real port stays discoverable via `properties.localPort` and `/connect`.

Claims are released on stop, on start failure, and on shutdown, so deleting and recreating a server reclaims its port — the `terraform destroy && apply` workflow the key exists for. PostgreSQL had no start-failure path at all; it now releases the claim and rethrows. (Cleaning up the orphaned container on that path is a separate pre-existing bug and is deliberately not folded in.)

Found while acting on review feedback for #288, which flagged that the new MySQL/MariaDB pages documented a fixed-port option that did not exist.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Azure Compatibility

No wire-protocol change. Incorrect behaviour: `FLOCI_AZ_SERVICES_{SQL,POSTGRES,MYSQL,MARIA_DB}_DEFAULT_PORT` had no effect at all; the host port was always OS-assigned.

## Checklist

- [x] `./mvnw test` passes locally (1052 tests, 0 failures)
- [x] New or updated integration test added (`PortAllocatorTest`, `MySqlDefaultPortMockedTest`)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

Verified against real Docker with `FLOCI_AZ_SERVICES_MYSQL_DEFAULT_PORT=15306`:

| step | result |
|---|---|
| first server | `0.0.0.0:15306->3306/tcp`, `localPort: 15306` |
| second server | HTTP 201 on OS-assigned `64545`, with the documented WARN |
| delete + recreate first | reclaimed `15306` |
| `/connect` | reported the fixed port throughout |

## Release invariant (after review)

The claim is released **by construction**, not per call site: each manager wraps create through hand-off in one `try` with a `claimTransferred` flag and a `finally` that releases unless ownership moved to `claimedPorts`. Review found that the first fix covered MySQL and MariaDB but left SQL Server (`createAndStart` and the readback) and PostgreSQL (the readback, and a readiness failure after the record); a fourth path turned up in all four `stopServer` methods, where `stopAndRemove` ran first and unguarded, so a daemon hiccup stranded the port with nothing to retry it.

The image pull also moved ahead of the claim (`ContainerLifecycleManager.ensureImageAvailable`), so a cold pull no longer holds a claimed-but-unbound port for minutes.

`PortClaimReleaseTest` drives the real managers with a mocked `ContainerLifecycleManager` and covers all four paths. Every case was checked against the pre-fix code and fails there. It also asserts the spec Docker was asked to create carried the configured port, so a manager that threw *before* claiming cannot satisfy the assertions for the wrong reason.

**Review note:** three of these managers use field injection, and the new dependency follows the style already in each class rather than converting them mid-change (AGENTS.md allows staying consistent within a class when the migration is not small). Converting all three would roughly triple the diff — happy to do it if you would rather.

