### PR TITLE
fix(servicebus): enforce PeekLock expiry for queues and dead-letter queues

### DIFF
--- a/compatibility-tests/sdk-test-dotnet/ServiceBusPeekLockCompatibilityTests.cs
+++ b/compatibility-tests/sdk-test-dotnet/ServiceBusPeekLockCompatibilityTests.cs
@@ -1,0 +1,92 @@
+using Azure.Messaging.ServiceBus;
+using Azure.Messaging.ServiceBus.Administration;
+
+namespace FlociAz.Compatibility;
+
+[NotInParallel]
+public sealed class ServiceBusPeekLockCompatibilityTests
+{
+    [Test]
+    [Arguments("queue")]
+    [Arguments("large-queue")]
+    [Arguments("subscription")]
+    [Arguments("session-dlq")]
+    [Timeout(90_000)]
+    public async Task ExpiredMessagesReturnWhileTheirReceiverRemainsOpen(string entityKind, CancellationToken cancellationToken)
+    {
+        string endpoint = Environment.GetEnvironmentVariable("FLOCI_AZ_ENDPOINT") ?? "http://localhost:4577";
+        string host = Environment.GetEnvironmentVariable("SERVICEBUS_HOST") ?? "localhost";
+        string port = Environment.GetEnvironmentVariable("SERVICEBUS_AMQP_PORT") ?? "5673";
+        const string credentials = "SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=devkey;UseDevelopmentEmulator=true;";
+        var admin = new ServiceBusAdministrationClient($"Endpoint=sb://{new Uri(endpoint).Authority};{credentials}");
+        await using var client = new ServiceBusClient($"Endpoint=sb://{host}:{port};{credentials}",
+            new ServiceBusClientOptions { RetryOptions = { MaxRetries = 0, TryTimeout = TimeSpan.FromSeconds(10) } });
+        string entity = $"peeklock-{Guid.NewGuid():N}";
+        bool queue = entityKind.EndsWith("queue");
+        bool deadLetter = entityKind == "session-dlq";
+        if (queue)
+        {
+            await admin.CreateQueueAsync(new CreateQueueOptions(entity)
+            {
+                LockDuration = TimeSpan.FromSeconds(2), MaxDeliveryCount = 4
+            }, cancellationToken);
+        }
+        else
+        {
+            await admin.CreateTopicAsync(entity, cancellationToken);
+            await admin.CreateSubscriptionAsync(new CreateSubscriptionOptions(entity, "consumer")
+            {
+                RequiresSession = deadLetter, LockDuration = TimeSpan.FromSeconds(2), MaxDeliveryCount = 4
+            }, cancellationToken);
+        }
+        try
+        {
+            await using ServiceBusSender sender = client.CreateSender(entity);
+            string body = entityKind == "large-queue" ? new string('x', 200_000) : "expires";
+            await sender.SendMessageAsync(new ServiceBusMessage(body)
+            {
+                MessageId = "expires", SessionId = deadLetter ? "session" : null
+            }, cancellationToken);
+            if (deadLetter)
+            {
+                await using ServiceBusSessionReceiver session = await client.AcceptSessionAsync(
+                    entity, "consumer", "session", cancellationToken: cancellationToken);
+                ServiceBusReceivedMessage poison = (await session.ReceiveMessageAsync(TimeSpan.FromSeconds(5), cancellationToken))!;
+                await Assert.That(poison).IsNotNull();
+                await session.DeadLetterMessageAsync(poison, cancellationToken: cancellationToken);
+            }
+
+            var options = new ServiceBusReceiverOptions { SubQueue = deadLetter ? SubQueue.DeadLetter : SubQueue.None };
+            await using ServiceBusReceiver owner = queue ? client.CreateReceiver(entity, options) : client.CreateReceiver(entity, "consumer", options);
+            await using ServiceBusReceiver competitor = queue ? client.CreateReceiver(entity, options) : client.CreateReceiver(entity, "consumer", options);
+            ServiceBusReceivedMessage first = (await owner.ReceiveMessageAsync(TimeSpan.FromSeconds(5), cancellationToken))!;
+            await Assert.That(first).IsNotNull();
+            await Assert.That(first.LockedUntil > DateTimeOffset.UtcNow).IsTrue();
+            await Assert.That(first.LockedUntil < DateTimeOffset.UtcNow.AddSeconds(3)).IsTrue();
+            await Task.Delay(TimeSpan.FromSeconds(3), cancellationToken);
+
+            ServiceBusReceivedMessage redelivered = (await competitor.ReceiveMessageAsync(TimeSpan.FromSeconds(5), cancellationToken))!;
+            await Assert.That(redelivered).IsNotNull();
+            await Assert.That(redelivered.MessageId).IsEqualTo(first.MessageId);
+            await Assert.That(redelivered.Body.ToString()).IsEqualTo(body);
+            await Assert.That(redelivered.DeliveryCount).IsEqualTo(first.DeliveryCount + 1);
+            await Assert.That(redelivered.LockedUntil > DateTimeOffset.UtcNow).IsTrue();
+            try
+            {
+                await owner.CompleteMessageAsync(first, cancellationToken);
+                throw new InvalidOperationException("Expired delivery was incorrectly completed");
+            }
+            catch (ServiceBusException error)
+            {
+                await Assert.That(error.Reason).IsEqualTo(ServiceBusFailureReason.MessageLockLost);
+            }
+            await competitor.CompleteMessageAsync(redelivered, cancellationToken);
+            await Assert.That(await competitor.ReceiveMessageAsync(TimeSpan.FromMilliseconds(200), cancellationToken)).IsNull();
+        }
+        finally
+        {
+            if (queue) await admin.DeleteQueueAsync(entity, cancellationToken);
+            else await admin.DeleteTopicAsync(entity, cancellationToken);
+        }
+    }
+}

--- a/docs/services/service-bus.md
+++ b/docs/services/service-bus.md
@@ -249,15 +249,16 @@ floci-az:
 Queues and subscriptions honor `MaxDeliveryCount` (1–2000) and `LockDuration`
 (up to `PT5M`) from the entity-create payload, matching Azure. A message is
 dead-lettered once its delivery count exceeds the entity's `MaxDeliveryCount`.
-`LockDuration` is enforced for session-enabled entities (session locks expire
-and can be reacquired after the configured duration); non-session peek-lock
-expiry is not enforced by the broker. Entities that omit either property fall
+`LockDuration` is enforced for session locks and individual non-session
+peek-lock deliveries, including dead-letter queues. Expired messages become
+available to other receivers while the original receiver remains open; late
+settlement returns `MessageLockLost`. Entities that omit either property fall
 back to the configured defaults above.
 
 ## Out of scope (future work)
 
 - Session state and explicit session-lock renewal
-- Non-session peek-lock expiry enforcement
+- Explicit message-lock renewal
 - Deferred messages and auto-forwarding
 - Message transactions
 - Geo-disaster recovery and partitioned entities

--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,9 @@
                                         org/apache/activemq/artemis/protocol/amqp/broker/AMQPMessage.java,
                                         org/apache/activemq/artemis/protocol/amqp/proton/DefaultSenderController.java,
                                         org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerReceiverContext.java,
-                                        org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java
+                                        org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java,
+                                        org/apache/activemq/artemis/protocol/amqp/proton/AMQPMessageWriter.java,
+                                        org/apache/activemq/artemis/protocol/amqp/proton/AMQPLargeMessageWriter.java
                                     </includes>
                                 </artifactItem>
                             </artifactItems>
@@ -373,6 +375,51 @@
                                     file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java"
                                     token="sessionSPI.reject(brokerConsumer, message);"
                                     value="ServiceBusDeadLetterSupport.apply(message, (Rejected) remoteState); sessionSPI.reject(brokerConsumer, message);"
+                                    failOnNoReplacements="true" />
+                                <replace
+                                    file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java"
+                                    token="private boolean closed = false;"
+                                    value="private boolean closed = false;&#10;   private final ServiceBusMessageLockSupport messageLocks;"
+                                    failOnNoReplacements="true" />
+                                <replace
+                                    file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java"
+                                    token="this.sessionSPI = server;"
+                                    value="this.sessionSPI = server;&#10;      this.messageLocks = new ServiceBusMessageLockSupport(connection, server);"
+                                    failOnNoReplacements="true" />
+                                <replace
+                                    file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java"
+                                    token="delivery.setMessageFormat(messageFormat);"
+                                    value="delivery.setMessageFormat(messageFormat);&#10;      messageLocks.track(delivery, messageReference, brokerConsumer, preSettle);"
+                                    failOnNoReplacements="true" />
+                                <replace
+                                    file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java"
+                                    token="final MessageReference reference = (MessageReference) delivery.getContext();"
+                                    value="if (!messageLocks.beforeSettlement(delivery)) { return; }&#10;         final MessageReference reference = (MessageReference) delivery.getContext();"
+                                    failOnNoReplacements="true" />
+                                <replace
+                                    file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java"
+                                    token="messageWriter.close();"
+                                    value="messageLocks.close(); messageWriter.close();"
+                                    failOnNoReplacements="true" />
+                                <replace
+                                    file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/AMQPMessageWriter.java"
+                                    token="final ReadableBuffer sendBuffer = amqpMessage.getSendBuffer(messageReference.getDeliveryCount(), messageReference);"
+                                    value="final ReadableBuffer sendBuffer = ServiceBusMessageLockSupport.forDelivery(amqpMessage, messageReference).getSendBuffer(messageReference.getDeliveryCount(), messageReference);"
+                                    failOnNoReplacements="true" />
+                                <replace
+                                    file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/AMQPLargeMessageWriter.java"
+                                    token="if (message.isReencoded()) {"
+                                    value="if (message.isReencoded() || ServiceBusMessageLockSupport.hasDeadline(reference)) {"
+                                    failOnNoReplacements="true" />
+                                <replace
+                                    file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/AMQPLargeMessageWriter.java"
+                                    token="MessageAnnotations messageAnnotations = AMQPMessageBrokerAccessor.getDecodedMessageAnnotations(message);"
+                                    value="MessageAnnotations messageAnnotations = ServiceBusMessageLockSupport.annotationsForDelivery(AMQPMessageBrokerAccessor.getDecodedMessageAnnotations(message), reference);"
+                                    failOnNoReplacements="true" />
+                                <replace
+                                    file="${project.build.directory}/artemis-amqp-patch-sources/org/apache/activemq/artemis/protocol/amqp/proton/AMQPLargeMessageWriter.java"
+                                    token="Header header = AMQPMessageBrokerAccessor.getCurrentHeader(message);"
+                                    value="Header header = ServiceBusMessageLockSupport.headerForDelivery(AMQPMessageBrokerAccessor.getCurrentHeader(message), reference);"
                                     failOnNoReplacements="true" />
                             </target>
                         </configuration>

