### PR TITLE
fix(cosmos): preserve query continuation after page deletion

### DIFF
--- a/compatibility-tests/sdk-test-dotnet/CosmosTransactionalBatchCompatibilityTests.cs
+++ b/compatibility-tests/sdk-test-dotnet/CosmosTransactionalBatchCompatibilityTests.cs
@@ -11,6 +11,84 @@ public sealed class CosmosTransactionalBatchCompatibilityTests
         Environment.GetEnvironmentVariable("FLOCI_AZ_ENDPOINT") ?? "http://localhost:4577";
 
     [Test]
+    [Arguments(false)]
+    [Arguments(true)]
+    [Timeout(60_000)]
+    public async Task QueryContinuesAfterDeletingEachPage(bool ordered, CancellationToken cancellationToken)
+    {
+        using CosmosClient client = CreateClient($"dotnetpurge{Guid.NewGuid():N}");
+        Database database = await client.CreateDatabaseAsync(
+            $"db-{Guid.NewGuid():N}", cancellationToken: cancellationToken);
+        try
+        {
+            Container container = await database.CreateContainerAsync(
+                new ContainerProperties("items", "/tenant"), cancellationToken: cancellationToken);
+            string[] expected = Enumerable.Range(0, 7).Select(i => $"item-{i}").ToArray();
+            for (int i = 0; i < expected.Length; i++)
+            {
+                await container.CreateItemAsync(new { id = expected[i], tenant = "target", rank = i / 3 },
+                    new PartitionKey("target"), cancellationToken: cancellationToken);
+                await container.CreateItemAsync(new { id = expected[i], tenant = "other", rank = i / 3 },
+                    new PartitionKey("other"), cancellationToken: cancellationToken);
+            }
+
+            string sql = "SELECT c.id FROM c" + (ordered ? " ORDER BY c.rank DESC" : "");
+            var options = new QueryRequestOptions { PartitionKey = new PartitionKey("target"), MaxItemCount = 2 };
+            using FeedIterator<JObject> iterator = container.GetItemQueryIterator<JObject>(sql, requestOptions: options);
+            var visited = new List<string>();
+            int pages = 0;
+            while (iterator.HasMoreResults)
+            {
+                FeedResponse<JObject> page = await iterator.ReadNextAsync(cancellationToken);
+                if (++pages > 7)
+                {
+                    throw new InvalidOperationException("Query continuation did not terminate");
+                }
+                if (page.Count == 0)
+                {
+                    continue;
+                }
+                await Assert.That(page.Count <= 2).IsTrue();
+                TransactionalBatch batch = container.CreateTransactionalBatch(new PartitionKey("target"));
+                foreach (JObject item in page)
+                {
+                    string id = item.Value<string>("id")!;
+                    visited.Add(id);
+                    batch.DeleteItem(id);
+                }
+                using TransactionalBatchResponse deleted = await batch.ExecuteAsync(cancellationToken);
+                await Assert.That(deleted.IsSuccessStatusCode).IsTrue();
+                await Assert.That(deleted.Count).IsEqualTo(page.Count);
+                for (int i = 0; i < deleted.Count; i++)
+                {
+                    await Assert.That(deleted[i].StatusCode).IsEqualTo(HttpStatusCode.NoContent);
+                }
+            }
+
+            await Assert.That(visited).IsEquivalentTo(expected);
+            using FeedIterator<JObject> remaining = container.GetItemQueryIterator<JObject>(
+                "SELECT c.id FROM c", requestOptions: options);
+            while (remaining.HasMoreResults)
+            {
+                await Assert.That((await remaining.ReadNextAsync(cancellationToken)).Count).IsEqualTo(0);
+            }
+            using FeedIterator<JObject> other = container.GetItemQueryIterator<JObject>(
+                "SELECT c.id FROM c",
+                requestOptions: new QueryRequestOptions { PartitionKey = new PartitionKey("other") });
+            var preserved = new List<string>();
+            while (other.HasMoreResults)
+            {
+                preserved.AddRange((await other.ReadNextAsync(cancellationToken)).Select(item => item.Value<string>("id")!));
+            }
+            await Assert.That(preserved).IsEquivalentTo(expected);
+        }
+        finally
+        {
+            await database.DeleteAsync(cancellationToken: cancellationToken);
+        }
+    }
+
+    [Test]
     [Timeout(60_000)]
     public async Task DotnetSdkExecutesTransactionalBatches(CancellationToken cancellationToken)
     {

--- a/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/CosmosNoSqlEngineCompatibilityTest.java
+++ b/compatibility-tests/sdk-test-java/src/test/java/io/floci/az/compat/CosmosNoSqlEngineCompatibilityTest.java
@@ -416,6 +416,49 @@ class CosmosNoSqlEngineCompatibilityTest {
     }
 
     @Test
+    @DisplayName("query continuation visits remaining documents after each page is deleted")
+    void paginationAfterDeletingConsumedPages() {
+        for (String sql : List.of("SELECT c.id FROM c", "SELECT c.id FROM c ORDER BY c.rank DESC")) {
+            String id = dbId();
+            cosmosClient.createDatabase(id);
+            CosmosDatabase db = cosmosClient.getDatabase(id);
+            try {
+                db.createContainer("items", "/category");
+                CosmosContainer container = db.getContainer("items");
+                Set<String> expected = new HashSet<>();
+                for (int i = 0; i < 7; i++) {
+                    String itemId = "item-" + i;
+                    expected.add(itemId);
+                    container.createItem(doc(itemId, "target", "rank", i / 3));
+                    container.createItem(doc(itemId, "other", "rank", i / 3));
+                }
+                CosmosQueryRequestOptions options = new CosmosQueryRequestOptions()
+                        .setPartitionKey(new PartitionKey("target"))
+                        .setMaxBufferedItemCount(0);
+                List<String> visited = new ArrayList<>();
+                int pages = 0;
+                for (var page : container.queryItems(sql, options, Map.class).iterableByPage(2)) {
+                    assertTrue(++pages <= 7, "Continuation must terminate");
+                    assertTrue(page.getResults().size() <= 2);
+                    for (Map item : page.getResults()) {
+                        String itemId = (String) item.get("id");
+                        visited.add(itemId);
+                        container.deleteItem(itemId, new PartitionKey("target"), new CosmosItemRequestOptions());
+                    }
+                }
+                assertEquals(7, visited.size());
+                assertEquals(expected, new HashSet<>(visited));
+                assertEquals(0, container.queryItems("SELECT c.id FROM c", options, Map.class).stream().count());
+                assertEquals(7, container.queryItems("SELECT c.id FROM c",
+                        new CosmosQueryRequestOptions().setPartitionKey(new PartitionKey("other")), Map.class)
+                        .stream().count());
+            } finally {
+                db.delete();
+            }
+        }
+    }
+
+    @Test
     @DisplayName("CONTAINS, STARTSWITH, ENDSWITH string predicates in WHERE")
     @SuppressWarnings("unchecked")
     void stringPredicates() {

--- a/docs/services/cosmos.md
+++ b/docs/services/cosmos.md
@@ -27,6 +27,16 @@ keys respectively. Omitting the header permits cross-partition queries. Malforme
 Writes reject partition headers that disagree with the document body, and patches cannot change
 partition-key values. Transactional batches enforce the same rules before committing staged writes.
 
+Query continuation tokens bookmark the last source document and its `ORDER BY` values, including
+a stable identity to distinguish equal sort values. Deleting an already consumed page, including
+through transactional batches, does not skip remaining documents. This also applies to projections
+that omit the sort fields or return scalar values. `TOP` and `OFFSET ... LIMIT` retain their total
+query limits across pages. Tokens are stateless; no server-side query session is required.
+
+Pagination does not provide snapshot isolation for concurrent inserts or changes to sort values.
+Aggregate, `GROUP BY`, and `DISTINCT` queries retain the emulator's existing result-offset pagination;
+the document bookmark guarantee applies to queries without aggregation or deduplication.
+
 ### .NET query planner configuration
 
 The account response advertises query-engine capabilities. Floci-AZ emits 20 keys, while the

--- a/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosHandler.java
@@ -1186,26 +1186,21 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         } catch (IllegalArgumentException e) {
             return errorResponse(400, "BadRequest", e.getMessage());
         }
-        CosmosQueryEngine.QueryResult result = queryEngine.execute(parsed, scopedDocs);
-
-        // ---- Pagination ----
         int maxItemCount = parseMaxItemCount(req.headers().getHeaderString("x-ms-max-item-count"));
-        int skip         = decodeContinuationToken(req.headers().getHeaderString("x-ms-continuation"));
-
-        List<Object> allItems  = result.items();
-        List<Object> pageItems = skip > 0 ? allItems.subList(Math.min(skip, allItems.size()), allItems.size())
-                                          : new ArrayList<>(allItems);
-
-        String nextToken = null;
-        if (maxItemCount > 0 && pageItems.size() > maxItemCount) {
-            nextToken = encodeContinuationToken(skip + maxItemCount);
-            pageItems = pageItems.subList(0, maxItemCount);
+        final CosmosQueryEngine.QueryContinuation continuation;
+        try {
+            continuation = decodeContinuationToken(req.headers().getHeaderString("x-ms-continuation"));
+            if (continuation != null && continuation.rid() != null
+                    && continuation.orderValues().size() != parsed.orderBy().size()) {
+                throw new IllegalArgumentException("Continuation does not match query ordering");
+            }
+        } catch (IllegalArgumentException e) {
+            return errorResponse(400, "BadRequest", e.getMessage());
         }
-
-        return queryResponse(
-                new CosmosQueryEngine.QueryResult(pageItems, pageItems.size()),
+        CosmosQueryEngine.QueryPage page = queryEngine.executePage(parsed, scopedDocs, continuation, maxItemCount);
+        return queryResponse(page.result(),
                 collRid(req.accountName(), dbId, collId),
-                nextToken);
+                encodeContinuationToken(page.continuation()));
     }
 
     private Response queryResponse(CosmosQueryEngine.QueryResult result, String rid) {
@@ -1243,23 +1238,49 @@ public class CosmosHandler implements AzureServiceHandler, Resettable {
         catch (NumberFormatException e) { return -1; }
     }
 
-    private int decodeContinuationToken(String token) {
-        if (token == null || token.isBlank()) return 0;
+    private CosmosQueryEngine.QueryContinuation decodeContinuationToken(String token) {
+        if (token == null || token.isBlank()) {
+            return null;
+        }
         try {
             String json = new String(Base64.getDecoder().decode(token), StandardCharsets.UTF_8);
             Map<?, ?> map = MAPPER.readValue(json, Map.class);
-            return ((Number) map.get("skip")).intValue();
-        } catch (Exception e) {
-            return 0;
+            if (map == null) {
+                throw new IllegalArgumentException("Invalid continuation bookmark");
+            }
+            Object skip = map.get("skip");
+            if (!(skip instanceof Integer consumed) || consumed < 0) {
+                throw new IllegalArgumentException("Invalid continuation offset");
+            }
+            Object rid = map.get("rid");
+            if (rid == null) {
+                return new CosmosQueryEngine.QueryContinuation(consumed, null, List.of());
+            }
+            if (!(rid instanceof String identity) || identity.isBlank()
+                    || !(map.get("orderValues") instanceof List<?> values)) {
+                throw new IllegalArgumentException("Invalid continuation bookmark");
+            }
+            return new CosmosQueryEngine.QueryContinuation(consumed, identity, new ArrayList<>(values));
+        } catch (IOException | IllegalArgumentException e) {
+            throw new IllegalArgumentException("Invalid query continuation token", e);
         }
     }
 
-    private String encodeContinuationToken(int skip) {
-        try {
-            String json = MAPPER.writeValueAsString(Map.of("skip", skip));
-            return Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
-        } catch (Exception e) {
+    private String encodeContinuationToken(CosmosQueryEngine.QueryContinuation continuation) {
+        if (continuation == null) {
             return null;
+        }
+        try {
+            Map<String, Object> bookmark = new LinkedHashMap<>();
+            bookmark.put("skip", continuation.consumed());
+            if (continuation.rid() != null) {
+                bookmark.put("rid", continuation.rid());
+                bookmark.put("orderValues", continuation.orderValues());
+            }
+            String json = MAPPER.writeValueAsString(bookmark);
+            return Base64.getEncoder().encodeToString(json.getBytes(StandardCharsets.UTF_8));
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Cannot encode query continuation token", e);
         }
     }
 

--- a/src/main/java/io/floci/az/services/cosmos/CosmosQueryEngine.java
+++ b/src/main/java/io/floci/az/services/cosmos/CosmosQueryEngine.java
@@ -64,6 +64,10 @@ public class CosmosQueryEngine {
 
     public record QueryResult(List<Object> items, int count) {}
 
+    record QueryContinuation(int consumed, String rid, List<Object> orderValues) {}
+
+    record QueryPage(QueryResult result, QueryContinuation continuation) {}
+
     // -----------------------------------------------------------------------
     // Entry point
     // -----------------------------------------------------------------------
@@ -121,6 +125,65 @@ public class CosmosQueryEngine {
             filtered = stream.collect(Collectors.toCollection(ArrayList::new));
         }
 
+        return projectResults(q, filtered);
+    }
+
+    QueryPage executePage(ParsedQuery q, List<Map<String, Object>> documents,
+                          QueryContinuation continuation, int maxItemCount) {
+        int consumed = continuation == null ? 0 : continuation.consumed();
+        if (q.countQuery() || q.aggregateType() != null || !q.groupBy().isEmpty() || q.distinct()) {
+            List<Object> items = execute(q, documents).items();
+            int start = Math.min(consumed, items.size());
+            int size = pageSize(items.size() - start, maxItemCount);
+            List<Object> page = items.subList(start, start + size);
+            QueryContinuation next = start + size < items.size()
+                    ? new QueryContinuation(consumed + size, null, List.of()) : null;
+            return new QueryPage(new QueryResult(page, size), next);
+        }
+
+        // Keep source identities and sort values until after pagination, even for scalar projections.
+        Comparator<Map<String, Object>> comparator = buildComparator(q.orderBy())
+                .thenComparing(doc -> (String) doc.get("_rid"));
+        Stream<Map<String, Object>> remaining = documents.stream()
+                .filter(doc -> q.whereClause() == null || evalExpr(doc, q.whereClause()))
+                .sorted(comparator);
+        if (continuation != null && continuation.rid() != null) {
+            remaining = remaining.filter(doc -> compareContinuation(q, doc, continuation) > 0);
+        } else {
+            // Older emulator tokens contain only an offset. Upgrade them on the next page.
+            remaining = remaining.skip((long) q.offset() + consumed);
+        }
+        long available = q.top() < 0 ? Long.MAX_VALUE : Math.max(0L, (long) q.top() - q.offset());
+        if (q.limit() >= 0) {
+            available = Math.min(available, q.limit());
+        }
+        List<Map<String, Object>> rows = remaining.limit(Math.max(0L, available - consumed)).toList();
+        int size = pageSize(rows.size(), maxItemCount);
+        QueryContinuation next = null;
+        if (size < rows.size()) {
+            Map<String, Object> last = rows.get(size - 1);
+            List<Object> values = q.orderBy().stream().map(order -> resolve(last, order.path())).toList();
+            next = new QueryContinuation(consumed + size, (String) last.get("_rid"), values);
+        }
+        return new QueryPage(projectResults(q, rows.subList(0, size)), next);
+    }
+
+    private int pageSize(int available, int maxItemCount) {
+        return maxItemCount > 0 ? Math.min(available, maxItemCount) : available;
+    }
+
+    private int compareContinuation(ParsedQuery q, Map<String, Object> doc, QueryContinuation continuation) {
+        for (int i = 0; i < q.orderBy().size(); i++) {
+            OrderByField order = q.orderBy().get(i);
+            int comparison = compareSortValues(resolve(doc, order.path()), continuation.orderValues().get(i));
+            if (comparison != 0) {
+                return order.asc() ? comparison : -comparison;
+            }
+        }
+        return ((String) doc.get("_rid")).compareTo(continuation.rid());
+    }
+
+    private QueryResult projectResults(ParsedQuery q, List<Map<String, Object>> filtered) {
         List<Object> results;
         if (q.selectValue() && q.selectFields() != null && q.selectFields().size() == 1) {
             String path = q.selectFields().get(0);
@@ -641,15 +704,25 @@ public class CosmosQueryEngine {
             Comparator<Map<String, Object>> single = (a, b) -> {
                 Object va = resolve(a, path);
                 Object vb = resolve(b, path);
-                if (va == null && vb == null) return 0;
-                if (va == null) return -1;
-                if (vb == null) return 1;
-                return compareValues(va, vb);
+                return compareSortValues(va, vb);
             };
             if (!ob.asc()) single = single.reversed();
             comp = comp == null ? single : comp.thenComparing(single);
         }
         return comp != null ? comp : (a, b) -> 0;
+    }
+
+    private int compareSortValues(Object a, Object b) {
+        if (a == null && b == null) {
+            return 0;
+        }
+        if (a == null) {
+            return -1;
+        }
+        if (b == null) {
+            return 1;
+        }
+        return compareValues(a, b);
     }
 
     // -----------------------------------------------------------------------

--- a/src/test/java/io/floci/az/services/cosmos/CosmosQueryContinuationTest.java
+++ b/src/test/java/io/floci/az/services/cosmos/CosmosQueryContinuationTest.java
@@ -1,0 +1,154 @@
+package io.floci.az.services.cosmos;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@QuarkusTest
+class CosmosQueryContinuationTest {
+    private static final String DB = "/continuationacct-cosmos/dbs/pagination";
+    private static final String DOCS = DB + "/colls/items/docs";
+
+    @BeforeEach
+    void setup() {
+        given().post("/_admin/reset").then().statusCode(204);
+        given().contentType("application/json").body(Map.of("id", "pagination"))
+                .post("/continuationacct-cosmos/dbs").then().statusCode(201);
+        given().contentType("application/json").body("""
+                {"id":"items","partitionKey":{"paths":["/tenant"],"kind":"Hash"},
+                 "indexingPolicy":{"compositeIndexes":[[
+                     {"path":"/rank","order":"ascending"},
+                     {"path":"/id","order":"descending"}]]}}
+                """).post(DB + "/colls").then().statusCode(201);
+        for (int i = 0; i < 7; i++) {
+            insert("item-" + i, "alice", i < 2 ? null : i / 3);
+            insert("other-" + i, "bob", i < 2 ? null : i / 3);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "SELECT c.id FROM c",
+            "SELECT c.id FROM c ORDER BY c.rank",
+            "SELECT c.id FROM c ORDER BY c.rank DESC",
+            "SELECT c.id FROM c ORDER BY c.rank, c.id DESC",
+            "SELECT c.id FROM c ORDER BY c.rank DESC, c.id",
+            "SELECT VALUE c.id FROM c ORDER BY c.rank",
+            "SELECT * FROM c ORDER BY c.rank DESC"
+    })
+    void visitsEveryDocumentWhenConsumedPagesAreDeleted(String sql) {
+        List<String> expected = ids(query(sql, null, -1));
+        List<String> visited = new ArrayList<>();
+        String continuation = null;
+        int pages = 0;
+        do {
+            Response page = query(sql, continuation, 2);
+            List<String> ids = ids(page);
+            assertFalse(ids.isEmpty(), "Continuation must not skip remaining documents");
+            assertTrue(ids.size() <= 2);
+            visited.addAll(ids);
+            for (String id : ids) {
+                given().header("x-ms-documentdb-partitionkey", "[\"alice\"]")
+                        .delete(DOCS + "/" + id).then().statusCode(204);
+            }
+            continuation = page.header("x-ms-continuation");
+            assertTrue(++pages <= 4, "Continuation must terminate");
+        } while (continuation != null);
+
+        assertEquals(expected, visited);
+        assertEquals(4, pages);
+        query("SELECT c.id FROM c", null, -1).then().body("_count", is(0));
+        given().contentType("application/query+json").header("x-ms-documentdb-isquery", "true")
+                .header("x-ms-documentdb-partitionkey", "[\"bob\"]")
+                .body(Map.of("query", "SELECT c.id FROM c"))
+                .post(DOCS).then().statusCode(200).body("_count", is(7));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "SELECT TOP 5 c.id FROM c ORDER BY c.rank",
+            "SELECT c.id FROM c ORDER BY c.rank DESC OFFSET 1 LIMIT 5",
+            "SELECT TOP 6 c.id FROM c ORDER BY c.rank OFFSET 1 LIMIT 5"
+    })
+    void preservesQueryLimitsAndReplaysBookmarksAfterDeletion(String sql) {
+        List<String> expected = ids(query(sql, null, -1));
+        List<String> visited = new ArrayList<>();
+        String continuation = null;
+        do {
+            Response page = query(sql, continuation, visited.isEmpty() ? 2 : 1);
+            List<String> pageIds = ids(page);
+            assertFalse(pageIds.isEmpty());
+            visited.addAll(pageIds);
+            assertTrue(visited.size() <= 5);
+            for (String id : pageIds) {
+                given().header("x-ms-documentdb-partitionkey", "[\"alice\"]")
+                        .delete(DOCS + "/" + id).then().statusCode(204);
+            }
+            continuation = page.header("x-ms-continuation");
+            if (continuation != null) {
+                assertEquals(ids(query(sql, continuation, 1)), ids(query(sql, continuation, 1)));
+            }
+        } while (continuation != null);
+        assertEquals(expected, visited);
+        assertEquals(5, visited.size());
+    }
+
+    @Test
+    void resumesLegacyOffsetTokens() {
+        String sql = "SELECT c.id FROM c ORDER BY c.rank";
+        List<String> expected = ids(query(sql, null, -1));
+        String token = Base64.getEncoder().encodeToString("{\"skip\":2}".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        Response page = query(sql, token, 2);
+        assertEquals(expected.subList(2, 4), ids(page));
+        assertEquals(expected.subList(4, 7), ids(query(sql, page.header("x-ms-continuation"), -1)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"null", "{}", "[]", "{\"skip\":-1}", "{\"skip\":1.5}",
+            "{\"skip\":2,\"rid\":\"bookmark\",\"orderValues\":[]}"})
+    void rejectsInvalidContinuationWithoutRestartingQuery(String json) {
+        String token = Base64.getEncoder().encodeToString(json.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        given().contentType("application/query+json").header("x-ms-documentdb-isquery", "true")
+                .header("x-ms-continuation", token)
+                .body(Map.of("query", "SELECT c.id FROM c ORDER BY c.rank"))
+                .post(DOCS).then().statusCode(400).body("code", is("BadRequest"));
+    }
+
+    private void insert(String id, String tenant, Integer rank) {
+        Map<String, Object> document = new HashMap<>(Map.of("id", id, "tenant", tenant));
+        document.put("rank", rank);
+        given().contentType("application/json").body(document)
+                .post(DOCS).then().statusCode(201);
+    }
+
+    private Response query(String sql, String continuation, int pageSize) {
+        var request = given().contentType("application/query+json")
+                .header("x-ms-documentdb-isquery", "true")
+                .header("x-ms-documentdb-partitionkey", "[\"alice\"]")
+                .header("x-ms-max-item-count", pageSize)
+                .body(Map.of("query", sql));
+        if (continuation != null) {
+            request.header("x-ms-continuation", continuation);
+        }
+        return request.post(DOCS).then().statusCode(200).extract().response();
+    }
+
+    private List<String> ids(Response response) {
+        return response.jsonPath().getList("Documents").stream()
+                .map(item -> item instanceof Map<?, ?> doc ? (String) doc.get("id") : (String) item)
+                .toList();
+    }
+}


### PR DESCRIPTION
Deleting documents from a consumed query page shifts the old numeric offset, causing continuation to skip documents that still exist. Use a stateless bookmark containing the source document identity and ORDER BY values, with a stable tie-breaker, before projecting each page. Preserve partition scope and total TOP/OFFSET/LIMIT bounds.

Legacy tokens retain their original offset ordering until completion. Decode integral offsets as 64-bit values, rejecting fractional, negative, and overflowing values without truncation. Bind new tokens to query text, parameters, account, container identity, and partition scope so accidental cross-query or cross-resource reuse returns 400. Scope normalization accepts equivalent parameter ordering, nested object member ordering, and numeric representations while preserving array order. Missing stored document identities now produce an explicit diagnostic, and the .NET purge test bounds its pagination loop more tightly.

Adds HTTP regression coverage, a Java SDK continuation case, and .NET SDK tests that delete each page through transactional batches before continuing.

Validation of the latest changes:
- Cosmos unit/integration tests: 193 passed.
- Live .NET Cosmos SDK tests: 8 passed, including page deletion, TOP/OFFSET/LIMIT bounds, and iterator recreation.
- Live Java Cosmos SDK tests: 32 passed, including the explicitly enabled embedded NoSQL suite.
- Live Node.js Cosmos SDK tests: 19 passed.
- Live Python Cosmos SDK tests: 19 passed.
- JVM package build and git diff --check passed.

Documented limits: aggregates, GROUP BY, DISTINCT, and legacy tokens retain offset pagination. Bookmarks do not provide snapshot isolation for concurrent inserts or changes to sort values.

Fixes #301.
