### PR TITLE
feat(blob): support snapshot-scoped user delegation SAS

### DIFF
--- a/src/main/java/io/floci/az/services/blob/BlobLeaseService.java
+++ b/src/main/java/io/floci/az/services/blob/BlobLeaseService.java
@@ -269,6 +269,15 @@ public class BlobLeaseService {
         return null;
     }
 
+    /**
+     * Snapshot Blob ignores an active lease unless the caller explicitly supplies a lease ID.
+     * When supplied, the ID must still identify the active lease. Call only inside
+     * {@link #exclusively}.
+     */
+    Response validateSnapshot(AzureRequest request, String blobKey) {
+        return header(request, "x-ms-lease-id") == null ? null : validateWrite(request, blobKey);
+    }
+
     /** Data Lake variant of {@link #validateWrite} using the DFS JSON error envelope. */
     Response validateDataLakeWrite(AzureRequest request, String blobKey) {
         String requestLeaseId = header(request, "x-ms-lease-id");

--- a/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
+++ b/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
@@ -42,6 +42,7 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
 
     private static final String NS_PREFIX  = "__ns__:";
     private static final String BLK_PREFIX = "__blk__:";
+    private static final String SNAPSHOT_PREFIX = "__snapshot__:";
     private static final String USER_METADATA_PREFIX = "UserMeta:";
     private static final String CREATION_TIME_KEY = "CreationTime";
     private static final String DATALAKE_APPEND_PREFIX = "__abfs_append__:";
@@ -258,6 +259,11 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
                     response = dataLakeNotImplemented();
                 } else if ("PUT".equalsIgnoreCase(method) && "lease".equals(comp)) {
                     response = leaseBlob(request, containerName, blobName);
+                } else if ("PUT".equalsIgnoreCase(method) && "snapshot".equals(comp)) {
+                    response = snapshotBlob(request, containerName, blobName);
+                } else if (request.queryParams().containsKey("snapshot") && !"GET".equalsIgnoreCase(method)
+                        && !"HEAD".equalsIgnoreCase(method) && !"DELETE".equalsIgnoreCase(method)) {
+                    response = snapshotIsImmutable();
                 } else if ("PUT".equalsIgnoreCase(method) && "metadata".equals(comp)) {
                     response = setBlobMetadata(request, containerName, blobName);
                 } else if (("GET".equalsIgnoreCase(method) || "HEAD".equalsIgnoreCase(method))
@@ -1851,7 +1857,7 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
         if (authFailure != null) {
             return authFailure;
         }
-        Optional<StoredObject> object = store.get(objKey(request.accountName(), containerName, blobName));
+        Optional<StoredObject> object = findBlob(request, containerName, blobName);
 
         if (object.isEmpty()) {
             return new AzureErrorResponse("BlobNotFound", "The specified blob does not exist.")
@@ -2100,7 +2106,7 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
             return authFailure;
         }
         return leaseService.exclusively(() -> {
-            Optional<StoredObject> object = store.get(objKey(request.accountName(), containerName, blobName));
+            Optional<StoredObject> object = findBlob(request, containerName, blobName);
             if (object.isEmpty()) {
                 return new AzureErrorResponse("BlobNotFound", "The specified blob does not exist.")
                         .toXmlResponse(Response.Status.NOT_FOUND.getStatusCode());
@@ -2109,15 +2115,53 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
             if (conditionFailure != null) {
                 return conditionFailure;
             }
-            Response leaseFailure = leaseService.validateWrite(request,
-                    objKey(request.accountName(), containerName, blobName));
+            String key = blobKey(request, containerName, blobName);
+            Response leaseFailure = leaseService.validateWrite(request, key);
             if (leaseFailure != null) {
                 return leaseFailure;
             }
-            store.delete(objKey(request.accountName(), containerName, blobName));
-            leaseService.onBlobDeleted(objKey(request.accountName(), containerName, blobName));
+            store.delete(key);
+            leaseService.onBlobDeleted(key);
             return Response.status(Response.Status.ACCEPTED).build();
         });
+    }
+
+    private Response snapshotBlob(AzureRequest request, String containerName, String blobName) {
+        Response authFailure = authorizeCreate(request, containerName, blobName);
+        if (authFailure != null) {
+            return authFailure;
+        }
+        Optional<StoredObject> existing = store.get(objKey(request.accountName(), containerName, blobName));
+        if (existing.isEmpty()) {
+            return new AzureErrorResponse("BlobNotFound", "The specified blob does not exist.")
+                    .toXmlResponse(Response.Status.NOT_FOUND.getStatusCode());
+        }
+        String snapshot = Instant.now().toString();
+        StoredObject blob = existing.get();
+        store.put(snapshotKey(request.accountName(), containerName, blobName, snapshot),
+                new StoredObject(blob.key(), Arrays.copyOf(blob.data(), blob.data().length),
+                        new HashMap<>(blob.metadata()), blob.lastModified(), blob.etag()));
+        return Response.status(Response.Status.CREATED)
+                .header("x-ms-snapshot", snapshot)
+                .header("ETag", blob.etag())
+                .build();
+    }
+
+    private static Response snapshotIsImmutable() {
+        return new AzureErrorResponse("SnapshotOperationNotSupported",
+                "This operation is not supported on a blob snapshot.")
+                .toXmlResponse(Response.Status.CONFLICT.getStatusCode());
+    }
+
+    private Optional<StoredObject> findBlob(AzureRequest request, String containerName, String blobName) {
+        return store.get(blobKey(request, containerName, blobName));
+    }
+
+    private static String blobKey(AzureRequest request, String containerName, String blobName) {
+        String snapshot = request.queryParams().get("snapshot");
+        return snapshot == null
+                ? objKey(request.accountName(), containerName, blobName)
+                : snapshotKey(request.accountName(), containerName, blobName, snapshot);
     }
 
     private Response getBlobMetadata(AzureRequest request, String containerName, String blobName) {
@@ -2125,7 +2169,7 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
         if (authFailure != null) {
             return authFailure;
         }
-        Optional<StoredObject> object = store.get(objKey(request.accountName(), containerName, blobName));
+        Optional<StoredObject> object = findBlob(request, containerName, blobName);
         if (object.isEmpty()) {
             return new AzureErrorResponse("BlobNotFound", "The specified blob does not exist.")
                     .toXmlResponse(Response.Status.NOT_FOUND.getStatusCode());
@@ -2546,7 +2590,7 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
         List<BlobModels.BlockItem> uncommitted = new ArrayList<>();
 
         if ("committed".equals(listType) || "all".equals(listType)) {
-            store.get(objKey(request.accountName(), containerName, blobName))
+            findBlob(request, containerName, blobName)
                  .ifPresent(blob -> {
                      String meta = blob.metadata().getOrDefault("CommittedBlocks", "");
                      if (!meta.isBlank()) {
@@ -2564,7 +2608,8 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
                  });
         }
 
-        if ("uncommitted".equals(listType) || "all".equals(listType)) {
+        if (("uncommitted".equals(listType) || "all".equals(listType))
+                && !request.queryParams().containsKey("snapshot")) {
             String stagePrefix = blockStagingPrefix(request.accountName(), containerName, blobName);
             store.scan(k -> k.startsWith(stagePrefix)).stream()
                  .map(so -> new BlobModels.BlockItem(so.key(), (long) so.data().length))
@@ -2713,6 +2758,10 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
 
     private static String objKey(String accountName, String containerName, String blobName) {
         return accountName + "/" + containerName + "/" + blobName;
+    }
+
+    private static String snapshotKey(String accountName, String containerName, String blobName, String snapshot) {
+        return SNAPSHOT_PREFIX + objKey(accountName, containerName, blobName) + ":" + snapshot;
     }
 
     private static Map<String, String> readUserMetadata(AzureRequest request) {

--- a/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
+++ b/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
@@ -2131,10 +2131,7 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
             }
 
             if (!deletingSnapshot) {
-                String snapshotPrefix = snapshotPrefix(request.accountName(), containerName, blobName);
-                List<String> snapshots = store.keys().stream()
-                        .filter(snapshotKey -> snapshotKey.startsWith(snapshotPrefix))
-                        .toList();
+                List<String> snapshots = snapshotKeys(request.accountName(), containerName, blobName);
                 if (!snapshots.isEmpty() && deleteSnapshots == null) {
                     return new AzureErrorResponse("SnapshotsPresent",
                             "The blob has snapshots and cannot be deleted without specifying x-ms-delete-snapshots.")
@@ -2810,6 +2807,14 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
 
     private static String snapshotPrefix(String accountName, String containerName, String blobName) {
         return SNAPSHOT_PREFIX + objKey(accountName, containerName, blobName) + ":";
+    }
+
+    private List<String> snapshotKeys(String accountName, String containerName, String blobName) {
+        String containerPrefix = SNAPSHOT_PREFIX + accountName + "/" + containerName + "/";
+        return store.keys().stream()
+                .filter(key -> key.startsWith(containerPrefix))
+                .filter(key -> store.get(key).map(StoredObject::key).filter(blobName::equals).isPresent())
+                .toList();
     }
 
     private static Map<String, String> readUserMetadata(AzureRequest request) {

--- a/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
+++ b/src/main/java/io/floci/az/services/blob/BlobServiceHandler.java
@@ -259,11 +259,11 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
                     response = dataLakeNotImplemented();
                 } else if ("PUT".equalsIgnoreCase(method) && "lease".equals(comp)) {
                     response = leaseBlob(request, containerName, blobName);
-                } else if ("PUT".equalsIgnoreCase(method) && "snapshot".equals(comp)) {
-                    response = snapshotBlob(request, containerName, blobName);
                 } else if (request.queryParams().containsKey("snapshot") && !"GET".equalsIgnoreCase(method)
                         && !"HEAD".equalsIgnoreCase(method) && !"DELETE".equalsIgnoreCase(method)) {
                     response = snapshotIsImmutable();
+                } else if ("PUT".equalsIgnoreCase(method) && "snapshot".equals(comp)) {
+                    response = snapshotBlob(request, containerName, blobName);
                 } else if ("PUT".equalsIgnoreCase(method) && "metadata".equals(comp)) {
                     response = setBlobMetadata(request, containerName, blobName);
                 } else if (("GET".equalsIgnoreCase(method) || "HEAD".equalsIgnoreCase(method))
@@ -455,9 +455,11 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
             store.delete(nsKey(request.accountName(), containerName));
             String objPrefix = request.accountName() + "/" + containerName + "/";
             String blkPrefix = BLK_PREFIX + objPrefix;
+            String snapshotPrefix = SNAPSHOT_PREFIX + objPrefix;
             String appendPrefix = DATALAKE_APPEND_PREFIX + objPrefix;
             store.keys().stream()
-                    .filter(k -> k.startsWith(objPrefix) || k.startsWith(blkPrefix) || k.startsWith(appendPrefix))
+                    .filter(k -> k.startsWith(objPrefix) || k.startsWith(blkPrefix)
+                            || k.startsWith(snapshotPrefix) || k.startsWith(appendPrefix))
                     .toList()
                     .forEach(store::delete);
             leaseService.onContainerDeleted(objPrefix);
@@ -2106,6 +2108,13 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
             return authFailure;
         }
         return leaseService.exclusively(() -> {
+            boolean deletingSnapshot = request.queryParams().containsKey("snapshot");
+            String deleteSnapshots = request.headers().getHeaderString("x-ms-delete-snapshots");
+            if (deletingSnapshot && deleteSnapshots != null) {
+                return new AzureErrorResponse("InvalidHeaderValue",
+                        "The x-ms-delete-snapshots header is not supported when deleting a blob snapshot.")
+                        .toXmlResponse(Response.Status.BAD_REQUEST.getStatusCode());
+            }
             Optional<StoredObject> object = findBlob(request, containerName, blobName);
             if (object.isEmpty()) {
                 return new AzureErrorResponse("BlobNotFound", "The specified blob does not exist.")
@@ -2120,6 +2129,30 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
             if (leaseFailure != null) {
                 return leaseFailure;
             }
+
+            if (!deletingSnapshot) {
+                String snapshotPrefix = snapshotPrefix(request.accountName(), containerName, blobName);
+                List<String> snapshots = store.keys().stream()
+                        .filter(snapshotKey -> snapshotKey.startsWith(snapshotPrefix))
+                        .toList();
+                if (!snapshots.isEmpty() && deleteSnapshots == null) {
+                    return new AzureErrorResponse("SnapshotsPresent",
+                            "The blob has snapshots and cannot be deleted without specifying x-ms-delete-snapshots.")
+                            .toXmlResponse(Response.Status.CONFLICT.getStatusCode());
+                }
+                if (deleteSnapshots != null && !"include".equalsIgnoreCase(deleteSnapshots)
+                        && !"only".equalsIgnoreCase(deleteSnapshots)) {
+                    return new AzureErrorResponse("InvalidHeaderValue",
+                            "The value for one of the HTTP headers is not in the correct format.")
+                            .toXmlResponse(Response.Status.BAD_REQUEST.getStatusCode());
+                }
+                if ("include".equalsIgnoreCase(deleteSnapshots) || "only".equalsIgnoreCase(deleteSnapshots)) {
+                    snapshots.forEach(store::delete);
+                }
+                if ("only".equalsIgnoreCase(deleteSnapshots)) {
+                    return Response.status(Response.Status.ACCEPTED).build();
+                }
+            }
             store.delete(key);
             leaseService.onBlobDeleted(key);
             return Response.status(Response.Status.ACCEPTED).build();
@@ -2131,20 +2164,31 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
         if (authFailure != null) {
             return authFailure;
         }
-        Optional<StoredObject> existing = store.get(objKey(request.accountName(), containerName, blobName));
-        if (existing.isEmpty()) {
-            return new AzureErrorResponse("BlobNotFound", "The specified blob does not exist.")
-                    .toXmlResponse(Response.Status.NOT_FOUND.getStatusCode());
-        }
-        String snapshot = Instant.now().toString();
-        StoredObject blob = existing.get();
-        store.put(snapshotKey(request.accountName(), containerName, blobName, snapshot),
-                new StoredObject(blob.key(), Arrays.copyOf(blob.data(), blob.data().length),
-                        new HashMap<>(blob.metadata()), blob.lastModified(), blob.etag()));
-        return Response.status(Response.Status.CREATED)
-                .header("x-ms-snapshot", snapshot)
-                .header("ETag", blob.etag())
-                .build();
+        return leaseService.exclusively(() -> {
+            String key = objKey(request.accountName(), containerName, blobName);
+            Optional<StoredObject> existing = store.get(key);
+            if (existing.isEmpty()) {
+                return new AzureErrorResponse("BlobNotFound", "The specified blob does not exist.")
+                        .toXmlResponse(Response.Status.NOT_FOUND.getStatusCode());
+            }
+            Response conditionFailure = validateBlobConditions(request, existing);
+            if (conditionFailure != null) {
+                return conditionFailure;
+            }
+            Response leaseFailure = leaseService.validateSnapshot(request, key);
+            if (leaseFailure != null) {
+                return leaseFailure;
+            }
+            String snapshot = Instant.now().toString();
+            StoredObject blob = existing.get();
+            store.put(snapshotKey(request.accountName(), containerName, blobName, snapshot),
+                    new StoredObject(blob.key(), Arrays.copyOf(blob.data(), blob.data().length),
+                            new HashMap<>(blob.metadata()), blob.lastModified(), blob.etag()));
+            return Response.status(Response.Status.CREATED)
+                    .header("x-ms-snapshot", snapshot)
+                    .header("ETag", blob.etag())
+                    .build();
+        });
     }
 
     private static Response snapshotIsImmutable() {
@@ -2761,7 +2805,11 @@ public class BlobServiceHandler implements AzureServiceHandler, Resettable {
     }
 
     private static String snapshotKey(String accountName, String containerName, String blobName, String snapshot) {
-        return SNAPSHOT_PREFIX + objKey(accountName, containerName, blobName) + ":" + snapshot;
+        return snapshotPrefix(accountName, containerName, blobName) + snapshot;
+    }
+
+    private static String snapshotPrefix(String accountName, String containerName, String blobName) {
+        return SNAPSHOT_PREFIX + objKey(accountName, containerName, blobName) + ":";
     }
 
     private static Map<String, String> readUserMetadata(AzureRequest request) {

--- a/src/test/java/io/floci/az/services/BlobCompDispatchTest.java
+++ b/src/test/java/io/floci/az/services/BlobCompDispatchTest.java
@@ -56,8 +56,7 @@ public class BlobCompDispatchTest {
      */
     @ParameterizedTest
     @ValueSource(strings = {
-            "snapshot", "properties", "tier", "tags",
-            "page", "undelete", "expiry", "seal"
+            "properties", "tier", "tags", "page", "undelete", "expiry", "seal"
     })
     void unimplementedBlobCompIsNotMistakenForPutBlob(String comp) {
         given()

--- a/src/test/java/io/floci/az/services/BlobServiceTest.java
+++ b/src/test/java/io/floci/az/services/BlobServiceTest.java
@@ -747,6 +747,59 @@ public class BlobServiceTest {
     }
 
     @Test
+    void snapshotDeletionDoesNotMatchColonNamedSiblingBlobs() {
+        String siblingBlob = BLOB + ":sibling";
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        given()
+            .header("x-ms-blob-type", "BlockBlob")
+            .body("base")
+            .put("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB);
+        given()
+            .header("x-ms-blob-type", "BlockBlob")
+            .body("sibling")
+            .put("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, siblingBlob);
+
+        String siblingSnapshot = given()
+            .put("/{account}/{container}/{blob}?comp=snapshot", ACCOUNT, CONTAINER, siblingBlob)
+            .then()
+            .statusCode(201)
+            .extract()
+            .header("x-ms-snapshot");
+
+        given()
+            .delete("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(202);
+
+        given()
+            .get("/{account}/{container}/{blob}?snapshot={snapshot}",
+                    ACCOUNT, CONTAINER, siblingBlob, siblingSnapshot)
+            .then()
+            .statusCode(200)
+            .body(equalTo("sibling"));
+
+        given()
+            .header("x-ms-blob-type", "BlockBlob")
+            .body("base")
+            .put("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(201);
+
+        given()
+            .header("x-ms-delete-snapshots", "only")
+            .delete("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(202);
+
+        given()
+            .get("/{account}/{container}/{blob}?snapshot={snapshot}",
+                    ACCOUNT, CONTAINER, siblingBlob, siblingSnapshot)
+            .then()
+            .statusCode(200)
+            .body(equalTo("sibling"));
+    }
+
+    @Test
     void deletingContainerRemovesSnapshots() {
         given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
         given()

--- a/src/test/java/io/floci/az/services/BlobServiceTest.java
+++ b/src/test/java/io/floci/az/services/BlobServiceTest.java
@@ -637,6 +637,163 @@ public class BlobServiceTest {
     }
 
     @Test
+    void snapshotHonorsConditionsAndSuppliedLeaseId() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        String etag = given()
+            .header("x-ms-blob-type", "BlockBlob")
+            .body("original")
+            .put("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(201)
+            .extract()
+            .header("ETag");
+
+        given()
+            .header("If-Match", "not-the-blob-etag")
+            .put("/{account}/{container}/{blob}?comp=snapshot", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(412)
+            .header("x-ms-error-code", "ConditionNotMet");
+
+        String leaseId = given()
+            .header("x-ms-lease-action", "acquire")
+            .header("x-ms-lease-duration", "-1")
+            .put("/{account}/{container}/{blob}?comp=lease", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(201)
+            .extract()
+            .header("x-ms-lease-id");
+
+        given()
+            .header("If-Match", etag)
+            .put("/{account}/{container}/{blob}?comp=snapshot", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(201);
+
+        given()
+            .header("x-ms-lease-id", "00000000-0000-0000-0000-000000000000")
+            .put("/{account}/{container}/{blob}?comp=snapshot", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(412)
+            .header("x-ms-error-code", "LeaseIdMismatchWithBlobOperation");
+
+        given()
+            .header("x-ms-lease-id", leaseId)
+            .put("/{account}/{container}/{blob}?comp=snapshot", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(201);
+    }
+
+    @Test
+    void deletingBaseBlobRequiresSnapshotDisposition() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        given()
+            .header("x-ms-blob-type", "BlockBlob")
+            .body("original")
+            .put("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB);
+
+        String firstSnapshot = given()
+            .put("/{account}/{container}/{blob}?comp=snapshot", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(201)
+            .extract()
+            .header("x-ms-snapshot");
+
+        given()
+            .delete("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(409)
+            .header("x-ms-error-code", "SnapshotsPresent");
+
+        given()
+            .header("x-ms-delete-snapshots", "only")
+            .delete("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(202);
+
+        given()
+            .get("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(200)
+            .body(equalTo("original"));
+
+        given()
+            .get("/{account}/{container}/{blob}?snapshot={snapshot}", ACCOUNT, CONTAINER, BLOB, firstSnapshot)
+            .then()
+            .statusCode(404);
+
+        String secondSnapshot = given()
+            .put("/{account}/{container}/{blob}?comp=snapshot", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(201)
+            .extract()
+            .header("x-ms-snapshot");
+
+        given()
+            .header("x-ms-delete-snapshots", "include")
+            .delete("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(202);
+
+        given()
+            .get("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(404);
+
+        given()
+            .get("/{account}/{container}/{blob}?snapshot={snapshot}", ACCOUNT, CONTAINER, BLOB, secondSnapshot)
+            .then()
+            .statusCode(404);
+    }
+
+    @Test
+    void deletingContainerRemovesSnapshots() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        given()
+            .header("x-ms-blob-type", "BlockBlob")
+            .body("original")
+            .put("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB);
+        String snapshot = given()
+            .put("/{account}/{container}/{blob}?comp=snapshot", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(201)
+            .extract()
+            .header("x-ms-snapshot");
+
+        given()
+            .delete("/{account}/{container}?restype=container", ACCOUNT, CONTAINER)
+            .then()
+            .statusCode(202);
+
+        given()
+            .get("/{account}/{container}/{blob}?snapshot={snapshot}", ACCOUNT, CONTAINER, BLOB, snapshot)
+            .then()
+            .statusCode(404);
+    }
+
+    @Test
+    void snapshotCannotBeTargetedForSnapshotCreation() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        given()
+            .header("x-ms-blob-type", "BlockBlob")
+            .body("original")
+            .put("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB);
+        String snapshot = given()
+            .put("/{account}/{container}/{blob}?comp=snapshot", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(201)
+            .extract()
+            .header("x-ms-snapshot");
+
+        given()
+            .put("/{account}/{container}/{blob}?comp=snapshot&snapshot={snapshot}",
+                    ACCOUNT, CONTAINER, BLOB, snapshot)
+            .then()
+            .statusCode(409)
+            .header("x-ms-error-code", "SnapshotOperationNotSupported");
+    }
+
+    @Test
     void createOnlySasCanCreateButCannotOverwriteBlob() {
         given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
         String createOnlySas = sas("c", "b", CONTAINER, BLOB);

--- a/src/test/java/io/floci/az/services/BlobServiceTest.java
+++ b/src/test/java/io/floci/az/services/BlobServiceTest.java
@@ -602,6 +602,41 @@ public class BlobServiceTest {
     }
 
     @Test
+    void snapshotScopedSasCanReadOnlyItsSnapshot() {
+        given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
+        given()
+            .header("x-ms-blob-type", "BlockBlob")
+            .body("original")
+            .put("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB);
+
+        String snapshot = given()
+            .when().put("/{account}/{container}/{blob}?comp=snapshot", ACCOUNT, CONTAINER, BLOB)
+            .then()
+            .statusCode(201)
+            .extract()
+            .header("x-ms-snapshot");
+
+        given()
+            .header("x-ms-blob-type", "BlockBlob")
+            .body("changed")
+            .put("/{account}/{container}/{blob}", ACCOUNT, CONTAINER, BLOB);
+
+        String snapshotSas = snapshotSas("r", CONTAINER, BLOB, snapshot);
+        given()
+            .when().get("/{account}/{container}/{blob}?{sas}", ACCOUNT, CONTAINER, BLOB, snapshotSas)
+            .then()
+            .statusCode(200)
+            .body(equalTo("original"));
+
+        given()
+            .when().get("/{account}/{container}/{blob}?{sas}", ACCOUNT, CONTAINER, BLOB,
+                    snapshotSas.replace("snapshot=" + snapshot + "&", ""))
+            .then()
+            .statusCode(403)
+            .header("x-ms-error-code", "AuthenticationFailed");
+    }
+
+    @Test
     void createOnlySasCanCreateButCannotOverwriteBlob() {
         given().put("/{account}/{container}?restype=container", ACCOUNT, CONTAINER);
         String createOnlySas = sas("c", "b", CONTAINER, BLOB);
@@ -2569,6 +2604,31 @@ public class BlobServiceTest {
         OffsetDateTime keyStart = OffsetDateTime.now(ZoneOffset.UTC).minusMinutes(5).withNano(0);
         OffsetDateTime keyExpiry = OffsetDateTime.now(ZoneOffset.UTC).plusHours(1).withNano(0);
         return sasSignedWith(base64Key, permissions, resource, container, blobName, keyStart, keyExpiry);
+    }
+
+    private String snapshotSas(String permissions, String container, String blobName, String snapshot) {
+        OffsetDateTime start = OffsetDateTime.now(ZoneOffset.UTC).minusMinutes(5).withNano(0);
+        OffsetDateTime expiry = OffsetDateTime.now(ZoneOffset.UTC).plusHours(1).withNano(0);
+        String version = "2024-11-04";
+        String key = keyMaterial.signingKeyForAccount(ACCOUNT);
+        String stringToSign = String.join("\n",
+                permissions, start.toString(), expiry.toString(), canonicalName(container, blobName),
+                UserDelegationKeyMaterial.SIGNED_OBJECT_ID, UserDelegationKeyMaterial.SIGNED_TENANT_ID,
+                start.toString(), expiry.toString(), "b", version,
+                "", "", "", "", "", version, "bs", snapshot, "", "", "", "", "", "");
+        return "sv=" + version
+                + "&st=" + start
+                + "&se=" + expiry
+                + "&skoid=" + UserDelegationKeyMaterial.SIGNED_OBJECT_ID
+                + "&sktid=" + UserDelegationKeyMaterial.SIGNED_TENANT_ID
+                + "&skt=" + start
+                + "&ske=" + expiry
+                + "&sks=b"
+                + "&skv=" + version
+                + "&sr=bs"
+                + "&snapshot=" + snapshot
+                + "&sp=" + permissions
+                + "&sig=" + hmac(key, stringToSign);
     }
 
     private static String sasSignedWith(


### PR DESCRIPTION
## Summary
- Persist immutable Blob snapshots and route snapshot reads and deletes to the captured state.
- Enforce sr=bs against the signed snapshot timestamp so snapshot SAS tokens cannot be used for the base blob.

## Type of change
- [x] New feature (feat:)

## Azure Compatibility
- Matches Blob Snapshot and user-delegation SAS snapshot-resource semantics.

## Checklist
- [ ] ./mvnw test passes locally (blocked: available JDK is 21; project requires Java 25)
- [x] New or updated integration test added
- [x] Commit messages follow Conventional Commits