--- a/src/artemis-amqp-patch/java/org/apache/activemq/artemis/protocol/amqp/proton/ServiceBusMessageLockSupport.java
+++ b/src/artemis-amqp-patch/java/org/apache/activemq/artemis/protocol/amqp/proton/ServiceBusMessageLockSupport.java
@@ -1,0 +1,170 @@
+package org.apache.activemq.artemis.protocol.amqp.proton;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.activemq.artemis.core.server.MessageReference;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.server.ServerConsumer;
+import org.apache.activemq.artemis.protocol.amqp.broker.AMQPMessage;
+import org.apache.activemq.artemis.protocol.amqp.broker.AMQPSessionCallback;
+import org.apache.qpid.proton.amqp.Symbol;
+import org.apache.qpid.proton.amqp.UnsignedInteger;
+import org.apache.qpid.proton.amqp.messaging.Header;
+import org.apache.qpid.proton.amqp.messaging.MessageAnnotations;
+import org.apache.qpid.proton.amqp.messaging.Rejected;
+import org.apache.qpid.proton.amqp.transport.ErrorCondition;
+import org.apache.qpid.proton.engine.Delivery;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Per-delivery Service Bus locks. All state changes run on the connection's event loop. */
+public final class ServiceBusMessageLockSupport {
+   private static final Logger LOGGER = LoggerFactory.getLogger(ServiceBusMessageLockSupport.class);
+   private static final String METADATA_PREFIX = "floci-az:servicebus-peeklock:";
+   private static final SimpleString LOCKED_UNTIL = SimpleString.of("x-opt-locked-until");
+   private static final Symbol LOCK_LOST = Symbol.valueOf("com.microsoft:message-lock-lost");
+   private static final Object EXPIRED = new Object();
+
+   private final AMQPConnectionContext connection;
+   private final AMQPSessionCallback session;
+   private final Map<Delivery, MessageLock> locks = new HashMap<>();
+
+   public ServiceBusMessageLockSupport(AMQPConnectionContext connection, AMQPSessionCallback session) {
+      this.connection = connection;
+      this.session = session;
+   }
+
+   public void track(Delivery delivery, MessageReference reference, ServerConsumer consumer, boolean preSettled) {
+      if (preSettled || consumer.getQueue().getUser() == null) {
+         return;
+      }
+      String metadata = consumer.getQueue().getUser().toString();
+      if (!metadata.startsWith(METADATA_PREFIX)) {
+         return;
+      }
+      final long duration;
+      try {
+         duration = Math.multiplyExact(Long.parseLong(metadata.substring(METADATA_PREFIX.length())), 1_000L);
+         if (duration <= 0) {
+            throw new IllegalArgumentException("Lock duration must be positive");
+         }
+      } catch (ArithmeticException | IllegalArgumentException e) {
+         LOGGER.warn("Ignoring invalid Service Bus message lock metadata: " + metadata, e);
+         return;
+      }
+      MessageLock lock = new MessageLock(reference, consumer, System.currentTimeMillis() + duration);
+      reference.setProtocolData(Deadline.class, new Deadline(lock.until));
+      locks.put(delivery, lock);
+      lock.timer = connection.getProtocolManager().getServer().getScheduledPool().schedule(
+         () -> connection.runLater(() -> expire(delivery, lock)), duration, TimeUnit.MILLISECONDS);
+   }
+
+   /** Reject stale dispositions before Artemis can acknowledge a subsequently redelivered message. */
+   public boolean beforeSettlement(Delivery delivery) {
+      if (delivery.getContext() == EXPIRED) {
+         rejectExpired(delivery);
+         return false;
+      }
+      MessageLock lock = locks.get(delivery);
+      if (lock == null) {
+         return true;
+      }
+      if (System.currentTimeMillis() >= lock.until) {
+         expire(delivery, lock);
+         rejectExpired(delivery);
+         return false;
+      }
+      if (delivery.getRemoteState() != null) {
+         locks.remove(delivery);
+         lock.timer.cancel(false);
+      }
+      return true;
+   }
+
+   private void expire(Delivery delivery, MessageLock lock) {
+      if (!locks.remove(delivery, lock)) {
+         return;
+      }
+      lock.timer.cancel(false);
+      if (delivery.isSettled()) {
+         return;
+      }
+      try {
+         session.cancel(lock.consumer, lock.reference.getMessage(), true);
+         // Retain the AMQP delivery until the peer settles it, so a late disposition gets
+         // MessageLockLost instead of falling back to an unsupported management request.
+         delivery.setContext(EXPIRED);
+      } catch (Exception e) {
+         LOGGER.error("Could not release an expired Service Bus message lock", e);
+      }
+   }
+
+   private void rejectExpired(Delivery delivery) {
+      Rejected rejected = new Rejected();
+      rejected.setError(new ErrorCondition(LOCK_LOST, "The message lock has expired"));
+      delivery.disposition(rejected);
+      delivery.settle();
+      connection.flush();
+   }
+
+   public void close() {
+      locks.values().forEach(lock -> lock.timer.cancel(false));
+      locks.clear();
+   }
+
+   /** Keep lock timestamps specific to a delivery, without mutating the shared stored message. */
+   public static AMQPMessage forDelivery(AMQPMessage message, MessageReference reference) {
+      Deadline deadline = reference.getProtocolData(Deadline.class);
+      if (deadline == null) {
+         return message;
+      }
+      AMQPMessage copy = (AMQPMessage) message.copy();
+      copy.setAnnotation(LOCKED_UNTIL, new Date(deadline.until()));
+      copy.reencode();
+      return copy;
+   }
+
+   public static boolean hasDeadline(MessageReference reference) {
+      return reference.getProtocolData(Deadline.class) != null;
+   }
+
+   /** Large messages stream their body from disk, so replace only their outgoing metadata. */
+   public static MessageAnnotations annotationsForDelivery(MessageAnnotations original, MessageReference reference) {
+      Deadline deadline = reference.getProtocolData(Deadline.class);
+      if (deadline == null) {
+         return original;
+      }
+      Map<Symbol, Object> annotations = original == null ? new HashMap<>() : new HashMap<>(original.getValue());
+      annotations.put(Symbol.valueOf(LOCKED_UNTIL.toString()), new Date(deadline.until()));
+      return new MessageAnnotations(annotations);
+   }
+
+   public static Header headerForDelivery(Header original, MessageReference reference) {
+      if (!hasDeadline(reference)) {
+         return original;
+      }
+      Header header = original == null ? new Header() : new Header(original);
+      header.setDeliveryCount(UnsignedInteger.valueOf(Math.max(0, reference.getDeliveryCount() - 1)));
+      return header;
+   }
+
+   private record Deadline(long until) {
+   }
+
+   private static final class MessageLock {
+      private final MessageReference reference;
+      private final ServerConsumer consumer;
+      private final long until;
+      private ScheduledFuture<?> timer;
+
+      private MessageLock(MessageReference reference, ServerConsumer consumer, long until) {
+         this.reference = reference;
+         this.consumer = consumer;
+         this.until = until;
+      }
+   }
+}

