### PR TITLE
fix(blob): allow write SAS append blocks

### DIFF
--- a/src/main/java/io/floci/az/core/auth/StorageSasAuthorization.java
+++ b/src/main/java/io/floci/az/core/auth/StorageSasAuthorization.java
@@ -396,7 +396,7 @@ public class StorageSasAuthorization {
         APPEND {
             @Override
             boolean allowedBy(StorageSasToken token) {
-                return token.hasPermission('a');
+                return token.hasAnyPermission('a', 'w');
             }
         };
 

--- a/src/test/java/io/floci/az/services/BlobServiceTest.java
+++ b/src/test/java/io/floci/az/services/BlobServiceTest.java
@@ -516,6 +516,30 @@ public class BlobServiceTest {
     }
 
     @Test
+    void writeOnlySasCanAppendToAppendBlob() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        given()
+            .header("x-ms-blob-type", "AppendBlob")
+            .body("")
+            .put("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB);
+
+        given()
+            .body("first")
+            .when().put("/{account}/{container}/{blob}?comp=appendblock&{sas}",
+                    ACCOUNT, CONTAINER, BLOB, sas("w", "b", CONTAINER, BLOB))
+            .then()
+            .statusCode(201)
+            .header("x-ms-blob-append-offset", "0")
+            .header("x-ms-blob-committed-block-count", "1");
+
+        given()
+            .when().get("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(200)
+            .body(equalTo("first"));
+    }
+
+    @Test
     void appendBlockHonorsConditionsAndLeaseGuards() {
         given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
         given()


### PR DESCRIPTION
Summary:
- Allow write-only SAS tokens to append blocks to existing Append Blobs.
- Preserve append-only SAS authorization and existing append conditions and lease checks.

Type of change:
- [x] Bug fix (fix:)

Azure Compatibility:
- Matches Azurite Append Block authorization, which accepts either a or w permission.

Checklist:
- [x] ./mvnw test passes locally
- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits
