### PR TITLE
test: derive the patched jar name from the pom, not a literal

### DIFF
--- a/src/test/java/org/apache/activemq/artemis/protocol/amqp/proton/AmqpEntityAddressTest.java
+++ b/src/test/java/org/apache/activemq/artemis/protocol/amqp/proton/AmqpEntityAddressTest.java
@@ -6,9 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
-import java.net.URL;
 import java.net.URLClassLoader;
-import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -24,10 +22,7 @@ class AmqpEntityAddressTest {
 
     @BeforeAll
     static void loadFromPatchJar() throws Exception {
-        Path patchJar = Path.of("target", "classes", "artemis",
-                "artemis-amqp-protocol-2.44.0-floci-az-artemis-amqp-patch.jar");
-        loader = new URLClassLoader(new URL[]{patchJar.toUri().toURL()},
-                AmqpEntityAddressTest.class.getClassLoader());
+        loader = PatchJarLoader.open();
         toEntityPath = Class.forName(
                         "org.apache.activemq.artemis.protocol.amqp.proton.AmqpEntityAddress",
                         true, loader)

--- a/src/test/java/org/apache/activemq/artemis/protocol/amqp/proton/EventHubFilterSupportTest.java
+++ b/src/test/java/org/apache/activemq/artemis/protocol/amqp/proton/EventHubFilterSupportTest.java
@@ -6,9 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Method;
-import java.net.URL;
 import java.net.URLClassLoader;
-import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -26,10 +24,7 @@ class EventHubFilterSupportTest {
 
     @BeforeAll
     static void loadFromPatchJar() throws Exception {
-        Path patchJar = Path.of("target", "classes", "artemis",
-                "artemis-amqp-protocol-2.44.0-floci-az-artemis-amqp-patch.jar");
-        loader = new URLClassLoader(new URL[]{patchJar.toUri().toURL()},
-                EventHubFilterSupportTest.class.getClassLoader());
+        loader = PatchJarLoader.open();
         rewriteSelector = Class.forName(
                         "org.apache.activemq.artemis.protocol.amqp.proton.EventHubFilterSupport",
                         true, loader)

--- a/src/test/java/org/apache/activemq/artemis/protocol/amqp/proton/PatchJarLoader.java
+++ b/src/test/java/org/apache/activemq/artemis/protocol/amqp/proton/PatchJarLoader.java
@@ -1,0 +1,42 @@
+package org.apache.activemq.artemis.protocol.amqp.proton;
+
+import io.floci.az.services.servicebus.ArtemisPatchVersions;
+
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Opens the patched {@code artemis-amqp-protocol} jar the build writes.
+ *
+ * The classes it holds shadow ones inside the stock Artemis jar, so they are not on the test
+ * classpath and a test reaches them through a loader of its own.
+ *
+ * The jar's name carries the Artemis version, and that version lives in the pom alone — the same
+ * value names the jar, the paths inside the sidecar container and the image tag, so they cannot
+ * drift apart. Spelling the version here as a literal would put it back in a second place: the
+ * next Artemis bump would then fail these tests with a file-not-found instead of the message
+ * {@code ArtemisPatchVersionsTest} exists to give.
+ */
+final class PatchJarLoader {
+
+    private PatchJarLoader() {
+    }
+
+    /** A loader over the patched jar, with the test classpath as its parent. */
+    static URLClassLoader open() throws Exception {
+        // The constant is a classpath resource ("/artemis/…"); the same file is written under
+        // target/classes, so the resource path resolves against it once the leading slash is gone.
+        Path jar = Path.of("target", "classes")
+                .resolve(ArtemisPatchVersions.ARTEMIS_AMQP_PATCH_RESOURCE.substring(1));
+        if (!Files.exists(jar)) {
+            throw new IllegalStateException(
+                    "Patched jar not found: " + jar + " — it is written by the "
+                            + "package-servicebus-artemis-patches step in pom.xml, so run the "
+                            + "build rather than the test alone");
+        }
+        return new URLClassLoader(new URL[]{jar.toUri().toURL()},
+                PatchJarLoader.class.getClassLoader());
+    }
+}

--- a/src/test/java/org/apache/activemq/artemis/protocol/amqp/proton/ServiceBusDeadLetterSupportTest.java
+++ b/src/test/java/org/apache/activemq/artemis/protocol/amqp/proton/ServiceBusDeadLetterSupportTest.java
@@ -6,9 +6,7 @@ import org.apache.qpid.proton.amqp.messaging.Rejected;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.junit.jupiter.api.Test;
 
-import java.net.URL;
 import java.net.URLClassLoader;
-import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Date;
 import java.util.Map;
@@ -29,10 +27,7 @@ class ServiceBusDeadLetterSupportTest {
                 Symbol.valueOf("attempt"), 3));
         rejected.setError(error);
 
-        Path patchJar = Path.of("target", "classes", "artemis",
-                "artemis-amqp-protocol-2.44.0-floci-az-artemis-amqp-patch.jar");
-        try (URLClassLoader loader = new URLClassLoader(
-                new URL[]{patchJar.toUri().toURL()}, getClass().getClassLoader())) {
+        try (URLClassLoader loader = PatchJarLoader.open()) {
             Class<?> support = Class.forName(
                     "org.apache.activemq.artemis.protocol.amqp.proton.ServiceBusDeadLetterSupport",
                     true,


### PR DESCRIPTION
The follow-up you asked for on #285.

## The problem

Three tests open the patched `artemis-amqp-protocol` jar through a loader of their own, and each spelled the file name out with the Artemis version in it:

```java
Path patchJar = Path.of("target", "classes", "artemis",
        "artemis-amqp-protocol-2.44.0-floci-az-artemis-amqp-patch.jar");
```

#282 moved that version into the pom alone, so the jar names, the container paths and the sidecar image tag cannot drift apart. A literal in a test puts it back in a second place — and the next Artemis bump would fail these three with a file-not-found instead of the message `ArtemisPatchVersionsTest` exists to give.

## The change

One helper, `PatchJarLoader`, derives the name from `ArtemisPatchVersions.ARTEMIS_AMQP_PATCH_RESOURCE` — a resource path, so it resolves against `target/classes` once the leading slash is gone. All three tests call it.

A helper rather than three copies of the derivation, because the literal spread the same way: copied from one test into the next as each new one was written. One spelling is now the only spelling — `grep -rn "2.44.0" src/test/` finds nothing.

It also reports a missing jar as a missing jar, naming the build step that writes it, rather than leaving a `NoSuchFileException` from a URL nobody can see.

## Scope

`ServiceBusDeadLetterSupportTest` predates the Event Hubs work and carried the same literal. I fixed it too — leaving it would have left the trap in place for exactly the bump that trips it, and it is the test the other two were modelled on.

## Testing

```
1037 tests, 0 failures
```

(`AksDockerTest` and `PostgresDockerTest` are excluded — they fail the same way on a clean `main` on this machine, which runs k3d and a dozen containers.)

One thing I could not verify end to end, so I would rather say it than imply otherwise: I tried simulating a bump by setting `artemis.version` to a fictitious `2.45.0`, but the build then fails at dependency resolution before any test runs, so it proves nothing about the test path. The guarantee rests on the derivation itself plus the four tests passing against the real version — including `ArtemisPatchVersionsTest`, which is the guard that should speak first when a bump forgets the image.