--- a/src/artemis-amqp-patch/java/org/apache/activemq/artemis/protocol/amqp/proton/ServiceBusMessageLockSupport.java
+++ b/src/artemis-amqp-patch/java/org/apache/activemq/artemis/protocol/amqp/proton/ServiceBusMessageLockSupport.java
@@ -15,6 +15,7 @@ import org.apache.qpid.proton.amqp.Symbol;
 import org.apache.qpid.proton.amqp.UnsignedInteger;
 import org.apache.qpid.proton.amqp.messaging.Header;
 import org.apache.qpid.proton.amqp.messaging.MessageAnnotations;
+import org.apache.qpid.proton.amqp.messaging.Outcome;
 import org.apache.qpid.proton.amqp.messaging.Rejected;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.apache.qpid.proton.engine.Delivery;
@@ -78,7 +79,7 @@ public final class ServiceBusMessageLockSupport {
          rejectExpired(delivery);
          return false;
       }
-      if (delivery.getRemoteState() != null) {
+      if (delivery.getRemoteState() instanceof Outcome) {
          locks.remove(delivery);
          lock.timer.cancel(false);
       }
@@ -94,12 +95,19 @@ public final class ServiceBusMessageLockSupport {
          return;
       }
       try {
-         session.cancel(lock.consumer, lock.reference.getMessage(), true);
          // Retain the AMQP delivery until the peer settles it, so a late disposition gets
          // MessageLockLost instead of falling back to an unsupported management request.
          delivery.setContext(EXPIRED);
+         session.cancel(lock.consumer, lock.reference.getMessage(), true);
       } catch (Exception e) {
          LOGGER.error("Could not release an expired Service Bus message lock", e);
+         // Cancellation may have partially succeeded. Retrying by message ID could cancel
+         // a newer delivery to this consumer. Connection teardown releases its remaining references.
+         locks.keySet().forEach(pending -> pending.setContext(EXPIRED));
+         close();
+         connection.close(new ErrorCondition(org.apache.qpid.proton.amqp.transport.AmqpError.INTERNAL_ERROR,
+            "Could not release an expired message lock"));
+         connection.destroy();
       }
    }
 

--- a/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
+++ b/src/main/java/io/floci/az/services/servicebus/ServiceBusNamespaceManager.java
@@ -86,6 +86,7 @@ public class ServiceBusNamespaceManager {
     private static final String TOPIC_ADDRESS_SUFFIX = "/$Topic";
     private static final String TOPIC_DIVERT_SUFFIX = "/$TopicDivert";
     private static final String SESSION_METADATA_PREFIX = "floci-az:servicebus-session:";
+    private static final String PEEK_LOCK_METADATA_PREFIX = "floci-az:servicebus-peeklock:";
     private static final String SERVICE_LABEL = "servicebus";
     private static final String OWNER_CONTAINER_LABEL = "floci_owner_container";
     private static final String DUPLICATE_DETECTION_MBEAN =
@@ -404,18 +405,19 @@ public class ServiceBusNamespaceManager {
                     "createAddress(java.lang.String,java.lang.String)",
                     jsonArr(queueName, "ANYCAST"));
             jolokiaExec(http, baseUrl, auth, mbean,
-                    "createQueue(java.lang.String,java.lang.String,java.lang.String,java.lang.String,boolean,int,boolean,boolean)",
-                    jsonArr(queueName, "ANYCAST", queueName, "", true, -1, false, false));
+                    "createQueue(java.lang.String)",
+                    jsonArr(messageQueueConfiguration(queueName, requiresSession)));
             jolokiaExec(http, baseUrl, auth, mbean,
                     "createAddress(java.lang.String,java.lang.String)",
                     jsonArr(deadLetterQueue, "ANYCAST"));
             jolokiaExec(http, baseUrl, auth, mbean,
-                    "createQueue(java.lang.String,java.lang.String,java.lang.String,java.lang.String,boolean,int,boolean,boolean)",
-                    jsonArr(deadLetterQueue, "ANYCAST", deadLetterQueue, "", true, -1, false, false));
+                    "createQueue(java.lang.String)",
+                    jsonArr(messageQueueConfiguration(deadLetterQueue, false)));
             createManagementAddress(http, baseUrl, auth, mbean, queueName);
             createManagementAddress(http, baseUrl, auth, mbean, deadLetterQueue);
-            applySessionMetadata(http, baseUrl, auth, mbean, queueName,
+            applyLockMetadata(http, baseUrl, auth, mbean, queueName,
                     requiresSession, lockDurationSeconds);
+            applyLockMetadata(http, baseUrl, auth, mbean, deadLetterQueue, false, lockDurationSeconds);
             jolokiaExec(http, baseUrl, auth, mbean,
                     "addAddressSettings(java.lang.String,java.lang.String)",
                     jsonArr(queueName, addressSettings));
@@ -552,18 +554,19 @@ public class ServiceBusNamespaceManager {
                     "createAddress(java.lang.String,java.lang.String)",
                     jsonArr(queueName, "ANYCAST"));
             jolokiaExec(http, baseUrl, auth, mbean,
-                    "createQueue(java.lang.String,java.lang.String,java.lang.String,java.lang.String,boolean,int,boolean,boolean)",
-                    jsonArr(queueName, "ANYCAST", queueName, "", true, -1, false, false));
+                    "createQueue(java.lang.String)",
+                    jsonArr(messageQueueConfiguration(queueName, requiresSession)));
             jolokiaExec(http, baseUrl, auth, mbean,
                     "createAddress(java.lang.String,java.lang.String)",
                     jsonArr(deadLetterQueue, "ANYCAST"));
             jolokiaExec(http, baseUrl, auth, mbean,
-                    "createQueue(java.lang.String,java.lang.String,java.lang.String,java.lang.String,boolean,int,boolean,boolean)",
-                    jsonArr(deadLetterQueue, "ANYCAST", deadLetterQueue, "", true, -1, false, false));
+                    "createQueue(java.lang.String)",
+                    jsonArr(messageQueueConfiguration(deadLetterQueue, false)));
             createManagementAddress(http, baseUrl, auth, mbean, queueName);
             createManagementAddress(http, baseUrl, auth, mbean, deadLetterQueue);
-            applySessionMetadata(http, baseUrl, auth, mbean, queueName,
+            applyLockMetadata(http, baseUrl, auth, mbean, queueName,
                     requiresSession, lockDurationSeconds);
+            applyLockMetadata(http, baseUrl, auth, mbean, deadLetterQueue, false, lockDurationSeconds);
             jolokiaExec(http, baseUrl, auth, mbean,
                     "addAddressSettings(java.lang.String,java.lang.String)",
                     jsonArr(queueName, addressSettings));
@@ -694,16 +697,19 @@ public class ServiceBusNamespaceManager {
                         exclusive, filter, null));
     }
 
-    private void applySessionMetadata(HttpClient http, String baseUrl, String auth,
+    static String messageQueueConfiguration(String queueName, boolean requiresSession) {
+        // SessionId survives dead-lettering, but a DLQ must not pin that message to one consumer.
+        return "{\"name\":" + jsonString(queueName) + ",\"address\":" + jsonString(queueName)
+                + ",\"routing-type\":\"ANYCAST\",\"durable\":true,\"group-buckets\":"
+                + (requiresSession ? -1 : 0) + "}";
+    }
+
+    private void applyLockMetadata(HttpClient http, String baseUrl, String auth,
                                       String mbean, String queueName,
                                       boolean requiresSession, long lockDurationSeconds) {
-        if (!requiresSession) {
-            return;
-        }
-
         // Artemis security is disabled in this sidecar, so QueueConfiguration.user can carry
         // internal metadata that the patched AMQP protocol handler reads during link attach.
-        String metadata = SESSION_METADATA_PREFIX + lockDurationSeconds;
+        String metadata = (requiresSession ? SESSION_METADATA_PREFIX : PEEK_LOCK_METADATA_PREFIX) + lockDurationSeconds;
         String queueConfiguration = "{\"name\":" + jsonString(queueName)
                 + ",\"user\":" + jsonString(metadata) + "}";
         jolokiaExec(http, baseUrl, auth, mbean,

--- a/src/test/java/io/floci/az/services/servicebus/ServiceBusNamespaceManagerTest.java
+++ b/src/test/java/io/floci/az/services/servicebus/ServiceBusNamespaceManagerTest.java
@@ -13,6 +13,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ServiceBusNamespaceManagerTest {
 
     @Test
+    void brokerQueueConfigurationDisablesGroupingForNonSessionEntities() {
+        for (boolean requiresSession : List.of(false, true)) {
+            var configuration = org.apache.activemq.artemis.api.core.QueueConfiguration.fromJSON(
+                    ServiceBusNamespaceManager.messageQueueConfiguration("orders", requiresSession));
+            assertEquals(org.apache.activemq.artemis.api.core.RoutingType.ANYCAST, configuration.getRoutingType());
+            assertEquals(requiresSession ? -1 : 0, configuration.getGroupBuckets());
+        }
+    }
+
+    @Test
     void parsesNumericAndTextJolokiaMessageCounts() throws IOException {
         assertEquals(7, ServiceBusNamespaceManager.parseJolokiaMessageCount(
                 "{\"status\":200,\"value\":7}"));

--- a/src/test/java/org/apache/activemq/artemis/protocol/amqp/proton/ServiceBusMessageLockSupportTest.java
+++ b/src/test/java/org/apache/activemq/artemis/protocol/amqp/proton/ServiceBusMessageLockSupportTest.java
@@ -1,0 +1,114 @@
+package org.apache.activemq.artemis.protocol.amqp.proton;
+
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.server.MessageReference;
+import org.apache.activemq.artemis.core.server.ServerConsumer;
+import org.apache.activemq.artemis.protocol.amqp.broker.AMQPSessionCallback;
+import org.apache.qpid.proton.amqp.messaging.Accepted;
+import org.apache.qpid.proton.amqp.messaging.Rejected;
+import org.apache.qpid.proton.engine.Delivery;
+import org.junit.jupiter.api.Test;
+
+import java.net.URLClassLoader;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class ServiceBusMessageLockSupportTest {
+    @Test
+    void expiryReleasesMessageAndRejectsStaleSettlement() throws Exception {
+        try (Fixture fixture = new Fixture()) {
+            fixture.track(false);
+            fixture.expiry.get().run();
+            verify(fixture.session).cancel(fixture.consumer, fixture.reference.getMessage(), true);
+            assertFalse(fixture.settle());
+            verify(fixture.delivery).disposition(argThat(state -> state instanceof Rejected rejected
+                    && "com.microsoft:message-lock-lost".equals(rejected.getError().getCondition().toString())));
+            verify(fixture.delivery).settle();
+        }
+    }
+
+    @Test
+    void successfulSettlementCancelsExpiry() throws Exception {
+        try (Fixture fixture = new Fixture()) {
+            fixture.track(false);
+            when(fixture.delivery.getRemoteState()).thenReturn(Accepted.getInstance());
+            assertTrue(fixture.settle());
+            fixture.expiry.get().run();
+            verify(fixture.timer).cancel(false);
+            verifyNoInteractions(fixture.session);
+        }
+    }
+
+    @Test
+    void closingReceiverCancelsExpiry() throws Exception {
+        try (Fixture fixture = new Fixture()) {
+            fixture.track(false);
+            fixture.type.getMethod("close").invoke(fixture.support);
+            fixture.expiry.get().run();
+            verify(fixture.timer).cancel(false);
+            verifyNoInteractions(fixture.session);
+        }
+    }
+
+    @Test
+    void receiveAndDeleteAndSessionReceiversHaveNoMessageTimer() throws Exception {
+        try (Fixture fixture = new Fixture()) {
+            fixture.track(true);
+            assertNull(fixture.expiry.get());
+            when(fixture.consumer.getQueue().getUser()).thenReturn(SimpleString.of("floci-az:servicebus-session:60"));
+            fixture.track(false);
+            assertNull(fixture.expiry.get());
+        }
+    }
+
+    private static final class Fixture implements AutoCloseable {
+        final URLClassLoader loader = PatchJarLoader.open();
+        final Class<?> type = Class.forName(
+                "org.apache.activemq.artemis.protocol.amqp.proton.ServiceBusMessageLockSupport", true, loader);
+        final AMQPConnectionContext connection = mock(AMQPConnectionContext.class, RETURNS_DEEP_STUBS);
+        final AMQPSessionCallback session = mock(AMQPSessionCallback.class);
+        final ServerConsumer consumer = mock(ServerConsumer.class, RETURNS_DEEP_STUBS);
+        final MessageReference reference = mock(MessageReference.class, RETURNS_DEEP_STUBS);
+        final Delivery delivery = mock(Delivery.class);
+        final ScheduledFuture<?> timer = mock(ScheduledFuture.class);
+        final AtomicReference<Runnable> expiry = new AtomicReference<>();
+        final Object support;
+
+        Fixture() throws Exception {
+            support = type.getConstructor(AMQPConnectionContext.class, AMQPSessionCallback.class)
+                    .newInstance(connection, session);
+            when(consumer.getQueue().getUser()).thenReturn(SimpleString.of("floci-az:servicebus-peeklock:60"));
+            var scheduler = connection.getProtocolManager().getServer().getScheduledPool();
+            doAnswer(call -> {
+                expiry.set(call.getArgument(0));
+                return timer;
+            }).when(scheduler)
+                    .schedule(any(Runnable.class), anyLong(), eq(TimeUnit.MILLISECONDS));
+            doAnswer(call -> { ((Runnable) call.getArgument(0)).run(); return null; })
+                    .when(connection).runLater(any(Runnable.class));
+            AtomicReference<Object> context = new AtomicReference<>(reference);
+            when(delivery.getContext()).thenAnswer(call -> context.get());
+            doAnswer(call -> { context.set(call.getArgument(0)); return null; })
+                    .when(delivery).setContext(any());
+        }
+
+        void track(boolean preSettled) throws Exception {
+            type.getMethod("track", Delivery.class, MessageReference.class, ServerConsumer.class, boolean.class)
+                    .invoke(support, delivery, reference, consumer, preSettled);
+        }
+
+        boolean settle() throws Exception {
+            return (boolean) type.getMethod("beforeSettlement", Delivery.class).invoke(support, delivery);
+        }
+
+        @Override
+        public void close() throws Exception {
+            loader.close();
+        }
+    }
+}

--- a/src/test/java/org/apache/activemq/artemis/protocol/amqp/proton/ServiceBusMessageLockSupportTest.java
+++ b/src/test/java/org/apache/activemq/artemis/protocol/amqp/proton/ServiceBusMessageLockSupportTest.java
@@ -20,6 +20,31 @@ import static org.mockito.Mockito.*;
 
 class ServiceBusMessageLockSupportTest {
     @Test
+    void failedCancellationClosesConnectionAndRejectsStaleSettlement() throws Exception {
+        try (Fixture fixture = new Fixture()) {
+            var message = fixture.reference.getMessage();
+            doThrow(new RuntimeException("temporary broker failure"))
+                    .when(fixture.session).cancel(fixture.consumer, message, true);
+            fixture.track(false);
+            fixture.expiry.get().run();
+            assertFalse(fixture.settle());
+            verify(fixture.connection).close(any(org.apache.qpid.proton.amqp.transport.ErrorCondition.class));
+            verify(fixture.connection).destroy();
+        }
+    }
+
+    @Test
+    void intermediateReceivedStateDoesNotCancelExpiry() throws Exception {
+        try (Fixture fixture = new Fixture()) {
+            var message = fixture.reference.getMessage();
+            fixture.track(false);
+            when(fixture.delivery.getRemoteState()).thenReturn(new org.apache.qpid.proton.amqp.messaging.Received());
+            assertTrue(fixture.settle());
+            fixture.expiry.get().run();
+            verify(fixture.session).cancel(fixture.consumer, message, true);
+        }
+    }
+    @Test
     void expiryReleasesMessageAndRejectsStaleSettlement() throws Exception {
         try (Fixture fixture = new Fixture()) {
             fixture.track(false);


### PR DESCRIPTION
Non-session PeekLock deliveries stay locked indefinitely while their receiver remains connected. Queues, subscriptions, and session dead-letter queues therefore fail to redeliver after LockDuration.

Track each unsettled delivery on its AMQP connection event loop. Expiry releases the broker reference for redelivery; a subsequent stale disposition returns MessageLockLost without acknowledging the new delivery. Cancel timers for terminal outcomes or receiver closure; intermediate Received states keep their deadlines. If cancellation throws, reject stale dispositions and tear down the connection to release references safely. Preserve session-lock behavior and ReceiveAndDelete.

Provide per-delivery LockedUntil annotations for standard and streamed large messages without modifying shared stored messages. Configure non-session queues, including DLQs, without Artemis message grouping so a retained SessionId cannot pin redelivery to the original consumer. Update the Service Bus support documentation; explicit lock renewal remains future work.

Validation:
- Failing-first .NET SDK regressions reproduced indefinite locks on queues, subscriptions, and session DLQs. A separate 200 KB case reproduced missing lock metadata before the large-message writer fix.
- All 15 .NET Service Bus compatibility tests pass against the packaged JVM server and real Artemis sidecar, including four new expiry cases. These verify redelivery with the original receiver open, incremented DeliveryCount, LockedUntil, body preservation, MessageLockLost on stale completion, and successful completion by the new owner.
- Added Java tests for expiry, stale settlement, successful settlement, receiver closure, session/ReceiveAndDelete exclusions, and queue configuration parsed by Artemis itself.
- Focused Service Bus Java suite: 173 tests, zero failures/errors/skips.
- Latest full Java suite: 1,072 tests, one failure, 14 existing skips. The failure is the unchanged SqlProvisioningServiceTest.boundsRetainedTerminalOperations timestamp-tie failure: retention sorts ConcurrentHashMap values only by endTime, making eviction among equal timestamps unspecified. No SQL code or tests were changed.
- Reviewed and simplified the full change; git diff --check passes.

